### PR TITLE
Adjusting command name for surround.with.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/SurroundWithHint.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/SurroundWithHint.java
@@ -80,7 +80,7 @@ import org.openide.util.lookup.ServiceProvider;
 public final class SurroundWithHint extends CodeActionsProvider {
 
     private static final String COMMAND_INSERT_SNIPPET = "editor.action.insertSnippet";
-    private static final String COMMAND_SURROUND_WITH = "surround.with";
+    private static final String COMMAND_SURROUND_WITH = "nbls.surround.with";
     private static final String DOTS = "...";
     private static final String SNIPPET = "snippet";
     private static final String SELECTION_VAR = "${selection}";


### PR DESCRIPTION
One forgotten place where an unprefixed command name is used. It is used for the generic "Surround with ..." action. The frontend already uses the correct name:
https://github.com/apache/netbeans/blob/348b0cd2951cabc5dcc06e2f5f585a0a1b345fdd/java/java.lsp.server/vscode/src/extension.ts#L526

Sorry for missing this.
