### PR TITLE
Updated test results window

### DIFF
--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultPanelTree.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultPanelTree.java
@@ -72,7 +72,7 @@ final class ResultPanelTree extends JPanel implements ExplorerManager.Provider, 
     private final ResultDisplayHandler displayHandler;
 
     private final ResultBar resultBar = new ResultBar();
-    private StatisticsPanel statPanel;
+    private final StatisticsPanel statPanel;
 
     ResultPanelTree(ResultDisplayHandler displayHandler, StatisticsPanel statPanel) {
         super(new BorderLayout());
@@ -248,6 +248,7 @@ final class ResultPanelTree extends JPanel implements ExplorerManager.Provider, 
 
     /**
      */
+    @Override
     public void propertyChange(PropertyChangeEvent e) {
         if (ExplorerManager.PROP_SELECTED_NODES.equals(
                         e.getPropertyName())) {
@@ -339,7 +340,7 @@ final class ResultPanelTree extends JPanel implements ExplorerManager.Provider, 
     }
 
     private List<TestMethodNode> getFailedTestMethodNodes() {
-        List<TestMethodNode> result = new ArrayList<TestMethodNode>();
+        List<TestMethodNode> result = new ArrayList<>();
         for (Node each : explorerManager.getRootContext().getChildren().getNodes()) {
             if (each instanceof TestsuiteNode) {
                 TestsuiteNode suite = (TestsuiteNode) each;
@@ -362,8 +363,8 @@ final class ResultPanelTree extends JPanel implements ExplorerManager.Provider, 
     }
 
     private List<TestsuiteNode> getFailedSuiteNodes(TestsuiteNode selected) {
-        List<TestsuiteNode> before = new ArrayList<TestsuiteNode>();
-        List<TestsuiteNode> after = new ArrayList<TestsuiteNode>();
+        List<TestsuiteNode> before = new ArrayList<>();
+        List<TestsuiteNode> after = new ArrayList<>();
         boolean selectedEncountered = false;
         for (Node each : explorerManager.getRootContext().getChildren().getNodes()) {
             if (each instanceof TestsuiteNode) {
@@ -511,6 +512,7 @@ final class ResultPanelTree extends JPanel implements ExplorerManager.Provider, 
     }
     /**
      */
+    @Override
     public ExplorerManager getExplorerManager() {
         return explorerManager;
     }

--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultTreeView.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultTreeView.java
@@ -68,6 +68,7 @@ final class ResultTreeView extends BeanTreeView implements Runnable {
      */
     private final class DelegatingTreeCellRenderer implements TreeCellRenderer {
 
+        @Override
         public Component getTreeCellRendererComponent(JTree tree,
                                                       Object value,
                                                       boolean selected,
@@ -126,6 +127,7 @@ final class ResultTreeView extends BeanTreeView implements Runnable {
     
     /**
      */
+    @Override
     public void run() {
         tree.setScrollsOnExpand(true);
     }

--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/StatisticsPanel.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/StatisticsPanel.java
@@ -21,8 +21,6 @@ package org.netbeans.modules.gsf.testrunner.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.util.List;
@@ -34,8 +32,6 @@ import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
 import javax.swing.SwingConstants;
 import javax.swing.UIManager;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 import org.netbeans.modules.gsf.testrunner.ui.api.Manager;
 import org.netbeans.modules.gsf.testrunner.api.Report;
 import org.netbeans.modules.gsf.testrunner.api.RerunHandler;
@@ -184,23 +180,20 @@ public final class StatisticsPanel extends JPanel {
 	newButton.getAccessibleContext().setAccessibleName(accessibleName);
 	boolean isSelected = NbPreferences.forModule(StatisticsPanel.class).getBoolean(property, false);
 	newButton.setSelected(isSelected);
-	newButton.addItemListener(new ItemListener() {
-	    @Override
-	    public void itemStateChanged(ItemEvent e) {
-		boolean selected;
-		switch (e.getStateChange()) {
-		    case ItemEvent.SELECTED:
-			selected = true;
-			break;
-		    case ItemEvent.DESELECTED:
-			selected = false;
-			break;
-		    default:
-			return;
-		}
-		ResultWindow.getInstance().updateOptionStatus(property, selected);
-	    }
-	});
+	newButton.addItemListener((ItemEvent e) -> {
+            boolean selected;
+            switch (e.getStateChange()) {
+                case ItemEvent.SELECTED:
+                    selected = true;
+                    break;
+                case ItemEvent.DESELECTED:
+                    selected = false;
+                    break;
+                default:
+                    return;
+            }
+            ResultWindow.getInstance().updateOptionStatus(property, selected);
+        });
 	return newButton;
     }
 
@@ -229,24 +222,9 @@ public final class StatisticsPanel extends JPanel {
 
         final RerunHandler rerunHandler = displayHandler.getSession().getRerunHandler();
         if (rerunHandler != null) {
-            rerunButton.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    rerunHandler.rerun();
-                }
-            });
-            rerunFailedButton.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    rerunHandler.rerun(treePanel.getFailedTests());
-                }
-            });
-            rerunHandler.addChangeListener(new ChangeListener() {
-                @Override
-                public void stateChanged(ChangeEvent e) {
-                    updateButtons();
-                }
-            });
+            rerunButton.addActionListener(e -> rerunHandler.rerun());
+            rerunFailedButton.addActionListener(e -> rerunHandler.rerun(treePanel.getFailedTests()));
+            rerunHandler.addChangeListener(e -> updateButtons());
             updateButtons();
         }
     }
@@ -356,24 +334,11 @@ public final class StatisticsPanel extends JPanel {
     private void createNextPrevFailureButtons() {
         nextFailure = new JButton(ImageUtilities.loadImageIcon("org/netbeans/modules/gsf/testrunner/resources/nextmatch.png", true));
         nextFailure.setToolTipText(Bundle.MSG_NextFailure());
-        nextFailure.addActionListener(new ActionListener() {
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                selectNextFailure();
-            }
-        });
+        nextFailure.addActionListener(e -> selectNextFailure());
 
         previousFailure = new JButton(ImageUtilities.loadImageIcon("org/netbeans/modules/gsf/testrunner/resources/prevmatch.png", true));
-
         previousFailure.setToolTipText(Bundle.MSG_PreviousFailure());
-        previousFailure.addActionListener(new ActionListener() {
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                selectPreviousFailure();
-            }
-        });
+        previousFailure.addActionListener(e -> selectPreviousFailure());
     }
 
     void selectPreviousFailure() {

--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestRunnerSettings.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestRunnerSettings.java
@@ -33,7 +33,7 @@ public final class TestRunnerSettings {
     private static final String RESULTS_SPLITPANE_DIVIDER_HORIZONTAL = "resultsSplitDividerHorizontal"; //NOI18N
     private static final String RESULTS_SPLITPANE_ORIENTATION = "resultsSplitOrientation"; //NOI18N
     private static final int DEFAULT_DIVIDER_LOCATION_VERTICAL = 120;
-    private static final int DEFAULT_DIVIDER_LOCATION_HORIZONTAL = 300;
+    private static final int DEFAULT_DIVIDER_LOCATION_HORIZONTAL = 500;
     private static final int DEFAULT_DIVIDER_ORIENTATION = JSplitPane.HORIZONTAL_SPLIT;
 
     private static final TestRunnerSettings INSTANCE = new TestRunnerSettings();

--- a/java/junit.ui/src/org/netbeans/modules/junit/ui/api/JUnitCallstackFrameNode.java
+++ b/java/junit.ui/src/org/netbeans/modules/junit/ui/api/JUnitCallstackFrameNode.java
@@ -19,10 +19,10 @@
 
 package org.netbeans.modules.junit.ui.api;
 
+import java.awt.Color;
 import org.netbeans.modules.java.testrunner.ui.api.JumpAction;
-import java.util.ArrayList;
-import java.util.List;
 import javax.swing.Action;
+import javax.swing.UIManager;
 import org.netbeans.modules.gsf.testrunner.ui.api.CallstackFrameNode;
 
 /**
@@ -41,12 +41,40 @@ public class JUnitCallstackFrameNode extends CallstackFrameNode{
 
     @Override
     public Action[] getActions(boolean context) {
-        List<Action> actions = new ArrayList<Action>();
         Action preferred = getPreferredAction();
-        if (preferred != null){
-            actions.add(preferred);
+        if (preferred != null) {
+            return new Action[] { preferred };
         }
-        return actions.toArray(new Action[actions.size()]);
+        return new Action[0];
+    }
+
+    @Override
+    public String getDisplayName() {
+        String line = super.getDisplayName();
+        String trimmed = line.trim();
+        if (trimmed.startsWith("at ") && line.endsWith(")")) {
+            return isRelevant(trimmed) ?
+                    "<html>    <a href=\"\">"+line+"</a></html>" 
+                  : "<html>    <font color="+hiddenColor()+">"+line+"</font></html>";
+        }
+        return line;
+    }
+
+    private static String hiddenColor() {
+        // note: the tree adjusts the color automatically if the contrast is too low
+        // which would have the opposite effect of what we are trying to achieve here
+        float a = 0.6f;
+        Color f = UIManager.getColor("Tree.foreground");
+        Color b = UIManager.getColor("Tree.background");
+        return String.format("#%02x%02x%02x", 
+                (int)(b.getRed()   + a * (f.getRed()   - b.getRed())),
+                (int)(b.getGreen() + a * (f.getGreen() - b.getGreen())),
+                (int)(b.getBlue()  + a * (f.getBlue()  - b.getBlue())));
+    }
+
+    private boolean isRelevant(String stackFrame) {
+        return !stackFrame.startsWith("at org.junit.Ass")
+            && !stackFrame.startsWith("at org.junit.jupiter.api.Ass");
     }
 
     @Override

--- a/java/junit.ui/src/org/netbeans/modules/junit/ui/api/JUnitTestMethodNode.java
+++ b/java/junit.ui/src/org/netbeans/modules/junit/ui/api/JUnitTestMethodNode.java
@@ -52,6 +52,7 @@ public class JUnitTestMethodNode extends TestMethodNode {
         return new JumpAction(this, null, projectType, testingFramework);
     }
 
+    @Override
     public JUnitTestcase getTestcase() {
         return (JUnitTestcase) testcase;
     }

--- a/java/junit.ui/src/org/netbeans/modules/junit/ui/wizards/JavaChildren.java
+++ b/java/junit.ui/src/org/netbeans/modules/junit/ui/wizards/JavaChildren.java
@@ -20,7 +20,6 @@
 package org.netbeans.modules.junit.ui.wizards;
 
 import org.openide.filesystems.FileObject;
-import org.openide.loaders.DataObject;
 import org.openide.nodes.Children;
 import org.openide.nodes.FilterNode;
 import org.openide.nodes.Node;


### PR DESCRIPTION
 - flat look without gradients + new in-progress animation
 - visual indication that the stacktrace links are clickable
 - uninteresting stack frames (e.g from the junit testing framwork) are grayed out and not underscored
 - increased initial width of tree component via splitter location
 - added BUILD SUCCESS output line coloring, analog to failure msg
 - minor language level code cleanup in the touched files

![test-results-update](https://github.com/apache/netbeans/assets/114367/a51f4c32-b2b9-4176-8124-ab775a098b4d)
![test-results-update-2](https://github.com/apache/netbeans/assets/114367/47abe3c1-9905-4896-9604-30f2368d60d3)



todo: 
 - ~ot tested with screen scaling enabled~ 2x scaling looks fine, that is the only scaling which works on my screen resolution.
 - ~only tested with junit/java, i think the UI is used with other languages too~