### PR TITLE
Bump hardcoded maven compiler and resource plugin version defaults.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/options/MavenVersionSettings.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/MavenVersionSettings.java
@@ -60,12 +60,11 @@ public final class MavenVersionSettings {
     public String getVersion(String plugin) {
         String toRet = getProperty(plugin);
         if (toRet == null) {
-            // XXX these should rather read the most recent version from the repository index
+            // XXX these should rather read the most recent version from the repository index (agreed)
             if (VERSION_RESOURCES.equals(plugin)) {
-                toRet = "2.4.3"; //NOI18N
-            }
-            else if (VERSION_COMPILER.equals(plugin)) {
-                toRet = "2.3.2"; //NOI18N
+                toRet = "3.3.1"; //NOI18N
+            } else if (VERSION_COMPILER.equals(plugin)) {
+                toRet = "3.11.0"; //NOI18N
             }
         }
         if (toRet == null) {


### PR DESCRIPTION
This caused the build to fail when deprecation warnings were toggled via maven project properties UI, since the inserted maven compiler plugin is not compatible with current JDKs.

At some point we should consolidate this and use the index, like already done [in other places](https://github.com/mbien/netbeans/blob/cb124b2dfb01bfd441b45b62a4618945f3a32234/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenNbModuleImpl.java#L125C29-L134). But looking at the call hierarchy of the method this is too risky as last minute change IMO.