### PR TITLE
LSP: Minor changes.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -207,7 +207,7 @@ public final class Server {
                 LOG.log(Level.WARNING, "Error occurred during LSP message dispatch", t);
                 if (t instanceof CompletionException) {
                     if (t.getCause() instanceof ResponseErrorException) {
-                        return ((ResponseErrorException)t).getResponseError();
+                        return ((ResponseErrorException)t.getCause()).getResponseError();
                     }
                     Throwable cause = t.getCause();
                     ResponseError error = new ResponseError();

--- a/java/java.lsp.server/vscode/package-lock.json
+++ b/java/java.lsp.server/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "apache-netbeans-java",
-	"version": "19.0.301",
+	"version": "0.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "apache-netbeans-java",
-			"version": "19.0.301",
+			"version": "0.1.0",
 			"license": "Apache 2.0",
 			"dependencies": {
 				"@vscode/debugadapter": "1.55.1",

--- a/java/java.lsp.server/vscode/src/nbcode.ts
+++ b/java/java.lsp.server/vscode/src/nbcode.ts
@@ -88,7 +88,7 @@ export function launch(
     return process;
 }
 
-if (typeof process === 'object' && process.argv0 === 'node') {
+if (typeof process === 'object' && typeof process.argv0 ==='string' && process.argv0.startsWith('node')) {
     let extension = path.join(process.argv[1], '..', '..');
     let nbcode = path.join(extension, 'nbcode');
     if (!fs.existsSync(nbcode)) {


### PR DESCRIPTION
- Minor bug in sending erroneous responses from LSP server fixed
- Version in `package-lock.json` should correspond to version in `package.json`
- Current Node LTS installed from package on OpenSUSE is identified as `node20` instead of `node`