### PR TITLE
Attempt to fix navigator popup menu race.

### DIFF
--- a/java/java.navigation/src/org/netbeans/modules/java/navigation/ClassMemberPanelUI.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/navigation/ClassMemberPanelUI.java
@@ -785,21 +785,18 @@ public class ClassMemberPanelUI extends javax.swing.JPanel
     @Override
     public void propertyChange(final PropertyChangeEvent evt) {
         if (ExplorerManager.PROP_SELECTED_NODES.equals(evt.getPropertyName())) {
+            final Node[] oldNodes = (Node[]) evt.getOldValue();
+            final Node[] newNodes = (Node[]) evt.getNewValue();
+            for (Node n : oldNodes) {
+                selectedNodes.remove(n);
+            }
+            for (Node n : newNodes) {
+                selectedNodes.add(n);
+            }
             final boolean javadocDone = ignoreJavaDoc.get() == Boolean.TRUE;
-            RP.execute(new Runnable() {
-                @Override
-                public void run() {
-                    final Node[] oldNodes = (Node[]) evt.getOldValue();
-                    final Node[] newNodes = (Node[]) evt.getNewValue();
-                    for (Node n : oldNodes) {
-                        selectedNodes.remove(n);
-                    }
-                    for (Node n : newNodes) {
-                        selectedNodes.add(n);
-                    }
-                    if (newNodes.length > 0 && !javadocDone && JavadocTopComponent.shouldUpdate()) {
-                        scheduleJavadocRefresh(JDOC_TIME);
-                    }
+            RP.execute(() -> {
+                if (newNodes.length > 0 && !javadocDone && JavadocTopComponent.shouldUpdate()) {
+                    scheduleJavadocRefresh(JDOC_TIME);
                 }
             });
         } else if (TapPanel.EXPANDED_PROPERTY.equals(evt.getPropertyName())) {


### PR DESCRIPTION
"Find Usages" and "Refactor" were occasionally disabled when switching between selections with right click.

fixes #4024

~todo: needs testing and another careful look since I am not 100% sure how InstanceContext works when accessed from different threads~