### PR TITLE
Allow to configure just JVM params or app params

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
@@ -53,8 +53,7 @@ class NetBeansRunSinglePlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.afterEvaluate(p -> {
             if (project.getPlugins().hasPlugin("java") 
-                    && (project.getTasks().findByPath(RUN_SINGLE_TASK) == null)
-                    && project.hasProperty(RUN_SINGLE_MAIN)) {
+                    && project.getTasks().findByPath(RUN_SINGLE_TASK) == null) {
                 Set<Task> runTasks = p.getTasksByName("run", false);
                 Task r = runTasks.isEmpty() ? null : runTasks.iterator().next();
                 p.getTasks().withType(JavaExec.class).configureEach(je -> configureJavaExec(project, je));
@@ -64,12 +63,14 @@ class NetBeansRunSinglePlugin implements Plugin<Project> {
     }
     
     private void configureJavaExec(Project project, JavaExec je) {
-        String mainClass = project.property(RUN_SINGLE_MAIN).toString();
-        if (GRADLE_VERSION.compareTo(GradleVersion.version("6.4")) < 0) {
-            // Using setMain to keep the backward compatibility before Gradle 6.4
-            je.setMain(mainClass);
-        } else {
-            je.getMainClass().set(mainClass);
+        if (project.hasProperty(RUN_SINGLE_MAIN)) {
+            String mainClass = project.property(RUN_SINGLE_MAIN).toString();
+            if (GRADLE_VERSION.compareTo(GradleVersion.version("6.4")) < 0) {
+                // Using setMain to keep the backward compatibility before Gradle 6.4
+                je.setMain(mainClass);
+            } else {
+                je.getMainClass().set(mainClass);
+            }
         }
         if (project.hasProperty(RUN_SINGLE_ARGS)) {
             je.setArgs(asList(project.property(RUN_SINGLE_ARGS).toString().split(" ")));

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/action-mapping.xml
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/action-mapping.xml
@@ -88,7 +88,7 @@
             <actions>
                 <apply-for plugins="java">
                     <action name="run.single">
-                        <args>-PrunClassName=${selectedClass} ${javaExec.workingDir} ${javaExec.environment} runSingle --continuous ${javaExec.jvmArgs} ${javaExec.args}</args>
+                        <args>-PrunClassName=${selectedClass} ${javaExec.workingDir} ${javaExec.environment} run --continuous ${javaExec.jvmArgs} ${javaExec.args}</args>
                     </action>
                     <action name="test.single">
                         <args>"${cleanTestTaskName}" "${testTaskName}" --tests "${selectedClass}" --continuous</args>


### PR DESCRIPTION
Unless `run.single` action is run, the project main class is left unspecified by the action mappings. The `SingleRunPlugin` in that case fails to configure the `JavaExec` task with the remaining properties (app args, jvm args, working dir).

Small fix is to use `run` instead of `runSingle` in the `runSingle` action mapping: `runSingle` task now prints a deprecation warning.

It's hard to reproduce from NB GUI, but can be well reproduced from vscode client with custom launch configurations. I'll try to add a test, since the situation can be achieved with `ExplicitProgressParameters` API that adds parameters to the launched application.