### PR TITLE
Don't scroll output window on link click.

### DIFF
--- a/platform/core.output2/src/org/netbeans/core/output2/OutputPane.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/OutputPane.java
@@ -48,10 +48,12 @@ class OutputPane extends AbstractOutputPane {
         findOutputTab().documentChanged(this);
     }
 
+    @Override
     protected void caretPosChanged(int pos) {
         findOutputTab().caretPosChanged(pos);
     }
 
+    @Override
     protected void lineClicked(int line, int pos) {
         if ((getDocument() instanceof OutputDocument)) {
             findOutputTab().lineClicked(line, pos);
@@ -64,6 +66,7 @@ class OutputPane extends AbstractOutputPane {
         findOutputTab().enterPressed(caret.getMark(), caret.getDot());
     }
 
+    @Override
     protected void postPopupMenu(Point p, Component src) {
         if (src.isShowing()) {
             findOutputTab().postPopupMenu(p, src);
@@ -116,6 +119,7 @@ class OutputPane extends AbstractOutputPane {
     }
     
     
+    @Override
     public void setWrapped (boolean val) {
         if (val != isWrapped() || !(getEditorKit() instanceof OutputEditorKit)) {
             NbPreferences.forModule(OutputPane.class).putBoolean("wrap", val); //NOI18N
@@ -138,6 +142,7 @@ class OutputPane extends AbstractOutputPane {
             //been fully readjusted to its new dimensions, scroll bounds, etc.
             SwingUtilities.invokeLater (new Runnable() {
                 private boolean first = true;
+                @Override
                 public void run() {
                     if (first) {
                         first = false;
@@ -160,6 +165,7 @@ class OutputPane extends AbstractOutputPane {
         }
     }
     
+    @Override
     public boolean isWrapped() {
         if (getEditorKit() instanceof OutputEditorKit) {
             return getEditorKit() instanceof OutputEditorKit 
@@ -169,6 +175,7 @@ class OutputPane extends AbstractOutputPane {
         }
     }
 
+    @Override
     protected JEditorPane createTextView() {
         JEditorPane result = new JEditorPane();
         if ("Aqua".equals(UIManager.getLookAndFeel().getID())) {
@@ -187,6 +194,7 @@ class OutputPane extends AbstractOutputPane {
         result.setInputMap(JEditorPane.WHEN_FOCUSED, myMap);
         
         Action act = new AbstractAction() {
+            @Override
             public void actionPerformed(ActionEvent arg0) {
                 OutputDocument od =(OutputDocument)((JEditorPane)arg0.getSource()).getDocument();
                 findOutputTab().inputSent(od.sendLine());
@@ -195,6 +203,7 @@ class OutputPane extends AbstractOutputPane {
         result.getActionMap().put("SENDLINE", act);
         
         act = new AbstractAction() {
+            @Override
             public void actionPerformed(ActionEvent arg0) {
                 OutputDocument od =(OutputDocument)((JEditorPane)arg0.getSource()).getDocument();
                 findOutputTab().inputSent(od.sendLine());

--- a/platform/core.output2/src/org/netbeans/core/output2/OutputTab.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/OutputTab.java
@@ -33,7 +33,6 @@ import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.CharConversionException;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -51,7 +50,6 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
-import javax.swing.JSeparator;
 import javax.swing.KeyStroke;
 import javax.swing.RootPaneContainer;
 import javax.swing.SwingUtilities;
@@ -74,9 +72,6 @@ import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.openide.windows.IOContainer;
 import org.openide.windows.OutputListener;
-import org.openide.windows.WindowManager;
-import org.openide.xml.XMLUtil;
-
 import static org.netbeans.core.output2.OutputTab.ACTION.*;
 import org.netbeans.core.output2.options.OutputOptions;
 import org.netbeans.core.output2.ui.OutputKeymapManager;
@@ -197,10 +192,12 @@ final class OutputTab extends AbstractOutputTab implements IOContainer.CallBacks
         return null;
     }
 
+    @Override
     protected AbstractOutputPane createOutputPane() {
         return new OutputPane(this);
     }
 
+    @Override
     public void inputSent(String txt) {
         if (Controller.LOG) Controller.log("Input sent on OutputTab: " + txt);
         getOutputPane().lockScroll();
@@ -212,6 +209,7 @@ final class OutputTab extends AbstractOutputTab implements IOContainer.CallBacks
         }
     }
 
+    @Override
     protected void inputEof() {
         if (Controller.LOG) Controller.log ("Input EOF");
         NbIO.IOReader in = io.in();
@@ -220,6 +218,7 @@ final class OutputTab extends AbstractOutputTab implements IOContainer.CallBacks
         }
     }
 
+    @Override
     public void hasSelectionChanged(boolean val) {
         if (isShowing() && actionsLoaded) {
             actions.get(ACTION.COPY).setEnabled(val);
@@ -246,7 +245,7 @@ final class OutputTab extends AbstractOutputTab implements IOContainer.CallBacks
             l.outputLineAction(oe);
             //Select the text on click if it is still visible
             if (getOutputPane().getLength() >= range[1]) { // #179768
-                getOutputPane().sendCaretToPos(range[0], range[1], true);
+                getOutputPane().sendCaretToPos(range[0], range[1], true, false);
             }
         }
     }
@@ -327,10 +326,12 @@ final class OutputTab extends AbstractOutputTab implements IOContainer.CallBacks
         }
     }
 
+    @Override
     public void activated() {
         updateActions();
     }
 
+    @Override
     public void closed() {
         io.setClosed(true);
         io.setStreamClosed(true);
@@ -351,9 +352,11 @@ final class OutputTab extends AbstractOutputTab implements IOContainer.CallBacks
         }
     }
 
+    @Override
     public void deactivated() {
     }
 
+    @Override
     public void selected() {
     }
 
@@ -642,7 +645,7 @@ final class OutputTab extends AbstractOutputTab implements IOContainer.CallBacks
             }
         }
 
-        List<TabAction> activeActions = new ArrayList<TabAction>(popupItems.length);
+        List<TabAction> activeActions = new ArrayList<>(popupItems.length);
         for (int i = 0; i < popupItems.length; i++) {
             if (popupItems[i] == null) {
                 popup.addSeparator();
@@ -756,18 +759,6 @@ final class OutputTab extends AbstractOutputTab implements IOContainer.CallBacks
         return origPane != null ? filtOut.getWriter() : outWriter;
     }
 
-    private void disableHtmlName() {
-        Controller.getDefault().removeFromUpdater(this);
-        String escaped;
-        try {
-            escaped = XMLUtil.toAttributeValue(io.getName() + " ");
-        } catch (CharConversionException e) {
-            escaped = io.getName() + " ";
-        }
-        //#88204 apostophes are escaped in xm but not html
-        io.getIOContainer().setTitle(this, escaped.replace("&apos;", "'"));
-    }
-
     private void initOptionsListener() {
         optionsListener = new PropertyChangeListener() {
             @Override
@@ -872,7 +863,7 @@ final class OutputTab extends AbstractOutputTab implements IOContainer.CallBacks
             EXPAND_TREE
     };
 
-    private final Map<ACTION, TabAction> actions = new EnumMap<ACTION, TabAction>(ACTION.class);
+    private final Map<ACTION, TabAction> actions = new EnumMap<>(ACTION.class);
 
     private void createActions() {
         KeyStrokeUtils.refreshActionCache();
@@ -1090,6 +1081,7 @@ final class OutputTab extends AbstractOutputTab implements IOContainer.CallBacks
             return super.isEnabled();
         }
 
+        @Override
         public void actionPerformed(ActionEvent e) {
             if (getIO().isClosed()) {
                 // Cached action for an already closed tab.
@@ -1257,6 +1249,7 @@ final class OutputTab extends AbstractOutputTab implements IOContainer.CallBacks
             orig = original;
         }
 
+        @Override
         public Object getValue(String key) {
             if (Action.SMALL_ICON.equals(key)) {
                 return null;
@@ -1264,26 +1257,32 @@ final class OutputTab extends AbstractOutputTab implements IOContainer.CallBacks
             return orig.getValue(key);
         }
 
+        @Override
         public void putValue(String key, Object value) {
             orig.putValue(key, value);
         }
 
+        @Override
         public void setEnabled(boolean b) {
             orig.setEnabled(b);
         }
 
+        @Override
         public boolean isEnabled() {
             return orig.isEnabled();
         }
 
+        @Override
         public void addPropertyChangeListener(PropertyChangeListener listener) {
             orig.addPropertyChangeListener(listener);
         }
 
+        @Override
         public void removePropertyChangeListener(PropertyChangeListener listener) {
             orig.removePropertyChangeListener(listener);
         }
 
+        @Override
         public void actionPerformed(ActionEvent e) {
             orig.actionPerformed(e);
         }
@@ -1303,6 +1302,7 @@ final class OutputTab extends AbstractOutputTab implements IOContainer.CallBacks
             handle = escHandle;
         }
 
+        @Override
         public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
             JPopupMenu popup = (JPopupMenu) e.getSource();
             popup.removeAll();
@@ -1320,10 +1320,12 @@ final class OutputTab extends AbstractOutputTab implements IOContainer.CallBacks
             }
         }
 
+        @Override
         public void popupMenuCanceled(PopupMenuEvent e) {
             popupMenuWillBecomeInvisible(e);
         }
 
+        @Override
         public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
             //do nothing
         }

--- a/platform/core.output2/src/org/netbeans/core/output2/ui/AbstractOutputPane.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/ui/AbstractOutputPane.java
@@ -156,6 +156,7 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
      * Scrolls the pane to the bottom, invokeLatered to ensure all state has
      * been updated, so the bottom really *is* the bottom.
      */
+    @Override
     public void run() {
         enqueued = false;
         if (locked) {
@@ -384,12 +385,18 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
     }
 
     public final void sendCaretToPos(int startPos, int endPos, boolean select) {
+        sendCaretToPos(startPos, endPos, select, true);
+    }
+
+    public final void sendCaretToPos(int startPos, int endPos, boolean select, boolean scroll) {
         inSendCaretToLine = true;
         try {
             getCaret().setVisible(true);
             getCaret().setSelectionVisible(true);
             if (select) {
-                scrollTo(endPos);
+                if (scroll) {
+                    scrollTo(endPos);
+                }
                 getCaret().setDot(endPos);
                 getCaret().moveDot(startPos);
                 textView.repaint();
@@ -409,7 +416,12 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
 
     private boolean inSendCaretToLine = false;
     private int lineToScroll = -1;
+
     public final boolean sendCaretToLine(int idx, boolean select) {
+        return sendCaretToLine(idx, select, true);
+    }
+
+    public final boolean sendCaretToLine(int idx, boolean select, boolean scroll) {
         int lastLine = getLineCount() - 1;
         if (idx > lastLine) {
             idx = lastLine;
@@ -428,7 +440,7 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
                 getCaret().setDot(position);
             }
 
-            if (!scrollToLine(idx + 3) && isScrollLocked()) {
+            if (scroll && !scrollToLine(idx + 3) && isScrollLocked()) {
                 lineToScroll = idx + 3;
             }
         } catch (Error sie) {
@@ -462,25 +474,6 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
 
         Rectangle visRect = textView.getVisibleRect();
         return line == lineIdx && visRect.y + visRect.height == rect.y + rect.height;
-    }
-
-    boolean scrollToPos(int pos) {
-        Rectangle rect = null;
-        try {
-            rect = textView.modelToView(pos);
-        } catch (BadLocationException ex) {
-            Exceptions.printStackTrace(ex);
-        }
-
-        if (rect == null) {
-            return false;
-        }
-
-        boolean oldLocked = locked;
-        textView.scrollRectToVisible(rect);
-        locked = oldLocked;
-
-        return true;
     }
 
     public final void lockScroll() {
@@ -543,6 +536,7 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
 
 //***********************Listener implementations*****************************
 
+    @Override
     public void stateChanged(ChangeEvent e) {
         if (e.getSource() == getVerticalScrollBar().getModel()) {
             if (!locked) { //XXX check if doc is still being written?
@@ -594,6 +588,7 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
         }
     }
 
+    @Override
     public final void changedUpdate(DocumentEvent e) {
         //Ensure it is consumed
         e.getLength();
@@ -609,6 +604,7 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
         }
     }
 
+    @Override
     public final void insertUpdate(DocumentEvent e) {
         //Ensure it is consumed
         e.getLength();
@@ -624,12 +620,14 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
         }
     }
 
+    @Override
     public final void removeUpdate(DocumentEvent e) {
         //Ensure it is consumed
         e.getLength();
         documentChanged();
     }
 
+    @Override
     public void mouseClicked(MouseEvent e) {
         if (e.isAltDown() || e.isAltGraphDown() || e.isControlDown()
                 && SwingUtilities.isMiddleMouseButton(e)) {
@@ -639,9 +637,11 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
         }
     }
 
+    @Override
     public void mouseEntered(MouseEvent e) {
     }
 
+    @Override
     public void mouseExited(MouseEvent e) {
         resetCursor();
     }
@@ -675,6 +675,7 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
         }
     }
 
+    @Override
     public void mouseMoved(MouseEvent e) {
         if (e.getSource() == textView) {
             if (isOnHyperlink(e.getPoint())) {
@@ -688,6 +689,7 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
         }
     }
 
+    @Override
     public void mouseDragged(MouseEvent e) {
         if (e.getSource() == getVerticalScrollBar()) {
             int y = e.getY();
@@ -700,6 +702,7 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
     /** last pressed position for hyperlink test */
     private int lastPressedPos = -1;
 
+    @Override
     public void mousePressed(MouseEvent e) {
         if (e.getSource() == textView && SwingUtilities.isLeftMouseButton(e)) {
             lastPressedPos = textView.viewToModel(e.getPoint());
@@ -725,6 +728,7 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
         }
     }
 
+    @Override
     public final void mouseReleased(MouseEvent e) {
         if (e.getSource() == textView && SwingUtilities.isLeftMouseButton(e)) {
             int pos = textView.viewToModel(e.getPoint());
@@ -748,6 +752,7 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
         }
     }
 
+    @Override
     public void keyPressed(KeyEvent keyEvent) {
         switch (keyEvent.getKeyCode()) {
             case KeyEvent.VK_END:
@@ -805,14 +810,17 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
         }
     }
 
+    @Override
     public void keyReleased(KeyEvent keyEvent) {
     }
 
+    @Override
     public void keyTyped(KeyEvent keyEvent) {
     }
 
     protected abstract void changeFontSizeBy(int change);
 
+    @Override
     public final void mouseWheelMoved(MouseWheelEvent e) {
         if (e.isAltDown() || e.isAltGraphDown() || e.isControlDown()) {
             int change = -e.getWheelRotation();


### PR DESCRIPTION
 - adds another boolean to control if caret positioning should scroll (for `sendCaretToPos` and `sendCaretToLine` in `AbstractOutputPane`)
 - calls it with `false` on link clicks (in `OutputTab:lineClicked`), overloaded method default remains `true`
 - adds `@Override` to the hierarchy to be able to safely make changes. This also exposed duplicated/dead code which was removed
 - luckily its all internal API

run test snippet to create some links and click on them:
```java
public class Mavenproject2 {
    public static void main(String[] args) {
        System.out.println(Runtime.version().major()); // <- linked deprecation warning
        throw new RuntimeException("click on stack"); // <- stack trace
    }
}
```
