### PR TITLE
PHP 8.2 Support: Disjunctive Normal Form Types #4725

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/CodeUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/CodeUtils.java
@@ -88,6 +88,7 @@ public final class CodeUtils {
     public static final String STATIC_METHOD_TYPE_PREFIX = "@static.mtd:"; // NOI18N
     public static final String NULLABLE_TYPE_PREFIX = "?"; // NOI18N
     public static final String ELLIPSIS = "..."; // NOI18N
+    public static final String VAR_TAG = "@var"; // NOI18N
 
     public static final Pattern WHITE_SPACES_PATTERN = Pattern.compile("\\s+"); // NOI18N
     public static final Pattern SPLIT_TYPES_PATTERN = Pattern.compile("[()|&]+"); // NOI18N

--- a/php/php.editor/src/org/netbeans/modules/php/editor/elements/BaseFunctionElementSupport.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/elements/BaseFunctionElementSupport.java
@@ -19,6 +19,8 @@
 
 package org.netbeans.modules.php.editor.elements;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -39,7 +41,6 @@ import org.netbeans.modules.php.editor.api.elements.TypeMemberElement;
 import org.netbeans.modules.php.editor.api.elements.TypeNameResolver;
 import org.netbeans.modules.php.editor.api.elements.TypeResolver;
 import org.netbeans.modules.php.editor.model.impl.Type;
-import org.netbeans.modules.php.editor.parser.astnodes.ASTNode;
 import org.netbeans.modules.php.editor.parser.astnodes.Expression;
 import org.netbeans.modules.php.editor.parser.astnodes.IntersectionType;
 import org.netbeans.modules.php.editor.parser.astnodes.UnionType;
@@ -159,6 +160,13 @@ public class BaseFunctionElementSupport  {
                 break;
             case ReturnTypes:
                 boolean hasArray = false;
+                String declaredReturnType = getDeclaredReturnType();
+                if (StringUtils.hasText(declaredReturnType)) {
+                    String typeTemplate = Type.toTypeTemplate(declaredReturnType);
+                    List<String> types = Arrays.asList(Type.splitTypes(declaredReturnType));
+                    template.append(String.format(typeTemplate, (Object[]) resolveReturnTypes(types, typeNameResolver, element)));
+                    break;
+                }
                 for (TypeResolver typeResolver : getReturnTypes()) {
                     if (typeResolver.isResolved()) {
                         QualifiedName typeName = typeResolver.getTypeName(false);
@@ -168,23 +176,7 @@ public class BaseFunctionElementSupport  {
                                 template.append(CodeUtils.NULLABLE_TYPE_PREFIX);
                             }
                             String returnType = typeNameResolver.resolve(typeName).toString();
-                            if (("\\" + Type.SELF).equals(returnType) // NOI18N
-                                    && element instanceof TypeMemberElement) {
-                                // #267563
-                                returnType = typeNameResolver.resolve(((TypeMemberElement) element).getType().getFullyQualifiedName()).toString();
-                            }
-                            if (("\\" + Type.PARENT).equals(returnType) // NOI18N
-                                    && element instanceof TypeMemberElement) {
-                                TypeElement typeElement = ((TypeMemberElement) element).getType();
-                                if (typeElement instanceof ClassElement) {
-                                    QualifiedName superClassName = ((ClassElement) typeElement).getSuperClassName();
-                                    if (superClassName != null) {
-                                        returnType = typeNameResolver.resolve(superClassName).toString();
-                                    } else {
-                                        returnType = Type.PARENT;
-                                    }
-                                }
-                            }
+                            returnType = resolveSpecialType(returnType, element, typeNameResolver);
                             // NETBEANS-5370: related to NETBEANS-4509
                             if (returnType.endsWith("[]")) { // NOI18N
                                 returnType = Type.ARRAY;
@@ -204,6 +196,54 @@ public class BaseFunctionElementSupport  {
                 assert false : as;
         }
         return template.toString();
+    }
+
+    private String[] resolveReturnTypes(List<String> types, TypeNameResolver typeNameResolver, BaseFunctionElement element) {
+        List<String> replaced = new ArrayList<>(types.size());
+        if (types.size() == getReturnTypes().size()) {
+            for (TypeResolver typeResolver : getReturnTypes()) {
+                if (typeResolver.isResolved()) {
+                    QualifiedName typeName = typeResolver.getTypeName(false);
+                    if (typeName != null) {
+                        String returnType = typeNameResolver.resolve(typeName).toString();
+                        // NETBEANS-5370: related to NETBEANS-4509
+                        if (returnType.endsWith("[]")) { // NOI18N
+                            returnType = Type.ARRAY;
+                        }
+                        returnType = resolveSpecialType(returnType, element, typeNameResolver);
+                        replaced.add(returnType);
+                    }
+                }
+            }
+        } else {
+            replaced.addAll(types);
+        }
+        return replaced.toArray(new String[0]);
+    }
+
+    private String resolveSpecialType(String returnType, BaseFunctionElement element, TypeNameResolver typeNameResolver) {
+        String resolvedType = returnType;
+        if (resolvedType.equals("\\" + Type.SELF) // NOI18N
+                || resolvedType.equals("\\" + Type.PARENT)) { // NOI18N
+            resolvedType = resolvedType.substring(1);
+        }
+        if ((Type.SELF).equals(resolvedType)
+                && element instanceof TypeMemberElement) {
+            // #267563
+            resolvedType = typeNameResolver.resolve(((TypeMemberElement) element).getType().getFullyQualifiedName()).toString();
+        } else if ((Type.PARENT).equals(resolvedType)
+                && element instanceof TypeMemberElement) {
+            TypeElement typeElement = ((TypeMemberElement) element).getType();
+            if (typeElement instanceof ClassElement) {
+                QualifiedName superClassName = ((ClassElement) typeElement).getSuperClassName();
+                if (superClassName != null) {
+                    resolvedType = typeNameResolver.resolve(superClassName).toString();
+                } else {
+                    resolvedType = Type.PARENT;
+                }
+            }
+        }
+        return resolvedType;
     }
 
     private void appendSeparator(StringBuilder template) {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/PHPVarCommentParser.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/PHPVarCommentParser.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.php.editor.parser;
 
 import java.util.ArrayList;
+import org.netbeans.modules.php.editor.CodeUtils;
 import org.netbeans.modules.php.editor.model.impl.Type;
 import org.netbeans.modules.php.editor.parser.astnodes.PHPDocNode;
 import org.netbeans.modules.php.editor.parser.astnodes.PHPDocStaticAccessType;
@@ -57,15 +58,19 @@ public class PHPVarCommentParser {
             }
             int startDocNode;
             int endPosition = 0;
-            String[] parts = definition.split("[ \t]+"); //NOI18N
+            String[] parts = CodeUtils.WHITE_SPACES_PATTERN.split(definition);
             if (isExpectedPartsLength(isPHPDoc, parts)
                     && parts[variableIndex].charAt(0) == '$') { //NOI18N
                 //counting types
-                String[] types = Type.splitTypes(parts[typeIndex]);
-                int typePosition = startOffset + comment.indexOf(parts[typeIndex]);
+                String typePart = parts[typeIndex];
+                String[] types = Type.splitTypes(typePart);
+                int typePosition = startOffset + comment.indexOf(typePart);
                 ArrayList<PHPDocTypeNode> typeNodes = new ArrayList<>();
+                int fromEndIndexOfLastType = 0;
                 for (String type: types) {
-                    startDocNode = typePosition + parts[typeIndex].indexOf(type);
+                    int indexOfType = typePart.indexOf(type, fromEndIndexOfLastType);
+                    startDocNode = typePosition + indexOfType;
+                    fromEndIndexOfLastType = indexOfType + type.length();
                     index = type.indexOf("::"); //NOI18N
                     boolean isArray = (type.indexOf('[') > 0  && type.indexOf(']') > 0);
                     if (isArray) {

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesConstructor/testDNFTypesConstructor.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesConstructor/testDNFTypesConstructor.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class DNFTypes
+{
+    private (Foo&Bar)|Baz $dnf1;
+    private Baz|(Foo&Bar&Baz) $dnf2;
+    private (Foo&Bar)|(Bar&Baz) $dnf3;
+    private (Foo&Bar)|Foo|(Bar&Baz) $dnf4;
+    private Foo|(Foo&Bar)|Baz $dnf5;
+    private static (Foo&Bar)|Baz $staticdnf;
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesConstructor/testDNFTypesConstructor.php.testDNFTypesConstructor.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesConstructor/testDNFTypesConstructor.php.testDNFTypesConstructor.codegen
@@ -1,0 +1,7 @@
+public function __construct((Foo&Bar)|Baz $dnf1, Baz|(Foo&Bar&Baz) $dnf2, (Foo&Bar)|(Bar&Baz) $dnf3, (Foo&Bar)|Foo|(Bar&Baz) $dnf4, Foo|(Foo&Bar)|Baz $dnf5) {
+$$this->dnf1 = $dnf1;
+$$this->dnf2 = $dnf2;
+$$this->dnf3 = $dnf3;
+$$this->dnf4 = $dnf4;
+$$this->dnf5 = $dnf5;${cursor}
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesGetter/testDNFTypesGetter.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesGetter/testDNFTypesGetter.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class DNFTypes
+{
+    private (Foo&Bar)|Baz $dnf1;
+    private Baz|(Foo&Bar&Baz) $dnf2;
+    private (Foo&Bar)|(Bar&Baz) $dnf3;
+    private (Foo&Bar)|Foo|(Bar&Baz) $dnf4;
+    private Foo|(Foo&Bar)|Baz $dnf5;
+    private static (Foo&Bar)|Baz $staticdnf;
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesGetter/testDNFTypesGetter.php.testDNFTypesGetter.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesGetter/testDNFTypesGetter.php.testDNFTypesGetter.codegen
@@ -1,0 +1,24 @@
+public  function getDnf1(): (Foo&Bar)|Baz  {
+return $$this->dnf1;
+}
+
+public  function getDnf2(): Baz|(Foo&Bar&Baz)  {
+return $$this->dnf2;
+}
+
+public  function getDnf3(): (Foo&Bar)|(Bar&Baz)  {
+return $$this->dnf3;
+}
+
+public  function getDnf4(): (Foo&Bar)|Foo|(Bar&Baz)  {
+return $$this->dnf4;
+}
+
+public  function getDnf5(): Foo|(Foo&Bar)|Baz  {
+return $$this->dnf5;
+}
+
+public static function getStaticdnf(): (Foo&Bar)|Baz  {
+return self::$$staticdnf;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod01/testDNFTypesImplementMethod01.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod01/testDNFTypesImplementMethod01.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+interface ImplementMethodTest {
+
+    public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): (Foo&Bar)|Baz;
+    /**
+     * @param (Foo&Bar)|Baz $param1 test
+     * @param Baz|(Foo&Bar) $param2 test
+     * @param (Foo&Bar)|(Bar&Baz) $param3 test
+     * @param Foo|(Bar&Baz)|null $param4 test
+     * @return (Foo&Bar)|Baz test
+     */
+    public function testPHPDoc($param1, $param2, $param3, $param4): object;
+}
+
+class Implement implements ImplementMethodTest {
+
+}
+
+class Foo {}
+class Bar {}
+class Baz {}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod01/testDNFTypesImplementMethod01.php.testDNFTypesImplementMethod01.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod01/testDNFTypesImplementMethod01.php.testDNFTypesImplementMethod01.codegen
@@ -1,0 +1,4 @@
+public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): (Foo&Bar)|Baz{
+}
+public function testPHPDoc($param1, $param2, $param3, $param4): object{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod02/testDNFTypesImplementMethod02.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod02/testDNFTypesImplementMethod02.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    use Test2\Foo;
+    use Test2\Bar;
+    use Test2\Baz;
+
+    interface ImplementMethodTest {
+
+        public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): (Foo&Bar)|Baz;
+    }
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+    }
+
+    class Foo {}
+
+    class Bar {}
+
+    class Baz {}
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod02/testDNFTypesImplementMethod02.php.testDNFTypesImplementMethod02.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod02/testDNFTypesImplementMethod02.php.testDNFTypesImplementMethod02.codegen
@@ -1,0 +1,2 @@
+public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): (Foo&Bar)|Baz{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod03/testDNFTypesImplementMethod03.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod03/testDNFTypesImplementMethod03.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    interface ImplementMethodTest {
+
+        public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): (Foo&Bar)|Baz;
+    }
+
+    class Foo {}
+    class Bar {}
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+    }
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod03/testDNFTypesImplementMethod03.php.testDNFTypesImplementMethod03.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod03/testDNFTypesImplementMethod03.php.testDNFTypesImplementMethod03.codegen
@@ -1,0 +1,2 @@
+public function testMethod((\Test1\Foo&\Test1\Bar)|\Test1\Baz $param1, \Test1\Baz|(\Test1\Foo&\Test1\Bar) $param2, (\Test1\Foo&\Test1\Bar)|(\Test1\Bar&\Test1\Baz) $param3, \Test1\Foo|(\Test1\Bar&\Test1\Baz)|null $param4): (\Test1\Foo&\Test1\Bar)|\Test1\Baz{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod04/testDNFTypesImplementMethod04.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod04/testDNFTypesImplementMethod04.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+abstract class ImplementMethodTest {
+
+    abstract public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): (Foo&Bar)|Baz;
+}
+
+class Implement extends ImplementMethodTest {
+
+}
+
+class Foo {}
+class Bar {}
+class Baz {}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod04/testDNFTypesImplementMethod04.php.testDNFTypesImplementMethod04.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesImplementMethod04/testDNFTypesImplementMethod04.php.testDNFTypesImplementMethod04.codegen
@@ -1,0 +1,2 @@
+public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): (Foo&Bar)|Baz{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesOverrideMethod01/testDNFTypesOverrideMethod01.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesOverrideMethod01/testDNFTypesOverrideMethod01.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+class OverrideMethodTest {
+
+    public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): (Foo&Bar)|Baz {
+        return new Foo();
+    }
+}
+
+class Child extends OverrideMethodTest {
+
+}
+
+class Foo {}
+class Bar {}
+class Baz {}
+
+$instance = new Child();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesOverrideMethod01/testDNFTypesOverrideMethod01.php.testDNFTypesOverrideMethod01.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesOverrideMethod01/testDNFTypesOverrideMethod01.php.testDNFTypesOverrideMethod01.codegen
@@ -1,0 +1,3 @@
+public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): (Foo&Bar)|Baz{
+return parent::testMethod($param1, $param2, $param3, $param4);
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesOverrideMethod02/testDNFTypesOverrideMethod02.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesOverrideMethod02/testDNFTypesOverrideMethod02.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    use Test2\Foo;
+    use Test2\Bar;
+    use Test2\Baz;
+
+    class OverrideMethodTest {
+
+        public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): Baz|(Foo&Bar) {
+            return new Foo();
+        }
+    }
+
+}
+
+namespace Test2 {
+
+    use Test1\OverrideMethodTest;
+
+    class Child extends OverrideMethodTest {
+    }
+
+    class Foo {}
+
+    class Bar {}
+
+    class Baz {}
+
+    $instance = new Child();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesOverrideMethod02/testDNFTypesOverrideMethod02.php.testDNFTypesOverrideMethod02.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesOverrideMethod02/testDNFTypesOverrideMethod02.php.testDNFTypesOverrideMethod02.codegen
@@ -1,0 +1,3 @@
+public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): Baz|(Foo&Bar){
+return parent::testMethod($param1, $param2, $param3, $param4);
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesOverrideMethod03/testDNFTypesOverrideMethod03.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesOverrideMethod03/testDNFTypesOverrideMethod03.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    class OverrideMethodTest {
+
+        public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): (Foo&Bar)|(Bar&Baz) {
+            return new Foo();
+        }
+    }
+
+    class Foo {}
+    class Bar {}
+    class Baz {}
+
+}
+
+namespace Test2 {
+
+    use Test1\OverrideMethodTest;
+
+    class Child extends OverrideMethodTest {
+    }
+
+    $instance = new Child();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesOverrideMethod03/testDNFTypesOverrideMethod03.php.testDNFTypesOverrideMethod03.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesOverrideMethod03/testDNFTypesOverrideMethod03.php.testDNFTypesOverrideMethod03.codegen
@@ -1,0 +1,3 @@
+public function testMethod((\Test1\Foo&\Test1\Bar)|\Test1\Baz $param1, \Test1\Baz|(\Test1\Foo&\Test1\Bar) $param2, (\Test1\Foo&\Test1\Bar)|(\Test1\Bar&\Test1\Baz) $param3, \Test1\Foo|(\Test1\Bar&\Test1\Baz)|null $param4): (\Test1\Foo&\Test1\Bar)|(\Test1\Bar&\Test1\Baz){
+return parent::testMethod($param1, $param2, $param3, $param4);
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesSetter/testDNFTypesSetter.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesSetter/testDNFTypesSetter.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class IntersectionTypes
+{
+    private (Foo&Bar)|Baz $dnf1;
+    private Baz|(Foo&Bar&Baz) $dnf2;
+    private (Foo&Bar)|(Bar&Baz) $dnf3;
+    private (Foo&Bar)|Foo|(Bar&Baz) $dnf4;
+    private Foo|(Foo&Bar)|Baz $dnf5;
+    private static (Foo&Bar)|Baz $staticdnf;
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesSetter/testDNFTypesSetter.php.testDNFTypesSetter.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testDNFTypesSetter/testDNFTypesSetter.php.testDNFTypesSetter.codegen
@@ -1,0 +1,24 @@
+public  function setDnf1((Foo&Bar)|Baz $$dnf1): void {
+$$this->dnf1 = $dnf1;
+}
+
+public  function setDnf2(Baz|(Foo&Bar&Baz) $$dnf2): void {
+$$this->dnf2 = $dnf2;
+}
+
+public  function setDnf3((Foo&Bar)|(Bar&Baz) $$dnf3): void {
+$$this->dnf3 = $dnf3;
+}
+
+public  function setDnf4((Foo&Bar)|Foo|(Bar&Baz) $$dnf4): void {
+$$this->dnf4 = $dnf4;
+}
+
+public  function setDnf5(Foo|(Foo&Bar)|Baz $$dnf5): void {
+$$this->dnf5 = $dnf5;
+}
+
+public static function setStaticdnf((Foo&Bar)|Baz $$staticdnf): void {
+self::$$staticdnf = $staticdnf;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod01/testDNFTypesImplementMethod01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod01/testDNFTypesImplementMethod01.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+interface ImplementMethodTest {
+
+    public function testMethod((Foo&Bar)|null $param): Foo|(Foo&Bar)|Bar;
+}
+
+class Implement implements ImplementMethodTest {
+    test
+}
+
+class Foo {}
+class Bar {}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod01/testDNFTypesImplementMethod01.php.testDNFTypesImplementMethod01.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod01/testDNFTypesImplementMethod01.php.testDNFTypesImplementMethod01.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testMethod
+public function testMethod((Foo&Bar)|null $param): Foo|(Foo&Bar)|Bar {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod02/testDNFTypesImplementMethod02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod02/testDNFTypesImplementMethod02.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    use Test2\Foo;
+    use Test2\Bar;
+    use Test2\Baz;
+
+    interface ImplementMethodTest {
+
+        public function testMethod(null|(Foo&Bar) $param1, (Foo&Bar)|Baz $pram2, (Foo&Bar)|(Bar&Baz) $param3): (Foo&Bar)|Bar|(Bar&Baz);
+    }
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+        test
+    }
+
+    class Foo {}
+
+    class Bar {}
+
+    class Baz {}
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod02/testDNFTypesImplementMethod02.php.testDNFTypesImplementMethod02.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod02/testDNFTypesImplementMethod02.php.testDNFTypesImplementMethod02.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testMethod
+public function testMethod(null|(Foo&Bar) $param1, (Foo&Bar)|Baz $pram2, (Foo&Bar)|(Bar&Baz) $param3): (Foo&Bar)|Bar|(Bar&Baz) {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod03a/testDNFTypesImplementMethod03a.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod03a/testDNFTypesImplementMethod03a.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    interface ImplementMethodTest {
+
+        public function testMethod(null|(Foo&Bar) $param1, (Foo&Bar)|Baz $pram2, (Foo&Bar)|(Bar&Baz) $param3): (Foo&Bar)|Bar|(Bar&Baz);
+    }
+
+    class Foo {}
+    class Bar {}
+    class Baz {}
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+        test
+    }
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod03a/testDNFTypesImplementMethod03a.php.testDNFTypesImplementMethod03a.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod03a/testDNFTypesImplementMethod03a.php.testDNFTypesImplementMethod03a.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testMethod
+public function testMethod(null|(\Test1\Foo&\Test1\Bar) $param1, (\Test1\Foo&\Test1\Bar)|\Test1\Baz $pram2, (\Test1\Foo&\Test1\Bar)|(\Test1\Bar&\Test1\Baz) $param3): (\Test1\Foo&\Test1\Bar)|\Test1\Bar|(\Test1\Bar&\Test1\Baz) {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod03b/testDNFTypesImplementMethod03b.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod03b/testDNFTypesImplementMethod03b.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    interface ImplementMethodTest {
+
+        public function testMethod(null|(Foo&Bar) $param1, (Foo&Bar)|Baz $pram2, (Foo&Bar)|(Bar&Baz) $param3): (Foo&Bar)|Bar|(Bar&Baz);
+    }
+
+    class Foo {}
+    class Bar {}
+    class Baz {}
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+    use Test1\Foo;
+    use Test1\Bar;
+    use Test1\Baz;
+
+    class Implement implements ImplementMethodTest {
+        test
+    }
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod03b/testDNFTypesImplementMethod03b.php.testDNFTypesImplementMethod03b.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod03b/testDNFTypesImplementMethod03b.php.testDNFTypesImplementMethod03b.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testMethod
+public function testMethod(null|(Foo&Bar) $param1, (Foo&Bar)|Baz $pram2, (Foo&Bar)|(Bar&Baz) $param3): (Foo&Bar)|Bar|(Bar&Baz) {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod04/testDNFTypesImplementMethod04.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod04/testDNFTypesImplementMethod04.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+abstract class ImplementMethodTest {
+
+    abstract public function testMethod(null|(Foo&Bar) $param1, (Foo&Bar)|Baz $pram2, (Foo&Bar)|(Bar&Baz) $param3): (Foo&Bar)|Baz;
+}
+
+class Implement extends ImplementMethodTest {
+    test
+}
+
+class Foo {}
+class Bar {}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod04/testDNFTypesImplementMethod04.php.testDNFTypesImplementMethod04.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesImplementMethod04/testDNFTypesImplementMethod04.php.testDNFTypesImplementMethod04.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testMethod
+public function testMethod(null|(Foo&Bar) $param1, (Foo&Bar)|Baz $pram2, (Foo&Bar)|(Bar&Baz) $param3): (Foo&Bar)|Baz {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethod01/testDNFTypesOverrideMethod01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethod01/testDNFTypesOverrideMethod01.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+class OverrideMethodTest {
+
+    public function testMethod(null|(Foo&\Bar) $param1, (Foo&Bar)|Baz $pram2, (Foo&Bar)|(Bar&Baz) $param3): (Foo&Bar)|Bar|(Bar&Baz) {
+        return new Foo();
+    }
+}
+
+class Child extends OverrideMethodTest {
+    test
+}
+
+class Foo {}
+class Bar {}
+
+$instance = new Child();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethod01/testDNFTypesOverrideMethod01.php.testDNFTypesOverrideMethod01.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethod01/testDNFTypesOverrideMethod01.php.testDNFTypesOverrideMethod01.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testMethod
+public function testMethod(null|(Foo&\Bar) $param1, (Foo&Bar)|Baz $pram2, (Foo&Bar)|(Bar&Baz) $param3): (Foo&Bar)|Bar|(Bar&Baz) {
+${cursor}return parent::testMethod($param1, $pram2, $param3);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethod02/testDNFTypesOverrideMethod02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethod02/testDNFTypesOverrideMethod02.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    use Test2\Foo;
+    use Test2\Bar;
+    use Test2\Baz;
+
+    class OverrideMethodTest {
+
+        public function testMethod(null|(Foo&\Bar) $param1, (Foo&Bar)|Baz $pram2, (Foo&Bar)|(Bar&Baz) $param3): Bar|(Bar&Baz) {
+            return new Foo();
+        }
+    }
+
+}
+
+namespace Test2 {
+
+    use Test1\OverrideMethodTest;
+
+    class Child extends OverrideMethodTest {
+        test
+    }
+
+    class Foo {}
+
+    class Bar {}
+
+    class Baz {}
+
+    $instance = new Child();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethod02/testDNFTypesOverrideMethod02.php.testDNFTypesOverrideMethod02.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethod02/testDNFTypesOverrideMethod02.php.testDNFTypesOverrideMethod02.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testMethod
+public function testMethod(null|(Foo&\Bar) $param1, (Foo&Bar)|Baz $pram2, (Foo&Bar)|(Bar&Baz) $param3): Bar|(Bar&Baz) {
+${cursor}return parent::testMethod($param1, $pram2, $param3);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethod03/testDNFTypesOverrideMethod03.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethod03/testDNFTypesOverrideMethod03.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    class OverrideMethodTest {
+
+        public function testMethod(null|(Foo&\Bar) $param1, (Foo&Bar)|Baz $pram2, (Foo&Bar)|(Bar&Baz) $param3): (Foo&Bar)|Baz {
+            return new Foo();
+        }
+    }
+
+    class Foo {}
+    class Bar {}
+    class Baz {}
+
+}
+
+namespace Test2 {
+
+    use Test1\OverrideMethodTest;
+
+    class Child extends OverrideMethodTest {
+        test
+    }
+
+    $instance = new Child();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethod03/testDNFTypesOverrideMethod03.php.testDNFTypesOverrideMethod03.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethod03/testDNFTypesOverrideMethod03.php.testDNFTypesOverrideMethod03.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testMethod
+public function testMethod(null|(\Test1\Foo&\Bar) $param1, (\Test1\Foo&\Test1\Bar)|\Test1\Baz $pram2, (\Test1\Foo&\Test1\Bar)|(\Test1\Bar&\Test1\Baz) $param3): (\Test1\Foo&\Test1\Bar)|\Test1\Baz {
+${cursor}return parent::testMethod($param1, $pram2, $param3);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes01/testDNFTypesOverrideMethodSpecialTypes01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes01/testDNFTypesOverrideMethodSpecialTypes01.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace TestParent1;
+
+interface InterfaceTest {
+
+}
+
+class ParentClass implements InterfaceTest {
+}
+
+class Child extends ParentClass {
+    public function testParent(parent $parent): parent {
+        return new ParentClass();
+    }
+    public function testUniontypes((Foo&Bar)|self $self, parent|(Foo&Bar) $parent): (Foo&Bar)|parent|self|null {
+        return new ParentClass();
+    }
+}
+
+class Foo{}
+class Bar{}
+
+namespace TestParent2;
+
+use TestParent1\Child;
+use TestParent1\ParentClass;
+
+class Grandchild extends Child {
+    test
+}
+
+$instance = new Grandchild();
+$instance->test(new ParentClass());
+var_dump($instance);

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes01/testDNFTypesOverrideMethodSpecialTypes01.php.testDNFTypesOverrideMethodSpecialTypes01.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes01/testDNFTypesOverrideMethodSpecialTypes01.php.testDNFTypesOverrideMethodSpecialTypes01.cccustomtpl
@@ -1,0 +1,9 @@
+Name: testParent
+public function testParent(ParentClass $parent): ParentClass {
+${cursor}return parent::testParent($parent);
+}
+
+Name: testUniontypes
+public function testUniontypes((\TestParent1\Foo&\TestParent1\Bar)|Child $self, ParentClass|(\TestParent1\Foo&\TestParent1\Bar) $parent): (\TestParent1\Foo&\TestParent1\Bar)|ParentClass|Child|null {
+${cursor}return parent::testUniontypes($self, $parent);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes02/testDNFTypesOverrideMethodSpecialTypes02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes02/testDNFTypesOverrideMethodSpecialTypes02.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace TestParent1;
+
+interface InterfaceTest {
+
+}
+
+class ParentClass implements InterfaceTest {
+}
+
+class Child extends ParentClass {
+    public function testParent(parent $parent): parent {
+        return new ParentClass();
+    }
+    public function testUniontypes((Foo&Bar)|self $self, parent|(Foo&Bar) $parent): (Foo&Bar)|parent|self|null {
+        return new ParentClass();
+    }
+}
+
+class Foo{}
+class Bar{}
+
+namespace TestParent2;
+
+use TestParent1\Child;
+
+class Grandchild extends Child {
+    test
+}
+
+$instance = new Grandchild();
+$instance->test(new ParentClass());
+var_dump($instance);

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes02/testDNFTypesOverrideMethodSpecialTypes02.php.testDNFTypesOverrideMethodSpecialTypes02.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes02/testDNFTypesOverrideMethodSpecialTypes02.php.testDNFTypesOverrideMethodSpecialTypes02.cccustomtpl
@@ -1,0 +1,9 @@
+Name: testParent
+public function testParent(\TestParent1\ParentClass $parent): \TestParent1\ParentClass {
+${cursor}return parent::testParent($parent);
+}
+
+Name: testUniontypes
+public function testUniontypes((\TestParent1\Foo&\TestParent1\Bar)|Child $self, \TestParent1\ParentClass|(\TestParent1\Foo&\TestParent1\Bar) $parent): (\TestParent1\Foo&\TestParent1\Bar)|\TestParent1\ParentClass|Child|null {
+${cursor}return parent::testUniontypes($self, $parent);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes03/testDNFTypesOverrideMethodSpecialTypes03.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes03/testDNFTypesOverrideMethodSpecialTypes03.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace TestParent1;
+
+interface InterfaceTest {
+
+}
+
+class ParentClass implements InterfaceTest {
+}
+
+class Child extends ParentClass {
+    public function testParent(parent $parent): parent {
+        return new ParentClass();
+    }
+    public function testUniontypes((Foo&Bar)|self $self, parent|(Foo&Bar) $parent): (Foo&Bar)|parent|self|null {
+        return new ParentClass();
+    }
+}
+
+class Foo{}
+class Bar{}
+
+class Grandchild extends Child {
+    test
+}
+
+$instance = new Grandchild();
+$instance->test(new ParentClass());
+var_dump($instance);

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes03/testDNFTypesOverrideMethodSpecialTypes03.php.testDNFTypesOverrideMethodSpecialTypes03.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes03/testDNFTypesOverrideMethodSpecialTypes03.php.testDNFTypesOverrideMethodSpecialTypes03.cccustomtpl
@@ -1,0 +1,9 @@
+Name: testParent
+public function testParent(ParentClass $parent): ParentClass {
+${cursor}return parent::testParent($parent);
+}
+
+Name: testUniontypes
+public function testUniontypes((Foo&Bar)|Child $self, ParentClass|(Foo&Bar) $parent): (Foo&Bar)|ParentClass|Child|null {
+${cursor}return parent::testUniontypes($self, $parent);
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes04/testDNFTypesOverrideMethodSpecialTypes04.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes04/testDNFTypesOverrideMethodSpecialTypes04.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+interface InterfaceTest {
+
+}
+
+class ParentClass implements InterfaceTest {
+}
+
+class Child extends ParentClass {
+    public function testParent(parent $parent): parent {
+        return new ParentClass();
+    }
+    public function testUniontypes((Foo&Bar)|self $self, parent|(Foo&Bar) $parent): (Foo&Bar)|parent|self|null {
+        return new ParentClass();
+    }
+}
+
+class Foo{}
+class Bar{}
+
+class Grandchild extends Child {
+    test
+}
+
+$instance = new Grandchild();
+$instance->test(new ParentClass());
+var_dump($instance);

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes04/testDNFTypesOverrideMethodSpecialTypes04.php.testDNFTypesOverrideMethodSpecialTypes04.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php82/testDNFTypesOverrideMethodSpecialTypes04/testDNFTypesOverrideMethodSpecialTypes04.php.testDNFTypesOverrideMethodSpecialTypes04.cccustomtpl
@@ -1,0 +1,9 @@
+Name: testParent
+public function testParent(\ParentClass $parent): \ParentClass {
+${cursor}return parent::testParent($parent);
+}
+
+Name: testUniontypes
+public function testUniontypes((\Foo&\Bar)|\Child $self, \ParentClass|(\Foo&\Bar) $parent): (\Foo&\Bar)|\ParentClass|\Child|null {
+${cursor}return parent::testUniontypes($self, $parent);
+}

--- a/php/php.editor/test/unit/data/testfiles/gotodeclaration/php82/testDNFType/testDNFType.php
+++ b/php/php.editor/test/unit/data/testfiles/gotodeclaration/php82/testDNFType/testDNFType.php
@@ -1,0 +1,114 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  Barou may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANBar
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class Foo {
+    public const CONSTANT_FOO = "test";
+    public (Foo&Bar)|Foo $fieldFoo;
+    public static (Foo&Bar)|Bar $staticFieldFoo;
+
+    public function methodFoo(): (Foo&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(Foo|Bar $param): void {}
+}
+class Bar {
+    public const CONSTANT_BAR = "test";
+    public (Foo&Bar)|(Baz&Foo) $fieldBar;
+    public static (Foo&Bar)|Bar $staticFieldBar;
+
+    public function methodBar(): (Foo&Bar)|Baz {}
+    public static function staticMethodBar(Foo|Bar $param): void {}
+}
+class Baz {
+    public const CONSTANT_BAZ = "test";
+    public (Foo&Bar)|(Baz&Foo) $fieldBaz;
+    public static (Foo&Bar)|Bar $staticFieldBaz;
+
+    public function methodBaz(): Foo|(Bar&Baz) {}
+    public static function staticMethodBaz(Foo&Bar $param): void {}
+}
+
+function paramType((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3): void {
+}
+
+function returnType1(): (Foo&Bar)|Baz {}
+function returnType2(): Baz|(Foo&Bar) {}
+function returnType3(): Baz|(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&Baz) {}
+
+/**
+ * @method (Foo&Bar)|(Bar&Baz) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&Baz) $param2) Description
+ * @method static (Foo&Bar)|Baz staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&Baz) $param2) Description
+ * @property Foo|(Bar&Baz) $propertyTag Description
+ */
+class TestClass {
+    private (Foo&Bar)|Baz $fieldClass; // class
+    private static Bar|(Bar&Baz) $staticFieldClass; // class
+
+    public function paramType((Foo&Baz)|(Foo&Bar)|Baz $test): void { // class
+        $this->fieldClass = $test;
+        $this->fieldClass::CONSTANT_FOO;
+        $this->fieldClass::$staticFieldBaz;
+        $this->fieldClass->fieldBar;
+        $test::CONSTANT_BAZ;
+        $test::$staticFieldBar;
+        self::$staticFieldClass->methodBar();
+        self::$staticFieldClass::staticmethodBaz(null);
+    }
+
+    public function returnType(): (Foo&Bar)|Baz { // class
+        return $this->fieldClass;
+    }
+}
+
+trait TestTrait {
+    private (Foo&Bar)|Baz $test; // trait
+
+    public function paramType((Foo&Bar)|(Bar&Baz) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    }
+
+    public function returnType(): Foo|(Foo&Bar) { // trait
+    }
+}
+
+interface TestInterfase {
+
+    public function paramType(Foo|(Foo&Bar)|null $test);
+    public function returnType(): (Foo&Bar)|(Bar&Baz);
+
+}
+
+$closure = function(Foo|(Foo&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&Bar)|null {};
+
+$arrow = fn(Foo|Bar|(Foo&Bar) $test) => $test;
+$arrow = fn((Foo&Bar)|null $test): Foo|(Foo&Bar) => $test;
+
+/** @var (Foo&Bar)|Foo|(Bar&Baz&Foo) $vardoc1 */
+$vardoc1->methodFoo();
+
+/* @var $vardoc2 (Foo&Bar)|Baz */
+$vardoc2::staticMethodBaz(null);
+
+/** @var Bar|Baz|Foo $unionType */
+$unionType->methodFoo();
+
+/** @var Bar&Baz&Foo $intersectionType */
+$intersectionType->methodFoo();
+
+/** @var ?Foo $nullableType */
+$nullableType->methodFoo();

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php
@@ -1,0 +1,114 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  Barou may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANBar
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class Foo {
+    public const CONSTANT_FOO = "test";
+    public (Foo&Bar)|Foo $fieldFoo;
+    public static (Foo&Bar)|Bar $staticFieldFoo;
+
+    public function methodFoo(): (Foo&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(Foo|Bar $param): void {}
+}
+class Bar {
+    public const CONSTANT_BAR = "test";
+    public (Foo&Bar)|(Baz&Foo) $fieldBar;
+    public static (Foo&Bar)|Bar $staticFieldBar;
+
+    public function methodBar(): (Foo&Bar)|Baz {}
+    public static function staticMethodBar(Foo|Bar $param): void {}
+}
+class Baz {
+    public const CONSTANT_BAZ = "test";
+    public (Foo&Bar)|(Baz&Foo) $fieldBaz;
+    public static (Foo&Bar)|Bar $staticFieldBaz;
+
+    public function methodBaz(): Foo|(Bar&Baz) {}
+    public static function staticMethodBaz(Foo&Bar $param): void {}
+}
+
+function paramType((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3): void {
+}
+
+function returnType1(): (Foo&Bar)|Baz {}
+function returnType2(): Baz|(Foo&Bar) {}
+function returnType3(): Baz|(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&Baz) {}
+
+/**
+ * @method (Foo&Bar)|(Bar&Baz) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&Baz) $param2) Description
+ * @method static (Foo&Bar)|Baz staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&Baz) $param2) Description
+ * @property Foo|(Bar&Baz) $propertyTag Description
+ */
+class TestClass {
+    private (Foo&Bar)|Baz $fieldClass; // class
+    private static Bar|(Bar&Baz) $staticFieldClass; // class
+
+    public function paramType((Foo&Baz)|(Foo&Bar)|Baz $test): void { // class
+        $this->fieldClass = $test;
+        $this->fieldClass::CONSTANT_FOO;
+        $this->fieldClass::$staticFieldBaz;
+        $this->fieldClass->fieldBar;
+        $test::CONSTANT_BAZ;
+        $test::$staticFieldBar;
+        self::$staticFieldClass->methodBar();
+        self::$staticFieldClass::staticmethodBaz(null);
+    }
+
+    public function returnType(): (Foo&Bar)|Baz { // class
+        return $this->fieldClass;
+    }
+}
+
+trait TestTrait {
+    private (Foo&Bar)|Baz $test; // trait
+
+    public function paramType((Foo&Bar)|(Bar&Baz) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    }
+
+    public function returnType(): Foo|(Foo&Bar) { // trait
+    }
+}
+
+interface TestInterfase {
+
+    public function paramType(Foo|(Foo&Bar)|null $test);
+    public function returnType(): (Foo&Bar)|(Bar&Baz);
+
+}
+
+$closure = function(Foo|(Foo&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&Bar)|null {};
+
+$arrow = fn(Foo|Bar|(Foo&Bar) $test) => $test;
+$arrow = fn((Foo&Bar)|null $test): Foo|(Foo&Bar) => $test;
+
+/** @var (Foo&Bar)|Foo|(Bar&Baz&Foo) $vardoc1 */
+$vardoc1->methodFoo();
+
+/* @var $vardoc2 (Foo&Bar)|Baz */
+$vardoc2::staticMethodBaz(null);
+
+/** @var Bar|Baz|Foo $unionType */
+$unionType->methodFoo();
+
+/** @var Bar&Baz&Foo $intersectionType */
+$intersectionType->methodFoo();
+
+/** @var ?Foo $nullableType */
+$nullableType->methodFoo();

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a01.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:F^oo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a02.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Fo^o<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a03.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a03.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:F^oo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a04.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a04.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:F^oo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a05.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a05.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Fo^o<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a06.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a06.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:F^oo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a07.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a07.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Fo^o<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a08.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a08.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Fo^o<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a09.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a09.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:F^oo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a10.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a10.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:F^oo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a11.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a11.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Fo^o<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a12.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a12.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Fo^o<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a13.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a13.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Fo^o<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a14.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a14.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Fo^o<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a15.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a15.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Fo^o<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a16.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a16.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Fo^o<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a17.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a17.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Fo^o<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a18.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a18.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Fo^o<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a19.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a19.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:F^oo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a20.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a20.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Fo^o<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a21.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a21.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:F^oo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a22.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a22.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Fo^o<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a23.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a23.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)|^|>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a24.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a24.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Fo^o<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a25.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a25.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Fo^o<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a26.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a26.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Fo^o<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a27.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a27.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Fo^o<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a28.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a28.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:F^oo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a29.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a29.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:F^oo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a30.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a30.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:F^oo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a31.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a31.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (^|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a32.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a32.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Fo^o<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a33.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a33.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Fo^o<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a34.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a34.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:F^oo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a35.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a35.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:F^oo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a36.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a36.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Fo^o<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a37.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a37.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Fo^o<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a38.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a38.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Fo^o<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a39.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a39.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:F^oo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a40.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a40.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Fo^o<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a41.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a41.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Fo^o<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a42.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a42.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Fo^o<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a43.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a43.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Fo^o<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a44.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a44.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Fo^o<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a45.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a45.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Fo^o<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a46.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a46.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Fo^o<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a47.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a47.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Fo^o<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a48.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a48.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Fo^o<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a49.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a49.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:F^oo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a50.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a50.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:F^oo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a51.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a51.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:F^oo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a52.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a52.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Fo^o<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a53.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a53.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:F^oo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a54.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a54.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Fo^o<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a55.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a55.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:F^oo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a56.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a56.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Fo^o<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a57.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a57.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Fo^o<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a58.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a58.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:F^oo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a59.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a59.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Fo^o<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Foo<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a60.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_a60.occurrences
@@ -1,0 +1,38 @@
+class |>MARK_OCCURRENCES:Foo<| {
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| $fieldFoo;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldFoo;
+    public function methodFoo(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) {}
+    public static function staticMethodFoo(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBar;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBar;
+    public function methodBar(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+    public static function staticMethodBar(|>MARK_OCCURRENCES:Foo<||Bar $param): void {}
+    public (|>MARK_OCCURRENCES:Foo<|&Bar)|(Baz&|>MARK_OCCURRENCES:Foo<|) $fieldBaz;
+    public static (|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $staticFieldBaz;
+    public function methodBaz(): |>MARK_OCCURRENCES:Foo<||(Bar&Baz) {}
+    public static function staticMethodBaz(|>MARK_OCCURRENCES:Foo<|&Bar $param): void {}
+function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $param1, Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) $param2, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param3): void {
+function returnType1(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz {}
+function returnType2(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar) {}
+function returnType3(): Baz|(|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<| {}
+function returnType4(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(|>MARK_OCCURRENCES:Foo<|&Baz) {}
+ * @method (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) methodTag((|>MARK_OCCURRENCES:Foo<|&Bar)|Bar $param1, |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $param2) Description
+ * @method static (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz staticMethodTag(Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $param1, (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $param2) Description
+ * @property |>MARK_OCCURRENCES:Foo<||(Bar&Baz) $propertyTag Description
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $fieldClass; // class
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Baz)|(|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test): void { // class
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz { // class
+    private (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz $test; // trait
+    public function paramType((|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) $test2): void { // trait
+    public function returnType(): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) { // trait
+    public function paramType(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|null $test);
+    public function returnType(): (|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz);
+$closure = function(|>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar)|(Bar&Baz) $test1, $test2): void {};
+$closure = function(int $test): (|>MARK_OCCURRENCES:Foo<|&Bar)|null {};
+$arrow = fn(|>MARK_OCCURRENCES:Foo<||Bar|(|>MARK_OCCURRENCES:Foo<|&Bar) $test) => $test;
+$arrow = fn((|>MARK_OCCURRENCES:Foo<|&Bar)|null $test): |>MARK_OCCURRENCES:Foo<||(|>MARK_OCCURRENCES:Foo<|&Bar) => $test;
+/** @var (|>MARK_OCCURRENCES:Foo<|&Bar)||>MARK_OCCURRENCES:Foo<||(Bar&Baz&|>MARK_OCCURRENCES:Foo<|) $vardoc1 */
+/* @var $vardoc2 (|>MARK_OCCURRENCES:Foo<|&Bar)|Baz */
+/** @var Bar|Baz||>MARK_OCCURRENCES:Foo<| $unionType */
+/** @var Bar&Baz&|>MARK_OCCURRENCES:Foo<| $intersectionType */
+/** @var ?|>MARK_OCCURRENCES:Fo^o<| $nullableType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b01.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Ba^r<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b02.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Ba^r<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b03.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b03.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:B^ar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b04.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b04.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Ba^r<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b05.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b05.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar^<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b06.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b06.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Ba^r<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b07.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b07.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:B^ar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b08.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b08.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:B^ar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b09.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b09.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Ba^r<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b10.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b10.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:B^ar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b11.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b11.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Ba^r<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b12.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b12.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo|^|>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b13.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b13.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Ba^r<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b14.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b14.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Ba^r<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b15.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b15.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Ba^r<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b16.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b16.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Ba^r<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b17.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b17.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Ba^r<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b18.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b18.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:B^ar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b19.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b19.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:B^ar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b20.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b20.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Ba^r<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b21.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b21.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Ba^r<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b22.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b22.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:B^ar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b23.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b23.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:B^ar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b24.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b24.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Ba^r<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b25.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b25.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:B^ar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b26.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b26.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:B^ar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b27.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b27.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Ba^r<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b28.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b28.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:B^ar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b29.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b29.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Ba^r<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b30.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b30.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(^|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b31.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b31.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Ba^r<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b32.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b32.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:B^ar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b33.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b33.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:B^ar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b34.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b34.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&^|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b35.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b35.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Ba^r<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b36.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b36.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:B^ar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b37.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b37.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:B^ar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b38.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b38.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:B^ar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b39.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b39.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Ba^r<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b40.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b40.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:B^ar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b41.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b41.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:B^ar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b42.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b42.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:B^ar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b43.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b43.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Ba^r<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b44.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b44.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:B^ar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b45.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b45.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&^|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b46.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b46.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:B^ar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b47.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b47.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:B^ar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b48.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b48.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar^<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b49.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b49.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:B^ar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b50.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b50.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:B^ar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b51.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b51.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:B^ar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b52.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b52.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:B^ar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b53.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b53.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:B^ar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b54.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b54.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:B^ar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b55.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b55.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:B^ar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b56.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b56.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Ba^r<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b57.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b57.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&^|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b58.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b58.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Ba^r<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b59.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b59.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Ba^r<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b60.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b60.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Ba^r<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:Bar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b61.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_b61.occurrences
@@ -1,0 +1,38 @@
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo $fieldFoo;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldFoo;
+    public function methodFoo(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodFoo(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+class |>MARK_OCCURRENCES:Bar<| {
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBar;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBar;
+    public function methodBar(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+    public static function staticMethodBar(Foo||>MARK_OCCURRENCES:Bar<| $param): void {}
+    public (Foo&|>MARK_OCCURRENCES:Bar<|)|(Baz&Foo) $fieldBaz;
+    public static (Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $staticFieldBaz;
+    public function methodBaz(): Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) {}
+    public static function staticMethodBaz(Foo&|>MARK_OCCURRENCES:Bar<| $param): void {}
+function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $param1, Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) $param2, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param3): void {
+function returnType1(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz {}
+function returnType2(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|) {}
+function returnType3(): Baz|(Foo&|>MARK_OCCURRENCES:Bar<|)|Foo {}
+function returnType4(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(Foo&Baz) {}
+ * @method (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) methodTag((Foo&|>MARK_OCCURRENCES:Bar<|)||>MARK_OCCURRENCES:Bar<| $param1, Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @method static (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz staticMethodTag(|>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $param1, (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $param2) Description
+ * @property Foo|(|>MARK_OCCURRENCES:Bar<|&Baz) $propertyTag Description
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $fieldClass; // class
+    private static |>MARK_OCCURRENCES:Bar<||(|>MARK_OCCURRENCES:Bar<|&Baz) $staticFieldClass; // class
+    public function paramType((Foo&Baz)|(Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test): void { // class
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz { // class
+    private (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz $test; // trait
+    public function paramType((Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) $test2): void { // trait
+    public function returnType(): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) { // trait
+    public function paramType(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|null $test);
+    public function returnType(): (Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz);
+$closure = function(Foo|(Foo&|>MARK_OCCURRENCES:Bar<|)|(|>MARK_OCCURRENCES:Bar<|&Baz) $test1, $test2): void {};
+$closure = function(int $test): (Foo&|>MARK_OCCURRENCES:Bar<|)|null {};
+$arrow = fn(Foo||>MARK_OCCURRENCES:Bar<||(Foo&|>MARK_OCCURRENCES:Bar<|) $test) => $test;
+$arrow = fn((Foo&|>MARK_OCCURRENCES:Bar<|)|null $test): Foo|(Foo&|>MARK_OCCURRENCES:Bar<|) => $test;
+/** @var (Foo&|>MARK_OCCURRENCES:Bar<|)|Foo|(|>MARK_OCCURRENCES:Bar<|&Baz&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&|>MARK_OCCURRENCES:Bar<|)|Baz */
+/** @var |>MARK_OCCURRENCES:Bar<||Baz|Foo $unionType */
+/** @var |>MARK_OCCURRENCES:B^ar<|&Baz&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c01.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:B^az<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c02.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Ba^z<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c03.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c03.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:B^az<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c04.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c04.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:B^az<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c05.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c05.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Ba^z<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c06.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c06.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Ba^z<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c07.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c07.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:B^az<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c08.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c08.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:B^az<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c09.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c09.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&^|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c10.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c10.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:B^az<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c11.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c11.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Ba^z<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c12.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c12.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:B^az<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c13.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c13.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Ba^z<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c14.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c14.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:B^az<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c15.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c15.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Ba^z<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c16.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c16.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:B^az<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c17.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c17.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&^|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c18.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c18.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:B^az<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c19.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c19.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:B^az<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c20.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c20.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Ba^z<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c21.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c21.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Ba^z<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c22.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c22.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:B^az<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c23.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c23.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:B^az<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c24.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c24.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:B^az<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c25.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c25.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Ba^z<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c26.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c26.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&^|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c27.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c27.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:B^az<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c28.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c28.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Ba^z<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c29.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c29.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)|^|>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c30.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c30.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Ba^z<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:Baz<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c31.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_c31.occurrences
@@ -1,0 +1,26 @@
+    public function methodFoo(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBar;
+    public function methodBar(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+class |>MARK_OCCURRENCES:Baz<| {
+    public (Foo&Bar)|(|>MARK_OCCURRENCES:Baz<|&Foo) $fieldBaz;
+    public function methodBaz(): Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) {}
+function paramType((Foo&Bar)||>MARK_OCCURRENCES:Baz<| $param1, |>MARK_OCCURRENCES:Baz<||(Foo&Bar) $param2, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param3): void {
+function returnType1(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| {}
+function returnType2(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar) {}
+function returnType3(): |>MARK_OCCURRENCES:Baz<||(Foo&Bar)|Foo {}
+function returnType4(): (Foo&Bar)|(Foo&|>MARK_OCCURRENCES:Baz<|) {}
+ * @method (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @method static (Foo&Bar)||>MARK_OCCURRENCES:Baz<| staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $param2) Description
+ * @property Foo|(Bar&|>MARK_OCCURRENCES:Baz<|) $propertyTag Description
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $fieldClass; // class
+    private static Bar|(Bar&|>MARK_OCCURRENCES:Baz<|) $staticFieldClass; // class
+    public function paramType((Foo&|>MARK_OCCURRENCES:Baz<|)|(Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test): void { // class
+    public function returnType(): (Foo&Bar)||>MARK_OCCURRENCES:Baz<| { // class
+    private (Foo&Bar)||>MARK_OCCURRENCES:Baz<| $test; // trait
+    public function paramType((Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, Foo|(Foo&Bar) $test2): void { // trait
+    public function returnType(): (Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|);
+$closure = function(Foo|(Foo&Bar)|(Bar&|>MARK_OCCURRENCES:Baz<|) $test1, $test2): void {};
+/** @var (Foo&Bar)|Foo|(Bar&|>MARK_OCCURRENCES:Baz<|&Foo) $vardoc1 */
+/* @var $vardoc2 (Foo&Bar)||>MARK_OCCURRENCES:Baz<| */
+/** @var Bar||>MARK_OCCURRENCES:Baz<||Foo $unionType */
+/** @var Bar&|>MARK_OCCURRENCES:B^az<|&Foo $intersectionType */

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_d01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_d01.occurrences
@@ -1,0 +1,2 @@
+    public const |>MARK_OCCURRENCES:CONSTAN^T_FOO<| = "test";
+        $this->fieldClass::|>MARK_OCCURRENCES:CONSTANT_FOO<|;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_d02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_d02.occurrences
@@ -1,0 +1,2 @@
+    public const |>MARK_OCCURRENCES:CONSTANT_FOO<| = "test";
+        $this->fieldClass::|>MARK_OCCURRENCES:CONSTANT_F^OO<|;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_e01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_e01.occurrences
@@ -1,0 +1,2 @@
+    public static (Foo&Bar)|Bar $|>MARK_OCCURRENCES:stat^icFieldBaz<|;
+        $this->fieldClass::$|>MARK_OCCURRENCES:staticFieldBaz<|;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_e02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_e02.occurrences
@@ -1,0 +1,2 @@
+    public static (Foo&Bar)|Bar $|>MARK_OCCURRENCES:staticFieldBaz<|;
+        $this->fieldClass::$|>MARK_OCCURRENCES:staticFi^eldBaz<|;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_f01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_f01.occurrences
@@ -1,0 +1,2 @@
+    public (Foo&Bar)|(Baz&Foo) $|>MARK_OCCURRENCES:field^Bar<|;
+        $this->fieldClass->|>MARK_OCCURRENCES:fieldBar<|;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_f02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_f02.occurrences
@@ -1,0 +1,2 @@
+    public (Foo&Bar)|(Baz&Foo) $|>MARK_OCCURRENCES:fieldBar<|;
+        $this->fieldClass->|>MARK_OCCURRENCES:fieldB^ar<|;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_g01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_g01.occurrences
@@ -1,0 +1,2 @@
+    public const |>MARK_OCCURRENCES:CON^STANT_BAZ<| = "test";
+        $test::|>MARK_OCCURRENCES:CONSTANT_BAZ<|;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_g02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_g02.occurrences
@@ -1,0 +1,2 @@
+    public const |>MARK_OCCURRENCES:CONSTANT_BAZ<| = "test";
+        $test::|>MARK_OCCURRENCES:CONSTANT^_BAZ<|;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_h01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_h01.occurrences
@@ -1,0 +1,2 @@
+    public static (Foo&Bar)|Bar $|>MARK_OCCURRENCES:staticF^ieldBar<|;
+        $test::$|>MARK_OCCURRENCES:staticFieldBar<|;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_h02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_h02.occurrences
@@ -1,0 +1,2 @@
+    public static (Foo&Bar)|Bar $|>MARK_OCCURRENCES:staticFieldBar<|;
+        $test::$|>MARK_OCCURRENCES:staticFi^eldBar<|;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_i01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_i01.occurrences
@@ -1,0 +1,2 @@
+    public function |>MARK_OCCURRENCES:metho^dBar<|(): (Foo&Bar)|Baz {}
+        self::$staticFieldClass->|>MARK_OCCURRENCES:methodBar<|();

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_i02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_i02.occurrences
@@ -1,0 +1,2 @@
+    public function |>MARK_OCCURRENCES:methodBar<|(): (Foo&Bar)|Baz {}
+        self::$staticFieldClass->|>MARK_OCCURRENCES:metho^dBar<|();

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_j01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_j01.occurrences
@@ -1,0 +1,3 @@
+    public static function |>MARK_OCCURRENCES:staticMethodB^az<|(Foo&Bar $param): void {}
+        self::$staticFieldClass::|>MARK_OCCURRENCES:staticmethodBaz<|(null);
+$vardoc2::|>MARK_OCCURRENCES:staticMethodBaz<|(null);

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_j02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_j02.occurrences
@@ -1,0 +1,3 @@
+    public static function |>MARK_OCCURRENCES:staticMethodBaz<|(Foo&Bar $param): void {}
+        self::$staticFieldClass::|>MARK_OCCURRENCES:staticmethod^Baz<|(null);
+$vardoc2::|>MARK_OCCURRENCES:staticMethodBaz<|(null);

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_j03.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_j03.occurrences
@@ -1,0 +1,3 @@
+    public static function |>MARK_OCCURRENCES:staticMethodBaz<|(Foo&Bar $param): void {}
+        self::$staticFieldClass::|>MARK_OCCURRENCES:staticmethodBaz<|(null);
+$vardoc2::|>MARK_OCCURRENCES:staticMethodB^az<|(null);

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_k01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_k01.occurrences
@@ -1,0 +1,5 @@
+    public function |>MARK_OCCURRENCES:method^Foo<|(): (Foo&Bar)|(Bar&Baz) {}
+$vardoc1->|>MARK_OCCURRENCES:methodFoo<|();
+$unionType->|>MARK_OCCURRENCES:methodFoo<|();
+$intersectionType->|>MARK_OCCURRENCES:methodFoo<|();
+$nullableType->|>MARK_OCCURRENCES:methodFoo<|();

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_k02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_k02.occurrences
@@ -1,0 +1,5 @@
+    public function |>MARK_OCCURRENCES:methodFoo<|(): (Foo&Bar)|(Bar&Baz) {}
+$vardoc1->|>MARK_OCCURRENCES:method^Foo<|();
+$unionType->|>MARK_OCCURRENCES:methodFoo<|();
+$intersectionType->|>MARK_OCCURRENCES:methodFoo<|();
+$nullableType->|>MARK_OCCURRENCES:methodFoo<|();

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_k03.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_k03.occurrences
@@ -1,0 +1,5 @@
+    public function |>MARK_OCCURRENCES:methodFoo<|(): (Foo&Bar)|(Bar&Baz) {}
+$vardoc1->|>MARK_OCCURRENCES:methodFoo<|();
+$unionType->|>MARK_OCCURRENCES:methodF^oo<|();
+$intersectionType->|>MARK_OCCURRENCES:methodFoo<|();
+$nullableType->|>MARK_OCCURRENCES:methodFoo<|();

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_k04.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_k04.occurrences
@@ -1,0 +1,5 @@
+    public function |>MARK_OCCURRENCES:methodFoo<|(): (Foo&Bar)|(Bar&Baz) {}
+$vardoc1->|>MARK_OCCURRENCES:methodFoo<|();
+$unionType->|>MARK_OCCURRENCES:methodFoo<|();
+$intersectionType->|>MARK_OCCURRENCES:metho^dFoo<|();
+$nullableType->|>MARK_OCCURRENCES:methodFoo<|();

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_k05.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php82/testDNFType/testDNFType.php.testDNFType_k05.occurrences
@@ -1,0 +1,5 @@
+    public function |>MARK_OCCURRENCES:methodFoo<|(): (Foo&Bar)|(Bar&Baz) {}
+$vardoc1->|>MARK_OCCURRENCES:methodFoo<|();
+$unionType->|>MARK_OCCURRENCES:methodFoo<|();
+$intersectionType->|>MARK_OCCURRENCES:methodFoo<|();
+$nullableType->|>MARK_OCCURRENCES:methodF^oo<|();

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod01.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod01.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+interface ImplementMethodTest {
+
+    public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): (Foo&Bar)|Baz;
+}
+
+class Implement implements ImplementMethodTest {
+
+}
+
+class Foo {}
+class Bar {}
+class Baz {}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod01.php.testDNFTypesFix_01.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod01.php.testDNFTypesFix_01.fixed
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+interface ImplementMethodTest {
+
+    public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): (Foo&Bar)|Baz;
+}
+
+class Implement implements ImplementMethodTest {
+    public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): (Foo&Bar)|Baz {
+        
+    }
+}
+
+class Foo {}
+class Bar {}
+class Baz {}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod01.php.testDNFTypes_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod01.php.testDNFTypes_01.hints
@@ -1,0 +1,5 @@
+class Implement implements ImplementMethodTest {
+      ---------
+HINT:\Test\Implement is not abstract and does not override abstract method  testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4) in \Test\ImplementMethodTest
+FIX:Implement All Abstract Methods
+FIX:Declare Abstract Class

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod02.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod02.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    use Test2\Foo;
+    use Test2\Bar;
+    use Test2\Baz;
+
+    interface ImplementMethodTest {
+
+        public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): Baz|(Foo&Bar);
+    }
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+    }
+
+    class Foo {}
+
+    class Bar {}
+
+    class Baz {}
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod02.php.testDNFTypesFix_02.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod02.php.testDNFTypesFix_02.fixed
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    use Test2\Foo;
+    use Test2\Bar;
+    use Test2\Baz;
+
+    interface ImplementMethodTest {
+
+        public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): Baz|(Foo&Bar);
+    }
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+        public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): Baz|(Foo&Bar) {
+            
+        }
+    }
+
+    class Foo {}
+
+    class Bar {}
+
+    class Baz {}
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod02.php.testDNFTypes_02.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod02.php.testDNFTypes_02.hints
@@ -1,0 +1,5 @@
+    class Implement implements ImplementMethodTest {
+          ---------
+HINT:\Test2\Implement is not abstract and does not override abstract method  testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4) in \Test1\ImplementMethodTest
+FIX:Implement All Abstract Methods
+FIX:Declare Abstract Class

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod03.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod03.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    interface ImplementMethodTest {
+
+        public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): (Foo&Bar)|(Bar&Baz);
+    }
+
+    class Foo {}
+    class Bar {}
+    class Baz {}
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+    }
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod03.php.testDNFTypesFix_03.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod03.php.testDNFTypesFix_03.fixed
@@ -1,0 +1,46 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test1 {
+
+    interface ImplementMethodTest {
+
+        public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): (Foo&Bar)|(Bar&Baz);
+    }
+
+    class Foo {}
+    class Bar {}
+    class Baz {}
+
+}
+
+namespace Test2 {
+
+    use Test1\ImplementMethodTest;
+
+    class Implement implements ImplementMethodTest {
+        public function testMethod((\Test1\Foo&\Test1\Bar)|\Test1\Baz $param1, \Test1\Baz|(\Test1\Foo&\Test1\Bar) $param2, (\Test1\Foo&\Test1\Bar)|(\Test1\Bar&\Test1\Baz) $param3, \Test1\Foo|(\Test1\Bar&\Test1\Baz)|null $param4): (\Test1\Foo&\Test1\Bar)|(\Test1\Bar&\Test1\Baz) {
+            
+        }
+    }
+
+    $instance = new Implement();
+    $instance->testMethod(null);
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod03.php.testDNFTypes_03.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod03.php.testDNFTypes_03.hints
@@ -1,0 +1,5 @@
+    class Implement implements ImplementMethodTest {
+          ---------
+HINT:\Test2\Implement is not abstract and does not override abstract method  testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4) in \Test1\ImplementMethodTest
+FIX:Implement All Abstract Methods
+FIX:Declare Abstract Class

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod04.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod04.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+abstract class ImplementMethodTest {
+
+    abstract public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): Foo|(Foo&Bar)|Baz;
+}
+
+class Implement extends ImplementMethodTest {
+}
+
+class Foo {}
+class Bar {}
+class Baz {}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod04.php.testDNFTypesFix_04.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod04.php.testDNFTypesFix_04.fixed
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Test;
+
+abstract class ImplementMethodTest {
+
+    abstract public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): Foo|(Foo&Bar)|Baz;
+}
+
+class Implement extends ImplementMethodTest {
+    public function testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4): Foo|(Foo&Bar)|Baz {
+        
+    }
+}
+
+class Foo {}
+class Bar {}
+class Baz {}
+
+$instance = new Implement();
+$instance->testMethod(null);

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod04.php.testDNFTypes_04.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testDNFTypesImplementMethod04.php.testDNFTypes_04.hints
@@ -1,0 +1,5 @@
+class Implement extends ImplementMethodTest {
+      ---------
+HINT:\Test\Implement is not abstract and does not override abstract method  testMethod((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3, Foo|(Bar&Baz)|null $param4) in \Test\ImplementMethodTest
+FIX:Implement All Abstract Methods
+FIX:Declare Abstract Class

--- a/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace InitializeField;
+
+use \Test\Foo;
+use \Test\Bar;
+use \Test\Baz;
+
+class DnfTypes
+{
+    function __construct(
+            (Foo&Bar)|Baz $param1,
+            (\Test\Foo&Bar)|(Foo&Baz) $param2,
+            Foo|(Foo&Baz) $param3,
+            Foo|(Foo&Baz)|null $param4,
+    ) {
+    }
+}
+
+new IntersectionTypes(new Foo(), new Bar(), new Baz(), null);
+
+namespace Test;
+
+class Foo {}
+class Bar {}
+class Baz {}

--- a/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypesFix_01a.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypesFix_01a.fixed
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace InitializeField;
+
+use \Test\Foo;
+use \Test\Bar;
+use \Test\Baz;
+
+class DnfTypes
+{
+
+    private (Foo&Bar)|Baz $param1;
+
+    function __construct(
+            (Foo&Bar)|Baz $param1,
+            (\Test\Foo&Bar)|(Foo&Baz) $param2,
+            Foo|(Foo&Baz) $param3,
+            Foo|(Foo&Baz)|null $param4,
+    ) {
+        $this->param1 = $param1;
+    }
+}
+
+new IntersectionTypes(new Foo(), new Bar(), new Baz(), null);
+
+namespace Test;
+
+class Foo {}
+class Bar {}
+class Baz {}

--- a/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypesFix_01b.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypesFix_01b.fixed
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace InitializeField;
+
+use \Test\Foo;
+use \Test\Bar;
+use \Test\Baz;
+
+class DnfTypes
+{
+
+    private (\Test\Foo&Bar)|(Foo&Baz) $param2;
+
+    function __construct(
+            (Foo&Bar)|Baz $param1,
+            (\Test\Foo&Bar)|(Foo&Baz) $param2,
+            Foo|(Foo&Baz) $param3,
+            Foo|(Foo&Baz)|null $param4,
+    ) {
+        $this->param2 = $param2;
+    }
+}
+
+new IntersectionTypes(new Foo(), new Bar(), new Baz(), null);
+
+namespace Test;
+
+class Foo {}
+class Bar {}
+class Baz {}

--- a/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypesFix_01c.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypesFix_01c.fixed
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace InitializeField;
+
+use \Test\Foo;
+use \Test\Bar;
+use \Test\Baz;
+
+class DnfTypes
+{
+
+    private Foo|(Foo&Baz) $param3;
+
+    function __construct(
+            (Foo&Bar)|Baz $param1,
+            (\Test\Foo&Bar)|(Foo&Baz) $param2,
+            Foo|(Foo&Baz) $param3,
+            Foo|(Foo&Baz)|null $param4,
+    ) {
+        $this->param3 = $param3;
+    }
+}
+
+new IntersectionTypes(new Foo(), new Bar(), new Baz(), null);
+
+namespace Test;
+
+class Foo {}
+class Bar {}
+class Baz {}

--- a/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypesFix_01d.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypesFix_01d.fixed
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace InitializeField;
+
+use \Test\Foo;
+use \Test\Bar;
+use \Test\Baz;
+
+class DnfTypes
+{
+
+    private Foo|(Foo&Baz)|null $param4;
+
+    function __construct(
+            (Foo&Bar)|Baz $param1,
+            (\Test\Foo&Bar)|(Foo&Baz) $param2,
+            Foo|(Foo&Baz) $param3,
+            Foo|(Foo&Baz)|null $param4,
+    ) {
+        $this->param4 = $param4;
+    }
+}
+
+new IntersectionTypes(new Foo(), new Bar(), new Baz(), null);
+
+namespace Test;
+
+class Foo {}
+class Bar {}
+class Baz {}

--- a/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypes_01a.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypes_01a.hints
@@ -1,0 +1,16 @@
+            (Foo&Bar)|Baz $para^m1,
+            ---------------------
+HINT:Initialize Field: $param1
+FIX:Initialize Field: $param1
+            (\Test\Foo&Bar)|(Foo&Baz) $param2,
+            ---------------------------------
+HINT:Initialize Field: $param2
+FIX:Initialize Field: $param2
+            Foo|(Foo&Baz) $param3,
+            ---------------------
+HINT:Initialize Field: $param3
+FIX:Initialize Field: $param3
+            Foo|(Foo&Baz)|null $param4,
+            --------------------------
+HINT:Initialize Field: $param4
+FIX:Initialize Field: $param4

--- a/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypes_01b.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypes_01b.hints
@@ -1,0 +1,16 @@
+            (Foo&Bar)|Baz $param1,
+            ---------------------
+HINT:Initialize Field: $param1
+FIX:Initialize Field: $param1
+            (\Test\Foo&Bar)|(Foo&Baz) $par^am2,
+            ---------------------------------
+HINT:Initialize Field: $param2
+FIX:Initialize Field: $param2
+            Foo|(Foo&Baz) $param3,
+            ---------------------
+HINT:Initialize Field: $param3
+FIX:Initialize Field: $param3
+            Foo|(Foo&Baz)|null $param4,
+            --------------------------
+HINT:Initialize Field: $param4
+FIX:Initialize Field: $param4

--- a/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypes_01c.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypes_01c.hints
@@ -1,0 +1,16 @@
+            (Foo&Bar)|Baz $param1,
+            ---------------------
+HINT:Initialize Field: $param1
+FIX:Initialize Field: $param1
+            (\Test\Foo&Bar)|(Foo&Baz) $param2,
+            ---------------------------------
+HINT:Initialize Field: $param2
+FIX:Initialize Field: $param2
+            Foo|(Foo&Baz) $para^m3,
+            ---------------------
+HINT:Initialize Field: $param3
+FIX:Initialize Field: $param3
+            Foo|(Foo&Baz)|null $param4,
+            --------------------------
+HINT:Initialize Field: $param4
+FIX:Initialize Field: $param4

--- a/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypes_01d.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/InitializeFieldsSuggestion/dnfTypes_01.php.testDnfTypes_01d.hints
@@ -1,0 +1,16 @@
+            (Foo&Bar)|Baz $param1,
+            ---------------------
+HINT:Initialize Field: $param1
+FIX:Initialize Field: $param1
+            (\Test\Foo&Bar)|(Foo&Baz) $param2,
+            ---------------------------------
+HINT:Initialize Field: $param2
+FIX:Initialize Field: $param2
+            Foo|(Foo&Baz) $param3,
+            ---------------------
+HINT:Initialize Field: $param3
+FIX:Initialize Field: $param3
+            Foo|(Foo&Baz)|null $para^m4,
+            --------------------------
+HINT:Initialize Field: $param4
+FIX:Initialize Field: $param4

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
@@ -750,4 +750,85 @@ public class SelectedPropertyMethodsCreatorTest extends PHPTestBase {
         ));
     }
 
+    // GH-4725 PHP 8.2
+    public void testDNFTypesConstructor() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("^}", PhpVersion.PHP_82);
+        cgsInfo.setPublicModifier(true);
+        selectAllProperties(cgsInfo.getInstanceProperties());
+        checkResult(CGSGenerator.GenType.CONSTRUCTOR.getTemplateText(cgsInfo));
+    }
+
+    public void testDNFTypesGetter() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("^}", PhpVersion.PHP_82);
+        cgsInfo.setPublicModifier(true);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectAllProperties(cgsInfo.getPossibleGetters()),
+                new SinglePropertyMethodCreator.SingleGetterCreator(cgsInfo)
+        ));
+    }
+
+    public void testDNFTypesSetter() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("^}", PhpVersion.PHP_82);
+        cgsInfo.setPublicModifier(true);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectAllProperties(cgsInfo.getPossibleSetters()),
+                new SinglePropertyMethodCreator.SingleSetterCreator(cgsInfo)
+        ));
+    }
+
+    public void testDNFTypesOverrideMethod01() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Child extends OverrideMethodTest {^", PhpVersion.PHP_82);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "testMethod"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testDNFTypesOverrideMethod02() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Child extends OverrideMethodTest {^", PhpVersion.PHP_82);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "testMethod"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testDNFTypesOverrideMethod03() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Child extends OverrideMethodTest {^", PhpVersion.PHP_82);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "testMethod"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testDNFTypesImplementMethod01() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Implement implements ImplementMethodTest {^", PhpVersion.PHP_82);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "test"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testDNFTypesImplementMethod02() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Implement implements ImplementMethodTest {^", PhpVersion.PHP_82);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "testMethod"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testDNFTypesImplementMethod03() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Implement implements ImplementMethodTest {^", PhpVersion.PHP_82);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "testMethod"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testDNFTypesImplementMethod04() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Implement extends ImplementMethodTest {^", PhpVersion.PHP_82);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "testMethod"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
 }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHP82CodeCompletionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHP82CodeCompletionTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.Map;
 import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.api.PhpVersion;
 import org.netbeans.modules.php.project.api.PhpSourcePath;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
@@ -627,6 +628,66 @@ public class PHP82CodeCompletionTest extends PHPCodeCompletionTestBase {
 
     public void testDNFTypes_ParameterTypeInCCList01() throws Exception {
         checkCompletion("dnfTypes", "$this->param^(null);");
+    }
+
+    public void testDNFTypesImplementMethod01() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testDNFTypesImplementMethod01"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_82, "test"), true);
+    }
+
+    public void testDNFTypesImplementMethod02() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testDNFTypesImplementMethod02"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_82, "test"), true);
+    }
+
+    public void testDNFTypesImplementMethod03a() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testDNFTypesImplementMethod03a"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_82, "test"), true);
+    }
+
+    public void testDNFTypesImplementMethod03b() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testDNFTypesImplementMethod03b"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_82, "test"), true);
+    }
+
+    public void testDNFTypesImplementMethod04() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testDNFTypesImplementMethod04"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_82, "test"), true);
+    }
+
+    public void testDNFTypesOverrideMethod01() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testDNFTypesOverrideMethod01"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_82, "test"), true);
+    }
+
+    public void testDNFTypesOverrideMethod02() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testDNFTypesOverrideMethod02"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_82, "test"), true);
+    }
+
+    public void testDNFTypesOverrideMethod03() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testDNFTypesOverrideMethod03"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_82, "test"), true);
+    }
+
+    public void testDNFTypesOverrideMethodSpecialTypes01() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testDNFTypesOverrideMethodSpecialTypes01"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_82, "test"), true);
+    }
+
+    public void testDNFTypesOverrideMethodSpecialTypes02() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testDNFTypesOverrideMethodSpecialTypes02"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_82, "test"), true);
+    }
+
+    public void testDNFTypesOverrideMethodSpecialTypes03() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testDNFTypesOverrideMethodSpecialTypes03"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_82, "test"), true);
+    }
+
+    public void testDNFTypesOverrideMethodSpecialTypes04() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("testDNFTypesOverrideMethodSpecialTypes04"), "    test^",
+                new DefaultFilter(PhpVersion.PHP_82, "test"), true);
     }
 
 }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/GotoDeclarationPHP82Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/GotoDeclarationPHP82Test.java
@@ -77,4 +77,480 @@ public class GotoDeclarationPHP82Test extends GotoDeclarationTestBase {
         checkDeclaration(getTestPath(), "        echo parent::PUBLI^C_TRAIT . PHP_EOL; // child", "    public const ^PUBLIC_TRAIT = 'ExampleTrait public';");
     }
 
+    public void testDNFType_Param_a01() throws Exception {
+        checkDeclaration(getTestPath(), "function paramType((F^oo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3): void {", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a02() throws Exception {
+        checkDeclaration(getTestPath(), "function paramType((Foo&Bar)|Baz $param1, Baz|(Fo^o&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3): void {", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a03() throws Exception {
+        checkDeclaration(getTestPath(), "function paramType((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (F^oo&Bar)|(Bar&Baz) $param3): void {", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a04() throws Exception {
+        checkDeclaration(getTestPath(), "    public function paramType((F^oo&Baz)|(Foo&Bar)|Baz $test): void { // class", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a05() throws Exception {
+        checkDeclaration(getTestPath(), "    public function paramType((Foo&Baz)|(Fo^o&Bar)|Baz $test): void { // class", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a06() throws Exception {
+        checkDeclaration(getTestPath(), "    public function paramType((F^oo&Bar)|(Bar&Baz) $test1, Foo|(Foo&Bar) $test2): void { // trait", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a07() throws Exception {
+        checkDeclaration(getTestPath(), "    public function paramType((Foo&Bar)|(Bar&Baz) $test1, Fo^o|(Foo&Bar) $test2): void { // trait", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a08() throws Exception {
+        checkDeclaration(getTestPath(), "    public function paramType((Foo&Bar)|(Bar&Baz) $test1, Foo|(F^oo&Bar) $test2): void { // trait", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a09() throws Exception {
+        checkDeclaration(getTestPath(), "    public function paramType(F^oo|(Foo&Bar)|null $test);", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a10() throws Exception {
+        checkDeclaration(getTestPath(), "    public function paramType(Foo|(Fo^o&Bar)|null $test);", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a11() throws Exception {
+        checkDeclaration(getTestPath(), "$closure = function(Fo^o|(Foo&Bar)|(Bar&Baz) $test1, $test2): void {};", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a12() throws Exception {
+        checkDeclaration(getTestPath(), "$closure = function(Foo|(Fo^o&Bar)|(Bar&Baz) $test1, $test2): void {};", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a13() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow = fn(F^oo|Bar|(Foo&Bar) $test) => $test;", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a14() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow = fn(Foo|Bar|(Fo^o&Bar) $test) => $test;", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a15() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow = fn((F^oo&Bar)|null $test): Foo|(Foo&Bar) => $test;", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a16() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow = fn((F^oo&Bar)|null $test): Foo|(Foo&Bar) => $test;", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a17() throws Exception {
+        checkDeclaration(getTestPath(), " * @method (Foo&Bar)|(Bar&Baz) methodTag((Fo^o&Bar)|Bar $param1, Foo|(Bar&Baz) $param2) Description", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a18() throws Exception {
+        checkDeclaration(getTestPath(), " * @method (Foo&Bar)|(Bar&Baz) methodTag((Foo&Bar)|Bar $param1, Fo^o|(Bar&Baz) $param2) Description", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a19() throws Exception {
+        checkDeclaration(getTestPath(), " * @method static (Foo&Bar)|Baz staticMethodTag(Bar|(F^oo&Bar) $param1, (Foo&Bar)|(Bar&Baz) $param2) Description", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_a20() throws Exception {
+        checkDeclaration(getTestPath(), " * @method static (Foo&Bar)|Baz staticMethodTag(Bar|(Foo&Bar) $param1, (F^oo&Bar)|(Bar&Baz) $param2) Description", "class ^Foo {");
+    }
+
+    public void testDNFType_Param_b01() throws Exception {
+        checkDeclaration(getTestPath(), "function paramType((Foo&B^ar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3): void {", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b02() throws Exception {
+        checkDeclaration(getTestPath(), "function paramType((Foo&Bar)|Baz $param1, Baz|(Foo&Ba^r) $param2, (Foo&Bar)|(Bar&Baz) $param3): void {", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b03() throws Exception {
+        checkDeclaration(getTestPath(), "function paramType((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&B^ar)|(Bar&Baz) $param3): void {", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b04() throws Exception {
+        checkDeclaration(getTestPath(), "function paramType((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Ba^r&Baz) $param3): void {", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b05() throws Exception {
+        checkDeclaration(getTestPath(), "    public function paramType((Foo&Baz)|(Foo&B^ar)|Baz $test): void { // class", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b06() throws Exception {
+        checkDeclaration(getTestPath(), "    public function paramType((Foo&Ba^r)|(Bar&Baz) $test1, Foo|(Foo&Bar) $test2): void { // trait", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b07() throws Exception {
+        checkDeclaration(getTestPath(), "    public function paramType((Foo&Bar)|(Ba^r&Baz) $test1, Foo|(Foo&Bar) $test2): void { // trait", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b08() throws Exception {
+        checkDeclaration(getTestPath(), "    public function paramType((Foo&Bar)|(Bar&Baz) $test1, Foo|(Foo&Ba^r) $test2): void { // trait", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b09() throws Exception {
+        checkDeclaration(getTestPath(), "    public function paramType(Foo|(Foo&^Bar)|null $test);", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b10() throws Exception {
+        checkDeclaration(getTestPath(), "$closure = function(Foo|(Foo&B^ar)|(Bar&Baz) $test1, $test2): void {};", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b11() throws Exception {
+        checkDeclaration(getTestPath(), "$closure = function(Foo|(Foo&Bar)|(Ba^r&Baz) $test1, $test2): void {};", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b12() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow = fn(Foo|B^ar|(Foo&Bar) $test) => $test;", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b13() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow = fn(Foo|Bar|(Foo&Ba^r) $test) => $test;", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b14() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow = fn((Foo&Ba^r)|null $test): Foo|(Foo&Bar) => $test;", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b15() throws Exception {
+        checkDeclaration(getTestPath(), " * @method (Foo&Bar)|(Bar&Baz) methodTag((Foo&B^ar)|Bar $param1, Foo|(Bar&Baz) $param2) Description", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b16() throws Exception {
+        checkDeclaration(getTestPath(), " * @method (Foo&Bar)|(Bar&Baz) methodTag((Foo&Bar)|Ba^r $param1, Foo|(Bar&Baz) $param2) Description", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b17() throws Exception {
+        checkDeclaration(getTestPath(), " * @method (Foo&Bar)|(Bar&Baz) methodTag((Foo&Bar)|Bar $param1, Foo|(B^ar&Baz) $param2) Description", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b18() throws Exception {
+        checkDeclaration(getTestPath(), " * @method static (Foo&Bar)|Baz staticMethodTag(B^ar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&Baz) $param2) Description", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b19() throws Exception {
+        checkDeclaration(getTestPath(), " * @method static (Foo&Bar)|Baz staticMethodTag(Bar|(Foo&Ba^r) $param1, (Foo&Bar)|(Bar&Baz) $param2) Description", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b20() throws Exception {
+        checkDeclaration(getTestPath(), " * @method static (Foo&Bar)|Baz staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Ba^r)|(Bar&Baz) $param2) Description", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_b21() throws Exception {
+        checkDeclaration(getTestPath(), " * @method static (Foo&Bar)|Baz staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Ba^r&Baz) $param2) Description", "class ^Bar {");
+    }
+
+    public void testDNFType_Param_c01() throws Exception {
+        checkDeclaration(getTestPath(), "function paramType((Foo&Bar)|Ba^z $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3): void {", "class ^Baz {");
+    }
+
+    public void testDNFType_Param_c02() throws Exception {
+        checkDeclaration(getTestPath(), "function paramType((Foo&Bar)|Baz $param1, Ba^z|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3): void {", "class ^Baz {");
+    }
+
+    public void testDNFType_Param_c03() throws Exception {
+        checkDeclaration(getTestPath(), "function paramType((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Ba^z) $param3): void {", "class ^Baz {");
+    }
+
+    public void testDNFType_Param_c04() throws Exception {
+        checkDeclaration(getTestPath(), "    public function paramType((Foo&Ba^z)|(Foo&Bar)|Baz $test): void { // class", "class ^Baz {");
+    }
+
+    public void testDNFType_Param_c05() throws Exception {
+        checkDeclaration(getTestPath(), "    public function paramType((Foo&Baz)|(Foo&Bar)|^Baz $test): void { // class", "class ^Baz {");
+    }
+
+    public void testDNFType_Param_c06() throws Exception {
+        checkDeclaration(getTestPath(), "    public function paramType((Foo&Bar)|(Bar&Baz^) $test1, Foo|(Foo&Bar) $test2): void { // trait", "class ^Baz {");
+    }
+
+    public void testDNFType_Param_c07() throws Exception {
+        checkDeclaration(getTestPath(), "$closure = function(Foo|(Foo&Bar)|(Bar&B^az) $test1, $test2): void {};", "class ^Baz {");
+    }
+
+    public void testDNFType_Param_c08() throws Exception {
+        checkDeclaration(getTestPath(), " * @method (Foo&Bar)|(Bar&Baz) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&Ba^z) $param2) Description", "class ^Baz {");
+    }
+
+    public void testDNFType_Param_c09() throws Exception {
+        checkDeclaration(getTestPath(), " * @method static (Foo&Bar)|Baz staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&^Baz) $param2) Description", "class ^Baz {");
+    }
+
+    public void testDNFType_Return_a01() throws Exception {
+        checkDeclaration(getTestPath(), "function returnType1(): (^Foo&Bar)|Baz {}", "class ^Foo {");
+    }
+
+    public void testDNFType_Return_a02() throws Exception {
+        checkDeclaration(getTestPath(), "function returnType2(): Baz|(Fo^o&Bar) {}", "class ^Foo {");
+    }
+
+    public void testDNFType_Return_a03() throws Exception {
+        checkDeclaration(getTestPath(), "function returnType3(): Baz|(Fo^o&Bar)|Foo {}", "class ^Foo {");
+    }
+
+    public void testDNFType_Return_a04() throws Exception {
+        checkDeclaration(getTestPath(), "function returnType3(): Baz|(Foo&Bar)|Fo^o {}", "class ^Foo {");
+    }
+
+    public void testDNFType_Return_a05() throws Exception {
+        checkDeclaration(getTestPath(), "function returnType4(): (Fo^o&Bar)|(Foo&Baz) {}", "class ^Foo {");
+    }
+
+    public void testDNFType_Return_a06() throws Exception {
+        checkDeclaration(getTestPath(), "function returnType4(): (Foo&Bar)|(Fo^o&Baz) {}", "class ^Foo {");
+    }
+
+    public void testDNFType_Return_a07() throws Exception {
+        checkDeclaration(getTestPath(), "    public function returnType(): (F^oo&Bar)|Baz { // class", "class ^Foo {");
+    }
+
+    public void testDNFType_Return_a08() throws Exception {
+        checkDeclaration(getTestPath(), "    public function returnType(): F^oo|(Foo&Bar) { // trait", "class ^Foo {");
+    }
+
+    public void testDNFType_Return_a09() throws Exception {
+        checkDeclaration(getTestPath(), "    public function returnType(): Foo|(Fo^o&Bar) { // trait", "class ^Foo {");
+    }
+
+    public void testDNFType_Return_a10() throws Exception {
+        checkDeclaration(getTestPath(), "    public function returnType(): (F^oo&Bar)|(Bar&Baz);", "class ^Foo {");
+    }
+
+    public void testDNFType_Return_a11() throws Exception {
+        checkDeclaration(getTestPath(), "$closure = function(int $test): (Foo^&Bar)|null {};", "class ^Foo {");
+    }
+
+    public void testDNFType_Return_a12() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow = fn((Foo&Bar)|null $test): Fo^o|(Foo&Bar) => $test;", "class ^Foo {");
+    }
+
+    public void testDNFType_Return_a13() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow = fn((Foo&Bar)|null $test): Foo|(F^oo&Bar) => $test;", "class ^Foo {");
+    }
+
+    public void testDNFType_Return_a14() throws Exception {
+        checkDeclaration(getTestPath(), " * @method (F^oo&Bar)|(Bar&Baz) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&Baz) $param2) Description", "class ^Foo {");
+    }
+
+    public void testDNFType_Return_a15() throws Exception {
+        checkDeclaration(getTestPath(), " * @method static (^Foo&Bar)|Baz staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&Baz) $param2) Description", "class ^Foo {");
+    }
+
+    public void testDNFType_Return_b01() throws Exception {
+        checkDeclaration(getTestPath(), "function returnType1(): (Foo&B^ar)|Baz {}", "class ^Bar {");
+    }
+
+    public void testDNFType_Return_b02() throws Exception {
+        checkDeclaration(getTestPath(), "function returnType2(): Baz|(Foo&^Bar) {}", "class ^Bar {");
+    }
+
+    public void testDNFType_Return_b03() throws Exception {
+        checkDeclaration(getTestPath(), "function returnType3(): Baz|(Foo&B^ar)|Foo {}", "class ^Bar {");
+    }
+
+    public void testDNFType_Return_b04() throws Exception {
+        checkDeclaration(getTestPath(), "function returnType4(): (Foo&Ba^r)|(Foo&Baz) {}", "class ^Bar {");
+    }
+
+    public void testDNFType_Return_b05() throws Exception {
+        checkDeclaration(getTestPath(), "    public function returnType(): (Foo&Bar^)|Baz { // class", "class ^Bar {");
+    }
+
+    public void testDNFType_Return_b06() throws Exception {
+        checkDeclaration(getTestPath(), "    public function returnType(): Foo|(Foo&Ba^r) { // trait", "class ^Bar {");
+    }
+
+    public void testDNFType_Return_b07() throws Exception {
+        checkDeclaration(getTestPath(), "    public function returnType(): (Foo&Ba^r)|(Bar&Baz);", "class ^Bar {");
+    }
+
+    public void testDNFType_Return_b08() throws Exception {
+        checkDeclaration(getTestPath(), "    public function returnType(): (Foo&Bar)|(B^ar&Baz);", "class ^Bar {");
+    }
+
+    public void testDNFType_Return_b09() throws Exception {
+        checkDeclaration(getTestPath(), "$closure = function(int $test): (Foo&B^ar)|null {};", "class ^Bar {");
+    }
+
+    public void testDNFType_Return_b10() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow = fn((Foo&Bar)|null $test): Foo|(Foo&Ba^r) => $test;", "class ^Bar {");
+    }
+
+    public void testDNFType_Return_b11() throws Exception {
+        checkDeclaration(getTestPath(), " * @method (Foo&^Bar)|(Bar&Baz) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&Baz) $param2) Description", "class ^Bar {");
+    }
+
+    public void testDNFType_Return_b12() throws Exception {
+        checkDeclaration(getTestPath(), " * @method (Foo&Bar)|(Ba^r&Baz) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&Baz) $param2) Description", "class ^Bar {");
+    }
+
+    public void testDNFType_Return_b13() throws Exception {
+        checkDeclaration(getTestPath(), " * @method static (Foo&B^ar)|Baz staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&Baz) $param2) Description", "class ^Bar {");
+    }
+
+    public void testDNFType_Return_c01() throws Exception {
+        checkDeclaration(getTestPath(), "function returnType1(): (Foo&Bar)|B^az {}", "class ^Baz {");
+    }
+
+    public void testDNFType_Return_c02() throws Exception {
+        checkDeclaration(getTestPath(), "function returnType2(): Ba^z|(Foo&Bar) {}", "class ^Baz {");
+    }
+
+    public void testDNFType_Return_c03() throws Exception {
+        checkDeclaration(getTestPath(), "function returnType3(): Baz^|(Foo&Bar)|Foo {}", "class ^Baz {");
+    }
+
+    public void testDNFType_Return_c04() throws Exception {
+        checkDeclaration(getTestPath(), "function returnType4(): (Foo&Bar)|(Foo&Ba^z) {}", "class ^Baz {");
+    }
+
+    public void testDNFType_Return_c05() throws Exception {
+        checkDeclaration(getTestPath(), "    public function returnType(): (Foo&Bar)|(Bar&B^az);", "class ^Baz {");
+    }
+
+    public void testDNFType_Return_c06() throws Exception {
+        checkDeclaration(getTestPath(), " * @method (Foo&Bar)|(Bar&Ba^z) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&Baz) $param2) Description", "class ^Baz {");
+    }
+
+    public void testDNFType_Return_c07() throws Exception {
+        checkDeclaration(getTestPath(), " * @method static (Foo&Bar)|^Baz staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&Baz) $param2) Description", "class ^Baz {");
+    }
+
+    public void testDNFType_Field_a01() throws Exception {
+        checkDeclaration(getTestPath(), "    private (^Foo&Bar)|Baz $fieldClass; // class", "class ^Foo {");
+    }
+
+    public void testDNFType_Field_a02() throws Exception {
+        checkDeclaration(getTestPath(), "    private (Fo^o&Bar)|Baz $test; // trait", "class ^Foo {");
+    }
+
+    public void testDNFType_Field_a03() throws Exception {
+        checkDeclaration(getTestPath(), " * @property F^oo|(Bar&Baz) $propertyTag Description", "class ^Foo {");
+    }
+
+    public void testDNFType_Field_b01() throws Exception {
+        checkDeclaration(getTestPath(), "    private (Foo&Ba^r)|Baz $fieldClass; // class", "class ^Bar {");
+    }
+
+    public void testDNFType_Field_b02() throws Exception {
+        checkDeclaration(getTestPath(), "    private static Ba^r|(Bar&Baz) $staticFieldClass; // class", "class ^Bar {");
+    }
+
+    public void testDNFType_Field_b03() throws Exception {
+        checkDeclaration(getTestPath(), "    private static Bar|(Ba^r&Baz) $staticFieldClass; // class", "class ^Bar {");
+    }
+
+    public void testDNFType_Field_b04() throws Exception {
+        checkDeclaration(getTestPath(), "    private (Foo&Ba^r)|Baz $test; // trait", "class ^Bar {");
+    }
+
+    public void testDNFType_Field_b05() throws Exception {
+        checkDeclaration(getTestPath(), " * @property Foo|(Ba^r&Baz) $propertyTag Description", "class ^Bar {");
+    }
+
+    public void testDNFType_Field_c01() throws Exception {
+        checkDeclaration(getTestPath(), "    private (Foo&Bar)|Ba^z $fieldClass; // class", "class ^Baz {");
+    }
+
+    public void testDNFType_Field_c02() throws Exception {
+        checkDeclaration(getTestPath(), "    private static Bar|(Bar&^Baz) $staticFieldClass; // class", "class ^Baz {");
+    }
+
+    public void testDNFType_Field_c03() throws Exception {
+        checkDeclaration(getTestPath(), "    private (Foo&Bar)|Ba^z $test; // trait", "class ^Baz {");
+    }
+
+    public void testDNFType_Field_c04() throws Exception {
+        checkDeclaration(getTestPath(), " * @property Foo|(Bar&^Baz) $propertyTag Description", "class ^Baz {");
+    }
+
+    public void testDNFType_Vardoc_a01() throws Exception {
+        checkDeclaration(getTestPath(), "/** @var (F^oo&Bar)|Foo|(Bar&Baz&Foo) $vardoc1 */", "class ^Foo {");
+    }
+
+    public void testDNFType_Vardoc_a02() throws Exception {
+        checkDeclaration(getTestPath(), "/** @var (Foo&Bar)|Fo^o|(Bar&Baz&Foo) $vardoc1 */", "class ^Foo {");
+    }
+
+    public void testDNFType_Vardoc_a03() throws Exception {
+        checkDeclaration(getTestPath(), "/* @var $vardoc2 (F^oo&Bar)|Baz */", "class ^Foo {");
+    }
+
+    public void testDNFType_Vardoc_a04() throws Exception {
+        checkDeclaration(getTestPath(), "/** @var Bar|Baz|Fo^o $unionType */", "class ^Foo {");
+    }
+
+    public void testDNFType_Vardoc_a05() throws Exception {
+        checkDeclaration(getTestPath(), "/** @var Bar&Baz&F^oo $intersectionType */", "class ^Foo {");
+    }
+
+    public void testDNFType_Vardoc_a06() throws Exception {
+        checkDeclaration(getTestPath(), "/** @var ?F^oo $nullableType */", "class ^Foo {");
+    }
+
+    public void testDNFType_Vardoc_b01() throws Exception {
+        checkDeclaration(getTestPath(), "/** @var (Foo&Ba^r)|Foo|(Bar&Baz&Foo) $vardoc1 */", "class ^Bar {");
+    }
+
+    public void testDNFType_Vardoc_b02() throws Exception {
+        checkDeclaration(getTestPath(), "/** @var (Foo&Bar)|Foo|(^Bar&Baz&Foo) $vardoc1 */", "class ^Bar {");
+    }
+
+    public void testDNFType_Vardoc_b03() throws Exception {
+        checkDeclaration(getTestPath(), "/* @var $vardoc2 (Foo&Ba^r)|Baz */", "class ^Bar {");
+    }
+
+    public void testDNFType_Vardoc_b04() throws Exception {
+        checkDeclaration(getTestPath(), "/** @var B^ar|Baz|Foo $unionType */", "class ^Bar {");
+    }
+
+    public void testDNFType_Vardoc_b05() throws Exception {
+        checkDeclaration(getTestPath(), "/** @var Ba^r&Baz&Foo $intersectionType */", "class ^Bar {");
+    }
+
+    public void testDNFType_Vardoc_c01() throws Exception {
+        checkDeclaration(getTestPath(), "/** @var (Foo&Bar)|Foo|(Bar&Baz^&Foo) $vardoc1 */", "class ^Baz {");
+    }
+
+    public void testDNFType_Vardoc_c02() throws Exception {
+        checkDeclaration(getTestPath(), "/* @var $vardoc2 (Foo&Bar)|B^az */", "class ^Baz {");
+    }
+
+    public void testDNFType_Vardoc_c03() throws Exception {
+        checkDeclaration(getTestPath(), "/** @var Bar|Ba^z|Foo $unionType */", "class ^Baz {");
+    }
+
+    public void testDNFType_Vardoc_c04() throws Exception {
+        checkDeclaration(getTestPath(), "/** @var Bar&Ba^z&Foo $intersectionType */", "class ^Baz {");
+    }
+
+    public void testDNFType_01() throws Exception {
+        checkDeclaration(getTestPath(), "        $this->fieldClass::CONSTANT_FO^O;", "    public const ^CONSTANT_FOO = \"test\";");
+    }
+
+    public void testDNFType_02() throws Exception {
+        checkDeclaration(getTestPath(), "        $this->fieldClass::$staticFieldB^az;", "    public static (Foo&Bar)|Bar $^staticFieldBaz;");
+    }
+
+    public void testDNFType_03() throws Exception {
+        checkDeclaration(getTestPath(), "        $this->fieldClass->fieldB^ar;", "    public (Foo&Bar)|(Baz&Foo) $^fieldBar;");
+    }
+
+    public void testDNFType_04() throws Exception {
+        checkDeclaration(getTestPath(), "        $test::CONSTANT_BA^Z;", "    public const ^CONSTANT_BAZ = \"test\";");
+    }
+
+    public void testDNFType_05() throws Exception {
+        checkDeclaration(getTestPath(), "        $test::$staticFieldB^ar;", "    public static (Foo&Bar)|Bar $^staticFieldBar;");
+    }
+
+    public void testDNFType_06() throws Exception {
+        checkDeclaration(getTestPath(), "        self::$staticFieldClass->methodB^ar();", "    public function ^methodBar(): (Foo&Bar)|Baz {}");
+    }
+
+    public void testDNFType_07() throws Exception {
+        checkDeclaration(getTestPath(), "        self::$staticFieldClass::staticmethodBa^z(null);", "    public static function ^staticMethodBaz(Foo&Bar $param): void {}");
+    }
+
 }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImplPHP82Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImplPHP82Test.java
@@ -93,4 +93,691 @@ public class OccurrencesFinderImplPHP82Test extends OccurrencesFinderImplTestBas
         checkOccurrences(getTestPath(), "        echo parent::PU^BLIC_TRAIT . PHP_EOL; // child", true);
     }
 
+    public void testDNFType_a01() throws Exception {
+        checkOccurrences(getTestPath(), "class F^oo {", true);
+    }
+
+    public void testDNFType_a02() throws Exception {
+        checkOccurrences(getTestPath(), "    public (Fo^o&Bar)|Foo $fieldFoo;", true);
+    }
+
+    public void testDNFType_a03() throws Exception {
+        checkOccurrences(getTestPath(), "    public (Foo&Bar)|F^oo $fieldFoo;", true);
+    }
+
+    public void testDNFType_a04() throws Exception {
+        checkOccurrences(getTestPath(), "    public static (F^oo&Bar)|Bar $staticFieldFoo;", true);
+    }
+
+    public void testDNFType_a05() throws Exception {
+        checkOccurrences(getTestPath(), "    public function methodFoo(): (Fo^o&Bar)|(Bar&Baz) {}", true);
+    }
+
+    public void testDNFType_a06() throws Exception {
+        checkOccurrences(getTestPath(), "    public static function staticMethodFoo(F^oo|Bar $param): void {}", true);
+    }
+
+    public void testDNFType_a07() throws Exception {
+        checkOccurrences(getTestPath(), "    public (Fo^o&Bar)|(Baz&Foo) $fieldBar;", true);
+    }
+
+    public void testDNFType_a08() throws Exception {
+        checkOccurrences(getTestPath(), "    public (Foo&Bar)|(Baz&Fo^o) $fieldBar;", true);
+    }
+
+    public void testDNFType_a09() throws Exception {
+        checkOccurrences(getTestPath(), "    public static (F^oo&Bar)|Bar $staticFieldBar;", true);
+    }
+
+    public void testDNFType_a10() throws Exception {
+        checkOccurrences(getTestPath(), "    public function methodBar(): (F^oo&Bar)|Baz {}", true);
+    }
+
+    public void testDNFType_a11() throws Exception {
+        checkOccurrences(getTestPath(), "    public static function staticMethodBar(Fo^o|Bar $param): void {}", true);
+    }
+
+    public void testDNFType_a12() throws Exception {
+        checkOccurrences(getTestPath(), "    public (Fo^o&Bar)|(Baz&Foo) $fieldBaz;", true);
+    }
+
+    public void testDNFType_a13() throws Exception {
+        checkOccurrences(getTestPath(), "    public (Foo&Bar)|(Baz&Fo^o) $fieldBaz;", true);
+    }
+
+    public void testDNFType_a14() throws Exception {
+        checkOccurrences(getTestPath(), "    public static (Fo^o&Bar)|Bar $staticFieldBaz;", true);
+    }
+
+    public void testDNFType_a15() throws Exception {
+        checkOccurrences(getTestPath(), "    public function methodBaz(): Fo^o|(Bar&Baz) {}", true);
+    }
+
+    public void testDNFType_a16() throws Exception {
+        checkOccurrences(getTestPath(), "    public static function staticMethodBaz(Fo^o&Bar $param): void {}", true);
+    }
+
+    public void testDNFType_a17() throws Exception {
+        checkOccurrences(getTestPath(), "function paramType((Fo^o&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3): void {", true);
+    }
+
+    public void testDNFType_a18() throws Exception {
+        checkOccurrences(getTestPath(), "function paramType((Foo&Bar)|Baz $param1, Baz|(Fo^o&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3): void {", true);
+    }
+
+    public void testDNFType_a19() throws Exception {
+        checkOccurrences(getTestPath(), "function paramType((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (F^oo&Bar)|(Bar&Baz) $param3): void {", true);
+    }
+
+    public void testDNFType_a20() throws Exception {
+        checkOccurrences(getTestPath(), "function returnType1(): (Fo^o&Bar)|Baz {}", true);
+    }
+
+    public void testDNFType_a21() throws Exception {
+        checkOccurrences(getTestPath(), "function returnType2(): Baz|(F^oo&Bar) {}", true);
+    }
+
+    public void testDNFType_a22() throws Exception {
+        checkOccurrences(getTestPath(), "function returnType3(): Baz|(Fo^o&Bar)|Foo {}", true);
+    }
+
+    public void testDNFType_a23() throws Exception {
+        checkOccurrences(getTestPath(), "function returnType3(): Baz|(Foo&Bar)|^Foo {}", true);
+    }
+
+    public void testDNFType_a24() throws Exception {
+        checkOccurrences(getTestPath(), "function returnType4(): (Fo^o&Bar)|(Foo&Baz) {}", true);
+    }
+
+    public void testDNFType_a25() throws Exception {
+        checkOccurrences(getTestPath(), "function returnType4(): (Foo&Bar)|(Fo^o&Baz) {}", true);
+    }
+
+    public void testDNFType_a26() throws Exception {
+        checkOccurrences(getTestPath(), " * @method (Fo^o&Bar)|(Bar&Baz) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_a27() throws Exception {
+        checkOccurrences(getTestPath(), " * @method (Foo&Bar)|(Bar&Baz) methodTag((Fo^o&Bar)|Bar $param1, Foo|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_a28() throws Exception {
+        checkOccurrences(getTestPath(), " * @method (Foo&Bar)|(Bar&Baz) methodTag((Foo&Bar)|Bar $param1, F^oo|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_a29() throws Exception {
+        checkOccurrences(getTestPath(), " * @method static (F^oo&Bar)|Baz staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_a30() throws Exception {
+        checkOccurrences(getTestPath(), " * @method static (Foo&Bar)|Baz staticMethodTag(Bar|(F^oo&Bar) $param1, (Foo&Bar)|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_a31() throws Exception {
+        checkOccurrences(getTestPath(), " * @method static (Foo&Bar)|Baz staticMethodTag(Bar|(Foo&Bar) $param1, (^Foo&Bar)|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_a32() throws Exception {
+        checkOccurrences(getTestPath(), " * @property Fo^o|(Bar&Baz) $propertyTag Description", true);
+    }
+
+    public void testDNFType_a33() throws Exception {
+        checkOccurrences(getTestPath(), "    private (Fo^o&Bar)|Baz $fieldClass; // class", true);
+    }
+
+    public void testDNFType_a34() throws Exception {
+        checkOccurrences(getTestPath(), "    public function paramType((F^oo&Baz)|(Foo&Bar)|Baz $test): void { // class", true);
+    }
+
+    public void testDNFType_a35() throws Exception {
+        checkOccurrences(getTestPath(), "    public function paramType((Foo&Baz)|(F^oo&Bar)|Baz $test): void { // class", true);
+    }
+
+    public void testDNFType_a36() throws Exception {
+        checkOccurrences(getTestPath(), "    public function returnType(): (Fo^o&Bar)|Baz { // class", true);
+    }
+
+    public void testDNFType_a37() throws Exception {
+        checkOccurrences(getTestPath(), "    private (Fo^o&Bar)|Baz $test; // trait", true);
+    }
+
+    public void testDNFType_a38() throws Exception {
+        checkOccurrences(getTestPath(), "    public function paramType((Fo^o&Bar)|(Bar&Baz) $test1, Foo|(Foo&Bar) $test2): void { // trait", true);
+    }
+
+    public void testDNFType_a39() throws Exception {
+        checkOccurrences(getTestPath(), "    public function paramType((Foo&Bar)|(Bar&Baz) $test1, F^oo|(Foo&Bar) $test2): void { // trait", true);
+    }
+
+    public void testDNFType_a40() throws Exception {
+        checkOccurrences(getTestPath(), "    public function paramType((Foo&Bar)|(Bar&Baz) $test1, Foo|(Fo^o&Bar) $test2): void { // trait", true);
+    }
+
+    public void testDNFType_a41() throws Exception {
+        checkOccurrences(getTestPath(), "    public function returnType(): Fo^o|(Foo&Bar) { // trait", true);
+    }
+
+    public void testDNFType_a42() throws Exception {
+        checkOccurrences(getTestPath(), "    public function returnType(): Foo|(Fo^o&Bar) { // trait", true);
+    }
+
+    public void testDNFType_a43() throws Exception {
+        checkOccurrences(getTestPath(), "    public function paramType(Fo^o|(Foo&Bar)|null $test);", true);
+    }
+
+    public void testDNFType_a44() throws Exception {
+        checkOccurrences(getTestPath(), "    public function paramType(Foo|(Fo^o&Bar)|null $test);", true);
+    }
+
+    public void testDNFType_a45() throws Exception {
+        checkOccurrences(getTestPath(), "    public function returnType(): (Fo^o&Bar)|(Bar&Baz);", true);
+    }
+
+    public void testDNFType_a46() throws Exception {
+        checkOccurrences(getTestPath(), "$closure = function(Fo^o|(Foo&Bar)|(Bar&Baz) $test1, $test2): void {};", true);
+    }
+
+    public void testDNFType_a47() throws Exception {
+        checkOccurrences(getTestPath(), "$closure = function(Foo|(Fo^o&Bar)|(Bar&Baz) $test1, $test2): void {};", true);
+    }
+
+    public void testDNFType_a48() throws Exception {
+        checkOccurrences(getTestPath(), "$closure = function(int $test): (Fo^o&Bar)|null {};", true);
+    }
+
+    public void testDNFType_a49() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow = fn(F^oo|Bar|(Foo&Bar) $test) => $test;", true);
+    }
+
+    public void testDNFType_a50() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow = fn(Foo|Bar|(F^oo&Bar) $test) => $test;", true);
+    }
+
+    public void testDNFType_a51() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow = fn((F^oo&Bar)|null $test): Foo|(Foo&Bar) => $test;", true);
+    }
+
+    public void testDNFType_a52() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow = fn((Foo&Bar)|null $test): Fo^o|(Foo&Bar) => $test;", true);
+    }
+
+    public void testDNFType_a53() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow = fn((Foo&Bar)|null $test): Foo|(F^oo&Bar) => $test;", true);
+    }
+
+    public void testDNFType_a54() throws Exception {
+        checkOccurrences(getTestPath(), "/** @var (Fo^o&Bar)|Foo|(Bar&Baz&Foo) $vardoc1 */", true);
+    }
+
+    public void testDNFType_a55() throws Exception {
+        checkOccurrences(getTestPath(), "/** @var (Foo&Bar)|F^oo|(Bar&Baz&Foo) $vardoc1 */", true);
+    }
+
+    public void testDNFType_a56() throws Exception {
+        checkOccurrences(getTestPath(), "/** @var (Foo&Bar)|Foo|(Bar&Baz&Fo^o) $vardoc1 */", true);
+    }
+
+    public void testDNFType_a57() throws Exception {
+        checkOccurrences(getTestPath(), "/* @var $vardoc2 (Fo^o&Bar)|Baz */", true);
+    }
+
+    public void testDNFType_a58() throws Exception {
+        checkOccurrences(getTestPath(), "/** @var Bar|Baz|F^oo $unionType */", true);
+    }
+
+    public void testDNFType_a59() throws Exception {
+        checkOccurrences(getTestPath(), "/** @var Bar&Baz&Fo^o $intersectionType */", true);
+    }
+
+    public void testDNFType_a60() throws Exception {
+        checkOccurrences(getTestPath(), "/** @var ?Fo^o $nullableType */", true);
+    }
+
+    public void testDNFType_b01() throws Exception {
+        checkOccurrences(getTestPath(), "    public (Foo&Ba^r)|Foo $fieldFoo;", true);
+    }
+
+    public void testDNFType_b02() throws Exception {
+        checkOccurrences(getTestPath(), "    public static (Foo&Ba^r)|Bar $staticFieldFoo;", true);
+    }
+
+    public void testDNFType_b03() throws Exception {
+        checkOccurrences(getTestPath(), "    public static (Foo&Bar)|B^ar $staticFieldFoo;", true);
+    }
+
+    public void testDNFType_b04() throws Exception {
+        checkOccurrences(getTestPath(), "    public function methodFoo(): (Foo&Ba^r)|(Bar&Baz) {}", true);
+    }
+
+    public void testDNFType_b05() throws Exception {
+        checkOccurrences(getTestPath(), "    public function methodFoo(): (Foo&Bar)|(Bar^&Baz) {}", true);
+    }
+
+    public void testDNFType_b06() throws Exception {
+        checkOccurrences(getTestPath(), "    public static function staticMethodFoo(Foo|Ba^r $param): void {}", true);
+    }
+
+    public void testDNFType_b07() throws Exception {
+        checkOccurrences(getTestPath(), "class B^ar {", true);
+    }
+
+    public void testDNFType_b08() throws Exception {
+        checkOccurrences(getTestPath(), "    public (Foo&B^ar)|(Baz&Foo) $fieldBar;", true);
+    }
+
+    public void testDNFType_b09() throws Exception {
+        checkOccurrences(getTestPath(), "    public static (Foo&Ba^r)|Bar $staticFieldBar;", true);
+    }
+
+    public void testDNFType_b10() throws Exception {
+        checkOccurrences(getTestPath(), "    public static (Foo&Bar)|B^ar $staticFieldBar;", true);
+    }
+
+    public void testDNFType_b11() throws Exception {
+        checkOccurrences(getTestPath(), "    public function methodBar(): (Foo&Ba^r)|Baz {}", true);
+    }
+
+    public void testDNFType_b12() throws Exception {
+        checkOccurrences(getTestPath(), "    public static function staticMethodBar(Foo|^Bar $param): void {}", true);
+    }
+
+    public void testDNFType_b13() throws Exception {
+        checkOccurrences(getTestPath(), "    public (Foo&Ba^r)|(Baz&Foo) $fieldBaz;", true);
+    }
+
+    public void testDNFType_b14() throws Exception {
+        checkOccurrences(getTestPath(), "    public static (Foo&Ba^r)|Bar $staticFieldBaz;", true);
+    }
+
+    public void testDNFType_b15() throws Exception {
+        checkOccurrences(getTestPath(), "    public static (Foo&Bar)|Ba^r $staticFieldBaz;", true);
+    }
+
+    public void testDNFType_b16() throws Exception {
+        checkOccurrences(getTestPath(), "    public function methodBaz(): Foo|(Ba^r&Baz) {}", true);
+    }
+
+    public void testDNFType_b17() throws Exception {
+        checkOccurrences(getTestPath(), "    public static function staticMethodBaz(Foo&Ba^r $param): void {}", true);
+    }
+
+    public void testDNFType_b18() throws Exception {
+        checkOccurrences(getTestPath(), "function paramType((Foo&B^ar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3): void {", true);
+    }
+
+    public void testDNFType_b19() throws Exception {
+        checkOccurrences(getTestPath(), "function paramType((Foo&Bar)|Baz $param1, Baz|(Foo&B^ar) $param2, (Foo&Bar)|(Bar&Baz) $param3): void {", true);
+    }
+
+    public void testDNFType_b20() throws Exception {
+        checkOccurrences(getTestPath(), "function paramType((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Ba^r)|(Bar&Baz) $param3): void {", true);
+    }
+
+    public void testDNFType_b21() throws Exception {
+        checkOccurrences(getTestPath(), "function paramType((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Ba^r&Baz) $param3): void {", true);
+    }
+
+    public void testDNFType_b22() throws Exception {
+        checkOccurrences(getTestPath(), "function returnType1(): (Foo&B^ar)|Baz {}", true);
+    }
+
+    public void testDNFType_b23() throws Exception {
+        checkOccurrences(getTestPath(), "function returnType2(): Baz|(Foo&B^ar) {}", true);
+    }
+
+    public void testDNFType_b24() throws Exception {
+        checkOccurrences(getTestPath(), "function returnType3(): Baz|(Foo&Ba^r)|Foo {}", true);
+    }
+
+    public void testDNFType_b25() throws Exception {
+        checkOccurrences(getTestPath(), "function returnType4(): (Foo&B^ar)|(Foo&Baz) {}", true);
+    }
+
+    public void testDNFType_b26() throws Exception {
+        checkOccurrences(getTestPath(), " * @method (Foo&B^ar)|(Bar&Baz) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_b27() throws Exception {
+        checkOccurrences(getTestPath(), " * @method (Foo&Bar)|(Ba^r&Baz) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_b28() throws Exception {
+        checkOccurrences(getTestPath(), " * @method (Foo&Bar)|(Bar&Baz) methodTag((Foo&B^ar)|Bar $param1, Foo|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_b29() throws Exception {
+        checkOccurrences(getTestPath(), " * @method (Foo&Bar)|(Bar&Baz) methodTag((Foo&Bar)|Ba^r $param1, Foo|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_b30() throws Exception {
+        checkOccurrences(getTestPath(), " * @method (Foo&Bar)|(Bar&Baz) methodTag((Foo&Bar)|Bar $param1, Foo|(^Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_b31() throws Exception {
+        checkOccurrences(getTestPath(), " * @method static (Foo&Ba^r)|Baz staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_b32() throws Exception {
+        checkOccurrences(getTestPath(), " * @method static (Foo&Bar)|Baz staticMethodTag(B^ar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_b33() throws Exception {
+        checkOccurrences(getTestPath(), " * @method static (Foo&Bar)|Baz staticMethodTag(Bar|(Foo&B^ar) $param1, (Foo&Bar)|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_b34() throws Exception {
+        checkOccurrences(getTestPath(), " * @method static (Foo&Bar)|Baz staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&^Bar)|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_b35() throws Exception {
+        checkOccurrences(getTestPath(), " * @method static (Foo&Bar)|Baz staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Ba^r&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_b36() throws Exception {
+        checkOccurrences(getTestPath(), " * @property Foo|(B^ar&Baz) $propertyTag Description", true);
+    }
+
+    public void testDNFType_b37() throws Exception {
+        checkOccurrences(getTestPath(), "    private (Foo&B^ar)|Baz $fieldClass; // class", true);
+    }
+
+    public void testDNFType_b38() throws Exception {
+        checkOccurrences(getTestPath(), "    private static B^ar|(Bar&Baz) $staticFieldClass; // class", true);
+    }
+
+    public void testDNFType_b39() throws Exception {
+        checkOccurrences(getTestPath(), "    private static Bar|(Ba^r&Baz) $staticFieldClass; // class", true);
+    }
+
+    public void testDNFType_b40() throws Exception {
+        checkOccurrences(getTestPath(), "    public function paramType((Foo&Baz)|(Foo&B^ar)|Baz $test): void { // class", true);
+    }
+
+    public void testDNFType_b41() throws Exception {
+        checkOccurrences(getTestPath(), "    public function returnType(): (Foo&B^ar)|Baz { // class", true);
+    }
+
+    public void testDNFType_b42() throws Exception {
+        checkOccurrences(getTestPath(), "    private (Foo&B^ar)|Baz $test; // trait", true);
+    }
+
+    public void testDNFType_b43() throws Exception {
+        checkOccurrences(getTestPath(), "    public function paramType((Foo&Ba^r)|(Bar&Baz) $test1, Foo|(Foo&Bar) $test2): void { // trait", true);
+    }
+
+    public void testDNFType_b44() throws Exception {
+        checkOccurrences(getTestPath(), "    public function paramType((Foo&Bar)|(B^ar&Baz) $test1, Foo|(Foo&Bar) $test2): void { // trait", true);
+    }
+
+    public void testDNFType_b45() throws Exception {
+        checkOccurrences(getTestPath(), "    public function paramType((Foo&Bar)|(Bar&Baz) $test1, Foo|(Foo&^Bar) $test2): void { // trait", true);
+    }
+
+    public void testDNFType_b46() throws Exception {
+        checkOccurrences(getTestPath(), "    public function returnType(): Foo|(Foo&B^ar) { // trait", true);
+    }
+
+    public void testDNFType_b47() throws Exception {
+        checkOccurrences(getTestPath(), "    public function paramType(Foo|(Foo&B^ar)|null $test);", true);
+    }
+
+    public void testDNFType_b48() throws Exception {
+        checkOccurrences(getTestPath(), "    public function returnType(): (Foo&Bar^)|(Bar&Baz);", true);
+    }
+
+    public void testDNFType_b49() throws Exception {
+        checkOccurrences(getTestPath(), "    public function returnType(): (Foo&Bar)|(B^ar&Baz);", true);
+    }
+
+    public void testDNFType_b50() throws Exception {
+        checkOccurrences(getTestPath(), "$closure = function(Foo|(Foo&B^ar)|(Bar&Baz) $test1, $test2): void {};", true);
+    }
+
+    public void testDNFType_b51() throws Exception {
+        checkOccurrences(getTestPath(), "$closure = function(Foo|(Foo&Bar)|(B^ar&Baz) $test1, $test2): void {};", true);
+    }
+
+    public void testDNFType_b52() throws Exception {
+        checkOccurrences(getTestPath(), "$closure = function(int $test): (Foo&B^ar)|null {};", true);
+    }
+
+    public void testDNFType_b53() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow = fn(Foo|B^ar|(Foo&Bar) $test) => $test;", true);
+    }
+
+    public void testDNFType_b54() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow = fn(Foo|Bar|(Foo&B^ar) $test) => $test;", true);
+    }
+
+    public void testDNFType_b55() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow = fn((Foo&B^ar)|null $test): Foo|(Foo&Bar) => $test;", true);
+    }
+
+    public void testDNFType_b56() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow = fn((Foo&Bar)|null $test): Foo|(Foo&Ba^r) => $test;", true);
+    }
+
+    public void testDNFType_b57() throws Exception {
+        checkOccurrences(getTestPath(), "/** @var (Foo&^Bar)|Foo|(Bar&Baz&Foo) $vardoc1 */", true);
+    }
+
+    public void testDNFType_b58() throws Exception {
+        checkOccurrences(getTestPath(), "/** @var (Foo&Bar)|Foo|(Ba^r&Baz&Foo) $vardoc1 */", true);
+    }
+
+    public void testDNFType_b59() throws Exception {
+        checkOccurrences(getTestPath(), "/* @var $vardoc2 (Foo&Ba^r)|Baz */", true);
+    }
+
+    public void testDNFType_b60() throws Exception {
+        checkOccurrences(getTestPath(), "/** @var Ba^r|Baz|Foo $unionType */", true);
+    }
+
+    public void testDNFType_b61() throws Exception {
+        checkOccurrences(getTestPath(), "/** @var B^ar&Baz&Foo $intersectionType */", true);
+    }
+
+    public void testDNFType_c01() throws Exception {
+        checkOccurrences(getTestPath(), "    public function methodFoo(): (Foo&Bar)|(Bar&B^az) {}", true);
+    }
+
+    public void testDNFType_c02() throws Exception {
+        checkOccurrences(getTestPath(), "    public (Foo&Bar)|(Ba^z&Foo) $fieldBar;", true);
+    }
+
+    public void testDNFType_c03() throws Exception {
+        checkOccurrences(getTestPath(), "    public function methodBar(): (Foo&Bar)|B^az {}", true);
+    }
+
+    public void testDNFType_c04() throws Exception {
+        checkOccurrences(getTestPath(), "class B^az {", true);
+    }
+
+    public void testDNFType_c05() throws Exception {
+        checkOccurrences(getTestPath(), "    public (Foo&Bar)|(Ba^z&Foo) $fieldBaz;", true);
+    }
+
+    public void testDNFType_c06() throws Exception {
+        checkOccurrences(getTestPath(), "    public function methodBaz(): Foo|(Bar&Ba^z) {}", true);
+    }
+
+    public void testDNFType_c07() throws Exception {
+        checkOccurrences(getTestPath(), "function paramType((Foo&Bar)|B^az $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3): void {", true);
+    }
+
+    public void testDNFType_c08() throws Exception {
+        checkOccurrences(getTestPath(), "function paramType((Foo&Bar)|Baz $param1, B^az|(Foo&Bar) $param2, (Foo&Bar)|(Bar&Baz) $param3): void {", true);
+    }
+
+    public void testDNFType_c09() throws Exception {
+        checkOccurrences(getTestPath(), "function paramType((Foo&Bar)|Baz $param1, Baz|(Foo&Bar) $param2, (Foo&Bar)|(Bar&^Baz) $param3): void {", true);
+    }
+
+    public void testDNFType_c10() throws Exception {
+        checkOccurrences(getTestPath(), "function returnType1(): (Foo&Bar)|B^az {}", true);
+    }
+
+    public void testDNFType_c11() throws Exception {
+        checkOccurrences(getTestPath(), "function returnType2(): Ba^z|(Foo&Bar) {}", true);
+    }
+
+    public void testDNFType_c12() throws Exception {
+        checkOccurrences(getTestPath(), "function returnType3(): B^az|(Foo&Bar)|Foo {}", true);
+    }
+
+    public void testDNFType_c13() throws Exception {
+        checkOccurrences(getTestPath(), "function returnType4(): (Foo&Bar)|(Foo&Ba^z) {}", true);
+    }
+
+    public void testDNFType_c14() throws Exception {
+        checkOccurrences(getTestPath(), " * @method (Foo&Bar)|(Bar&B^az) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_c15() throws Exception {
+        checkOccurrences(getTestPath(), " * @method (Foo&Bar)|(Bar&Baz) methodTag((Foo&Bar)|Bar $param1, Foo|(Bar&Ba^z) $param2) Description", true);
+    }
+
+    public void testDNFType_c16() throws Exception {
+        checkOccurrences(getTestPath(), " * @method static (Foo&Bar)|B^az staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_c17() throws Exception {
+        checkOccurrences(getTestPath(), " * @method static (Foo&Bar)|Baz staticMethodTag(Bar|(Foo&Bar) $param1, (Foo&Bar)|(Bar&^Baz) $param2) Description", true);
+    }
+
+    public void testDNFType_c18() throws Exception {
+        checkOccurrences(getTestPath(), " * @property Foo|(Bar&B^az) $propertyTag Description", true);
+    }
+
+    public void testDNFType_c19() throws Exception {
+        checkOccurrences(getTestPath(), "    private (Foo&Bar)|B^az $fieldClass; // class", true);
+    }
+
+    public void testDNFType_c20() throws Exception {
+        checkOccurrences(getTestPath(), "    private static Bar|(Bar&Ba^z) $staticFieldClass; // class", true);
+    }
+
+    public void testDNFType_c21() throws Exception {
+        checkOccurrences(getTestPath(), "    public function paramType((Foo&Ba^z)|(Foo&Bar)|Baz $test): void { // class", true);
+    }
+
+    public void testDNFType_c22() throws Exception {
+        checkOccurrences(getTestPath(), "    public function paramType((Foo&Baz)|(Foo&Bar)|B^az $test): void { // class", true);
+    }
+
+    public void testDNFType_c23() throws Exception {
+        checkOccurrences(getTestPath(), "    public function returnType(): (Foo&Bar)|B^az { // class", true);
+    }
+
+    public void testDNFType_c24() throws Exception {
+        checkOccurrences(getTestPath(), "    private (Foo&Bar)|B^az $test; // trait", true);
+    }
+
+    public void testDNFType_c25() throws Exception {
+        checkOccurrences(getTestPath(), "    public function paramType((Foo&Bar)|(Bar&Ba^z) $test1, Foo|(Foo&Bar) $test2): void { // trait", true);
+    }
+
+    public void testDNFType_c26() throws Exception {
+        checkOccurrences(getTestPath(), "    public function returnType(): (Foo&Bar)|(Bar&^Baz);", true);
+    }
+
+    public void testDNFType_c27() throws Exception {
+        checkOccurrences(getTestPath(), "$closure = function(Foo|(Foo&Bar)|(Bar&B^az) $test1, $test2): void {};", true);
+    }
+
+    public void testDNFType_c28() throws Exception {
+        checkOccurrences(getTestPath(), "/** @var (Foo&Bar)|Foo|(Bar&Ba^z&Foo) $vardoc1 */", true);
+    }
+
+    public void testDNFType_c29() throws Exception {
+        checkOccurrences(getTestPath(), "/* @var $vardoc2 (Foo&Bar)|^Baz */", true);
+    }
+
+    public void testDNFType_c30() throws Exception {
+        checkOccurrences(getTestPath(), "/** @var Bar|Ba^z|Foo $unionType */", true);
+    }
+
+    public void testDNFType_c31() throws Exception {
+        checkOccurrences(getTestPath(), "/** @var Bar&B^az&Foo $intersectionType */", true);
+    }
+
+    public void testDNFType_d01() throws Exception {
+        checkOccurrences(getTestPath(), "    public const CONSTAN^T_FOO = \"test\";", true);
+    }
+
+    public void testDNFType_d02() throws Exception {
+        checkOccurrences(getTestPath(), "        $this->fieldClass::CONSTANT_F^OO;", true);
+    }
+
+    public void testDNFType_e01() throws Exception {
+        checkOccurrences(getTestPath(), "    public static (Foo&Bar)|Bar $stat^icFieldBaz;", true);
+    }
+
+    public void testDNFType_e02() throws Exception {
+        checkOccurrences(getTestPath(), "        $this->fieldClass::$staticFi^eldBaz;", true);
+    }
+
+    public void testDNFType_f01() throws Exception {
+        checkOccurrences(getTestPath(), "    public (Foo&Bar)|(Baz&Foo) $field^Bar;", true);
+    }
+
+    public void testDNFType_f02() throws Exception {
+        checkOccurrences(getTestPath(), "        $this->fieldClass->fieldB^ar;", true);
+    }
+
+    public void testDNFType_g01() throws Exception {
+        checkOccurrences(getTestPath(), "    public const CON^STANT_BAZ = \"test\";", true);
+    }
+
+    public void testDNFType_g02() throws Exception {
+        checkOccurrences(getTestPath(), "        $test::CONSTANT^_BAZ;", true);
+    }
+
+    public void testDNFType_h01() throws Exception {
+        checkOccurrences(getTestPath(), "    public static (Foo&Bar)|Bar $staticF^ieldBar;", true);
+    }
+
+    public void testDNFType_h02() throws Exception {
+        checkOccurrences(getTestPath(), "        $test::$staticFi^eldBar;", true);
+    }
+
+    public void testDNFType_i01() throws Exception {
+        checkOccurrences(getTestPath(), "    public function metho^dBar(): (Foo&Bar)|Baz {}", true);
+    }
+
+    public void testDNFType_i02() throws Exception {
+        checkOccurrences(getTestPath(), "        self::$staticFieldClass->metho^dBar();", true);
+    }
+
+    public void testDNFType_j01() throws Exception {
+        checkOccurrences(getTestPath(), "    public static function staticMethodB^az(Foo&Bar $param): void {}", true);
+    }
+
+    public void testDNFType_j02() throws Exception {
+        checkOccurrences(getTestPath(), "        self::$staticFieldClass::staticmethod^Baz(null);", true);
+    }
+
+    public void testDNFType_j03() throws Exception {
+        checkOccurrences(getTestPath(), "$vardoc2::staticMethodB^az(null);", true);
+    }
+
+    public void testDNFType_k01() throws Exception {
+        checkOccurrences(getTestPath(), "    public function method^Foo(): (Foo&Bar)|(Bar&Baz) {}", true);
+    }
+
+    public void testDNFType_k02() throws Exception {
+        checkOccurrences(getTestPath(), "$vardoc1->method^Foo();", true);
+    }
+
+    public void testDNFType_k03() throws Exception {
+        checkOccurrences(getTestPath(), "$unionType->methodF^oo();", true);
+    }
+
+    public void testDNFType_k04() throws Exception {
+        checkOccurrences(getTestPath(), "$intersectionType->metho^dFoo();", true);
+    }
+
+    public void testDNFType_k05() throws Exception {
+        checkOccurrences(getTestPath(), "$nullableType->methodF^oo();", true);
+    }
 }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/ImplementAbstractMethodsHintErrorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/ImplementAbstractMethodsHintErrorTest.java
@@ -273,6 +273,38 @@ public class ImplementAbstractMethodsHintErrorTest extends PHPHintsTestBase {
         applyHint(new ImplementAbstractMethodsHintError(), "testEnumerations_01.php", "enum TestEnumWith^Trait {", "Implement");
     }
 
+    public void testDNFTypes_01() throws Exception {
+        checkHints(new ImplementAbstractMethodsHintError(), "testDNFTypesImplementMethod01.php");
+    }
+
+    public void testDNFTypes_02() throws Exception {
+        checkHints(new ImplementAbstractMethodsHintError(), "testDNFTypesImplementMethod02.php");
+    }
+
+    public void testDNFTypes_03() throws Exception {
+        checkHints(new ImplementAbstractMethodsHintError(), "testDNFTypesImplementMethod03.php");
+    }
+
+    public void testDNFTypes_04() throws Exception {
+        checkHints(new ImplementAbstractMethodsHintError(), "testDNFTypesImplementMethod04.php");
+    }
+
+    public void testDNFTypesFix_01() throws Exception {
+        applyHint(new ImplementAbstractMethodsHintError(), "testDNFTypesImplementMethod01.php", "class Impleme^nt", "Implement");
+    }
+
+    public void testDNFTypesFix_02() throws Exception {
+        applyHint(new ImplementAbstractMethodsHintError(), "testDNFTypesImplementMethod02.php", "class Impleme^nt", "Implement");
+    }
+
+    public void testDNFTypesFix_03() throws Exception {
+        applyHint(new ImplementAbstractMethodsHintError(), "testDNFTypesImplementMethod03.php", "class Impleme^nt", "Implement");
+    }
+
+    public void testDNFTypesFix_04() throws Exception {
+        applyHint(new ImplementAbstractMethodsHintError(), "testDNFTypesImplementMethod04.php", "class Impleme^nt extends ImplementMethodTest {", "Implement");
+    }
+
     //~ Inner classes
     private static final class ImplementAbstractMethodsHintErrorStub extends ImplementAbstractMethodsHintError {
 

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/InitializeFieldsSuggestionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/InitializeFieldsSuggestionTest.java
@@ -223,6 +223,38 @@ public class InitializeFieldsSuggestionTest extends PHPHintsTestBase {
         applyHint(new InitializeFieldSuggestionStub(PhpVersion.PHP_81), "intersectionTypes_01.php", "            \\Test\\Foo&Bar $par^am2,", "Initialize Field");
     }
 
+    public void testDnfTypes_01a() throws Exception {
+        checkHints(new InitializeFieldSuggestion(), "dnfTypes_01.php", "            (Foo&Bar)|Baz $para^m1,");
+    }
+
+    public void testDnfTypes_01b() throws Exception {
+        checkHints(new InitializeFieldSuggestion(), "dnfTypes_01.php", "            (\\Test\\Foo&Bar)|(Foo&Baz) $par^am2,");
+    }
+
+    public void testDnfTypes_01c() throws Exception {
+        checkHints(new InitializeFieldSuggestion(), "dnfTypes_01.php", "            Foo|(Foo&Baz) $para^m3,");
+    }
+
+    public void testDnfTypes_01d() throws Exception {
+        checkHints(new InitializeFieldSuggestion(), "dnfTypes_01.php", "            Foo|(Foo&Baz)|null $para^m4,");
+    }
+
+    public void testDnfTypesFix_01a() throws Exception {
+        applyHint(new InitializeFieldSuggestionStub(PhpVersion.PHP_82), "dnfTypes_01.php", "            (Foo&Bar)|Baz $par^am1,", "Initialize Field");
+    }
+
+    public void testDnfTypesFix_01b() throws Exception {
+        applyHint(new InitializeFieldSuggestionStub(PhpVersion.PHP_82), "dnfTypes_01.php", "            (\\Test\\Foo&Bar)|(Foo&Baz) $pa^ram2,", "Initialize Field");
+    }
+
+    public void testDnfTypesFix_01c() throws Exception {
+        applyHint(new InitializeFieldSuggestionStub(PhpVersion.PHP_82), "dnfTypes_01.php", "            Foo|(Foo&Baz) $para^m3,", "Initialize Field");
+    }
+
+    public void testDnfTypesFix_01d() throws Exception {
+        applyHint(new InitializeFieldSuggestionStub(PhpVersion.PHP_82), "dnfTypes_01.php", "            Foo|(Foo&Baz)|null $para^m4,", "Initialize Field");
+    }
+
     //~ Inner classes
     private static class InitializeFieldSuggestionStub extends InitializeFieldSuggestion {
 


### PR DESCRIPTION
- #4725
- https://wiki.php.net/rfc/dnf_types

### PHP 8.2 Support: Disjunctive Normal Form Types (Part 9) 

- Fix the code completion, the code generator, and the `ImplementAbstractMethodsHintError` for overriding/implementing methods
- Add unit tests

### PHP 8.2 Support: Disjunctive Normal Form Types (Part 10) 

- Fix the mark occurrences and the go to declaration features
- Add unit tests

### PHP 8.2 Support: Disjunctive Normal Form Types (Part 11) 

- Add unit tests for the `InitializeFieldsSuggestion`