### PR TITLE
Avoid null type, derive from provider type params or fallback to Object.

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/GradleInternalAdapter.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/GradleInternalAdapter.java
@@ -122,7 +122,12 @@ public class GradleInternalAdapter {
                     return new ValueAndType(provided.getType());
                 }
                 if (isFixedValue("property " + propName, etv)) {
-                    return new ValueAndType(provided.getType(), etv.getFixedValue());
+                    Object fixed = etv.getFixedValue();
+                    Class t = provided.getType();
+                    if (t == null && fixed != null) {
+                        t = fixed.getClass();
+                    }
+                    return new ValueAndType(t, fixed);
                 } else {
                     return new ValueAndType(provided.getType());
                 }

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -718,9 +718,17 @@ class NbProjectInfoBuilder {
                     if (Provider.class.isAssignableFrom(t)) {
                         ValueAndType vt = adapter.findPropertyValueInternal(propName, value);
                         if (vt != null) {
-                            t = vt.type;
                             if (vt.value.isPresent()) {
                                 value = vt.value.get();
+                            }
+                            if (vt.type != null) {
+                                t = vt.type;
+                            } else if (typeParameters != null && !typeParameters.isEmpty() && (typeParameters.get(0) instanceof Class)) {
+                                // derive the type from the provider's type parameter
+                                t = (Class)typeParameters.get(0);
+                            } else {
+                                // null value with an unspecified type from the provider
+                                t = Object.class; 
                             }
                         }
                     }
@@ -940,6 +948,9 @@ class NbProjectInfoBuilder {
     }
     
     private static Class findNonDecoratedClass(Class clazz) {
+        if (clazz == null || clazz.isInterface()) {
+            return clazz;
+        }
         while (clazz != Object.class && (clazz.getModifiers() & 0x1000 /* Modifiers.SYNTHETIC */) > 0) {
             clazz = clazz.getSuperclass();
         }


### PR DESCRIPTION
This fixes a potential NPE thrown in some situations:
```
Cannot invoke "java.lang.Class.getModifiers()" because "clazz" is null
Error stack trace: org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.findNonDecoratedClass(NbProjectInfoBuilder.java:943)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.inspectObjectAndValues0(NbProjectInfoBuilder.java:746)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.inspectObjectAndValues(NbProjectInfoBuilder.java:597)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.startInspectObjectAndValues(NbProjectInfoBuilder.java:563)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.detectTaskProperties(NbProjectInfoBuilder.java:320)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.lambda$runAndRegisterPerf$7(NbProjectInfoBuilder.java:427)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.runAndRegisterPerf(NbProjectInfoBuilder.java:433)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.runAndRegisterPerf(NbProjectInfoBuilder.java:427)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.lambda$buildAll$3(NbProjectInfoBuilder.java:248)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.sinceGradle(NbProjectInfoBuilder.java:1850)
```
With `micronaut-core`, null is sometimes returned by the provider as a value, and the (Provider) type in `t` is overwritten by `null and subsequently fails in `findNonDecoratedClass`. Even when `getFixedValue()` returns != null, the provider's `getType()` sometimes returns `null` as a type - added a fallback to actual value's Class.

Lastly, if it is not possible to determien type from either a concrete value, or the provider's type parameter, the introspection falls back to `Object.class`.