### PR TITLE
DRAFT: Added autocomplete suggestions for PHP variables when they are declared with a namespace

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/CompletionContextFinder.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/CompletionContextFinder.java
@@ -116,6 +116,8 @@ final class CompletionContextFinder {
             new Object[]{PHPTokenId.PHP_USE, PHPTokenId.WHITESPACE, PHPTokenId.PHP_FUNCTION, PHPTokenId.WHITESPACE, PHPTokenId.PHP_STRING},
             new Object[]{PHPTokenId.PHP_USE, PHPTokenId.WHITESPACE, PHPTokenId.PHP_FUNCTION, PHPTokenId.WHITESPACE, NAMESPACE_FALSE_TOKEN},
             new Object[]{PHPTokenId.PHP_USE, PHPTokenId.WHITESPACE, PHPTokenId.PHP_FUNCTION, COMBINED_USE_STATEMENT_TOKENS});
+    private static final Object[] NAMESPACED_FUNCTION_PARAMETERS_IDENTIFIER =
+            new Object[]{NAMESPACE_FALSE_TOKEN, PHPTokenId.WHITESPACE, PHPTokenId.PHP_TOKEN};
     private static final List<Object[]> NAMESPACE_KEYWORD_TOKENS = Arrays.asList(
             new Object[]{PHPTokenId.PHP_NAMESPACE},
             new Object[]{PHPTokenId.PHP_NAMESPACE, PHPTokenId.WHITESPACE},
@@ -215,7 +217,7 @@ final class CompletionContextFinder {
         HTML, CLASS_NAME, INTERFACE_NAME, BACKING_TYPE,
         TYPE_NAME, RETURN_TYPE_NAME, RETURN_UNION_OR_INTERSECTION_TYPE_NAME, FIELD_TYPE_NAME, VISIBILITY_MODIFIER_OR_TYPE_NAME, STRING,
         CLASS_MEMBER, STATIC_CLASS_MEMBER, PHPDOC, INHERITANCE, EXTENDS, IMPLEMENTS, METHOD_NAME,
-        CLASS_MEMBER_PARAMETER_NAME, STATIC_CLASS_MEMBER_PARAMETER_NAME, FUNCTION_PARAMETER_NAME,
+        CLASS_MEMBER_PARAMETER_NAME, STATIC_CLASS_MEMBER_PARAMETER_NAME, FUNCTION_PARAMETER_NAME, NAMESPACED_FUNCTION_PARAMETER_IDENTIFIER,
         CLASS_CONTEXT_KEYWORDS, SERVER_ENTRY_CONSTANTS, NONE, NEW_CLASS, GLOBAL, NAMESPACE_KEYWORD,
         GROUP_USE_KEYWORD, GROUP_USE_CONST_KEYWORD, GROUP_USE_FUNCTION_KEYWORD,
         USE_KEYWORD, USE_CONST_KEYWORD, USE_FUNCTION_KEYWORD, DEFAULT_PARAMETER_VALUE, OPEN_TAG, THROW, THROW_NEW, CATCH, CLASS_MEMBER_IN_STRING,
@@ -315,7 +317,9 @@ final class CompletionContextFinder {
             }
             return CompletionContext.INTERFACE_CONTEXT_KEYWORDS;
         } else if (isInsideClassOrTraitOrEnumDeclarationBlock(info, caretOffset, tokenSequence)) {
-            if (acceptTokenChains(tokenSequence, USE_KEYWORD_TOKENS, moveNextSucces)) {
+            if (acceptTokenChain(tokenSequence, NAMESPACED_FUNCTION_PARAMETERS_IDENTIFIER, moveNextSucces)) {
+                return CompletionContext.NAMESPACED_FUNCTION_PARAMETER_IDENTIFIER;
+            } else if (acceptTokenChains(tokenSequence, USE_KEYWORD_TOKENS, moveNextSucces)) {
                 return CompletionContext.USE_TRAITS;
             } else if (acceptTokenChains(tokenSequence, METHOD_NAME_TOKENCHAINS, moveNextSucces)) {
                 return CompletionContext.METHOD_NAME;

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
@@ -51,6 +51,7 @@ import org.netbeans.modules.csl.api.CodeCompletionResult;
 import org.netbeans.modules.csl.api.CompletionProposal;
 import org.netbeans.modules.csl.api.Documentation;
 import org.netbeans.modules.csl.api.ElementHandle;
+import org.netbeans.modules.csl.api.ElementKind;
 import org.netbeans.modules.csl.api.ParameterInfo;
 import org.netbeans.modules.csl.spi.ParserResult;
 import org.netbeans.modules.csl.spi.support.CancelSupport;
@@ -643,6 +644,9 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
             case CLASS_MEMBER_IN_STRING:
                 autoCompleteClassFields(completionResult, request);
                 break;
+            case NAMESPACED_FUNCTION_PARAMETER_IDENTIFIER:
+                autoCompleteNamespacedFunctionParameterIdentifier(info, completionResult, request);
+                break;
             case SERVER_ENTRY_CONSTANTS:
                 //TODO: probably better PHPCompletionItem instance should be used
                 //autoCompleteMagicItems(proposals, request, PredefinedSymbols.SERVER_ENTRY_CONSTANTS);
@@ -1199,6 +1203,34 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
 
     private void autoCompleteInInterfaceContext(final PHPCompletionResult completionResult, final PHPCompletionItem.CompletionRequest request) {
         autoCompleteKeywords(completionResult, request, INTERFACE_CONTEXT_KEYWORD_PROPOSAL);
+    }
+
+    private void autoCompleteNamespacedFunctionParameterIdentifier(
+        ParserResult info,
+        final PHPCompletionResult completionResult,
+        PHPCompletionItem.CompletionRequest request) {
+        if (CancelSupport.getDefault().isCancelled()) {
+            return;
+        }
+
+        TokenHierarchy<?> th = info.getSnapshot().getTokenHierarchy();
+        TokenSequence<PHPTokenId> tokenSequence = th.tokenSequence(PHPTokenId.language());
+        assert tokenSequence != null;
+
+        tokenSequence.move(request.anchor - 1);
+
+        if (!tokenSequence.movePrevious()) {
+            return;
+        }
+
+        final String namespace = tokenSequence.token().text().toString();
+        final String varName = "$" + namespace.substring(0, 1).toLowerCase() + namespace.substring(1);
+        completionResult.add(new PHPCompletionItem.KeywordItem(varName, request) {
+            @Override
+            public ElementKind getKind() {
+                return ElementKind.VARIABLE;
+            }
+        });
     }
 
     private void autoCompleteInClassContext(


### PR DESCRIPTION
A simple feature present in most other IDEs. When declaring a variable with a namespace as type (method parameters, class variables), we usually just name the variable as that namespace like `FancyService $fancyService` and similar. At least, I do, so I figured, this would be a nice addition to NetBeans. After using most other IDEs and getting back to NetBeans, I personally miss this feature.

As my first contribution, I think this would be a great place to start. The PR is work in progress, since I haven't added tests for it yet, but I wanted to see what people think about the functionality itself and maybe get some suggestions for improvement.

Some examples illustrated:

![image](https://github.com/apache/netbeans/assets/13246873/48a92567-c69d-4ae8-9075-2aaed71812c1)

![image](https://github.com/apache/netbeans/assets/13246873/4f93cf8b-743e-4c90-ac06-db177cbe3a1c)

![image](https://github.com/apache/netbeans/assets/13246873/3ad5b515-4592-4f06-8e6d-008a5c5c05b0)

