### PR TITLE
The LSP client may send document content with non-LF line endings, normalize before comparing with NB document content.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -1661,10 +1661,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                 if (doc == null) {
                     doc = ec.openDocument();
                 }
-                if (!text.contentEquals(doc.getText(0, doc.getLength()))) {
-                    doc.remove(0, doc.getLength());
-                    doc.insertString(0, text, null);
-                }
+                updateDocumentIfNeeded(text, doc);
             } catch (BadLocationException ex) {
                 Exceptions.printStackTrace(ex);
                 //TODO: include stack trace:
@@ -1681,6 +1678,42 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
         } finally {
             reportNotificationDone("didOpen", params);
         }
+    }
+
+    static void updateDocumentIfNeeded(String text, Document doc) throws BadLocationException {
+        String docText = doc.getText(0, doc.getLength());
+
+        if (text.contentEquals(docText)) {
+            //the texts are the same, no need to change the Document content:
+            return ;
+        }
+
+        //normalize line endings:
+        StringBuilder newText = new StringBuilder(text.length());
+        int len = text.length();
+        boolean modified = false;
+
+        for (int i = 0; i < len; i++) {
+            char c = text.charAt(i);
+            if (c == '\r') {
+                if (i + 1 < len && text.charAt(i + 1) == '\n') {
+                    i++;
+                }
+                c = '\n';
+                modified = true;
+            }
+            newText.append(c);
+        }
+
+        String newTextString = newText.toString();
+
+        if (modified && docText.equals(newTextString)) {
+            //only change in line endings, no need to change the Document content:
+            return ;
+        }
+
+        doc.remove(0, doc.getLength());
+        doc.insertString(0, newTextString, null);
     }
 
     @Override

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImplTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImplTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.PlainDocument;
+import org.netbeans.junit.NbTestCase;
+
+public class TextDocumentServiceImplTest extends NbTestCase {
+
+    public TextDocumentServiceImplTest(String name) {
+        super(name);
+    }
+
+    public void testNormalizeLineEndings1() throws BadLocationException {
+        Document doc = new PlainDocument();
+        doc.insertString(0, "a\nb\nc\n", null);
+        doc.addDocumentListener(new NoDocumentChanges());
+        TextDocumentServiceImpl.updateDocumentIfNeeded("a\nb\nc\n", doc);
+        assertEquals("a\nb\nc\n",
+                     doc.getText(0, doc.getLength()));
+    }
+
+    public void testNormalizeLineEndings2() throws BadLocationException {
+        Document doc = new PlainDocument();
+        doc.insertString(0, "a\nb\nc\n", null);
+        doc.addDocumentListener(new NoDocumentChanges());
+        TextDocumentServiceImpl.updateDocumentIfNeeded("a\rb\nc\r", doc);
+        assertEquals("a\nb\nc\n",
+                     doc.getText(0, doc.getLength()));
+    }
+
+    public void testNormalizeLineEndings3() throws BadLocationException {
+        Document doc = new PlainDocument();
+        doc.insertString(0, "a\nb\nc\n", null);
+        doc.addDocumentListener(new NoDocumentChanges());
+        TextDocumentServiceImpl.updateDocumentIfNeeded("a\r\nb\nc\r", doc);
+        assertEquals("a\nb\nc\n",
+                     doc.getText(0, doc.getLength()));
+    }
+
+    public void testNormalizeLineEndings4() throws BadLocationException {
+        Document doc = new PlainDocument();
+        doc.insertString(0, "a\nb\nc\n", null);
+        AtomicInteger insertCount = new AtomicInteger();
+        AtomicInteger removeCount = new AtomicInteger();
+        doc.addDocumentListener(new NoDocumentChanges() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                insertCount.incrementAndGet();
+            }
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                removeCount.incrementAndGet();
+            }
+        });
+        TextDocumentServiceImpl.updateDocumentIfNeeded("a\r\nd\nc\r", doc);
+        assertEquals("a\nd\nc\n",
+                     doc.getText(0, doc.getLength()));
+        assertEquals(1, insertCount.get());
+        assertEquals(1, removeCount.get());
+    }
+
+    public void testNormalizeLineEndings5() throws BadLocationException {
+        Document doc = new PlainDocument();
+        doc.insertString(0, "a\nb\nc\n", null);
+        AtomicInteger insertCount = new AtomicInteger();
+        AtomicInteger removeCount = new AtomicInteger();
+        doc.addDocumentListener(new NoDocumentChanges() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                insertCount.incrementAndGet();
+            }
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                removeCount.incrementAndGet();
+            }
+        });
+        TextDocumentServiceImpl.updateDocumentIfNeeded("a\nd\nc\n", doc);
+        assertEquals("a\nd\nc\n",
+                     doc.getText(0, doc.getLength()));
+        assertEquals(1, insertCount.get());
+        assertEquals(1, removeCount.get());
+    }
+
+    private static class NoDocumentChanges implements DocumentListener {
+        @Override
+        public void insertUpdate(DocumentEvent e) {
+            fail(String.valueOf(e));
+        }
+        @Override
+        public void removeUpdate(DocumentEvent e) {
+            fail(String.valueOf(e));
+        }
+        @Override
+        public void changedUpdate(DocumentEvent e) {
+            fail(String.valueOf(e));
+        }
+    }
+}


### PR DESCRIPTION
When a file is opened, the `didOpen` called in the LSP server is called. The LSP client (tested with Visual Studio Code) sends the file text/content with their real line endings, which may be `\r\n`. Internally, the NB server only uses `\n`. In the `didOpen` callback, when the server compares the text from the client and the internal document, the contents will be different, and the server will re-set the Document's content to the received file content.

Such Document is internally marked as modified, which may cause problems or accentuate other problems (see for example https://github.com/oracle/javavscode/issues/51 or https://github.com/oracle/javavscode/issues/26).

In this patch, I've tried to fix this, by normalizing the line endings before the comparison. I've tried to make this in a way that files with '\n' don't pay additional cost for line endings normalization in the common cases (i.e. when the file content as sent from the client, and the content of the document match).