### PR TITLE
Better transient repo deduplication.

### DIFF
--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImpl.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImpl.java
@@ -569,6 +569,10 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
                         removeGroupCache(repo);
                         fetchUpdateResult = remoteIndexUpdater.fetchAndUpdateIndex(iur);
                         storeGroupCache(repo, indexingContext);
+                        // register indexed repo in services view
+                        if (fetchUpdateResult.isFullUpdate() && fetchUpdateResult.isSuccessful()) {
+                            RepositoryPreferences.getInstance().addOrModifyRepositoryInfo(repo);
+                        }
                     } catch (IOException | AlreadyClosedException | IllegalArgumentException ex) {
                         // AlreadyClosedException can happen in low storage situations when lucene is trying to handle IOEs
                         // IllegalArgumentException signals remote archive format problems

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferences.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferences.java
@@ -80,6 +80,7 @@ public final class RepositoryPreferences {
     private static final String PROP_INDEX_DOWNLOAD_PERMISSIONS = "indexDownloadPermissions"; //NOI18N
     public static final String PROP_MT_INDEX_EXTRACTION = "indexMultiThreadedExtraction"; //NOI18N
     public static final String PROP_INDEX_DATE_CUTOFF_FILTER = "indexDateCotoffFilter"; //NOI18N
+    private static final String ALT_CENTRAL_URL = "https://repo1.maven.org/maven2"; //NOI18N
 
     public static final int FREQ_ONCE_WEEK = 0;
     public static final int FREQ_ONCE_DAY = 1;
@@ -545,12 +546,12 @@ public final class RepositoryPreferences {
             //only register repositories we can safely handle.. #227322
             return;
         }
+        if (url.equals(ALT_CENTRAL_URL) || url.equals(ALT_CENTRAL_URL+"/")) {
+            // map to primary URL to avoid duplicates
+            url = RepositorySystem.DEFAULT_REMOTE_REPO_URL;
+        }
         synchronized (infoCache) {
-            List<RepositoryInfo> infos = transients.get(key);
-            if (infos == null) {
-                infos = new ArrayList<>();
-                transients.put(key, infos);
-            }
+            List<RepositoryInfo> infos = transients.computeIfAbsent(key, k -> new ArrayList<>());
             RepositoryInfo info = new RepositoryInfo(id, displayName, null, url);
             info.setMirrorStrategy(strategy);
             infos.add(info);


### PR DESCRIPTION
Transient repos are added and removed based on what projects are open. NB does some deduplication since projects may define the same repo with a different ID or URL. This works fine until projects are closed and there is nothing to deduplicate anymore - NB might think that a repo is now new and index it again under a different ID.

this PR makes two changes:
 - `repo1.maven.org` is now tracked as `repo.maven.apache.org`
 - remote repos are registered in the services view once fully indexed, this makes them no longer transient

fixes #6753

previews PR #6754 updated the maven central URL project wide, this is part 2

transient repos can be monitored in real time by observing the services view:
![image](https://github.com/apache/netbeans/assets/114367/ce78efab-9946-4a88-98aa-9d217a95f922)

(for testing purposes I added a mirror as regular repo with a different ID, this is not recommended - use the mirror tag)