### PR TITLE
GIT: Removed unnecessary separators from the git toolbar

### DIFF
--- a/ide/git/src/org/netbeans/modules/git/git-layer.xml
+++ b/ide/git/src/org/netbeans/modules/git/git-layer.xml
@@ -72,10 +72,6 @@
                 <attr name="originalFile" stringvalue="Actions/Git/org-netbeans-modules-git-ui-diff-DiffAction.instance"/>
                 <attr name="position" intvalue="500"/>
             </file>
-            <file name="sep1.instance">
-                <attr name="instanceCreate" newvalue="javax.swing.JSeparator"/>
-                <attr intvalue="510" name="position"/>
-            </file>
             <file name="org-netbeans-modules-git-ui-branch-CreateBranchAction.shadow">
                 <attr name="originalFile" stringvalue="Actions/Git/org-netbeans-modules-git-ui-branch-CreateBranchAction.instance"/>
                 <attr name="position" intvalue="520"/>
@@ -83,10 +79,6 @@
             <file name="org-netbeans-modules-git-ui-checkout-SwitchBranchAction.instance.shadow">
                 <attr name="originalFile" stringvalue="Actions/Git/org-netbeans-modules-git-ui-checkout-SwitchBranchAction.instance"/>
                 <attr name="position" intvalue="525"/>
-            </file>
-            <file name="sep2.instance">
-                <attr name="instanceCreate" newvalue="javax.swing.JSeparator"/>
-                <attr intvalue="550" name="position"/>
             </file>
             <file name="org-netbeans-modules-git-ui-fetch-PullFromUpstreamAction.instance.shadow">
                   <attr name="originalFile" stringvalue="Actions/Git/org-netbeans-modules-git-ui-fetch-PullFromUpstreamAction.instance"/>


### PR DESCRIPTION
There are separators on the git toolbar that only show up in the `metal` theme, and they display oddly.
This PR removes these separators.

Toolbar in `metal` theme:
before:
![metal_before](https://github.com/apache/netbeans/assets/9607501/686e7f5f-c37e-4f5f-b126-3bee37652a19)
after:
![metal_after](https://github.com/apache/netbeans/assets/9607501/2944916a-c343-45a8-8f0a-8804d58ed946)

Toolbar in `nimbus` theme:
before:
![nimbus_before](https://github.com/apache/netbeans/assets/9607501/5d7cbf4f-e5d7-4954-a334-8dd5ffdfaf2f)
after:
![nimbus_after](https://github.com/apache/netbeans/assets/9607501/46c1f0e0-5ebe-4996-8286-8ce495209f97)

Toolbar in `motif` theme:
before:
![motif_before](https://github.com/apache/netbeans/assets/9607501/9df73036-2782-45cb-8bfa-8d749f7251e6)
after:
![motif_after](https://github.com/apache/netbeans/assets/9607501/06110a8c-dd5e-451d-ac6f-841f76a7e008)



Toolbar in `gtk` theme:
before:
![gtk_before](https://github.com/apache/netbeans/assets/9607501/59e66d27-58b8-4a0c-8655-5486e2b4da14)
after:
![gtk_after](https://github.com/apache/netbeans/assets/9607501/727cdb00-b5a3-4f8b-8bb7-23fc8f25b145)


Toolbar in `flatlaf` theme:
before:
![flatlaf_before](https://github.com/apache/netbeans/assets/9607501/1f9cfb86-a6ca-42f5-bfe2-943837988900)
after:
![flatlaf_after](https://github.com/apache/netbeans/assets/9607501/2775742b-3cab-400b-9732-bb3c5d5914d0)
