### PR TITLE
Prevent endless recursion, limit traversal depth.

### DIFF
--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -83,6 +83,19 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="gradle-report-severity">
+            <api name="general"/>
+            <summary>Gradle project problems have severity and stacktraces</summary>
+            <version major="2" minor="38"/>
+            <date day="13" month="11" year="2023"/>
+            <author login="sdedic"/>
+            <compatibility semantic="compatible"/>
+            <description>
+                <p>
+                    Reports from the NB tooling gradle plugin are now annotated by severity.
+                </p>
+            </description>
+        </change>
         <change id="gradle-setting-deprecation">
             <api name="general"/>
             <summary>Some Gradle Settings Removed from Use</summary>

--- a/extide/gradle/manifest.mf
+++ b/extide/gradle/manifest.mf
@@ -3,4 +3,4 @@ AutoUpdate-Show-In-Client: true
 OpenIDE-Module: org.netbeans.modules.gradle/2
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.37
+OpenIDE-Module-Specification-Version: 2.38

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -110,6 +110,7 @@ import org.gradle.language.java.artifact.JavadocArtifact;
 import org.gradle.plugin.use.PluginId;
 import org.gradle.util.GradleVersion;
 import org.netbeans.modules.gradle.tooling.internal.NbProjectInfo;
+import org.netbeans.modules.gradle.tooling.internal.NbProjectInfo.Report;
 
 /**
  *
@@ -125,6 +126,18 @@ class NbProjectInfoBuilder {
      * project loader is enabled to FINER level.
      */
     private static final Logger LOG =  Logging.getLogger(NbProjectInfoBuilder.class);
+    
+    /**
+     * Maximum recursion depth into structures, arrays and maps. If this depth is reached, the 
+     * builder will record a warning and stop descending.
+     */
+    private static final int MAX_INTROSPECTION_DEPTH = 25;
+    
+    /**
+     * If a warning is recorded during introspection, further warnings will
+     * be suppressed until the introspector goes up to this level.
+     */
+    private static final int INTROSPECTION_RESET_DEPTH_WARNING = 5;
 
     /**
      * Name of the default extensibility point for various domain objects defined by Gradle.
@@ -305,7 +318,7 @@ class NbProjectInfoBuilder {
             Class nonDecorated = findNonDecoratedClass(taskClass);
             
             taskPropertyTypes.put(task.getName(), nonDecorated.getName());
-            inspectObjectAndValues(taskClass, task, task.getName() + ".", globalTypes, taskPropertyTypes, taskProperties, EXCLUDE_TASK_PROPERTIES, true); // NOI18N
+            startInspectObjectAndValues(taskClass, task, task.getName() + ".", globalTypes, taskPropertyTypes, taskProperties, EXCLUDE_TASK_PROPERTIES, true); // NOI18N
         }
         
         model.getInfo().put("tasks.propertyValues", taskProperties); // NOI18N
@@ -539,19 +552,53 @@ class NbProjectInfoBuilder {
      * @param propertyTypes
      * @param defaultValues 
      */
+    private void startInspectObjectAndValues(Class clazz, Object object, String prefix, Map<String, Map<String, String>> globalTypes, Map<String, String> propertyTypes, Map<String, Object> defaultValues) {
+        depth = 0;
+        inspectObjectAndValues(clazz, object, prefix, globalTypes, propertyTypes, defaultValues, null, true);
+    }
+    
+    private void startInspectObjectAndValues(Class clazz, Object object, String prefix, Map<String, Map<String, String>> globalTypes, Map<String, String> propertyTypes, Map<String, Object> defaultValues, Set<String> excludes, boolean type) {
+        depth = 0;
+        inspectObjectAndValues(clazz, object, prefix, globalTypes, propertyTypes, defaultValues, excludes, type);
+    }
+
     private void inspectObjectAndValues(Class clazz, Object object, String prefix, Map<String, Map<String, String>> globalTypes, Map<String, String> propertyTypes, Map<String, Object> defaultValues) {
         inspectObjectAndValues(clazz, object, prefix, globalTypes, propertyTypes, defaultValues, null, true);
     }
+    /**
+     * The current introspection depth
+     */
+    private int depth;
+    
+    /**
+     * If true, depth exceeded warnings will not be logged.
+     */
+    private boolean suppressDepthWarning;
     
     private void inspectObjectAndValues(Class clazz, Object object, String prefix, Map<String, Map<String, String>> globalTypes, Map<String, String> propertyTypes, Map<String, Object> defaultValues, Set<String> excludes, boolean type) {
         if (valueIdentities.put(object, Boolean.TRUE) == Boolean.TRUE) {
             return;
         }
         try {
+            if (depth++ >= MAX_INTROSPECTION_DEPTH) {
+                if (!suppressDepthWarning) {
+                    LOG.warn("Too deep structure, truncating");
+                    model.noteProblem(Report.Severity.WARNING, 
+                            String.format("Object structure too deep encountered in class %s", clazz),
+                            String.format("Object structure is too deep for the project model builder. This is unlikely to affect basic project operations. "
+                                    + "Check logs and report this issue. The path for the object: %s, current value: %s", prefix, object));
+                    suppressDepthWarning = true;
+                }
+                return;
+            } else if (depth <= INTROSPECTION_RESET_DEPTH_WARNING) {
+                suppressDepthWarning = false;
+            }
             inspectObjectAndValues0(clazz, object, prefix, globalTypes, propertyTypes, defaultValues, excludes, type);
         } catch (RuntimeException ex) {
             LOG.warn("Error during inspection of {}, value {}, prefix {}", clazz, object, prefix);
+            model.noteProblem(ex, true);
         } finally {
+            depth--;
             valueIdentities.remove(object);
         }
     }
@@ -753,7 +800,7 @@ class NbProjectInfoBuilder {
             if (v == null) {
                 defaultValues.put(prefix + "." + k, null); // NOI18N
             } else {
-                defaultValues.put(prefix + "." + k, Objects.toString(v)); // NOI18N
+                defaultValues.put(prefix + "." + k, objectToString(v)); // NOI18N
                 inspectObjectAndValues(v.getClass(), v, newPrefix, globalTypes, propertyTypes, defaultValues, null, false);
             }
         }
@@ -789,8 +836,8 @@ class NbProjectInfoBuilder {
                 Object v = m.get(k);
                 if (v == null) {
                     defaultValues.put(prefix + "." + k, null); // NOI18N
-                } else {
-                    defaultValues.put(prefix + "." + k, Objects.toString(v)); // NOI18N
+                } else if (!v.equals(value)) {
+                    defaultValues.put(prefix + "." + k, objectToString(v)); // NOI18N
                     inspectObjectAndValues(v.getClass(), v, newPrefix, globalTypes, propertyTypes, defaultValues, null, false);
                 }
             }
@@ -821,7 +868,7 @@ class NbProjectInfoBuilder {
                         String newPrefix = prefix + "[" + index + "]."; // NOI18N
                         if (o == null) {
                             defaultValues.put(prefix + "[" + index + "]", null); //NOI18N
-                        } else {
+                        } else if (!o.equals(value)) {
                             defaultValues.put(prefix + "[" + index + "]", Objects.toString(o)); //NOI18N
                             inspectObjectAndValues(o.getClass(), o, newPrefix, globalTypes, propertyTypes, defaultValues, null, false);
                         }
@@ -869,8 +916,8 @@ class NbProjectInfoBuilder {
                     Object v = mvalue.get(o);
                     if (v == null) {
                         defaultValues.put(newPrefix, null); // NOI18N
-                    } else {
-                        defaultValues.put(newPrefix, Objects.toString(v)); // NOI18N
+                    } else if (!v.equals(value)) {
+                        defaultValues.put(newPrefix, objectToString(v)); // NOI18N
                         inspectObjectAndValues(v.getClass(), v, newPrefix + ".", globalTypes, propertyTypes, defaultValues, null, itemClass == null);
                     }
                 }
@@ -878,6 +925,17 @@ class NbProjectInfoBuilder {
             }
         }
         return dumped;
+    }
+    
+    private static String objectToString(Object o) {
+        if (o instanceof Map || o instanceof Iterable) {
+            return o.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(o));
+        } 
+        try {
+            return Objects.toString(o);
+        } catch (RuntimeException ex) {
+            return o.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(o));
+        }
     }
     
     private static Class findNonDecoratedClass(Class clazz) {
@@ -930,7 +988,7 @@ class NbProjectInfoBuilder {
             
             Class c = findNonDecoratedClass(ext.getClass());
             propertyTypes.put(prefix + extName, c.getName());
-            inspectObjectAndValues(ext.getClass(), ext, prefix + extName + ".", globalTypes, propertyTypes, values);
+            startInspectObjectAndValues(ext.getClass(), ext, prefix + extName + ".", globalTypes, propertyTypes, values);
             if (ext instanceof ExtensionAware) {
                 inspectExtensions(prefix + extName + ".", ((ExtensionAware)ext).getExtensions());  // NOI18N
             }
@@ -986,7 +1044,8 @@ class NbProjectInfoBuilder {
         try {
             model.getInfo().put("buildClassPath", storeSet(project.getBuildscript().getConfigurations().getByName("classpath").getFiles()));
         } catch (RuntimeException e) {
-            model.noteProblem(e);
+            // unexpected exception, build classpath should be available.
+            model.noteProblem(e, true);
         }
         Set<String[]> tasks = new HashSet<>();
         for (org.gradle.api.Task t : project.getTasks()) {
@@ -1206,7 +1265,7 @@ class NbProjectInfoBuilder {
                     } catch(Exception e) {
                         convertOfflineException(e);
                         // will not be reached
-                        model.noteProblem(e);
+                        model.noteProblem(e, false);
                     }
                     sinceGradle("4.6", () -> {
                         try {
@@ -1214,7 +1273,7 @@ class NbProjectInfoBuilder {
                         } catch(Exception e) {
                             convertOfflineException(e);
                             // will not be reached
-                            model.noteProblem(e);
+                            model.noteProblem(e, false);
                         }
                         model.getInfo().put(propBase + "configuration_annotation", getProperty(sourceSet, "annotationProcessorConfigurationName"));
                     });
@@ -1230,6 +1289,7 @@ class NbProjectInfoBuilder {
                 }
             } else {
                 model.getInfo().put("sourcesets", Collections.emptySet());
+                // TODO: should be this converted to Problem, severity INFO ?
                 model.noteProblem("No sourceSets found on this project. This project mightbe a Model/Rule based one which is not supported at the moment.");
             }
         }
@@ -1246,12 +1306,14 @@ class NbProjectInfoBuilder {
             try {
                 model.getInfo().put("exploded_war_dir", getProperty(project, "explodedWar", "destinationDir"));
             } catch(Exception e) {
-                model.noteProblem(e);
+                // probably not an internal error, but misconfiguration, omit trace
+                model.noteProblem(e, false);
             }
             try {
                 model.getInfo().put("web_classpath", getProperty(project, "war", "classpath", "files"));
             } catch(Exception e) {
-                model.noteProblem(e);
+                // probably not an internal error, but misconfiguration, omit trace
+                model.noteProblem(e, false);
             }
         }
         Map<String, Object> archives = new HashMap<>();
@@ -1540,7 +1602,7 @@ class NbProjectInfoBuilder {
 
                     walker.walkResolutionResult(it.getIncoming().getResolutionResult().getRoot());
                 } catch (ResolveException ex) {
-                    model.noteProblem(ex);
+                    model.noteProblem(ex, false);
                 }
             } else {
                 unresolvedIds.addAll(componentIds);

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansToolingPlugin.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansToolingPlugin.java
@@ -106,7 +106,8 @@ public class NetBeansToolingPlugin implements Plugin<Project> {
                 Throwable cause = ex;
                 while ((cause != null) && (cause.getCause() != cause)) {
                     if (cause instanceof GradleException) {
-                        ret.noteProblem((GradleException) cause);
+                        // unexpected exceptions at this level
+                        ret.noteProblem((GradleException) cause, true);
                         break;
                     }
                     cause = cause.getCause();

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/internal/NbProjectInfo.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/internal/NbProjectInfo.java
@@ -53,10 +53,19 @@ public interface NbProjectInfo extends Model, org.gradle.tooling.model.Model {
      * @since 2.23
      */
     interface Report {
+        /**
+         * Severity of the report.
+         */
+        enum Severity {
+            EXCEPTION, ERROR, WARNING, INFO
+        }
+        
+        public Severity getSeverity();
         public String getErrorClass();
         public String getScriptLocation();
         public int getLineNumber();
         public String getMessage();
+        public String getDetail();
         public Report getCause();
     }
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProject.java
@@ -135,11 +135,12 @@ public final class GradleProject implements Serializable, Lookup.Provider {
         NbGradleProjectImpl.ACCESSOR.setProblems(baseProject, problems);
     }
 
-    public static GradleReport createGradleReport(String errorClass, String location, int line, String message, GradleReport causedBy) {
-        return NbGradleProjectImpl.ACCESSOR.createReport(errorClass, location, line, message, causedBy);
+    public static GradleReport createGradleReport(GradleReport.Severity severity, String errorClass, String location, int line, String message, 
+            GradleReport causedBy, String... traceLines) {
+        return NbGradleProjectImpl.ACCESSOR.createReport(severity, errorClass, location, line, message, causedBy, traceLines);
     }
 
-    public static GradleReport createGradleReport(Path script, String message) {
-        return createGradleReport(null, Objects.toString(script), -1, message, null);
+    public static GradleReport createGradleReport(Path script, String message, String... detail) {
+        return createGradleReport(GradleReport.Severity.ERROR, null, Objects.toString(script), -1, message, null, detail);
     }
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -134,7 +134,8 @@ public final class NbGradleProjectImpl implements Project {
 
         public abstract void passivate(NbGradleProject watcher);
 
-        public abstract GradleReport createReport(String errorClass, String location, int line, String message, GradleReport causedBy);
+        public abstract GradleReport createReport(GradleReport.Severity severity, String errorClass, String location, int line, String message, 
+                GradleReport causedBy, String[] traceLines);
 
         public abstract void setProblems(GradleBaseProject baseProject, Set<GradleReport> problems);
     }

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/NbGradleProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/NbGradleProject.java
@@ -184,8 +184,9 @@ public final class NbGradleProject {
         }
 
         @Override
-        public GradleReport createReport(String errorClass, String location, int line, String message, GradleReport causedBy) {
-            return new GradleReport(errorClass, location, line, message, causedBy);
+        public GradleReport createReport(GradleReport.Severity severity, String errorClass, String location, int line, String message, 
+                GradleReport causedBy, String[] traceLines) {
+            return new GradleReport(severity, errorClass, location, line, message, causedBy, traceLines);
         }
 
         @Override

--- a/extide/gradle/test/unit/data/projects/spotbugs/.gitignore
+++ b/extide/gradle/test/unit/data/projects/spotbugs/.gitignore
@@ -1,0 +1,2 @@
+/.gradle
+/build/*

--- a/extide/gradle/test/unit/data/projects/spotbugs/build.gradle
+++ b/extide/gradle/test/unit/data/projects/spotbugs/build.gradle
@@ -1,0 +1,46 @@
+plugins {
+    id("com.github.spotbugs") version "6.0.0-beta.4"
+    id("application")
+    id("java")
+}
+
+description = "Test for a bug"
+group = "com.example"
+version = "1.0.0-2023.10.12"
+
+def artifactName = "testforbug"
+def moduleName = "com.example.gradlespotbugs"
+
+def versionAsm      = "9.5"
+def versionJcip     = "1.0-1"
+def versionSpotBugs = "4.7.3"
+def versionSlf4j    = "2.0.9"
+
+dependencies {
+    // SpotBugs + plugins
+    spotbugs(group: "com.github.spotbugs", name: "spotbugs", version: versionSpotBugs)
+    spotbugs(group: "org.slf4j", name: "slf4j-api", version: versionSlf4j)
+    spotbugs(group: "org.slf4j", name: "slf4j-simple", version: versionSlf4j)
+    spotbugs(group: "org.ow2.asm", name: "asm", version: versionAsm)
+    compileOnly(group: "com.github.spotbugs", name: "spotbugs-annotations", version: versionSpotBugs)
+    compileOnly(group: "com.github.stephenc.jcip", name: "jcip-annotations", version: versionJcip)
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+application {
+    mainClass = "com.example.gradlespotbugs.Hello"
+}
+
+var recursiveObject = new HashMap();
+var intermediateMap = new HashMap();
+
+recursiveObject.put("key1", recursiveObject);
+recursiveObject.put("key2", intermediateMap);
+intermediateMap.put("key3", recursiveObject);
+
+project.ext.set("recursiveProperty", recursiveObject);
+

--- a/extide/gradle/test/unit/data/projects/spotbugs/settings.gradle
+++ b/extide/gradle/test/unit/data/projects/spotbugs/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "Hello World"

--- a/extide/gradle/test/unit/data/projects/spotbugs/src/main/java/com/example/gradlespotbugs/Hello.java
+++ b/extide/gradle/test/unit/data/projects/spotbugs/src/main/java/com/example/gradlespotbugs/Hello.java
@@ -1,0 +1,7 @@
+package com.example.gradlespotbugs;
+
+public class Hello {
+    public static void main(String[] args) {
+        System.out.println("Hello World");
+    }
+}

--- a/extide/gradle/test/unit/data/projects/spotbugs/src/main/java/com/example/gradlespotbugs/package-info.java
+++ b/extide/gradle/test/unit/data/projects/spotbugs/src/main/java/com/example/gradlespotbugs/package-info.java
@@ -1,0 +1,1 @@
+package com.example.gradlespotbugs;

--- a/extide/gradle/test/unit/data/projects/spotbugs/src/main/java/module-info.java
+++ b/extide/gradle/test/unit/data/projects/spotbugs/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+@SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
+module com.example.gradlespotbugs {
+    requires transitive static com.github.spotbugs.annotations;
+}


### PR DESCRIPTION
Prevents infinite recursion through structures in project model, should fix #6674 and #4779. This is done by:
- in dump of container (iterable, map, named container) avoids to dump a value **equal** to the container itself. This avoids simple recursions, such as with Path reported in #6674
- limits deph of structure traversal
- wraps `toString()` calls in try-catch, so potential error (incl. stack overflow) does not abort and just dumps an object placeholder.

The other part delivers more error details to NB. Fo unexpected exceptions, stack traces are provided in the `detail` Report field. Reports are marked with `severity` so now the loader can declare unexpected (exception) fatal (error), nonfatal (warning) and info messaes.

Unexpected exceptions are presented in project problems with their (truncated to 100 lines) stacktraces. Build system exceptions (i.e. unresolved artifact) should not present stacktraces, but full details from the nested exceptions.

Just error and exception levels pop up project problems window and notifications. Stacktraces are received by NB and can be optionally logged (with appropriate loglevel) - useful for user diagnostic.

I have added a test that a project with Spotbugs plugin loads OK + checks to verify recursive structure avoidance.
