### PR TITLE
Use Ant for building NetBeans Gradle Tooling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,13 +133,6 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('*/external/binaries-list', '*/*/external/binaries-list') }}
           restore-keys: ${{ runner.os }}-
 
-      - name: Setup Gradle Daemon to run on JDK 11
-        if: ${{ matrix.java == '21' }}
-        run: |
-          mkdir -p ~/.gradle
-          #uses a preinstalled JDK 11 from the runner
-          echo "org.gradle.java.home=$JAVA_HOME_11_X64" >> ~/.gradle/gradle.properties
-
       - name: Build NetBeans
         run: ant $OPTS -quiet -Dcluster.config=$CLUSTER_CONFIG build-nozip
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ $ ant -q clean
 #### Notes:
 * You can also use `php`, `enterprise`, etc. See the [cluster.properties](https://github.com/apache/netbeans/blob/master/nbbuild/cluster.properties) file.
 * Once built, you can simply open individual modules of interest with NetBeans and run/rebuild/debug them like any other project
-* Building the gradle modules on recent JDKs might fail with "Unsupported class file major version" errors. In that case the gradle daemon must be
-  configured to run on a compatible JDK (for example add `org.gradle.java.home=/home/duke/jdk17` to your `~/.gradle/gradle.properties`, see [gradle doc](https://docs.gradle.org/current/userguide/build_environment.html)).
 
 #### Generating Javadoc
 

--- a/extide/gradle/build.xml
+++ b/extide/gradle/build.xml
@@ -58,11 +58,7 @@
     </target>
 
     <target name="build-tooling-lib" depends="-download.release.files,-copy-gradle-wrapper,-uptodate-tooling" unless="tooling.uptodate">
-        <java fork="true" dir="${tooling}" classpath="${tooling}/gradle/wrapper/gradle-wrapper.jar" classname="org.gradle.wrapper.GradleWrapperMain" failonerror="true">
-            <sysproperty key="org.gradle.appname" value="Gradle"/>
-            <arg line="--offline"/>
-            <arg line="clean build -x check"/>
-        </java>
+        <ant dir="${tooling}" inheritAll="false" target="build" />
         <copy file="${tooling}/build/libs/${tooling}.jar" todir="build/tooling" overwrite="true"/>
         <copy file="${tooling}/src/main/resources/nb-tooling.gradle" todir="build/tooling" overwrite="true"/>
     </target>

--- a/extide/gradle/netbeans-gradle-tooling/build.xml
+++ b/extide/gradle/netbeans-gradle-tooling/build.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project basedir="." default="build" name="netbeans-gradle-tooling">
+    <description>Builds, tests, and runs the project org.netbeans.modules.gradle</description>
+
+    <property name="tooling" value="netbeans-gradle-tooling"/>
+    <property name="gradle.version" value="7.4" />
+
+    <available property="has.gradle-libs" file="build/gradle-libs" type="dir"/>
+    
+    <path id="compile.classpath">
+        <fileset dir="build/gradle-libs" includes="*.jar"/>
+    </path>
+    
+    <target name="prepare-libs" unless="has.gradle-libs">
+        <mkdir dir="build/gradle-libs"/>
+        <unzip src="../external/gradle-${gradle.version}-bin.zip" dest="build/gradle-libs">
+            <patternset>
+                <include name="gradle-${gradle.version}/lib/**/*.jar"/>
+            </patternset>
+            <mapper type="flatten"/>
+        </unzip>    
+    </target>
+    <target name="compile" depends="prepare-libs">
+        <mkdir dir="build/classes/java/main"/>
+        <javac srcdir="src/main/java" destdir="build/classes/java/main" classpathref="compile.classpath" release="8" includeantruntime="false"/>
+    </target>
+
+    <target name="jar" depends="compile">
+        <mkdir dir="build/libs"/>
+        <jar destfile="build/libs/${tooling}.jar" basedir="build/classes/java/main">
+            <fileset dir="src/main/resources"/>
+        </jar>
+    </target>
+    
+    <target name="build" depends="jar"/>
+    
+    <target name="clean">
+        <delete dir="build"/>
+    </target>
+</project>
+


### PR DESCRIPTION
Well, I do not necessarily like this one, however it helps building NetBeans without real Gradle Runtime dependencies.