### PR TITLE
Handle brackets other than string correctly when "]" is typed #6706

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/typinghooks/PhpTypedTextInterceptor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/typinghooks/PhpTypedTextInterceptor.java
@@ -539,13 +539,16 @@ public class PhpTypedTextInterceptor implements TypedTextInterceptor {
             }
             token = ts.token();
             while (token != null) {
-                if ((LexUtilities.textEquals(token.text(), '(')) || (LexUtilities.textEquals(token.text(), '['))) {
-                    if (LexUtilities.textEquals(token.text(), leftBracket)) {
-                        bracketBalanceWithNewBracket++;
-                    }
-                } else if ((LexUtilities.textEquals(token.text(), ')')) || (LexUtilities.textEquals(token.text(), ']'))) {
-                    if (LexUtilities.textEquals(token.text(), bracket)) {
-                        bracketBalanceWithNewBracket--;
+                // GH-6706 we can get "[" as PHP_ENCAPSED_AND_WHITESPACE token e.g. $x = "[$y example]"
+                if (token.id() == PHPTokenId.PHP_TOKEN) {
+                    if ((LexUtilities.textEquals(token.text(), '(')) || (LexUtilities.textEquals(token.text(), '['))) {
+                        if (LexUtilities.textEquals(token.text(), leftBracket)) {
+                            bracketBalanceWithNewBracket++;
+                        }
+                    } else if ((LexUtilities.textEquals(token.text(), ')')) || (LexUtilities.textEquals(token.text(), ']'))) {
+                        if (LexUtilities.textEquals(token.text(), bracket)) {
+                            bracketBalanceWithNewBracket--;
+                        }
                     }
                 }
                 if (!ts.moveNext()) {
@@ -553,11 +556,7 @@ public class PhpTypedTextInterceptor implements TypedTextInterceptor {
                 }
                 token = ts.token();
             }
-            if (bracketBalanceWithNewBracket == 0) {
-                skipClosingBracket = false;
-            } else {
-                skipClosingBracket = true;
-            }
+            skipClosingBracket = bracketBalanceWithNewBracket != 0;
         }
 
         return skipClosingBracket;

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/typinghooks/PhpTypedTextInterceptorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/typinghooks/PhpTypedTextInterceptorTest.java
@@ -698,6 +698,36 @@ public class PhpTypedTextInterceptorTest extends PhpTypinghooksTestBase {
         insertChar(original, ' ', expected);
     }
 
+    public void testIssueGH6706_01() throws Exception {
+        String original = ""
+                + "$test = \"[$variable test]\";\n"
+                + "$array['key'^];";
+        String expected = ""
+                + "$test = \"[$variable test]\";\n"
+                + "$array['key']^;";
+        insertChar(original, ']', expected);
+    }
+
+    public void testIssueGH6706_02() throws Exception {
+        String original = ""
+                + "$test = \"[test $variable]\";\n"
+                + "$array['key'^];";
+        String expected = ""
+                + "$test = \"[test $variable]\";\n"
+                + "$array['key']^;";
+        insertChar(original, ']', expected);
+    }
+
+    public void testIssueGH6706_03() throws Exception {
+        String original = ""
+                + "$test = \"[$variable]\";\n"
+                + "$array['key'^];";
+        String expected = ""
+                + "$test = \"[$variable]\";\n"
+                + "$array['key']^;";
+        insertChar(original, ']', expected);
+    }
+
 //    Uncomment when CslTestBase.insertChar() will support ambiguous selection strings
 //
 //    public void testIssue242358() throws Exception {


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/6706
- We can get "[" as PHP_ENCAPSED_AND_WHITESPACE token e.g. `$x = "[$y example]";`
- So, check also token ids
- Add unit tests
