### PR TITLE
Fix the formatting for a method invocation with a ternary or null-coalescing operator #5380

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
@@ -3133,6 +3133,17 @@ public class FormatVisitor extends DefaultVisitor {
             removedWS = formatTokens.remove(formatTokens.size() - 1);
             index--;
             lastToken = formatTokens.get(index);
+        } else if (lastToken.getId() == FormatToken.Kind.INDENT) {
+            // GH-5380 there are whitespaces before ")" in the method invocation with ternary or null-coalescing operator
+            // e.g. var_dump($a ? 1 : 2  ); var_dump($a ?? null    );
+            if (index - 1 > 0) {
+                FormatToken possibleWSToken = formatTokens.get(index -1);
+                if (possibleWSToken.isWhitespace()) {
+                    removedWS = formatTokens.remove(index - 1);
+                    index -= 2;
+                    lastToken = formatTokens.get(index);
+                }
+            }
         }
 
         if (lastToken.getId() == FormatToken.Kind.WHITESPACE_AFTER_COMMA) {

--- a/php/php.editor/test/unit/data/testfiles/formatting/broken/issue197074_04.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/broken/issue197074_04.php.formatted
@@ -72,10 +72,10 @@ if ($request->isMethod('post') && $form->bindAndValid($request)) {
 
     $module_action = $this->getPage()->getModuleAction();
     if ($module_action == 'main/editCompanyAddress')
-        $
-            this->redirect ($this->getHelper()->link('main/editMyCompany')->getHref());
+        $t
+            his->redirect ($this->getHelper()->link('main/editMyCompany')->getHref());
 
 }
-$this->forms['CompanyAddresses '] = $form;
+$this->forms['CompanyAddresses  '] = $form;
 
 }

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/gh5380_01.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/gh5380_01.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var_dump(   $test   );
+var_dump(     $test ? 1 : 2     );
+var_dump(     $test ?? null     );

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/gh5380_01.php.testGH5380_01a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/gh5380_01.php.testGH5380_01a.formatted
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var_dump($test);
+var_dump($test ? 1 : 2);
+var_dump($test ?? null);

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/gh5380_01.php.testGH5380_01b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/gh5380_01.php.testGH5380_01b.formatted
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var_dump( $test );
+var_dump( $test ? 1 : 2 );
+var_dump( $test ?? null );

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/gh5380_02.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/gh5380_02.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var_dump($test);
+var_dump($test ? 1 : 2);
+var_dump($test ?? null);

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/gh5380_02.php.testGH5380_02a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/gh5380_02.php.testGH5380_02a.formatted
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var_dump($test);
+var_dump($test ? 1 : 2);
+var_dump($test ?? null);

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/gh5380_02.php.testGH5380_02b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/gh5380_02.php.testGH5380_02b.formatted
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var_dump( $test );
+var_dump( $test ? 1 : 2 );
+var_dump( $test ?? null );

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterSpacesTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterSpacesTest.java
@@ -1705,4 +1705,27 @@ public class PHPFormatterSpacesTest extends PHPFormatterTestBase {
         reformatFileContents("testfiles/formatting/spaces/php81/spaceWithinMethodCallParensWithFirstClassCallable_02b.php", options);
     }
 
+    public void testGH5380_01a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.SPACE_WITHIN_METHOD_CALL_PARENS, false);
+        reformatFileContents("testfiles/formatting/spaces/gh5380_01.php", options,  false, true);
+    }
+
+    public void testGH5380_01b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.SPACE_WITHIN_METHOD_CALL_PARENS, true);
+        reformatFileContents("testfiles/formatting/spaces/gh5380_01.php", options,  false, true);
+    }
+
+    public void testGH5380_02a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.SPACE_WITHIN_METHOD_CALL_PARENS, false);
+        reformatFileContents("testfiles/formatting/spaces/gh5380_02.php", options,  false, true);
+    }
+
+    public void testGH5380_02b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.SPACE_WITHIN_METHOD_CALL_PARENS, true);
+        reformatFileContents("testfiles/formatting/spaces/gh5380_02.php", options,  false, true);
+    }
 }


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/5380
- Add whitespaces after `UNBREAKABLE_SEQUENCE_END` token
- Check whether there is a whitespace token before an indent token
- Add unit tests