### PR TITLE
Remove usages of the -Xdebug option.

### DIFF
--- a/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/project/resources/action-mapping.xml
+++ b/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/project/resources/action-mapping.xml
@@ -66,7 +66,7 @@
             <goal>payara-micro:start</goal>
         </goals>
         <properties>
-            <exec.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address}</exec.args>
+            <exec.args>-Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address}</exec.args>
             <jpda.listen>true</jpda.listen>
             <netbeans.deploy.debugmode>true</netbeans.deploy.debugmode>
             <netbeans.deploy>false</netbeans.deploy>
@@ -85,7 +85,7 @@
             <goal>payara-micro:start</goal>
         </goals>
         <properties>
-            <exec.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address}</exec.args>
+            <exec.args>-Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address}</exec.args>
             <jpda.listen>true</jpda.listen>
             <netbeans.deploy.clientUrlPart>${webpagePath}</netbeans.deploy.clientUrlPart>
             <netbeans.deploy.debugmode>true</netbeans.deploy.debugmode>

--- a/java/java.lsp.server/vscode/src/nbcode.ts
+++ b/java/java.lsp.server/vscode/src/nbcode.ts
@@ -76,7 +76,7 @@ export function launch(
     ideArgs.push(...extraArgs);
     
     if (env['netbeans_debug'] && extraArgs && extraArgs.find(s => s.includes("--list"))) {
-        ideArgs.push(...['-J-Xdebug', '-J-Dnetbeans.logger.console=true', '-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000']);
+        ideArgs.push(...['-J-Dnetbeans.logger.console=true', '-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000']);
     }
 
     console.log(`Launching NBLS with arguments: ` + ideArgs);


### PR DESCRIPTION
 - Option is a no-op since Java 8 and deprecated for removal, see https://bugs.openjdk.org/browse/JDK-8312151.
 - I didn't touch build-impl.xml files or any code which scans jvm flags for its occurrence, see https://github.com/search?q=repo%3Aapache%2Fnetbeans+%22-Xdebug%22&type=code