### PR TITLE
Add missing git create-branch and switch-branch toolbar icons.

### DIFF
--- a/ide/git/src/org/netbeans/modules/git/ui/branch/CreateBranchAction.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/branch/CreateBranchAction.java
@@ -50,6 +50,16 @@ import org.openide.util.actions.SystemAction;
 public class CreateBranchAction extends SingleRepositoryAction {
 
     private static final Logger LOG = Logger.getLogger(CreateBranchAction.class.getName());
+    private static final String ICON_RESOURCE = "org/netbeans/modules/git/resources/icons/branch.png"; //NOI18N
+
+    public CreateBranchAction() {
+        super(ICON_RESOURCE);
+    }
+
+    @Override
+    protected String iconResource() {
+        return ICON_RESOURCE;
+    }
 
     @Override
     protected void performAction (File repository, File[] roots, VCSContext context) {

--- a/ide/git/src/org/netbeans/modules/git/ui/checkout/SwitchBranchAction.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/checkout/SwitchBranchAction.java
@@ -47,6 +47,17 @@ import org.openide.util.actions.SystemAction;
 @ActionRegistration(displayName = "#LBL_SwitchBranchAction_Name")
 public class SwitchBranchAction extends AbstractCheckoutAction {
 
+    private static final String ICON_RESOURCE = "org/netbeans/modules/git/resources/icons/active_branch.png"; //NOI18N
+
+    public SwitchBranchAction() {
+        super(ICON_RESOURCE);
+    }
+
+    @Override
+    protected String iconResource() {
+        return ICON_RESOURCE;
+    }
+
     @Override
     protected void performAction (File repository, File[] roots, VCSContext context) {
         RepositoryInfo info = RepositoryInfo.getInstance(repository);


### PR DESCRIPTION
 - only the two actions didn't have icons on the git toolbar
 - this makes the actions also available in the toolbar customization window

note: toolbar is off by default, can be switched on via right click menu

impl mirrors [commit action](https://github.com/apache/netbeans/blob/73237de9420b5847640cae2bc5fff940d7d5b346/ide/git/src/org/netbeans/modules/git/ui/commit/CommitAction.java#L99-L108)

![git-branch-icons](https://github.com/apache/netbeans/assets/114367/a81f7910-6a7e-429a-bcde-699770189e57)
![customize-toolbar-git-actions](https://github.com/apache/netbeans/assets/114367/4adbb6cf-c126-4959-a059-866d658ece51)
