### PR TITLE
Centralize internal maven artifact version queries.

### DIFF
--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenNbModuleImpl.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenNbModuleImpl.java
@@ -69,6 +69,7 @@ import org.netbeans.modules.maven.model.pom.Configuration;
 import org.netbeans.modules.maven.model.pom.POMExtensibilityElement;
 import org.netbeans.modules.maven.model.pom.POMModel;
 import org.netbeans.modules.maven.model.pom.Plugin;
+import org.netbeans.modules.maven.options.MavenVersionSettings;
 import org.netbeans.spi.project.AuxiliaryProperties;
 import org.netbeans.spi.project.ProjectServiceProvider;
 import org.netbeans.spi.project.ui.ProjectOpenedHook;
@@ -102,7 +103,6 @@ public class MavenNbModuleImpl implements NbModuleProvider {
     public static final String GROUPID_MOJO = "org.codehaus.mojo";
     public static final String GROUPID_APACHE = "org.apache.netbeans.utilities";
     public static final String NBM_PLUGIN = "nbm-maven-plugin";
-    static final String LATEST_NBM_PLUGIN_VERSION = "4.8";
 
     public static final String NETBEANSAPI_GROUPID = "org.netbeans.api";
 
@@ -123,14 +123,7 @@ public class MavenNbModuleImpl implements NbModuleProvider {
      * This method will not wait for the index to be downloaded, it will return a default value instead.
      */
     public static String getLatestNbmPluginVersion() {
-        RepositoryQueries.Result<NBVersionInfo> versionsResult = RepositoryQueries.getVersionsResult(GROUPID_APACHE, NBM_PLUGIN, null);
-
-        // Versions are sorted in descending order
-        return versionsResult.getResults().stream()
-                .map(NBVersionInfo::getVersion)
-                .filter(v -> !v.endsWith("-SNAPSHOT"))
-                .findFirst()
-                .orElse(LATEST_NBM_PLUGIN_VERSION);
+        return MavenVersionSettings.getDefault().getVersion(GROUPID_APACHE, NBM_PLUGIN);
     }
 
     private File getModuleXmlLocation() {

--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardPanelVisual.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardPanelVisual.java
@@ -39,6 +39,7 @@ import org.netbeans.modules.maven.indexer.api.RepositoryInfo;
 import org.netbeans.modules.maven.indexer.api.RepositoryPreferences;
 import org.netbeans.modules.maven.indexer.api.RepositoryQueries;
 import org.netbeans.modules.maven.indexer.api.RepositoryQueries.Result;
+import org.netbeans.modules.maven.options.MavenVersionSettings;
 import org.netbeans.validation.api.Problems;
 import org.netbeans.validation.api.Severity;
 import org.netbeans.validation.api.Validator;
@@ -152,6 +153,9 @@ public class NbmWizardPanelVisual extends javax.swing.JPanel {
                 .filter((v) -> !IGNORE_RELEASES.contains(v))
                 .sorted((v1, v2) -> v2.compareTo(v1))
                 .collect(Collectors.toCollection(ArrayList::new)); // must be mutable
+        if (versions.isEmpty()) {
+            versions.add(MavenVersionSettings.getDefault().getNBVersion()); // add a fallback version
+        }
         versions.add(NbmWizardIterator.SNAPSHOT_VERSION);
         return versions;
     }

--- a/java/maven/manifest.mf
+++ b/java/maven/manifest.mf
@@ -6,3 +6,4 @@ OpenIDE-Module-Layer: org/netbeans/modules/maven/layer.xml
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module-Package-Dependencies: com.sun.jdi[VirtualMachineManager]
 OpenIDE-Module-Recommends: org.netbeans.modules.maven.archetype
+OpenIDE-Module-Java-Dependencies: Java > 11

--- a/java/maven/nbproject/org-netbeans-modules-maven.sig
+++ b/java/maven/nbproject/org-netbeans-modules-maven.sig
@@ -2383,13 +2383,12 @@ supr java.lang.Enum<org.netbeans.modules.maven.options.MavenSettings$OutputTabNa
 CLSS public final org.netbeans.modules.maven.options.MavenVersionSettings
 fld public final static java.lang.String VERSION_COMPILER = "maven-compiler-plugin"
 fld public final static java.lang.String VERSION_RESOURCES = "maven-resources-plugin"
-meth protected final java.lang.String getProperty(java.lang.String)
-meth protected final java.lang.String putProperty(java.lang.String,java.lang.String)
-meth protected final java.util.prefs.Preferences getPreferences()
+meth public java.lang.String getNBVersion()
 meth public java.lang.String getVersion(java.lang.String)
+meth public java.lang.String getVersion(java.lang.String,java.lang.String)
 meth public static org.netbeans.modules.maven.options.MavenVersionSettings getDefault()
 supr java.lang.Object
-hfds INSTANCE
+hfds INSTANCE,fallback
 
 CLSS public final !enum org.netbeans.modules.maven.options.NetworkProxySettings
 fld public final static org.netbeans.modules.maven.options.NetworkProxySettings ASK

--- a/java/maven/nbproject/project.properties
+++ b/java/maven/nbproject/project.properties
@@ -17,7 +17,6 @@
 
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-cp.extra=${tools.jar}
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml
 javahelp.hs=maven.hs

--- a/java/maven/src/org/netbeans/modules/maven/api/ModelUtils.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/ModelUtils.java
@@ -24,7 +24,6 @@ package org.netbeans.modules.maven.api;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -121,7 +120,7 @@ public final class ModelUtils {
                 }
             }
         };
-        Utilities.performPOMModelOperations(pom, Collections.singletonList(operation));
+        Utilities.performPOMModelOperations(pom, List.of(operation));
     }
 
     public static Dependency checkModelDependency(POMModel pom, String groupId, String artifactId, boolean add) {
@@ -331,7 +330,7 @@ public final class ModelUtils {
             plugin = mdl.getFactory().createPlugin();
             plugin.setGroupId(Constants.GROUP_APACHE_PLUGINS);
             plugin.setArtifactId(Constants.PLUGIN_COMPILER);
-            plugin.setVersion(MavenVersionSettings.getDefault().getVersion(MavenVersionSettings.VERSION_COMPILER));
+            plugin.setVersion(MavenVersionSettings.getDefault().getVersion(Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_COMPILER));
             mdl.getProject().getBuild().addPlugin(plugin);
         }
         Configuration conf = plugin.getConfiguration();
@@ -435,8 +434,8 @@ public final class ModelUtils {
     }
     //for tests
     static Descriptor checkLibraries(Map<String, String> properties) {
-        List<LibraryDescriptor> libs = new ArrayList<LibraryDescriptor>();
-        List<RepositoryDescriptor> reps = new ArrayList<RepositoryDescriptor>();
+        List<LibraryDescriptor> libs = new ArrayList<>();
+        List<RepositoryDescriptor> reps = new ArrayList<>();
                 
         String dependencies = properties.get(LIBRARY_PROP_DEPENDENCIES);
         if (dependencies != null) {

--- a/java/maven/src/org/netbeans/modules/maven/customizer/CompilePanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/CompilePanel.java
@@ -21,14 +21,9 @@ package org.netbeans.modules.maven.customizer;
 
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Cursor;
 import java.awt.EventQueue;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -67,8 +62,6 @@ import org.netbeans.modules.maven.options.MavenVersionSettings;
 import org.netbeans.spi.project.AuxiliaryProperties;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
-import org.openide.awt.HtmlBrowser;
-import org.openide.util.Exceptions;
 import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
 import org.openide.util.Pair;
@@ -511,33 +504,33 @@ public class CompilePanel extends javax.swing.JPanel implements HelpCtx.Provider
 
         @Override
         public void performOperation(POMModel model) {
-        Plugin old = null;
-        Plugin plugin;
-        Build bld = model.getProject().getBuild();
-        if (bld != null) {
-            old = bld.findPluginById(Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_COMPILER);
-        } else {
-            bld = model.getFactory().createBuild();
-            model.getProject().setBuild(bld);
+            Plugin old = null;
+            Plugin plugin;
+            Build bld = model.getProject().getBuild();
+            if (bld != null) {
+                old = bld.findPluginById(Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_COMPILER);
+            } else {
+                bld = model.getFactory().createBuild();
+                model.getProject().setBuild(bld);
+            }
+            if (old != null) {
+                plugin = old;
+            } else {
+                plugin = model.getFactory().createPlugin();
+                plugin.setGroupId(Constants.GROUP_APACHE_PLUGINS);
+                plugin.setArtifactId(Constants.PLUGIN_COMPILER);
+                plugin.setVersion(MavenVersionSettings.getDefault().getVersion(Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_COMPILER));
+                bld.addPlugin(plugin);
+            }
+            Configuration config = plugin.getConfiguration();
+            if (config == null) {
+                config = model.getFactory().createConfiguration();
+                plugin.setConfiguration(config);
+            }
+            config.setSimpleParameter(param, value);
         }
-        if (old != null) {
-            plugin = old;
-        } else {
-            plugin = model.getFactory().createPlugin();
-            plugin.setGroupId(Constants.GROUP_APACHE_PLUGINS);
-            plugin.setArtifactId(Constants.PLUGIN_COMPILER);
-            plugin.setVersion(MavenVersionSettings.getDefault().getVersion(MavenVersionSettings.VERSION_COMPILER));
-            bld.addPlugin(plugin);
-        }
-        Configuration config = plugin.getConfiguration();
-        if (config == null) {
-            config = model.getFactory().createConfiguration();
-            plugin.setConfiguration(config);
-        }
-        config.setSimpleParameter(param, value);
-    }
 
-                    }
+    }
 
     String getCompilerParam(ModelHandle2 handle, String param) {
         CompilerParamOperation oper = operations.get(param);

--- a/java/maven/src/org/netbeans/modules/maven/customizer/SourcesPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/SourcesPanel.java
@@ -20,8 +20,6 @@
 package org.netbeans.modules.maven.customizer;
 
 import java.awt.Font;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -150,7 +148,7 @@ public class SourcesPanel extends JPanel implements HelpCtx.Provider {
             plugin = fact.createPlugin();
             plugin.setGroupId(Constants.GROUP_APACHE_PLUGINS);
             plugin.setArtifactId(Constants.PLUGIN_COMPILER);
-            plugin.setVersion(MavenVersionSettings.getDefault().getVersion(MavenVersionSettings.VERSION_COMPILER));
+            plugin.setVersion(MavenVersionSettings.getDefault().getVersion(Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_COMPILER));
             bld.addPlugin(plugin);
         }
         if (plugin != null) {
@@ -169,7 +167,7 @@ public class SourcesPanel extends JPanel implements HelpCtx.Provider {
             plugin2 = fact.createPlugin();
             plugin2.setGroupId(Constants.GROUP_APACHE_PLUGINS);
             plugin2.setArtifactId(Constants.PLUGIN_RESOURCES);
-            plugin2.setVersion(MavenVersionSettings.getDefault().getVersion(MavenVersionSettings.VERSION_RESOURCES));
+            plugin2.setVersion(MavenVersionSettings.getDefault().getVersion(Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_RESOURCES));
             bld.addPlugin(plugin2);
         }
         if (plugin2 != null) {
@@ -225,20 +223,10 @@ public class SourcesPanel extends JPanel implements HelpCtx.Provider {
         
         comEncoding.setModel(ProjectCustomizer.encodingModel(oldEncoding));
         comEncoding.setRenderer(ProjectCustomizer.encodingRenderer());
-        
-        comSourceLevel.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                handleSourceLevelChange();
-            }
-        });
-        
-        comEncoding.addActionListener(new ActionListener () {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                handleEncodingChange();
-            }            
-        });
+
+        comSourceLevel.addActionListener(e -> handleSourceLevelChange());
+        comEncoding.addActionListener(e -> handleEncodingChange());
+
         txtSrc.setText(handle.getProject().getBuild().getSourceDirectory());
         txtTestSrc.setText(handle.getProject().getBuild().getTestSourceDirectory());
     }
@@ -502,7 +490,7 @@ public class SourcesPanel extends JPanel implements HelpCtx.Provider {
                         current = incJavaSpecVersion(current);
                     }
                 }
-                sourceLevelCache = sourceLevels.toArray(new String[sourceLevels.size()]);
+                sourceLevelCache = sourceLevels.toArray(String[]::new);
             }
             return sourceLevelCache;
         }

--- a/java/maven/src/org/netbeans/modules/maven/nodes/BootCPNodeFactory.java
+++ b/java/maven/src/org/netbeans/modules/maven/nodes/BootCPNodeFactory.java
@@ -69,7 +69,7 @@ public class BootCPNodeFactory implements NodeFactory {
                         Collections.<Void>emptyList() :
                         Collections.<Void>singletonList(null);
             }
-            @Override public Node node(Void _) {
+            @Override public Node node(Void v) {
                 return new BootCPNode(p);
             }
         };

--- a/java/maven/src/org/netbeans/modules/maven/options/MavenVersionSettings.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/MavenVersionSettings.java
@@ -18,59 +18,92 @@
  */
 package org.netbeans.modules.maven.options;
 
-import java.util.prefs.Preferences;
-import org.openide.util.NbPreferences;
+import java.util.Map;
+import org.apache.maven.artifact.versioning.ComparableVersion;
+import org.netbeans.modules.maven.api.Constants;
+import org.netbeans.modules.maven.indexer.api.NBVersionInfo;
+import org.netbeans.modules.maven.indexer.api.RepositoryQueries;
+
+import static java.util.Map.entry;
 
 /**
- * Preferences class for externalizing the hardwired plugin versions to
- * allow changes by advanced users?
- * @author mkleint
+ * Utility class for internal artifact version queries.
+ *
+ * Will usually return the latest known version.
+ *
+ * @author mbien
  */
 public final class MavenVersionSettings {
+
+    @Deprecated    
+    public static final String VERSION_COMPILER = Constants.PLUGIN_COMPILER; //NOI18N
+    @Deprecated    
+    public static final String VERSION_RESOURCES = Constants.PLUGIN_RESOURCES; //NOI18N
+
+    private static final Map<String, String> fallback;
+
+    static {
+        // TODO update periodically - modifications might require unit test adjustments
+        String nb_version = "RELEASE200";
+        String nb_utilities_version = "14.0";
+        fallback = Map.ofEntries(
+            entry(key("org.netbeans.api", "org-netbeans-modules-editor"), nb_version), // represents all other nb artifacts
+            entry(key(Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_COMPILER), "3.11.0"),
+            entry(key(Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_RESOURCES), "3.3.1"),
+            entry(key(Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_FAILSAFE), "3.2.2"),
+            entry(key(Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_SUREFIRE), "3.2.2"),
+            entry(key("org.apache.netbeans.utilities", "utilities-parent"), nb_utilities_version),
+            entry(key("org.apache.netbeans.utilities", "nbm-maven-harness"), nb_utilities_version),
+            entry(key("org.apache.netbeans.utilities", "nbm-shared"), nb_utilities_version),
+            entry(key("org.apache.netbeans.utilities", "nbm-repository-plugin"), nb_utilities_version),
+            entry(key("org.apache.netbeans.utilities", "nbm-maven-plugin"), nb_utilities_version),
+            entry(key("org.apache.netbeans.archetypes", "nbm-archetype"), "1.18"),
+            entry(key("org.apache.netbeans.archetypes", "netbeans-platform-app-archetype"), "1.23")
+        );
+    }
+
     private static final MavenVersionSettings INSTANCE = new MavenVersionSettings();
-    
-    public static final String VERSION_COMPILER = "maven-compiler-plugin"; //NOI18N
-    public static final String VERSION_RESOURCES = "maven-resources-plugin"; //NOI18N
-    
+
+    private MavenVersionSettings() {}
+
     public static MavenVersionSettings getDefault() {
         return INSTANCE;
     }
-    
-    protected final Preferences getPreferences() {
-        return NbPreferences.root().node("org/netbeans/modules/maven/pluginVersions"); //NOI18N
-    }
-    
-    protected final String putProperty(String key, String value) {
-        String retval = getProperty(key);
-        if (value != null) {
-            getPreferences().put(key, value);
-        } else {
-            getPreferences().remove(key);
-        }
-        return retval;
+
+    public String getNBVersion() {
+        return getVersion("org.netbeans.api", "org-netbeans-modules-editor");
     }
 
-    protected final String getProperty(String key) {
-        return getPreferences().get(key, null);
-    }    
-    
-    private MavenVersionSettings() {
+    @Deprecated
+    public String getVersion(String artifactId) {
+        return getVersion(Constants.GROUP_APACHE_PLUGINS, artifactId);
     }
-    
-    public String getVersion(String plugin) {
-        String toRet = getProperty(plugin);
-        if (toRet == null) {
-            // XXX these should rather read the most recent version from the repository index (agreed)
-            if (VERSION_RESOURCES.equals(plugin)) {
-                toRet = "3.3.1"; //NOI18N
-            } else if (VERSION_COMPILER.equals(plugin)) {
-                toRet = "3.11.0"; //NOI18N
-            }
-        }
-        if (toRet == null) {
-            toRet = "RELEASE"; // this is wrong for 2.1
-        }
-        return toRet;
+
+    public String getVersion(String groupId, String artifactId) {
+        String key = key(groupId, artifactId);
+        return queryLatestKnownArtifactVersion(groupId, artifactId, fallback.get(key));
     }
-    
+
+    // non blocking query, might not succeed if index not available
+    private static String queryLatestKnownArtifactVersion(String gid, String aid, String min) {
+        RepositoryQueries.Result<NBVersionInfo> query = RepositoryQueries.getVersionsResult(gid, aid, null);
+        // Versions are sorted in descending order
+        return query.getResults().stream()
+                    .map(NBVersionInfo::getVersion)
+                    .filter(v -> !v.endsWith("-SNAPSHOT"))
+                    .findFirst()
+                    .filter(v -> min == null || new ComparableVersion(v).compareTo(new ComparableVersion(min)) > 0) // don't downgrade
+                    .orElse(min);
+    }
+
+    private static String key(String gid, String aid) {
+        if (gid == null || gid.isBlank()) {
+            throw new IllegalArgumentException("empty group id");
+        }
+        if (aid == null || aid.isBlank()) {
+            throw new IllegalArgumentException("empty artifact id");
+        }
+        return gid + ":" + aid;
+    }
+
 }


### PR DESCRIPTION
 - put all hardcoded fallback versions in one place
 - use index for updates if available

also fixes https://issues.apache.org/jira/browse/NETBEANS-6491 as side effect

note: its all internal, and only used in two modules for now