### PR TITLE
Support for multiple NetBeans Gradle Tooling

### DIFF
--- a/extide/gradle/manifest.mf
+++ b/extide/gradle/manifest.mf
@@ -3,4 +3,5 @@ AutoUpdate-Show-In-Client: true
 OpenIDE-Module: org.netbeans.modules.gradle/2
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/Bundle.properties
+OpenIDE-Module-Java-Dependencies: Java > 11
 OpenIDE-Module-Specification-Version: 2.38

--- a/extide/gradle/nbproject/project.properties
+++ b/extide/gradle/nbproject/project.properties
@@ -17,7 +17,8 @@
 
 file.reference.netbeans-gradle-tooling.jar=release/modules/gradle/netbeans-gradle-tooling.jar
 is.autoload=true
-javac.source=1.8
+javac.source=11
+javac.target=11
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
@@ -60,6 +60,7 @@ import org.netbeans.modules.gradle.execute.GradleNetworkProxySupport.ProxyResult
 import org.netbeans.modules.gradle.spi.GradleFiles;
 import org.netbeans.modules.gradle.spi.execute.GradleDistributionProvider;
 import org.netbeans.modules.gradle.spi.execute.GradleJavaPlatformProvider;
+import org.netbeans.modules.gradle.spi.loaders.GradlePluginProvider;
 import org.netbeans.spi.project.ui.support.BuildExecutionSupport;
 import org.openide.awt.StatusDisplayer;
 import org.openide.execution.ExecutorTask;
@@ -205,7 +206,8 @@ public final class GradleDaemonExecutor extends AbstractGradleExecutor {
 
             if (RunUtils.isAugmentedBuildEnabled(config.getProject())) {
                 augmented = new GradleCommandLine(cmd);
-                augmented.addParameter(GradleCommandLine.Parameter.INIT_SCRIPT, GradleDaemon.initScript());
+                augmented.addParameter(GradleCommandLine.Parameter.INIT_SCRIPT, 
+                        GradleDaemon.initScript(GradlePluginProvider.GradleRuntime.fromProject(config.getProject())));
             }
             GradleBaseProject gbp = GradleBaseProject.get(config.getProject());
             augmented.configure(buildLauncher, gbp != null ? gbp.getRootDir() : null);

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
@@ -39,6 +39,7 @@ import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
 import org.netbeans.modules.gradle.spi.GradleFiles;
 import org.netbeans.modules.gradle.spi.GradleSettings;
 import org.netbeans.modules.gradle.spi.ProjectInfoExtractor;
+import org.netbeans.modules.gradle.spi.loaders.GradlePluginProvider.GradleRuntime;
 import org.openide.util.Lookup;
 
 /**
@@ -86,10 +87,10 @@ public abstract class AbstractProjectLoader {
         }
     }
 
-    static GradleCommandLine injectNetBeansTooling(GradleCommandLine cmd) {
+    static GradleCommandLine injectNetBeansTooling(GradleCommandLine cmd, GradleRuntime rt) {
         GradleCommandLine ret = new GradleCommandLine(cmd);
         ret.setFlag(GradleCommandLine.Flag.CONFIGURE_ON_DEMAND, GradleSettings.getDefault().isConfigureOnDemand());
-        ret.addParameter(GradleCommandLine.Parameter.INIT_SCRIPT, GradleDaemon.initScript());
+        ret.addParameter(GradleCommandLine.Parameter.INIT_SCRIPT, GradleDaemon.initScript(rt));
         ret.setStackTrace(GradleCommandLine.StackTrace.SHORT);
         ret.addProjectProperty("nbSerializeCheck", "true");
         return ret;

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyGradlePluginProvider.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyGradlePluginProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.loaders;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.spi.loaders.GradlePluginProvider;
+import org.openide.modules.InstalledFileLocator;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author lkishalmi
+ */
+@ServiceProvider(service = GradlePluginProvider.class)
+public final class LegacyGradlePluginProvider implements GradlePluginProvider {
+
+    static final String TOOLING_JAR_NAME = "modules/gradle/netbeans-gradle-tooling.jar"; //NOI18N
+
+    private static final File TOOLING_JAR = InstalledFileLocator.getDefault().locate(TOOLING_JAR_NAME, NbGradleProject.CODENAME_BASE, false);
+
+    @Override
+    public Collection<File> classpath(GradleRuntime runtime) {
+        return Collections.singleton(TOOLING_JAR);
+    }
+
+    @Override
+    public Collection<String> plugins(GradleRuntime runtime) {
+        return List.of(
+            "org.netbeans.modules.gradle.tooling.NetBeansToolingPlugin",
+            "org.netbeans.modules.gradle.tooling.NetBeansRunSinglePlugin",
+            "org.netbeans.modules.gradle.tooling.NetBeansExplodedWarPlugin"
+        );
+    }
+    
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
@@ -83,6 +83,7 @@ import org.openide.util.Cancellable;
 import org.openide.util.NbBundle;
 
 import static org.netbeans.modules.gradle.loaders.Bundle.*;
+import org.netbeans.modules.gradle.spi.loaders.GradlePluginProvider;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
 import org.openide.util.RequestProcessor;
@@ -150,7 +151,7 @@ public class LegacyProjectLoader extends AbstractProjectLoader {
         GradleCommandLine cmd = new GradleCommandLine(RunUtils.getCompatibleGradleDistribution(ctx.project), ctx.cmd);
         cmd.setFlag(GradleCommandLine.Flag.CONFIGURE_ON_DEMAND, GradleSettings.getDefault().isConfigureOnDemand());
         cmd.setFlag(GradleCommandLine.Flag.CONFIGURATION_CACHE, GradleSettings.getDefault().getUseConfigCache());
-        cmd.addParameter(GradleCommandLine.Parameter.INIT_SCRIPT, GradleDaemon.initScript());
+        cmd.addParameter(GradleCommandLine.Parameter.INIT_SCRIPT, GradleDaemon.initScript(GradlePluginProvider.GradleRuntime.fromProject(ctx.project)));
         cmd.setStackTrace(GradleCommandLine.StackTrace.SHORT);
         cmd.addProjectProperty("nbSerializeCheck", "true");
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/ModelCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/ModelCache.java
@@ -31,6 +31,7 @@ import org.netbeans.modules.gradle.api.execute.RunUtils;
 import org.netbeans.modules.gradle.tooling.internal.ModelFetcher;
 import static org.netbeans.modules.gradle.loaders.ModelCache.State.*;
 import org.netbeans.modules.gradle.spi.GradleSettings;
+import org.netbeans.modules.gradle.spi.loaders.GradlePluginProvider;
 import org.openide.util.RequestProcessor;
 
 /**
@@ -77,7 +78,7 @@ public class ModelCache <T extends Model> {
         try {
             List<String> filteredTargets = descriptor.getTargets().stream().filter((String target) -> descriptor.needsRefresh(target)).collect(Collectors.toList());
             if (!filteredTargets.isEmpty()) {
-                final GradleCommandLine cmd = new GradleCommandLine(RunUtils.getCompatibleGradleDistribution(project), descriptor.gradleCommandLine());
+                final GradleCommandLine cmd = new GradleCommandLine(RunUtils.getCompatibleGradleDistribution(project), descriptor.gradleCommandLine(GradlePluginProvider.GradleRuntime.fromProject(project)));
 
                 cmd.setFlag(GradleCommandLine.Flag.CONFIGURE_ON_DEMAND, GradleSettings.getDefault().isConfigureOnDemand());
                 cmd.setFlag(GradleCommandLine.Flag.CONFIGURATION_CACHE, GradleSettings.getDefault().getUseConfigCache());

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/ModelCachingDescriptor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/ModelCachingDescriptor.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.gradle.loaders;
 import java.util.Set;
 import org.gradle.tooling.model.Model;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
+import org.netbeans.modules.gradle.spi.loaders.GradlePluginProvider.GradleRuntime;
 
 /**
  *
@@ -32,7 +33,7 @@ public interface ModelCachingDescriptor <T extends Model> {
 
     Set<String> getTargets();
 
-    GradleCommandLine gradleCommandLine();
+    GradleCommandLine gradleCommandLine(GradleRuntime rt);
 
     void onLoad(String target, T model);
     void onError(String target, Exception ex);

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/NbProjectInfoCachingDescriptor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/NbProjectInfoCachingDescriptor.java
@@ -27,6 +27,7 @@ import org.netbeans.modules.gradle.cache.ProjectInfoDiskCache;
 import org.netbeans.modules.gradle.spi.GradleFiles;
 
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.*;
+import org.netbeans.modules.gradle.spi.loaders.GradlePluginProvider.GradleRuntime;
 
 /**
  *
@@ -52,8 +53,8 @@ public final class NbProjectInfoCachingDescriptor implements ModelCachingDescrip
     }
 
     @Override
-    public GradleCommandLine gradleCommandLine() {
-        return AbstractProjectLoader.injectNetBeansTooling(new GradleCommandLine());
+    public GradleCommandLine gradleCommandLine(GradleRuntime rt) {
+        return AbstractProjectLoader.injectNetBeansTooling(new GradleCommandLine(), rt);
     }
 
     @Override

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/ProjectStructureCachingDescriptor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/ProjectStructureCachingDescriptor.java
@@ -25,6 +25,7 @@ import org.gradle.tooling.model.GradleProject;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
 import org.netbeans.modules.gradle.cache.SubProjectDiskCache;
 import org.netbeans.modules.gradle.cache.SubProjectDiskCache.SubProjectInfo;
+import org.netbeans.modules.gradle.spi.loaders.GradlePluginProvider.GradleRuntime;
 
 /**
  *
@@ -50,7 +51,7 @@ public class ProjectStructureCachingDescriptor implements ModelCachingDescriptor
     }
 
     @Override
-    public GradleCommandLine gradleCommandLine() {
+    public GradleCommandLine gradleCommandLine(GradleRuntime rt) {
         return new GradleCommandLine();
     }
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/loaders/GradlePluginProvider.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/loaders/GradlePluginProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.spi.loaders;
+
+import java.io.File;
+import java.util.Collection;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectUtils;
+import org.netbeans.modules.gradle.api.execute.GradleDistributionManager.GradleDistribution;
+import org.netbeans.modules.gradle.spi.execute.GradleDistributionProvider;
+import org.openide.filesystems.FileUtil;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public interface GradlePluginProvider {
+    
+    Collection<File> classpath(GradleRuntime runtime);
+    Collection<String> plugins(GradleRuntime runtime);
+    
+    public final static class GradleRuntime {
+        public final File rootDir;
+        public final GradleDistribution gradleDistribution;
+
+        private GradleRuntime(File rootDir, GradleDistribution dist) {
+            this.rootDir = rootDir;
+            this.gradleDistribution = dist;
+        }
+        
+        public File rootDir() {
+            return rootDir;
+        }
+        
+        public GradleDistribution gradleDistribution() {
+            return gradleDistribution;
+        }
+        
+        public static GradleRuntime fromProject(Project p) {
+            Project root = ProjectUtils.rootOf(p);
+            File rootDir = FileUtil.toFile(root.getProjectDirectory());
+            GradleDistributionProvider pvd = root.getLookup().lookup(GradleDistributionProvider.class);
+            return new GradleRuntime(rootDir, pvd.getGradleDistribution());            
+        }
+    }
+}


### PR DESCRIPTION

This one is a proposed draft to allow plugins to provide their own discovery tooling library.

The motivation is that right now every Gradle discovery has to go into `netbeans-gradle-tooling` external library,Which is already stuffed. Also to be future proof we probably would use different version of these libraries when working with different Gradle versions. Right now we are using Gradle 7.4 to build our tooling on, which still has support for deprecated APIs, but already has new enough recent features. That might be no longer true with Gradle 9.0.

This would be a multi commit series PR. The first one is extending NetBeans with a `GradlePluginProvider` service.
The following would be figuring out how to wire this support into the project introspection. 