### PR TITLE
Fix incorrect indentation behavior #6731

### DIFF
--- a/php/php.editor/test/unit/data/testfiles/indent/gh6731_01.php
+++ b/php/php.editor/test/unit/data/testfiles/indent/gh6731_01.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = test(
+    "test {$test}"
+);^

--- a/php/php.editor/test/unit/data/testfiles/indent/gh6731_01.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/indent/gh6731_01.php.indented
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = test(
+    "test {$test}"
+);
+^

--- a/php/php.editor/test/unit/data/testfiles/indent/gh6731_02.php
+++ b/php/php.editor/test/unit/data/testfiles/indent/gh6731_02.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = test(
+    "test {$test} test"
+);^

--- a/php/php.editor/test/unit/data/testfiles/indent/gh6731_02.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/indent/gh6731_02.php.indented
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = test(
+    "test {$test} test"
+);
+^

--- a/php/php.editor/test/unit/data/testfiles/indent/gh6731_03.php
+++ b/php/php.editor/test/unit/data/testfiles/indent/gh6731_03.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = test("test {$test} test");^

--- a/php/php.editor/test/unit/data/testfiles/indent/gh6731_03.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/indent/gh6731_03.php.indented
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = test("test {$test} test");
+^

--- a/php/php.editor/test/unit/data/testfiles/indent/gh6731_04.php
+++ b/php/php.editor/test/unit/data/testfiles/indent/gh6731_04.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = test(
+    "test"
+        . "test"
+        . "test"
+        . "test"
+        . "test {$test}"
+);^

--- a/php/php.editor/test/unit/data/testfiles/indent/gh6731_04.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/indent/gh6731_04.php.indented
@@ -1,0 +1,28 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = test(
+    "test"
+        . "test"
+        . "test"
+        . "test"
+        . "test {$test}"
+);
+^

--- a/php/php.editor/test/unit/data/testfiles/indent/gh6731_05.php
+++ b/php/php.editor/test/unit/data/testfiles/indent/gh6731_05.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH6731 {
+
+    public function test() {
+        $result = test(
+            "test {$test}"
+        );^
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/indent/gh6731_05.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/indent/gh6731_05.php.indented
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH6731 {
+
+    public function test() {
+        $result = test(
+            "test {$test}"
+        );
+        ^
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/indent/gh6731_06.php
+++ b/php/php.editor/test/unit/data/testfiles/indent/gh6731_06.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH6731 {
+
+    public function test() {
+        $result = $this->something(
+            "test {$test}"
+        );^
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/indent/gh6731_06.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/indent/gh6731_06.php.indented
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH6731 {
+
+    public function test() {
+        $result = $this->something(
+            "test {$test}"
+        );
+        ^
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/indent/gh6731_07.php
+++ b/php/php.editor/test/unit/data/testfiles/indent/gh6731_07.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH6731 {
+
+    public function test() {
+        $result = self::something(
+            "test {$test} test"
+        );^
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/indent/gh6731_07.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/indent/gh6731_07.php.indented
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH6731 {
+
+    public function test() {
+        $result = self::something(
+            "test {$test} test"
+        );
+        ^
+    }
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPNewLineIndenterTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPNewLineIndenterTest.java
@@ -1234,6 +1234,34 @@ public class PHPNewLineIndenterTest extends PHPTestBase {
         testIndentInFile("testfiles/indent/php81/enumerationsWithBackingType_03.php");
     }
 
+    public void testGH6731_01() throws Exception {
+        testIndentInFile("testfiles/indent/gh6731_01.php");
+    }
+
+    public void testGH6731_02() throws Exception {
+        testIndentInFile("testfiles/indent/gh6731_02.php");
+    }
+
+    public void testGH6731_03() throws Exception {
+        testIndentInFile("testfiles/indent/gh6731_03.php");
+    }
+
+    public void testGH6731_04() throws Exception {
+        testIndentInFile("testfiles/indent/gh6731_04.php");
+    }
+
+    public void testGH6731_05() throws Exception {
+        testIndentInFile("testfiles/indent/gh6731_05.php");
+    }
+
+    public void testGH6731_06() throws Exception {
+        testIndentInFile("testfiles/indent/gh6731_06.php");
+    }
+
+    public void testGH6731_07() throws Exception {
+        testIndentInFile("testfiles/indent/gh6731_07.php");
+    }
+
     @Override
     protected boolean runInEQ() {
         return true;


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/6731
- When a multi-line parameter of a function/method invocation has a string with a variable(e.g. `"example {$example}"`), ignore the variable within the string(i.e. {$example}) to avoid adding extra indentations 
 
Example:
```php
$x = test(
    "test {$test}"
);// enter key here
```

Before:
```php
$x = test(
    "test {$test}"
);
    // one indentation is added
```

After:
```php
$x = test(
    "test {$test}"
);
// no indentation
```