### PR TITLE
Detect JPA provider on classpath, removing requirement to have it as legacy library

### DIFF
--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/Provider.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/Provider.java
@@ -84,7 +84,7 @@ public abstract class Provider {
         if(ret && version != null)
         {
             if(Persistence.VERSION_3_1.equals(version)){
-                ret &= cp.findResource("jakarta/persistence/spi/TransformerException.class.class") != null;
+                ret &= cp.findResource("jakarta/persistence/spi/TransformerException.class") != null;
             } else if(Persistence.VERSION_3_0.equals(version)){
                 ret &= cp.findResource("jakarta/persistence/Entity.class") != null;
             } else if (Persistence.VERSION_2_2.equals(version)) {


### PR DESCRIPTION
In addition fixes typo in JPA 3.1 detection (duplicate ".class" suffix)