### PR TITLE
Fix ConcurrentModificationException in TestMethodController

### DIFF
--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestMethodController.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestMethodController.java
@@ -62,12 +62,10 @@ public class TestMethodController {
             doc.putProperty(TestMethodAnnotation.DOCUMENT_ANNOTATION_LINES_KEY, annotationLines);
         }
 
+        Set<TestMethod> added = new HashSet<>(methods);
         Map<TestMethod, TestMethodAnnotation> removed = new HashMap<>(annotations);
 
-        methods.forEach(tm -> removed.remove(tm));
-
-        Set<TestMethod> added = new HashSet<>(methods);
-
+        removed.keySet().removeAll(added);
         added.removeAll(annotations.keySet());
 
         for (TestMethod method : added) {

--- a/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/ComputeTestMethodsImpl.java
+++ b/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/ComputeTestMethodsImpl.java
@@ -103,7 +103,8 @@ public class ComputeTestMethodsImpl extends EditorAwareJavaSourceTaskFactory {
                 }
 
                 if (!cancel.get()) {
-                    WORKER.post(() -> TestMethodController.setTestMethods(doc, methods));
+                    List<TestMethod> updateMethods = new ArrayList<>(methods);
+                    WORKER.post(() -> TestMethodController.setTestMethods(doc, updateMethods));
                 }
             }
         }


### PR DESCRIPTION
Just happened to bump into this CME, while working on Jenkinsfile support. It seems this has been reported as #5148.

It seems the CME happens as the `methods` list is a live one passed over as parameter, so the collection can be changed during the time of `methods.forEach(tm -> removed.remove(tm))`. The solution would be to copy that collection before do the remove work. Interestingly we do have a copy of right after that call, so a simple reorder would solve the issue. I've just replaced the `forEach` call with `keySet().removeAll` as I think that reads better.

Otherwise the change is trivial. If it does not make into NB20, then I'd rebase this for master.