### PR TITLE
Add support for GlassFish 7.0.11

### DIFF
--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/Bundle.properties
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/Bundle.properties
@@ -177,6 +177,7 @@ STR_707_SERVER_NAME=GlassFish Server 7.0.7
 STR_708_SERVER_NAME=GlassFish Server 7.0.8
 STR_709_SERVER_NAME=GlassFish Server 7.0.9
 STR_7010_SERVER_NAME=GlassFish Server 7.0.10
+STR_7011_SERVER_NAME=GlassFish Server 7.0.11
 
 # CommonServerSupport.java
 MSG_FLAKEY_NETWORK=<html>Network communication problem<br/>Could not establish \

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
@@ -400,6 +400,17 @@ public enum ServerDetails {
         "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.10/glassfish-7.0.10.zip", // NOI18N
         "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.10/glassfish-7.0.10.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
+    ),
+    
+    /**
+     * details for an instance of GlassFish Server 7.0.11
+     */
+    GLASSFISH_SERVER_7_0_11(NbBundle.getMessage(ServerDetails.class, "STR_7011_SERVER_NAME", new Object[]{}), // NOI18N
+        GlassfishInstanceProvider.JAKARTAEE10_DEPLOYER_FRAGMENT,
+        GlassFishVersion.GF_7_0_11,
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.11/glassfish-7.0.11.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/7.0.11/glassfish-7.0.11.zip", // NOI18N
+        "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     );
     
     /**

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/wizards/Bundle.properties
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/wizards/Bundle.properties
@@ -178,6 +178,7 @@ STR_707_SERVER_NAME=GlassFish Server 7.0.7
 STR_708_SERVER_NAME=GlassFish Server 7.0.8
 STR_709_SERVER_NAME=GlassFish Server 7.0.9
 STR_7010_SERVER_NAME=GlassFish Server 7.0.10
+STR_7011_SERVER_NAME=GlassFish Server 7.0.11
 
 LBL_SELECT_BITS=Select
 LBL_ChooseOne=Choose server to download:

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersion.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersion.java
@@ -118,7 +118,9 @@ public enum GlassFishVersion {
     /** GlassFish 7.0.9 */
     GF_7_0_9       ((short) 7, (short) 0, (short) 9, (short) 0, GlassFishVersion.GF_7_0_9_STR),
     /** GlassFish 7.0.10 */
-    GF_7_0_10       ((short) 7, (short) 0, (short) 10, (short) 0, GlassFishVersion.GF_7_0_10_STR);
+    GF_7_0_10       ((short) 7, (short) 0, (short) 10, (short) 0, GlassFishVersion.GF_7_0_10_STR),
+    /** GlassFish 7.0.11 */
+    GF_7_0_11       ((short) 7, (short) 0, (short) 11, (short) 0, GlassFishVersion.GF_7_0_11_STR);
     ////////////////////////////////////////////////////////////////////////////
     // Class attributes                                                       //
     ////////////////////////////////////////////////////////////////////////////
@@ -323,6 +325,11 @@ public enum GlassFishVersion {
     static final String GF_7_0_10_STR = "7.0.10";
     /** Additional {@code String} representations of GF_7_0_10 value. */
     static final String GF_7_0_10_STR_NEXT[] = {"7.0.10", "7.0.10.0"};
+    
+    /** A {@code String} representation of GF_7_0_11 value. */
+    static final String GF_7_0_11_STR = "7.0.11";
+    /** Additional {@code String} representations of GF_7_0_11 value. */
+    static final String GF_7_0_11_STR_NEXT[] = {"7.0.11", "7.0.11.0"};
 
     /**
      * Stored <code>String</code> values for backward <code>String</code>
@@ -371,6 +378,7 @@ public enum GlassFishVersion {
         initStringValuesMapFromArray(GF_7_0_8, GF_7_0_8_STR_NEXT);
         initStringValuesMapFromArray(GF_7_0_9, GF_7_0_9_STR_NEXT);
         initStringValuesMapFromArray(GF_7_0_10, GF_7_0_10_STR_NEXT);
+        initStringValuesMapFromArray(GF_7_0_11, GF_7_0_11_STR_NEXT);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/ConfigBuilderProvider.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/ConfigBuilderProvider.java
@@ -168,6 +168,11 @@ public class ConfigBuilderProvider {
     private static final Config.Next CONFIG_V7_0_10
             = new Config.Next(GlassFishVersion.GF_7_0_10,
                     ConfigBuilderProvider.class.getResource("GlassFishV7_0_9.xml"));
+    
+    /** Library builder configuration since GlassFish 7.0.11. */
+    private static final Config.Next CONFIG_V7_0_11
+            = new Config.Next(GlassFishVersion.GF_7_0_11,
+                    ConfigBuilderProvider.class.getResource("GlassFishV7_0_9.xml"));
 
     /** Library builder configuration for GlassFish cloud. */
     private static final Config config
@@ -178,7 +183,7 @@ public class ConfigBuilderProvider {
                          CONFIG_V7_0_0, CONFIG_V7_0_1, CONFIG_V7_0_2,
                          CONFIG_V7_0_3, CONFIG_V7_0_4, CONFIG_V7_0_5,
                          CONFIG_V7_0_6, CONFIG_V7_0_7, CONFIG_V7_0_8,
-                         CONFIG_V7_0_9, CONFIG_V7_0_10);
+                         CONFIG_V7_0_9, CONFIG_V7_0_10, CONFIG_V7_0_11);
 
     /** Builders array for each server instance. */
     private static final ConcurrentMap<GlassFishServer, ConfigBuilder> builders

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/JavaSEPlatform.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/JavaSEPlatform.java
@@ -71,7 +71,9 @@ public enum JavaSEPlatform {
     /** JavaSE 21. */
     v21,
     /** JavaSE 22. */
-    v22;
+    v22,
+    /** JavaSE 23. */
+    v23;
 
     ////////////////////////////////////////////////////////////////////////////
     // Class attributes                                                       //

--- a/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/admin/AdminFactoryTest.java
+++ b/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/admin/AdminFactoryTest.java
@@ -168,7 +168,7 @@ public class AdminFactoryTest extends CommandTest {
     }
     
     /**
-     * Test factory functionality for GlassFish v. 7.0.10
+     * Test factory functionality for GlassFish v. 7.0.11
      * <p/>
      * Factory should initialize REST {@code Runner} and point it to
      * provided {@code Command} instance.
@@ -176,7 +176,7 @@ public class AdminFactoryTest extends CommandTest {
     @Test
     public void testGetInstanceforVersionGF7() {
         GlassFishServerEntity srv = new GlassFishServerEntity();
-        srv.setVersion(GlassFishVersion.GF_7_0_10);
+        srv.setVersion(GlassFishVersion.GF_7_0_11);
         AdminFactory af = AdminFactory.getInstance(srv.getVersion());
         assertTrue(af instanceof AdminFactoryRest);
         Command cmd = new CommandVersion();

--- a/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersionTest.java
+++ b/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersionTest.java
@@ -119,6 +119,8 @@ public class GlassFishVersionTest {
                 GlassFishVersion.GF_7_0_9_STR_NEXT);
         verifyToValueFromAdditionalArray(GlassFishVersion.GF_7_0_10,
                 GlassFishVersion.GF_7_0_10_STR_NEXT);
+        verifyToValueFromAdditionalArray(GlassFishVersion.GF_7_0_11,
+                GlassFishVersion.GF_7_0_11_STR_NEXT);
     }
 
     /**
@@ -145,7 +147,7 @@ public class GlassFishVersionTest {
             GlassFishVersion.GF_7_0_4, GlassFishVersion.GF_7_0_5,
             GlassFishVersion.GF_7_0_6, GlassFishVersion.GF_7_0_7,
             GlassFishVersion.GF_7_0_8, GlassFishVersion.GF_7_0_9,
-            GlassFishVersion.GF_7_0_10
+            GlassFishVersion.GF_7_0_10, GlassFishVersion.GF_7_0_11
         };
         String strings[] = {
             "1.0.1.4", "2.0.1.5", "2.1.0.3", "2.1.1.7",
@@ -157,7 +159,7 @@ public class GlassFishVersionTest {
             "6.2.4.0", "6.2.5.0", "7.0.0.0", "7.0.1.0",
             "7.0.2.0", "7.0.3.0", "7.0.4.0", "7.0.5.0",
             "7.0.6.0", "7.0.7.0", "7.0.8.0", "7.0.9.0",
-            "7.0.10.0"
+            "7.0.10.0", "7.0.11.0"
         };
         for (int i = 0; i < versions.length; i++) {
             GlassFishVersion version = GlassFishVersion.toValue(strings[i]);

--- a/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/utils/EnumUtilsTest.java
+++ b/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/utils/EnumUtilsTest.java
@@ -21,7 +21,7 @@ package org.netbeans.modules.glassfish.tooling.utils;
 import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_3;
 import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_4;
 import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_6_2_5;
-import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_7_0_10;
+import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_7_0_11;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import org.testng.annotations.Test;
@@ -47,8 +47,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testEq() {
-        assertFalse(EnumUtils.eq(GF_7_0_10, GF_6_2_5), "Equals for a > b shall be false.");
-        assertTrue(EnumUtils.eq(GF_7_0_10, GF_7_0_10), "Equals for a == b shall be true.");
+        assertFalse(EnumUtils.eq(GF_7_0_11, GF_6_2_5), "Equals for a > b shall be false.");
+        assertTrue(EnumUtils.eq(GF_7_0_11, GF_7_0_11), "Equals for a == b shall be true.");
         assertFalse(EnumUtils.eq(GF_4, GF_3), "Equals for a > b shall be false.");
         assertTrue(EnumUtils.eq(GF_4, GF_4), "Equals for a == b shall be true.");
         assertFalse(EnumUtils.eq(GF_3, GF_4), "Equals for a < b shall be false.");
@@ -69,8 +69,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testNe() {
-        assertTrue(EnumUtils.ne(GF_7_0_10, GF_6_2_5), "Not equals for a > b shall be true.");
-        assertFalse(EnumUtils.ne(GF_7_0_10, GF_7_0_10), "Not equals for a == b shall be false.");
+        assertTrue(EnumUtils.ne(GF_7_0_11, GF_6_2_5), "Not equals for a > b shall be true.");
+        assertFalse(EnumUtils.ne(GF_7_0_11, GF_7_0_11), "Not equals for a == b shall be false.");
         assertTrue(EnumUtils.ne(GF_4, GF_3), "Not equals for a > b shall be true.");
         assertFalse(EnumUtils.ne(GF_4, GF_4), "Not equals for a == b shall be false.");
         assertTrue(EnumUtils.ne(GF_3, GF_4), "Not equals for a < b shall be true.");
@@ -91,8 +91,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testLt() {
-        assertFalse(EnumUtils.lt(GF_7_0_10, GF_6_2_5), "Less than for a > b shall be false.");
-        assertFalse(EnumUtils.lt(GF_7_0_10, GF_7_0_10), "Less than for a == b shall be false.");
+        assertFalse(EnumUtils.lt(GF_7_0_11, GF_6_2_5), "Less than for a > b shall be false.");
+        assertFalse(EnumUtils.lt(GF_7_0_11, GF_7_0_11), "Less than for a == b shall be false.");
         assertFalse(EnumUtils.lt(GF_4, GF_3), "Less than for a > b shall be false.");
         assertFalse(EnumUtils.lt(GF_4, GF_4), "Less than for a == b shall be false.");
         assertTrue(EnumUtils.lt(GF_3, GF_4), "Less than for a < b shall be true.");
@@ -113,8 +113,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testLe() {
-        assertFalse(EnumUtils.le(GF_7_0_10, GF_6_2_5), "Less than or equal for a > b shall be false.");
-        assertTrue(EnumUtils.le(GF_7_0_10, GF_7_0_10), "Less than or equal for a == b shall be true.");
+        assertFalse(EnumUtils.le(GF_7_0_11, GF_6_2_5), "Less than or equal for a > b shall be false.");
+        assertTrue(EnumUtils.le(GF_7_0_11, GF_7_0_11), "Less than or equal for a == b shall be true.");
         assertFalse(EnumUtils.le(GF_4, GF_3), "Less than or equal for a > b shall be false.");
         assertTrue(EnumUtils.le(GF_4, GF_4), "Less than or equal for a == b shall be true.");
         assertTrue(EnumUtils.le(GF_3, GF_4), "Less than or equal for a < b shall be true.");
@@ -135,8 +135,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testGt() {
-        assertTrue(EnumUtils.gt(GF_7_0_10, GF_6_2_5), "Greater than for a > b shall be true.");
-        assertFalse(EnumUtils.gt(GF_7_0_10, GF_7_0_10), "Greater than for a == b shall be false.");
+        assertTrue(EnumUtils.gt(GF_7_0_11, GF_6_2_5), "Greater than for a > b shall be true.");
+        assertFalse(EnumUtils.gt(GF_7_0_11, GF_7_0_11), "Greater than for a == b shall be false.");
         assertTrue(EnumUtils.gt(GF_4, GF_3), "Greater than for a > b shall be true.");
         assertFalse(EnumUtils.gt(GF_4, GF_4), "Greater than for a == b shall be false.");
         assertFalse(EnumUtils.gt(GF_3, GF_4), "Greater than for a < b shall be false.");
@@ -157,8 +157,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testGe() {
-        assertTrue(EnumUtils.ge(GF_7_0_10, GF_6_2_5), "Greater than or equal for a > b shall be true.");
-        assertTrue(EnumUtils.ge(GF_7_0_10, GF_7_0_10), "Greater than or equal for a == b shall be true.");
+        assertTrue(EnumUtils.ge(GF_7_0_11, GF_6_2_5), "Greater than or equal for a > b shall be true.");
+        assertTrue(EnumUtils.ge(GF_7_0_11, GF_7_0_11), "Greater than or equal for a == b shall be true.");
         assertTrue(EnumUtils.ge(GF_4, GF_3), "Greater than or equal for a > b shall be true.");
         assertTrue(EnumUtils.ge(GF_4, GF_4), "Greater than or equal for a == b shall be true.");
         assertFalse(EnumUtils.ge(GF_3, GF_4), "Greater than or equal for a < b shall be false.");


### PR DESCRIPTION
NetBeans GlassFish module notes:

- Add support for GlassFish version 7.0.11
- Add Java SE 23 Enum

NetBeans Testing:

- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Verify Sigtests
- Verify successful execution of unit tests for modules `glassfish.common`, `glassfish.javaee`, `glassfish.tooling`, and `glassfish.eecommon`
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Successfully register GlassFish 7.0.11, create a web app and verify that it works.

[Release Notes](https://github.com/eclipse-ee4j/glassfish/releases/tag/7.0.11)