### PR TITLE
Improving handling of string templates in the Java syntax.

### DIFF
--- a/java/java.lsp.server/vscode/syntaxes/java.tmLanguage.json
+++ b/java/java.lsp.server/vscode/syntaxes/java.tmLanguage.json
@@ -1575,20 +1575,38 @@
 					"begin": "\"",
 					"beginCaptures": {
 						"0": {
-							"name": "punctuation.definition.string.begin.java"
+							"name": "punctuation.definition.string.begin.java string.quoted.double.java"
 						}
 					},
 					"end": "\"",
 					"endCaptures": {
 						"0": {
-							"name": "punctuation.definition.string.end.java"
+							"name": "punctuation.definition.string.end.java string.quoted.double.java"
 						}
 					},
-					"name": "string.quoted.double.java",
 					"patterns": [
 						{
+							"begin": "\\\\{",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.definition.string.end.java string.quoted.double.java"
+								}
+							},
+							"end": "}",
+							"endCaptures": {
+								"0": {
+									"name": "punctuation.definition.string.begin.java string.quoted.double.java"
+								}
+							},
+							"patterns": [{"include": "#code"}]
+						},
+						{
 							"match": "\\\\.",
-							"name": "constant.character.escape.java"
+							"name": "constant.character.escape.java string.quoted.double.java"
+						},
+						{
+							"match": ".",
+							"name": "string.quoted.double.java"
 						}
 					]
 				},


### PR DESCRIPTION
When String Templates (a Java preview feature) are used in the VS Code, the content may look very weird, like:
 - before semantic highlighting is applied: ![string-templates-original-before-semantic-highlighting](https://github.com/apache/netbeans/assets/51319204/4147f0ca-9f4d-4094-86cc-ccc441a723ab)
 - after semantic highlighting is applied: ![string-templates-original-after-semantic-highlighting](https://github.com/apache/netbeans/assets/51319204/e808e28a-76e2-445b-be33-32290a31b3dc)

Note that e.g. the nested String is not highlighted as a String. The "in String" and "outside of String" is inverted for the nested expression, as the grammar does not understand that the content of `\{...}` is not a String, but an expression.

This patch attempts to resolve that, by nesting `#code` inside `\{...}`. But, the inside of `\{...}` should not have `string.quoted.double.java` scope, so the scope is removed from the pattern that matches the string, and is moved to all the components, except the one of the inside of `\{...}`.

With this patch, the highlighting (with semantic highlighting) looks like this:
![string-templates-before-semantic-highlight](https://github.com/apache/netbeans/assets/51319204/5c78d28f-7d11-4096-aa85-e945e3ebd5f4)

Which seems satisfactory to me.
