### PR TITLE
Computing hints based on custom preferences

### DIFF
--- a/ide/api.lsp/apichanges.xml
+++ b/ide/api.lsp/apichanges.xml
@@ -51,6 +51,19 @@
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
 <changes>
+    <change id="ErrorProvider.Context.getHintsConfigFile">
+        <api name="LSP_API"/>
+        <summary>Adding ErrorProvider.Context.getHintsConfigFile() method</summary>
+        <version major="1" minor="25"/>
+        <date day="14" month="12" year="2023"/>
+        <author login="Achal1607"/>
+        <compatibility binary="compatible" source="compatible" addition="yes" deletion="no" />
+        <description>
+            An <code>ErrorProvider.Context.getHintsConfigFile()</code> method introduced that allows to
+            get hints preference file config.
+        </description>
+        <class package="org.netbeans.spi.lsp" name="ErrorProvider"/>
+    </change>
     <change id="Completion_getLabelDetail">
         <api name="LSP_API"/>
         <summary>Added Completion.getLabelDetail() and Completion.getLabelDescription() methods.</summary>

--- a/ide/api.lsp/src/org/netbeans/spi/lsp/ErrorProvider.java
+++ b/ide/api.lsp/src/org/netbeans/spi/lsp/ErrorProvider.java
@@ -50,6 +50,7 @@ public interface ErrorProvider {
         private final Kind errorKind;
         private final AtomicBoolean cancel = new AtomicBoolean();
         private final List<Runnable> cancelCallbacks = new ArrayList<>();
+        private final FileObject hintsConfigFile;
 
         /**
          * Construct a new {@code Context}.
@@ -71,9 +72,38 @@ public interface ErrorProvider {
          * @since 1.4
          */
         public Context(FileObject file, int offset, Kind errorKind) {
+            this(file, offset, errorKind, null);
+        }
+
+        /**
+         * Construct a new {@code Context}.
+         *
+         * @param file file for which the errors/warnings should be computed
+         * @param offset offset for which the errors/warnings should be computed
+         * @param errorKind the type of errors/warnings that should be computed
+         * @param hintsConfigFile file which contains preferences for the the errors/warnings to be computed
+         *
+         * @since 1.25
+         * 
+         */
+        public Context(FileObject file, int offset, Kind errorKind, FileObject hintsConfigFile) {
             this.file = file;
             this.offset = offset;
             this.errorKind = errorKind;
+            this.hintsConfigFile = hintsConfigFile;
+        }
+
+        /**
+         *
+         * The file which contains preferences for the the errors/warnings to be computed.
+         *
+         * @return the file which contains preferences for the the errors/warnings to be computed
+         *
+         * @since 1.25
+         * 
+         */
+        public FileObject getHintsConfigFile() {
+            return hintsConfigFile;
         }
 
         /**

--- a/java/java.hints/nbproject/project.xml
+++ b/java/java.hints/nbproject/project.xml
@@ -166,6 +166,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.editor.tools.storage</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.31</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.editor.util</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/JavaErrorProvider.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/JavaErrorProvider.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.prefs.Preferences;
 import javax.lang.model.element.Element;
 import org.netbeans.api.editor.mimelookup.MimeRegistration;
 import org.netbeans.api.java.source.CompilationController;
@@ -56,6 +57,7 @@ import org.netbeans.api.lsp.ResourceOperation.CreateFile;
 import org.netbeans.api.lsp.TextDocumentEdit;
 import org.netbeans.api.lsp.TextEdit;
 import org.netbeans.api.lsp.WorkspaceEdit;
+import org.netbeans.modules.editor.tools.storage.api.ToolPreferences;
 import org.netbeans.modules.java.hints.errors.ModificationResultBasedFix;
 import org.netbeans.modules.java.hints.errors.ImportClass;
 import org.netbeans.modules.java.hints.project.IncompleteClassPath;
@@ -85,7 +87,8 @@ import org.openide.util.Union2;
  */
 @MimeRegistration(mimeType="text/x-java", service=ErrorProvider.class)
 public class JavaErrorProvider implements ErrorProvider {
-
+    
+    public static final String HINTS_TOOL_ID = "hints";
     public static Consumer<ErrorProvider.Kind> computeDiagsCallback; //for tests
 
     @Override
@@ -113,7 +116,16 @@ public class JavaErrorProvider implements ErrorProvider {
                                 if (disabled.size() != Severity.values().length) {
                                     AtomicBoolean cancel = new AtomicBoolean();
                                     context.registerCancelCallback(() -> cancel.set(true));
-                                    result.addAll(convert2Diagnostic(context.errorKind(), new HintsInvoker(HintsSettings.getGlobalSettings(), context.getOffset(), cancel).computeHints(cc), ed -> !disabled.contains(ed.getSeverity())));
+                                    HintsSettings settings;
+                                    
+                                    if (context.getHintsConfigFile() != null) {
+                                        Preferences hintSettings = ToolPreferences.from(context.getHintsConfigFile().toURI()).getPreferences(HINTS_TOOL_ID, "text/x-java");
+                                        settings = HintsSettings.createPreferencesBasedHintsSettings(hintSettings, true, null);
+                                    } else {
+                                        settings = HintsSettings.getGlobalSettings();
+                                    }
+                                    result.addAll(convert2Diagnostic(context.errorKind(), new HintsInvoker(settings, context.getOffset(), cancel).computeHints(cc), ed -> !disabled.contains(ed.getSeverity())));
+                                    
                                 }
                                 break;
                         }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -165,6 +165,7 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
 
     private static final RequestProcessor WORKER = new RequestProcessor(WorkspaceServiceImpl.class.getName(), 1, false, false);
     private static final RequestProcessor PROJECT_WORKER = new RequestProcessor(WorkspaceServiceImpl.class.getName(), 5, false, false);
+    private static final String NETBEANS_JAVA_HINTS = "hints";
 
     private final Gson gson = new Gson();
     private final LspServerState server;
@@ -175,7 +176,7 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
      * and then updated by didChangeWorkspaceFolder notifications.
      */
     private volatile List<FileObject> clientWorkspaceFolders = Collections.emptyList();
-
+    
     WorkspaceServiceImpl(LspServerState server) {
         this.server = server;
     }
@@ -1331,6 +1332,7 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
         String fullConfigPrefix = client.getNbCodeCapabilities().getConfigurationPrefix();
         String configPrefix = fullConfigPrefix.substring(0, fullConfigPrefix.length() - 1);
         server.openedProjects().thenAccept(projects -> {
+            ((TextDocumentServiceImpl)server.getTextDocumentService()).updateJavaHintPreferences(((JsonObject) params.getSettings()).getAsJsonObject(configPrefix).getAsJsonObject(NETBEANS_JAVA_HINTS));
             if (projects != null && projects.length > 0) {
                 updateJavaFormatPreferences(projects[0].getProjectDirectory(), ((JsonObject) params.getSettings()).getAsJsonObject(configPrefix).getAsJsonObject("format"));
                 updateJavaImportPreferences(projects[0].getProjectDirectory(), ((JsonObject) params.getSettings()).getAsJsonObject(configPrefix).getAsJsonObject("java").getAsJsonObject("imports"));


### PR DESCRIPTION
Currently hints are computed on the basis of global default preferences in lsp server. So, added an option to compute hints on the basis of custom hint preferences file if available. 

Refer to [#javavscode-9](https://github.com/oracle/javavscode/issues/9)