### PR TITLE
Use vscode's selected launch config for project launch and codelens run/debug

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -1220,7 +1220,10 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                                         int start = (int) cc.getTrees().getSourcePositions().getStartPosition(cc.getCompilationUnit(), tree);
                                         int end = (int) cc.getTrees().getSourcePositions().getEndPosition(cc.getCompilationUnit(), tree);
                                         org.netbeans.api.lsp.Range range = new org.netbeans.api.lsp.Range(start, end);
-                                        List<Object> arguments = Collections.singletonList(uri);
+                                        List<Object> arguments = new ArrayList<>();
+                                        arguments.add(uri);
+                                        arguments.add(null);
+                                        arguments.add("");
                                         String method = el.getSimpleName().toString();
                                         lens.add(new org.netbeans.api.lsp.CodeLens(range,
                                                               new org.netbeans.api.lsp.Command(Bundle.LBL_Run(method), COMMAND_RUN_SINGLE, arguments),


### PR DESCRIPTION
The issue solved here is that when the Project > Run|Debug (from project's context menu) or from main class' Code lenses is used, the extension does not use the vscode's selected Laucnh configuration properly.

The original code went throug all defined `java+` launch configurations and extract settings from the first `java+` config found. So if the user intentionally selected 2nd and later config in the UI selector, Project > Run or Run codelen didn't use the parameters in there, instead of parameters from the 1st (texually) config were passed to NBLS.

Sadly, vscode does not support reading the configuration selector, so it is read using a hack: a temporary `DebugConfigurationProvider` is registered, which captures the `debugConfiguration` passed to it by vscode platform - and then aborts the exetion by returning `undefined` (this is permitted by API documentation). Then it uses the configuration object and overrides values with data passed to the `runDebug` function.

When no `java+` launch configurations are present in `launch.json`, vscode would display a QuickPick for the user - that's why the situation is tested at the start. In that case, a simple configuration is created and used as in the original code.

Since Run codelen is generated for all project configurations, the codelen needs to either
- specify the configuration (= configuration name)
-  specify the default configuration (= '')
- leave the config unspecified (the value in launch config is used)
I've changed both the codelen and `runDebug` to handle that.