### PR TITLE
CI: limit push trigger to primary branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,18 @@ name: NetBeans
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'delivery'
+      - 'release*'
+
   pull_request:
     # unlocked event is used as super secret restart button
     types: [opened, synchronize, unlocked]
+
+  # Allows you to run this workflow manually from the Actions tab in GitHub UI
+  # keep in mind this will have ALL tests enabled
+  workflow_dispatch:
 
 # cancel other PR workflow run in the same head-base group if it exists (e.g. during PR syncs)
 # if this is not a PR run (no github.head_ref and github.base_ref defined), use an UID as group

--- a/.github/workflows/native-binary-build-dlight.nativeexecution.yml
+++ b/.github/workflows/native-binary-build-dlight.nativeexecution.yml
@@ -42,9 +42,13 @@ name: NetBeans Native Execution Libraries
 
 
 on:
-  # Triggers the workflow on push or pull request events but only for
-  # relevant paths
   push:
+    branches:
+      - 'master'
+      - 'delivery'
+      - 'release*'
+    # Triggers the workflow on push or pull request events but only for
+    # relevant paths
     paths:
       - .github/workflows/native-binary-build-dlight.nativeexecution.y*
       - ide/dlight.nativeexecution/**

--- a/.github/workflows/native-binary-build-lib.profiler.yml
+++ b/.github/workflows/native-binary-build-lib.profiler.yml
@@ -51,9 +51,13 @@ name: NetBeans Profiler Libraries
 
 
 on:
-  # Triggers the workflow on push or pull request events but only for
-  # relevant paths
   push:
+    branches:
+      - 'master'
+      - 'delivery'
+      - 'release*'
+    # Triggers the workflow on push or pull request events but only for
+    # relevant paths
     paths:
       - .github/workflows/native-binary-build-lib.profiler.y*
       - profiler/lib.profiler/**


### PR DESCRIPTION
Limits automated CI to `master`, `delivery` and `release*` branches

context:
CI is running currently 10h+ in tests on push to any branch of the netbeans repo. This was intended for trunk branches like `master` or `delivery`, but falls apart as soon someone uses a feature branch since it would test everything multiple times additional to the PR triggered tests.

The second problem is cache size, since every root branch has a ~800mb footprint. During times with many concurrent dependency update PRs which write to the cache we can run out of cache.