### PR TITLE
Added warning for case where var and diamond operator are used together

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Bundle.properties
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Bundle.properties
@@ -49,6 +49,10 @@ DESC_org.netbeans.modules.java.hints.bugs.Tiny.equalsNull=Finds invocations of t
 ERR_equalsNull=Object equals "null" is never true
 FIX_equalsNull=Use == instead of equals method
 
+DN_org.netbeans.modules.java.hints.bugs.Tiny.varTypeDiamondOperator= var used with diamond operator
+DESC_org.netbeans.modules.java.hints.bugs.Tiny.varTypeDiamondOperator=Finds variables initialzed using var and diamond operator
+ERR_varTypeDiamondOperator=<> would be inferred as <Object>
+
 DN_org.netbeans.modules.java.hints.bugs.Tiny.resultSet=Incorrect column index in ResultSet
 DESC_org.netbeans.modules.java.hints.bugs.Tiny.resultSet=Reports Iincorrect column indices passed to various methods of java.sql.ResultSet
 ERR_ResultSetZero=Column index is zero, but ResultSet columns are counted from 1

--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Tiny.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Tiny.java
@@ -32,9 +32,11 @@ import com.sun.source.tree.LineMap;
 import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.SwitchTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
+import com.sun.source.tree.VariableTree;
 import com.sun.source.tree.WhileLoopTree;
 import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreePath;
@@ -51,6 +53,8 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -195,6 +199,42 @@ public class Tiny {
         return ErrorDescriptionFactory.forTree(ctx, ctx.getPath(), displayName, fix);
     }
 
+    @Hint(displayName = "#DN_org.netbeans.modules.java.hints.bugs.Tiny.varTypeDiamondOperator", description = "#DESC_org.netbeans.modules.java.hints.bugs.Tiny.varTypeDiamondOperator", category="bugs", suppressWarnings="AllowVarTypeDiamondOperator")
+    @TriggerPatterns({
+        @TriggerPattern(value="$mods$ $varType $name = new $type<>($args$)", constraints=@ConstraintVariableType(variable="$type", type="java.util.Collection")),
+        @TriggerPattern(value="$mods$ $varType $name = new $type<>($args$)", constraints=@ConstraintVariableType(variable="$type", type="java.util.Map"))
+    })
+    public static ErrorDescription varTypeDiamondOperator(HintContext ctx) {
+        TreePath path = ctx.getPath();
+        Boolean isVarUsed = ctx.getInfo().getTreeUtilities().isVarType(path);
+        if(!isVarUsed){
+            return null;
+        }
+
+        VariableTree vt = (VariableTree) ctx.getPath().getLeaf();
+        NewClassTree nct = (NewClassTree) vt.getInitializer();
+        Element constructorCand = ctx.getInfo().getTrees().getElement(new TreePath(ctx.getPath(), nct));
+
+        if (constructorCand.getKind() != ElementKind.CONSTRUCTOR) {
+            return null;
+        }
+
+        ExecutableElement constructor = (ExecutableElement) constructorCand;
+
+        for (VariableElement param : constructor.getParameters()) {
+            if (param.asType().getKind() == TypeKind.DECLARED) {
+                DeclaredType dt = (DeclaredType) param.asType();
+                if (!dt.getTypeArguments().isEmpty()) {
+                    return null;
+                }
+            }
+        }
+
+        String displayName = NbBundle.getMessage(Tiny.class, "ERR_varTypeDiamondOperator");
+
+        return ErrorDescriptionFactory.forTree(ctx, path, displayName);
+    }
+    
     @Hint(displayName = "#DN_org.netbeans.modules.java.hints.bugs.Tiny.resultSet", description = "#DESC_org.netbeans.modules.java.hints.bugs.Tiny.resultSet", category="bugs", suppressWarnings="UseOfIndexZeroInJDBCResultSet", options=Options.QUERY)
     @TriggerPattern(value="$set.$method($columnIndex, $other$)",
                     constraints={

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/Bundle_test.properties
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/Bundle_test.properties
@@ -33,6 +33,8 @@ ERR_system_arraycopy_negative={0} is negative
 ERR_equalsNull=ERR_equalsNull
 FIX_equalsNull=FIX_equalsNull
 
+ERR_varTypeDiamondOperator=ERR_varTypeDiamondOperator
+
 ERR_ResultSetZero=ERR_ResultSetZero
 ERR_ResultSetNegative=ERR_ResultSetNegative
 

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/TinyTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/TinyTest.java
@@ -356,6 +356,121 @@ public class TinyTest extends NbTestCase {
         }
     }
 
+    public void testVarUsageWithoutExplicitType() throws Exception {
+        HintTest.create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void test() {\n" +
+                       "        var v = new java.util.ArrayList<>();\n" +
+                       "    }\n" +
+                       "}\n")
+                .sourceLevel("11")
+                .run(Tiny.class)
+                .assertWarnings("3:8-3:44:verifier:ERR_varTypeDiamondOperator");
+    }
+    
+    public void testVarUsageWithoutExplicitType2() throws Exception {
+        HintTest.create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void test() {\n" +
+                       "        var v = new java.util.HashSet<>();\n" +
+                       "    }\n" +
+                       "}\n")
+                .sourceLevel("11")
+                .run(Tiny.class)
+                .assertWarnings("3:8-3:42:verifier:ERR_varTypeDiamondOperator");
+    }
+    
+    public void testVarUsageWithoutExplicitType3() throws Exception {
+        HintTest.create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void test() {\n" +
+                       "        var v = new java.util.HashMap<>();\n" +
+                       "    }\n" +
+                       "}\n")
+                .sourceLevel("11")
+                .run(Tiny.class)
+                .assertWarnings("3:8-3:42:verifier:ERR_varTypeDiamondOperator");
+    }
+    
+    public void testVarUsageWithExplicitType() throws Exception {
+        HintTest.create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void test() {\n" +
+                       "        var v = new java.util.ArrayList<Integer>();\n" +
+                       "    }\n" +
+                       "}\n")
+                .sourceLevel("11")
+                .run(Tiny.class)
+                .assertWarnings();
+    }
+
+    public void testVarUsageWithExplicitType2() throws Exception {
+        HintTest.create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void test() {\n" +
+                       "        var v = new String[2];\n" +
+                       "    }\n" +
+                       "}\n")
+                .sourceLevel("11")
+                .run(Tiny.class)
+                .assertWarnings();
+    }
+    
+    public void testWithoutVarUsageWithExplicitType() throws Exception {
+        HintTest.create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void test() {\n" +
+                       "        java.util.List<Integer> v = new java.util.ArrayList<Integer>();\n" +
+                       "    }\n" +
+                       "}\n")
+                .run(Tiny.class)
+                .assertWarnings();
+    }
+    
+    public void testWithoutVarUsageWithExplicitType2() throws Exception {
+        HintTest.create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void test() {\n" +
+                       "        java.util.List<Integer> v = new java.util.ArrayList<>();\n" +
+                       "    }\n" +
+                       "}\n")
+                .run(Tiny.class)
+                .assertWarnings();
+    }
+    
+    public void testVarUsageSensibleTypeInferred1() throws Exception {
+        HintTest.create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void test(java.util.Set<String> input) {\n" +
+                       "        var v = new java.util.HashSet<>(input);\n" +
+                       "    }\n" +
+                       "}\n")
+                .sourceLevel("11")
+                .run(Tiny.class)
+                .assertWarnings();
+    }
+
+    public void testVarUsageSensibleTypeInferred2() throws Exception {
+        HintTest.create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void test(java.util.Map<String, String> input) {\n" +
+                       "        var v = new java.util.HashMap<>(input);\n" +
+                       "    }\n" +
+                       "}\n")
+                .sourceLevel("11")
+                .run(Tiny.class)
+                .assertWarnings();
+    }
+
     private static Map<String, String> alterSettings(String... settings) throws Exception {
         //XXX: hack, need to initialize the HintTest's lookup before setting the
         //formatting preferences


### PR DESCRIPTION
The user may be surprised that `var v = new ArrayList<>();` will be inferred as `ArrayList<Object>`. So, added a warning for such case.

closes [#javavscode-69](https://github.com/oracle/javavscode/issues/69)