### PR TITLE
Adds null check before calling nullable repository variable method to avoid NPE #6682

### DIFF
--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/ClassPathProviderImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/ClassPathProviderImpl.java
@@ -203,7 +203,7 @@ public class ClassPathProviderImpl implements ClassPathProvider {
     @Override
     public ClassPath findClassPath(FileObject file, String type) {
         if (sourceCP.findOwnerRoot(file) != null) {
-            if (!repository.isAnyProjectOpened()) {
+            if (repository != null && !repository.isAnyProjectOpened()) {
                 //if no project is open, java.base may not be indexed. Fallback on default queries:
                 return null;
             }


### PR DESCRIPTION
Fixes apache/netbeans#6682.  The repository value that is passed to the `ClassPathProviderImpl` constructor is null when the file that triggered `ClassPathProviderImpl::findClassPath` is a Java source file in a JDK repo directory structure.