### PR TITLE
Fix Swaped proxy and exec combo in Gradle Options

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/options/SettingsPanel.form
+++ b/extide/gradle/src/org/netbeans/modules/gradle/options/SettingsPanel.form
@@ -41,7 +41,7 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,-90,0,0,2,-125"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,-90,0,0,2,-91"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
@@ -137,7 +137,7 @@
           <Layout>
             <DimensionLayout dim="0">
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" alignment="1" attributes="0">
+                  <Group type="102" attributes="0">
                       <EmptySpace max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="1" attributes="0">
                           <Component id="distributionPanel" max="32767" attributes="0"/>
@@ -154,7 +154,7 @@
                       <Component id="distributionPanel" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="executionPanel" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace pref="69" max="32767" attributes="0"/>
+                      <EmptySpace pref="66" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -194,7 +194,7 @@
                                       </Group>
                                       <Group type="102" attributes="0">
                                           <Component id="rbPreferWrapper" min="-2" max="-2" attributes="0"/>
-                                          <EmptySpace min="0" pref="13" max="32767" attributes="0"/>
+                                          <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                                       </Group>
                                   </Group>
                               </Group>
@@ -381,9 +381,9 @@
                                   </Group>
                                   <EmptySpace type="unrelated" max="-2" attributes="0"/>
                                   <Group type="103" groupAlignment="1" attributes="0">
-                                      <Component id="cbNetworkProxy" alignment="0" max="32767" attributes="0"/>
                                       <Component id="cbAllowExecution" max="32767" attributes="0"/>
                                       <Component id="cbJavaRuntime" alignment="0" max="32767" attributes="0"/>
+                                      <Component id="cbNetworkProxy" max="32767" attributes="0"/>
                                   </Group>
                                   <EmptySpace max="-2" attributes="0"/>
                                   <Component id="btManageRuntimes" min="-2" max="-2" attributes="0"/>
@@ -417,14 +417,14 @@
                           <EmptySpace min="-2" pref="6" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="3" attributes="0">
                               <Component id="lbAllowExecution" alignment="3" min="-2" max="-2" attributes="0"/>
-                              <Component id="cbNetworkProxy" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="cbAllowExecution" alignment="3" min="-2" max="-2" attributes="0"/>
                           </Group>
                           <EmptySpace min="-2" pref="5" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="3" attributes="0">
                               <Component id="lbNetworkProxy" alignment="3" min="-2" max="-2" attributes="0"/>
-                              <Component id="cbAllowExecution" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="cbNetworkProxy" alignment="3" min="-2" max="-2" attributes="0"/>
                           </Group>
-                          <EmptySpace type="separate" max="32767" attributes="0"/>
+                          <EmptySpace type="separate" pref="9" max="32767" attributes="0"/>
                       </Group>
                   </Group>
                 </DimensionLayout>
@@ -470,6 +470,9 @@
                 </Component>
                 <Component class="javax.swing.JLabel" name="lbJavaRuntime">
                   <Properties>
+                    <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+                      <ComponentRef name="cbJavaRuntime"/>
+                    </Property>
                     <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
                       <ResourceString bundle="org/netbeans/modules/gradle/options/Bundle.properties" key="SettingsPanel.lbJavaRuntime.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
                     </Property>
@@ -483,6 +486,9 @@
                 <Component class="javax.swing.JLabel" name="lbAllowExecution">
                   <Properties>
                     <Property name="horizontalAlignment" type="int" value="11"/>
+                    <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+                      <ComponentRef name="cbAllowExecution"/>
+                    </Property>
                     <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
                       <ResourceString bundle="org/netbeans/modules/gradle/options/Bundle.properties" key="SettingsPanel.lbAllowExecution.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
                     </Property>
@@ -495,15 +501,13 @@
                 </Component>
                 <Component class="javax.swing.JLabel" name="lbNetworkProxy">
                   <Properties>
+                    <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+                      <ComponentRef name="cbNetworkProxy"/>
+                    </Property>
                     <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
                       <ResourceString bundle="org/netbeans/modules/gradle/options/Bundle.properties" key="SettingsPanel.lbNetworkProxy.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
                     </Property>
                   </Properties>
-                </Component>
-                <Component class="javax.swing.JComboBox" name="cbNetworkProxy">
-                  <AuxValues>
-                    <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;NetworkProxySettings&gt;"/>
-                  </AuxValues>
                 </Component>
                 <Component class="javax.swing.JButton" name="btManageRuntimes">
                   <Properties>
@@ -514,6 +518,11 @@
                   <Events>
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btManageRuntimesActionPerformed"/>
                   </Events>
+                </Component>
+                <Component class="javax.swing.JComboBox" name="cbNetworkProxy">
+                  <AuxValues>
+                    <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;NetworkProxySettings&gt;"/>
+                  </AuxValues>
                 </Component>
               </SubComponents>
             </Container>
@@ -636,7 +645,7 @@
                       <Group type="102" alignment="0" attributes="0">
                           <EmptySpace max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="0" attributes="0">
-                              <Component id="cbReuseEditorOnStackTrace" pref="501" max="32767" attributes="0"/>
+                              <Component id="cbReuseEditorOnStackTrace" pref="525" max="32767" attributes="0"/>
                               <Component id="cbReuseOutputTabs" alignment="1" max="32767" attributes="0"/>
                               <Component id="cbAlwaysShowOutput" max="32767" attributes="0"/>
                           </Group>
@@ -744,7 +753,7 @@
                           </Group>
                           <EmptySpace type="unrelated" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="0" attributes="0">
-                              <Component id="cbDownloadSources" pref="198" max="32767" attributes="0"/>
+                              <Component id="cbDownloadSources" pref="195" max="32767" attributes="0"/>
                               <Component id="cbDownloadLibs" max="32767" attributes="0"/>
                               <Component id="cbDownloadJavadoc" max="32767" attributes="0"/>
                           </Group>
@@ -886,7 +895,7 @@
                       <Group type="102" alignment="0" attributes="0">
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="cbPreferMaven" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace pref="191" max="32767" attributes="0"/>
+                          <EmptySpace pref="185" max="32767" attributes="0"/>
                       </Group>
                   </Group>
                 </DimensionLayout>
@@ -965,7 +974,7 @@
                               <Component id="cbEnableCache" min="-2" max="-2" attributes="0"/>
                               <Component id="cbBundledLoading" alignment="0" min="-2" max="-2" attributes="0"/>
                           </Group>
-                          <EmptySpace pref="249" max="32767" attributes="0"/>
+                          <EmptySpace pref="254" max="32767" attributes="0"/>
                       </Group>
                   </Group>
                 </DimensionLayout>

--- a/extide/gradle/src/org/netbeans/modules/gradle/options/SettingsPanel.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/options/SettingsPanel.java
@@ -138,8 +138,8 @@ public class SettingsPanel extends javax.swing.JPanel {
         lbAllowExecution = new javax.swing.JLabel();
         cbAllowExecution = new javax.swing.JComboBox<>();
         lbNetworkProxy = new javax.swing.JLabel();
-        cbNetworkProxy = new javax.swing.JComboBox<>();
         btManageRuntimes = new javax.swing.JButton();
+        cbNetworkProxy = new javax.swing.JComboBox<>();
         pnlAppearance = new javax.swing.JPanel();
         javax.swing.JPanel jPanel4 = new javax.swing.JPanel();
         cbDisplayDescription = new javax.swing.JCheckBox();
@@ -275,7 +275,7 @@ public class SettingsPanel extends javax.swing.JPanel {
                                 .addComponent(btUseCustomGradle, javax.swing.GroupLayout.DEFAULT_SIZE, 102, Short.MAX_VALUE))
                             .addGroup(distributionPanelLayout.createSequentialGroup()
                                 .addComponent(rbPreferWrapper)
-                                .addGap(0, 13, Short.MAX_VALUE))))
+                                .addGap(0, 0, Short.MAX_VALUE))))
                     .addGroup(distributionPanelLayout.createSequentialGroup()
                         .addComponent(lblGradleUserHome)
                         .addGap(9, 9, 9)
@@ -330,11 +330,14 @@ public class SettingsPanel extends javax.swing.JPanel {
 
         org.openide.awt.Mnemonics.setLocalizedText(cbSkipTest, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.cbSkipTest.text")); // NOI18N
 
+        lbJavaRuntime.setLabelFor(cbJavaRuntime);
         org.openide.awt.Mnemonics.setLocalizedText(lbJavaRuntime, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.lbJavaRuntime.text")); // NOI18N
 
         lbAllowExecution.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
+        lbAllowExecution.setLabelFor(cbAllowExecution);
         org.openide.awt.Mnemonics.setLocalizedText(lbAllowExecution, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.lbAllowExecution.text")); // NOI18N
 
+        lbNetworkProxy.setLabelFor(cbNetworkProxy);
         org.openide.awt.Mnemonics.setLocalizedText(lbNetworkProxy, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.lbNetworkProxy.text")); // NOI18N
 
         org.openide.awt.Mnemonics.setLocalizedText(btManageRuntimes, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.btManageRuntimes.text")); // NOI18N
@@ -368,9 +371,9 @@ public class SettingsPanel extends javax.swing.JPanel {
                             .addComponent(lbNetworkProxy, javax.swing.GroupLayout.PREFERRED_SIZE, 142, javax.swing.GroupLayout.PREFERRED_SIZE))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                         .addGroup(executionPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                            .addComponent(cbNetworkProxy, javax.swing.GroupLayout.Alignment.LEADING, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                             .addComponent(cbAllowExecution, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                            .addComponent(cbJavaRuntime, javax.swing.GroupLayout.Alignment.LEADING, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                            .addComponent(cbJavaRuntime, javax.swing.GroupLayout.Alignment.LEADING, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                            .addComponent(cbNetworkProxy, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(btManageRuntimes)))
                 .addContainerGap())
@@ -399,19 +402,19 @@ public class SettingsPanel extends javax.swing.JPanel {
                 .addGap(6, 6, 6)
                 .addGroup(executionPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(lbAllowExecution)
-                    .addComponent(cbNetworkProxy, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addComponent(cbAllowExecution, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addGap(5, 5, 5)
                 .addGroup(executionPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(lbNetworkProxy)
-                    .addComponent(cbAllowExecution, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addGap(18, 18, Short.MAX_VALUE))
+                    .addComponent(cbNetworkProxy, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addGap(9, 9, Short.MAX_VALUE))
         );
 
         javax.swing.GroupLayout pnlExecutionLayout = new javax.swing.GroupLayout(pnlExecution);
         pnlExecution.setLayout(pnlExecutionLayout);
         pnlExecutionLayout.setHorizontalGroup(
             pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, pnlExecutionLayout.createSequentialGroup()
+            .addGroup(pnlExecutionLayout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
                     .addComponent(distributionPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
@@ -425,7 +428,7 @@ public class SettingsPanel extends javax.swing.JPanel {
                 .addComponent(distributionPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(executionPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(69, Short.MAX_VALUE))
+                .addContainerGap(66, Short.MAX_VALUE))
         );
 
         pnlCards.add(pnlExecution, "Execution");
@@ -476,7 +479,7 @@ public class SettingsPanel extends javax.swing.JPanel {
             .addGroup(jPanel5Layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(jPanel5Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(cbReuseEditorOnStackTrace, javax.swing.GroupLayout.DEFAULT_SIZE, 501, Short.MAX_VALUE)
+                    .addComponent(cbReuseEditorOnStackTrace, javax.swing.GroupLayout.DEFAULT_SIZE, 525, Short.MAX_VALUE)
                     .addComponent(cbReuseOutputTabs, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(cbAlwaysShowOutput, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addContainerGap())
@@ -546,7 +549,7 @@ public class SettingsPanel extends javax.swing.JPanel {
                     .addComponent(lbDownloadLibs, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addGroup(jPanel8Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(cbDownloadSources, 0, 198, Short.MAX_VALUE)
+                    .addComponent(cbDownloadSources, 0, 195, Short.MAX_VALUE)
                     .addComponent(cbDownloadLibs, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(cbDownloadJavadoc, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addContainerGap())
@@ -599,7 +602,7 @@ public class SettingsPanel extends javax.swing.JPanel {
             .addGroup(jPanel3Layout.createSequentialGroup()
                 .addContainerGap()
                 .addComponent(cbPreferMaven)
-                .addContainerGap(191, Short.MAX_VALUE))
+                .addContainerGap(185, Short.MAX_VALUE))
         );
         jPanel3Layout.setVerticalGroup(
             jPanel3Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -649,7 +652,7 @@ public class SettingsPanel extends javax.swing.JPanel {
                     .addComponent(cbOpenLazy)
                     .addComponent(cbEnableCache)
                     .addComponent(cbBundledLoading))
-                .addContainerGap(249, Short.MAX_VALUE))
+                .addContainerGap(254, Short.MAX_VALUE))
         );
         jPanel7Layout.setVerticalGroup(
             jPanel7Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)


### PR DESCRIPTION
Well, not a functional change. In NB20 the Gradle Proxy and Allow execution got unintentionally swapped.

Just wanted to set the Allow Gradle Exceution the other day and the walues made no sense there. Then it just hit me.
