### PR TITLE
Update maven central repo URL

### DIFF
--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardPanelVisual.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardPanelVisual.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.SwingUtilities;
+import org.apache.maven.repository.RepositorySystem;
 import org.netbeans.api.progress.aggregate.AggregateProgressHandle;
 import org.netbeans.modules.maven.api.MavenValidators;
 import org.netbeans.modules.maven.api.archetype.Archetype;
@@ -46,6 +47,7 @@ import org.netbeans.validation.api.builtin.stringvalidation.StringValidators;
 import org.netbeans.validation.api.ui.ValidationGroup;
 import org.netbeans.validation.api.ui.swing.SwingValidationGroup;
 import org.openide.WizardDescriptor;
+import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.RequestProcessor;
@@ -99,10 +101,16 @@ public class NbmWizardPanelVisual extends javax.swing.JPanel {
             if (info == null || info.contains(null)) {
                 try {
                     //transient remove central, make central transient too
-                    RepositoryPreferences.getInstance().addTransientRepository(key, "central", "central", "https://repo1.maven.org/maven2", RepositoryInfo.MirrorStrategy.NON_WILDCARD);
+                    RepositoryPreferences.getInstance().addTransientRepository(
+                            key,
+                            RepositorySystem.DEFAULT_REMOTE_REPO_ID,
+                            RepositorySystem.DEFAULT_REMOTE_REPO_ID,
+                            RepositorySystem.DEFAULT_REMOTE_REPO_URL,
+                            RepositoryInfo.MirrorStrategy.NON_WILDCARD
+                    );
                     info = MavenNbModuleImpl.netbeansRepo();
                 } catch (URISyntaxException x) {
-                    assert false : x;
+                    Exceptions.printStackTrace(x);
                 }
             }
 

--- a/contrib/groovy.grailsproject/test/unit/data/projects/completion/ivysettings.xml
+++ b/contrib/groovy.grailsproject/test/unit/data/projects/completion/ivysettings.xml
@@ -8,7 +8,7 @@
     <chain name="codehaus-plus" dual="true">
       <ibiblio name="codehaus-snapshots" root="http://snapshots.repository.codehaus.org" m2compatible="true" changingPattern=".*SNAPSHOT"/>
       <ibiblio name="codehaus" root="http://repository.codehaus.org" m2compatible="true"/>
-      <ibiblio name="javanet" root="https://repo1.maven.org/maven2/" m2compatible="true"/>
+      <ibiblio name="javanet" root="https://repo.maven.apache.org/maven2/" m2compatible="true"/>
       <resolver ref="public"/>
     </chain>
   </resolvers>

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
@@ -182,8 +182,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_5_1_0(NbBundle.getMessage(ServerDetails.class, "STR_510_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE8_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_5_1_0,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/5.1.0/glassfish-5.1.0.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/5.1.0/glassfish-5.1.0.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/5.1.0/glassfish-5.1.0.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/5.1.0/glassfish-5.1.0.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
 
@@ -193,8 +193,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_6(NbBundle.getMessage(ServerDetails.class, "STR_6_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE9_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_6,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.0.0/glassfish-6.0.0.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.0.0/glassfish-6.0.0.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.0.0/glassfish-6.0.0.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.0.0/glassfish-6.0.0.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
 
@@ -204,8 +204,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_6_1_0(NbBundle.getMessage(ServerDetails.class, "STR_610_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE91_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_6_1_0,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.1.0/glassfish-6.1.0.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.1.0/glassfish-6.1.0.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.1.0/glassfish-6.1.0.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.1.0/glassfish-6.1.0.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
 
@@ -215,8 +215,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_6_2_0(NbBundle.getMessage(ServerDetails.class, "STR_620_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE91_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_6_2_0,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.2.0/glassfish-6.2.0.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.2.0/glassfish-6.2.0.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.2.0/glassfish-6.2.0.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.2.0/glassfish-6.2.0.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
     
@@ -226,8 +226,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_6_2_1(NbBundle.getMessage(ServerDetails.class, "STR_621_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE91_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_6_2_1,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.2.1/glassfish-6.2.1.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.2.1/glassfish-6.2.1.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.2.1/glassfish-6.2.1.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.2.1/glassfish-6.2.1.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
     
@@ -237,8 +237,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_6_2_2(NbBundle.getMessage(ServerDetails.class, "STR_622_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE91_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_6_2_2,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.2.2/glassfish-6.2.2.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.2.2/glassfish-6.2.2.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.2.2/glassfish-6.2.2.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.2.2/glassfish-6.2.2.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
     
@@ -248,8 +248,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_6_2_3(NbBundle.getMessage(ServerDetails.class, "STR_623_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE91_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_6_2_3,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.2.3/glassfish-6.2.3.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.2.3/glassfish-6.2.3.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.2.3/glassfish-6.2.3.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.2.3/glassfish-6.2.3.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
     
@@ -259,8 +259,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_6_2_4(NbBundle.getMessage(ServerDetails.class, "STR_624_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE91_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_6_2_4,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.2.4/glassfish-6.2.4.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.2.4/glassfish-6.2.4.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.2.4/glassfish-6.2.4.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.2.4/glassfish-6.2.4.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
     
@@ -270,8 +270,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_6_2_5(NbBundle.getMessage(ServerDetails.class, "STR_625_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE91_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_6_2_5,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.2.5/glassfish-6.2.5.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.2.5/glassfish-6.2.5.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.2.5/glassfish-6.2.5.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/6.2.5/glassfish-6.2.5.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
     
@@ -281,8 +281,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_7_0_0(NbBundle.getMessage(ServerDetails.class, "STR_700_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE10_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_7_0_0,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.0/glassfish-7.0.0.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.0/glassfish-7.0.0.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.0/glassfish-7.0.0.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.0/glassfish-7.0.0.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
     
@@ -292,8 +292,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_7_0_1(NbBundle.getMessage(ServerDetails.class, "STR_701_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE10_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_7_0_1,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.1/glassfish-7.0.1.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.1/glassfish-7.0.1.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.1/glassfish-7.0.1.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.1/glassfish-7.0.1.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
     
@@ -303,8 +303,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_7_0_2(NbBundle.getMessage(ServerDetails.class, "STR_702_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE10_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_7_0_2,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.2/glassfish-7.0.2.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.2/glassfish-7.0.2.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.2/glassfish-7.0.2.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.2/glassfish-7.0.2.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
 
@@ -314,8 +314,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_7_0_3(NbBundle.getMessage(ServerDetails.class, "STR_703_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE10_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_7_0_3,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.3/glassfish-7.0.3.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.3/glassfish-7.0.3.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.3/glassfish-7.0.3.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.3/glassfish-7.0.3.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
 
@@ -325,8 +325,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_7_0_4(NbBundle.getMessage(ServerDetails.class, "STR_704_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE10_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_7_0_4,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.4/glassfish-7.0.4.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.4/glassfish-7.0.4.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.4/glassfish-7.0.4.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.4/glassfish-7.0.4.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
 
@@ -336,8 +336,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_7_0_5(NbBundle.getMessage(ServerDetails.class, "STR_705_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE10_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_7_0_5,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.5/glassfish-7.0.5.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.5/glassfish-7.0.5.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.5/glassfish-7.0.5.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.5/glassfish-7.0.5.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
 
@@ -347,8 +347,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_7_0_6(NbBundle.getMessage(ServerDetails.class, "STR_706_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE10_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_7_0_6,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.6/glassfish-7.0.6.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.6/glassfish-7.0.6.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.6/glassfish-7.0.6.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.6/glassfish-7.0.6.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
     
@@ -358,8 +358,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_7_0_7(NbBundle.getMessage(ServerDetails.class, "STR_707_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE10_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_7_0_7,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.7/glassfish-7.0.7.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.7/glassfish-7.0.7.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.7/glassfish-7.0.7.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.7/glassfish-7.0.7.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
     
@@ -369,8 +369,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_7_0_8(NbBundle.getMessage(ServerDetails.class, "STR_708_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE10_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_7_0_8,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.8/glassfish-7.0.8.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.8/glassfish-7.0.8.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.8/glassfish-7.0.8.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.8/glassfish-7.0.8.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     ),
     
@@ -380,8 +380,8 @@ public enum ServerDetails {
     GLASSFISH_SERVER_7_0_9(NbBundle.getMessage(ServerDetails.class, "STR_709_SERVER_NAME", new Object[]{}), // NOI18N
         GlassfishInstanceProvider.JAKARTAEE10_DEPLOYER_FRAGMENT,
         GlassFishVersion.GF_7_0_9,
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.9/glassfish-7.0.9.zip", // NOI18N
-        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/7.0.9/glassfish-7.0.9.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.9/glassfish-7.0.9.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.9/glassfish-7.0.9.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     );
     

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV3.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV3.xml
@@ -79,7 +79,7 @@
             </fileset>
         </classpath>
         <javadocs> 
-            <link url="https://repo1.maven.org/maven2/com/sun/jersey/glassfish/v32/jersey-gfv3-docs-and-samples/1.13/jersey-gfv3-docs-and-samples-1.13-project.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/com/sun/jersey/glassfish/v32/jersey-gfv3-docs-and-samples/1.13/jersey-gfv3-docs-and-samples-1.13-project.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV4.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV4.xml
@@ -76,7 +76,7 @@
             </fileset>
         </classpath>
         <javadocs> 
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/2.0/jersey-documentation-2.0-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/2.0/jersey-documentation-2.0-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV4_1.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV4_1.xml
@@ -77,7 +77,7 @@
             </fileset>
         </classpath>
         <javadocs> 
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/2.21/jersey-documentation-2.21-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/2.21/jersey-documentation-2.21-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV5.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV5.xml
@@ -77,7 +77,7 @@
             </fileset>
         </classpath>
         <javadocs>
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/2.28/jersey-documentation-2.28-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/2.28/jersey-documentation-2.28-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV5_1_0.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV5_1_0.xml
@@ -80,7 +80,7 @@
             </fileset>
         </classpath>
         <javadocs>
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/2.28/jersey-documentation-2.28-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/2.28/jersey-documentation-2.28-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6.xml
@@ -67,7 +67,7 @@
             </fileset>
         </classpath>
         <javadocs>
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/3.0.0-M1/jersey-documentation-3.0.0-M1-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/3.0.0-M1/jersey-documentation-3.0.0-M1-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6_1_0.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6_1_0.xml
@@ -67,7 +67,7 @@
             </fileset>
         </classpath>
         <javadocs>
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/3.0.1/jersey-documentation-3.0.1-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/3.0.1/jersey-documentation-3.0.1-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6_2_0.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6_2_0.xml
@@ -72,7 +72,7 @@
             </fileset>
         </classpath>
         <javadocs>
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/3.0.1/jersey-documentation-3.0.1-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/3.0.1/jersey-documentation-3.0.1-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6_2_1.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6_2_1.xml
@@ -73,7 +73,7 @@
             </fileset>
         </classpath>
         <javadocs>
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/3.0.3/jersey-documentation-3.0.3-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/3.0.3/jersey-documentation-3.0.3-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6_2_2.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6_2_2.xml
@@ -73,7 +73,7 @@
             </fileset>
         </classpath>
         <javadocs>
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/3.0.2/jersey-documentation-3.0.2-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/3.0.2/jersey-documentation-3.0.2-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6_2_3.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6_2_3.xml
@@ -73,7 +73,7 @@
             </fileset>
         </classpath>
         <javadocs>
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/3.0.3/jersey-documentation-3.0.3-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/3.0.3/jersey-documentation-3.0.3-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6_2_4.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6_2_4.xml
@@ -74,7 +74,7 @@
             </fileset>
         </classpath>
         <javadocs>
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/3.0.3/jersey-documentation-3.0.3-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/3.0.3/jersey-documentation-3.0.3-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV7_0_0.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV7_0_0.xml
@@ -75,7 +75,7 @@
             </fileset>
         </classpath>
         <javadocs>
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/3.1.0/jersey-documentation-3.1.0-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/3.1.0/jersey-documentation-3.1.0-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV7_0_1.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV7_0_1.xml
@@ -76,7 +76,7 @@
             </fileset>
         </classpath>
         <javadocs>
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/3.1.1/jersey-documentation-3.1.1-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/3.1.1/jersey-documentation-3.1.1-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV7_0_9.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV7_0_9.xml
@@ -77,7 +77,7 @@
             </fileset>
         </classpath>
         <javadocs>
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/3.1.3/jersey-documentation-3.1.3-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/3.1.3/jersey-documentation-3.1.3-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/payara.tooling/nbproject/org-netbeans-modules-payara-tooling.sig
+++ b/enterprise/payara.tooling/nbproject/org-netbeans-modules-payara-tooling.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.16
+#Version 2.17
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable
@@ -1325,7 +1325,7 @@ supr java.lang.Object
 hfds artifactId,groupId,version
 
 CLSS public org.netbeans.modules.payara.tooling.data.PayaraPlatformVersion
-fld public final static java.lang.String DEFAULT_REPOSITORY_URL = "https://repo1.maven.org/maven2/"
+fld public final static java.lang.String DEFAULT_REPOSITORY_URL = "https://repo.maven.apache.org/maven2/"
 fld public final static org.netbeans.modules.payara.tooling.data.PayaraPlatformVersionAPI EMPTY
 intf java.lang.Comparable<org.netbeans.modules.payara.tooling.data.PayaraPlatformVersionAPI>
 intf org.netbeans.modules.payara.tooling.data.PayaraPlatformVersionAPI

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/PayaraPlatformVersion.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/PayaraPlatformVersion.java
@@ -40,7 +40,6 @@ import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
 import org.netbeans.modules.maven.indexer.api.RepositoryInfo;
 import org.netbeans.modules.maven.indexer.api.RepositoryPreferences;
-import org.openide.util.NbBundle;
 
 /**
  * Payara Platform version.
@@ -61,7 +60,7 @@ public class PayaraPlatformVersion implements PayaraPlatformVersionAPI, Comparab
      */
     private static final String DOWNLOAD_URL = "fish/payara/distributions/payara/%s/payara-%s.zip"; // NOI18N
 
-    public static final String DEFAULT_REPOSITORY_URL = "https://repo1.maven.org/maven2/"; // NOI18N
+    public static final String DEFAULT_REPOSITORY_URL = "https://repo.maven.apache.org/maven2/"; // NOI18N
  
     private static final String METADATA_URL = "fish/payara/distributions/payara/maven-metadata.xml"; // NOI18N
 

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/config/PayaraV3.xml
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/config/PayaraV3.xml
@@ -79,7 +79,7 @@ under the License.
             </fileset>
         </classpath>
         <javadocs> 
-            <link url="https://repo1.maven.org/maven2/com/sun/jersey/glassfish/v32/jersey-gfv3-docs-and-samples/1.13/jersey-gfv3-docs-and-samples-1.13-project.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/com/sun/jersey/glassfish/v32/jersey-gfv3-docs-and-samples/1.13/jersey-gfv3-docs-and-samples-1.13-project.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/config/PayaraV4.xml
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/config/PayaraV4.xml
@@ -81,7 +81,7 @@ under the License.
             </fileset>
         </classpath>
         <javadocs> 
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/2.0-m05-2/jersey-documentation-2.0-m05-2-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/2.0-m05-2/jersey-documentation-2.0-m05-2-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/config/PayaraV5.xml
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/config/PayaraV5.xml
@@ -92,7 +92,7 @@ under the License.
             </fileset>
         </classpath>
         <javadocs> 
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/2.9.1/jersey-documentation-2.9.1-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/2.9.1/jersey-documentation-2.9.1-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/config/PayaraV6.xml
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/config/PayaraV6.xml
@@ -88,7 +88,7 @@ under the License.
             </fileset>
         </classpath>
         <javadocs>
-            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/3.1.0/jersey-documentation-3.1.0-docbook.zip"/>
+            <link url="https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-documentation/3.1.0/jersey-documentation-3.1.0-docbook.zip"/>
         </javadocs>
         <sources>
         </sources>

--- a/enterprise/web.core.syntax/external/tlddoc-1.3-license.txt
+++ b/enterprise/web.core.syntax/external/tlddoc-1.3-license.txt
@@ -3,7 +3,7 @@ Version: 1.3
 Description: Tag Library Documentation Generator is a utility for automatically generating javadoc-style documentation for JavaServer Pages (JSP) Technology Tag Libraries.
 License: BSD-tlddoc
 Origin: Sun Microsystems, Inc.
-Source: https://repo1.maven.org/maven2/taglibrarydoc/tlddoc/1.3/
+Source: https://repo.maven.apache.org/maven2/taglibrarydoc/tlddoc/1.3/
 Type: compile-time
 
 Copyright (c) 2003-2004, Sun Microsystems, Inc.

--- a/java/maven.indexer/external/indexer-core-7.0.4-license.txt
+++ b/java/maven.indexer/external/indexer-core-7.0.4-license.txt
@@ -3,7 +3,7 @@ Description: Maven remote repository indexing engine.
 Version: 7.0.4
 Origin: Apache Software Foundation
 License: Apache-2.0
-URL: https://repo1.maven.org/maven2/org/apache/maven/indexer/
+URL: https://repo.maven.apache.org/maven2/org/apache/maven/indexer/
 Source: https://github.com/apache/maven-indexer
 Files: indexer-core-7.0.4.jar search-api-7.0.4.jar search-backend-smo-7.0.4.jar
 

--- a/java/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferencesTest.java
+++ b/java/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferencesTest.java
@@ -127,16 +127,16 @@ public class RepositoryPreferencesTest extends NbTestCase {
             assertEquals("[eclipselink]", m.getMirroredRepositories().toString());
 
             //add central now.. should have 2 mirrored repositories..
-            rp.addTransientRepository(1, "central", "central", "https://repo1.maven.org/maven2", RepositoryInfo.MirrorStrategy.ALL);
+            rp.addTransientRepository(1, "central", "central", "https://repo.maven.apache.org/maven2", RepositoryInfo.MirrorStrategy.ALL);
             assertEquals("[local, mirror]", rp.getRepositoryInfos().toString());
             m = rp.getRepositoryInfoById("mirror");
             assertTrue(m.isMirror());
             assertEquals("[eclipselink, central]", m.getMirroredRepositories().toString());
 
             //add central AGAIN and AGAIN.. should have still just 2 mirrored repositories..
-            rp.addTransientRepository(2, "central", "central", "https://repo1.maven.org/maven2", RepositoryInfo.MirrorStrategy.ALL);
-            rp.addTransientRepository(3, "central", "central", "https://repo1.maven.org/maven2", RepositoryInfo.MirrorStrategy.ALL);
-            rp.addTransientRepository(4, "central", "central", "https://repo1.maven.org/maven2", RepositoryInfo.MirrorStrategy.ALL);
+            rp.addTransientRepository(2, "central", "central", "https://repo.maven.apache.org/maven2", RepositoryInfo.MirrorStrategy.ALL);
+            rp.addTransientRepository(3, "central", "central", "https://repo.maven.apache.org/maven2", RepositoryInfo.MirrorStrategy.ALL);
+            rp.addTransientRepository(4, "central", "central", "https://repo.maven.apache.org/maven2", RepositoryInfo.MirrorStrategy.ALL);
 
             assertEquals("[local, mirror]", rp.getRepositoryInfos().toString());
             m = rp.getRepositoryInfoById("mirror");
@@ -144,8 +144,8 @@ public class RepositoryPreferencesTest extends NbTestCase {
             assertEquals("[eclipselink, central]", m.getMirroredRepositories().toString());
 
             //try adding slightly modified transient repositories..
-            rp.addTransientRepository(3, "central", "central", "https://repo1.maven.org/maven2/", RepositoryInfo.MirrorStrategy.ALL);
-            rp.addTransientRepository(2, "central", "central rep", "https://repo1.maven.org/maven2", RepositoryInfo.MirrorStrategy.ALL);
+            rp.addTransientRepository(3, "central", "central", "https://repo.maven.apache.org/maven2/", RepositoryInfo.MirrorStrategy.ALL);
+            rp.addTransientRepository(2, "central", "central rep", "https://repo.maven.apache.org/maven2", RepositoryInfo.MirrorStrategy.ALL);
             rp.addTransientRepository(2, "eclipselink", "Repository for library Library", "http://ftp.ing.umu.se/mirror/eclipse/rt/eclipselink/maven.repo", RepositoryInfo.MirrorStrategy.ALL);
 
             assertEquals("[local, mirror]", rp.getRepositoryInfos().toString());

--- a/java/maven.model/test/unit/src/sample.pom
+++ b/java/maven.model/test/unit/src/sample.pom
@@ -348,7 +348,7 @@
       </snapshots>
       <id>central</id>
       <name>Maven Repository Switchboard</name>
-      <url>https://repo1.maven.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
     </repository>
   </repositories>
   <pluginRepositories>
@@ -369,7 +369,7 @@
       </snapshots>
       <id>central</id>
       <name>Maven Plugin Repository</name>
-      <url>https://repo1.maven.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
     </pluginRepository>
   </pluginRepositories>
   <dependencies>

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/classpath/CPExtenderTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/classpath/CPExtenderTest.java
@@ -61,8 +61,8 @@ public class CPExtenderTest extends NbTestCase {
 
     @RandomlyFails // frequently fails in NB-Core-Build; [CPExtender] checkLibraryForPoms on Library[Stuff] -> true and [Utilities] WORKDIR/o.n.m.m.c.C/testAddRemovePomLib/pom.xml@1:2: CHILD_REMOVED:org.netbeans.modules.maven.model.pom.impl.ProjectImpl$PList@4 yet [Utilities] no changes in org.openide.loaders.XMLDataObject@c[WORKDIR/o.n.m.m.c.C/testAddRemovePomLib/pom.xml@1:2] where modified=true
     public void testAddRemovePomLib() throws Exception {
-        Library lib = LibraryManager.getDefault().createLibrary("j2se", "Stuff", Collections.singletonMap("maven-pom", Collections.singletonList(new URL("https://repo1.maven.org/maven2/grp/stuff/1.0/stuff-1.0.pom"))));
-        Library lib2 = LibraryManager.getDefault().createLibrary("j2se", "Stuff2", Collections.singletonMap("maven-pom", Collections.singletonList(new URL("https://repo1.maven.org/maven2/grp/stuff/2.0/stuff-2.0.pom"))));
+        Library lib = LibraryManager.getDefault().createLibrary("j2se", "Stuff", Collections.singletonMap("maven-pom", Collections.singletonList(new URL("https://repo.maven.apache.org/maven2/grp/stuff/1.0/stuff-1.0.pom"))));
+        Library lib2 = LibraryManager.getDefault().createLibrary("j2se", "Stuff2", Collections.singletonMap("maven-pom", Collections.singletonList(new URL("https://repo.maven.apache.org/maven2/grp/stuff/2.0/stuff-2.0.pom"))));
         FileObject d = FileUtil.toFileObject(getWorkDir());
         TestFileUtils.writeFile(d, "pom.xml", "<project><modelVersion>4.0.0</modelVersion>"
                 + "<groupId>test</groupId><artifactId>prj</artifactId>"

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ParseProjectXml.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ParseProjectXml.java
@@ -1283,7 +1283,7 @@ public final class ParseProjectXml extends Task {
                } else {
                    builder.append("\nYou need to download and install org-netbeans-libs-junit4.nbm into the platform to run tests.");
                    builder.append("\nIf you have Maven and agree to http://www.opensource.org/licenses/cpl1.0.txt it suffices to run:");
-                   builder.append("\nmvn dependency:get -Dartifact=junit:junit:4.13.2 -DrepoUrl=https://repo1.maven.org/maven2/");
+                   builder.append("\nmvn dependency:get -Dartifact=junit:junit:4.13.2 -DrepoUrl=https://repo.maven.apache.org/maven2/");
                }
            }
            if (!missingEntries.isEmpty()) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
@@ -61,7 +61,7 @@ import org.apache.tools.ant.util.FileUtils;
  * Motivation: http://wiki.netbeans.org/wiki/view/HgMigration#section-HgMigration-Binaries
  */
 public class DownloadBinaries extends Task {
-    private static final String MAVEN_REPO = "https://repo1.maven.org/maven2/";
+    private static final String MAVEN_REPO = "https://repo.maven.apache.org/maven2/";
 
     private static final Pattern URL_PATTERN = Pattern.compile("((https?://|file:)\\S*[^/\\s]+)\\s+(\\S+)$");
 

--- a/nbbuild/binaries-default-properties.xml
+++ b/nbbuild/binaries-default-properties.xml
@@ -22,5 +22,5 @@
 <project name="binaries-default-properties" default="netbeans" basedir=".">
   <property name="binaries.cache" location="${user.home}/.hgexternalcache"/>
   <property name="binaries.server" value="https://netbeans.osuosl.org/binaries/"/>
-  <property name="binaries.repos" value="https://repo1.maven.org/maven2/"/>
+  <property name="binaries.repos" value="https://repo.maven.apache.org/maven2/"/>
 </project>

--- a/platform/core.startup/src/org/netbeans/core/startup/MavenRepoURLHandler.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/MavenRepoURLHandler.java
@@ -32,7 +32,7 @@ public final class MavenRepoURLHandler extends URLStreamHandler {
     private static final URI CENTRAL_REPO_URI;
     static {
         try {
-            CENTRAL_REPO_URI = new URI("https://repo1.maven.org/maven2/");
+            CENTRAL_REPO_URI = new URI("https://repo.maven.apache.org/maven2/");
         } catch (URISyntaxException ex) {
             throw new IllegalStateException(ex);
         }


### PR DESCRIPTION
 - switch everything to repo.maven.apache.org
 - which is the default used by maven
 - domain is managed by ASF which should make it future proof since it can redirect to other places