### PR TITLE
Stacktrace analyzer window fixes

### DIFF
--- a/java/java.navigation/manifest.mf
+++ b/java/java.navigation/manifest.mf
@@ -5,4 +5,4 @@ OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/java/navigation/Bundle.pr
 OpenIDE-Module-Requires: org.openide.windows.WindowManager
 OpenIDE-Module-Specification-Version: 1.63
 AutoUpdate-Show-In-Client: false
-
+OpenIDE-Module-Java-Dependencies: Java > 11

--- a/java/java.navigation/src/org/netbeans/modules/java/navigation/BreadCrumbsScanningTask.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/navigation/BreadCrumbsScanningTask.java
@@ -40,7 +40,6 @@ import org.netbeans.modules.parsing.spi.SchedulerEvent;
 import org.netbeans.modules.parsing.spi.SchedulerTask;
 import org.netbeans.modules.parsing.spi.TaskFactory;
 import org.netbeans.modules.parsing.spi.TaskIndexingMode;
-import org.openide.nodes.Node;
 
 /**
  *

--- a/java/java.navigation/src/org/netbeans/modules/java/navigation/ElementScanningTask.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/navigation/ElementScanningTask.java
@@ -52,7 +52,6 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.Elements;
 import javax.lang.model.util.Elements.Origin;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;

--- a/java/java.navigation/src/org/netbeans/modules/java/navigation/HTMLDocView.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/navigation/HTMLDocView.java
@@ -39,7 +39,6 @@ import javax.swing.text.html.HTMLEditorKit;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.editor.settings.FontColorNames;
 import org.netbeans.api.editor.settings.FontColorSettings;
-import org.netbeans.editor.EditorUI;
 
 /**
  *  HTML documentation view.
@@ -118,6 +117,7 @@ class HTMLDocView extends JEditorPane {
         });
     }
     
+    @Override
     protected EditorKit createDefaultEditorKit() {
         // it is extremelly slow to init it
         if (htmlKit == null){

--- a/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyserCellRenderer.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyserCellRenderer.java
@@ -98,19 +98,15 @@ class AnalyserCellRenderer extends DefaultListCellRenderer {
             if (isSelected) {
                 sb.append("<style> a.val {text-decoration: underline; color: "+toRgbText(getForeground())+"} </style><body>");
             }
-            String prefix = line.substring (0, link.getStartOffset ());
-            if (prefix.startsWith("at ")) {
-                prefix = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + prefix;
-            }
-            sb.append (prefix);
-            sb.append ("<a class=\"val\" href=\"\">");
-            sb.append (line.substring (link.getStartOffset (), link.getEndOffset ()));
-            sb.append ("</a>");
-            sb.append (line.substring (link.getEndOffset ()));
-            sb.append ("</body></html>");
-            setText (sb.toString ());
+            sb.append(indentAt(escapeAngleBrackets(line.substring(0, link.getStartOffset())), "&nbsp;"));
+            sb.append("<a class=\"val\" href=\"\">");
+            sb.append(escapeAngleBrackets(line.substring(link.getStartOffset(), link.getEndOffset())));
+            sb.append("</a>");
+            sb.append(escapeAngleBrackets(line.substring(link.getEndOffset())));
+            sb.append("</body></html>");
+            setText(sb.toString ());
         } else {
-            setText (line.trim ());
+            setText(indentAt(line.strip(), " "));
         }
 
         setEnabled (list.isEnabled ());
@@ -144,6 +140,14 @@ class AnalyserCellRenderer extends DefaultListCellRenderer {
 
     private String toRgbText(Color c) {
         return String.format("#%02x%02x%02x", c.getRed(), c.getGreen(), c.getBlue());
+    }
+
+    private String escapeAngleBrackets(String str) {
+        return str.replace("<", "&lt;");
+    }
+
+    private String indentAt(String str, String indent) {
+        return str.startsWith("at ") ? indent.repeat(8) + str : str;
     }
 }
 

--- a/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyzeStackAction.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyzeStackAction.java
@@ -34,6 +34,7 @@ public class AnalyzeStackAction extends AbstractAction {
 //        putValue(SMALL_ICON, new ImageIcon(Utilities.loadImage(AnalyzeStackTopComponent.ICON_PATH, true)));
     }
 
+    @Override
     public void actionPerformed(ActionEvent evt) {
         TopComponent win = AnalyzeStackTopComponent.findInstance();
         win.open();

--- a/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyzeStackTopComponent.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyzeStackTopComponent.java
@@ -139,7 +139,8 @@ final class AnalyzeStackTopComponent extends TopComponent {
         String lastLine = null;
         try {
             while ((currentLine = r.readLine()) != null) {
-                currentLine = currentLine.trim();
+                // strip ANSI symbols just in case the terminal/clipboard hasn't done that
+                currentLine = currentLine.replaceAll("\u001B\\[[\\d;]*[^\\d;]", "").strip();
                 if (StackLineAnalyser.matches(currentLine)) {
                     if (lastLine != null) {
                         model.addElement(lastLine);

--- a/java/java.navigation/test/unit/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyserTest.java
+++ b/java/java.navigation/test/unit/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyserTest.java
@@ -48,15 +48,38 @@ public class StackLineAnalyserTest extends NbTestCase {
         assertTrue(StackLineAnalyser.matches("             [exec]     at org.openide.filesystems.FileUtil.normalizeFileOnMac(FileUtil.java:1714)"));
         assertTrue(StackLineAnalyser.matches("at java.base/java.lang.String.lastIndexOf(String.java:1627)"));
         assertTrue(StackLineAnalyser.matches(" at java.base/java.lang.String.lastIndexOf(String.java:1627)"));
+        // some loggers (e.g. MavenSimpleLogger until MNG-7970/#1342 which is maven's default logger) seem to add a space before the '('
+        assertTrue(StackLineAnalyser.matches("    at java.util.zip.ZipFile$CleanableResource.<init> (ZipFile.java:742)"));
     }
 
     @Test
     public void testMatchesScalaLines() throws Exception {
-        assertTrue(StackLineAnalyser.matches("at org.enso.compiler.core.ir.MetadataStorage.$anonfun$getUnsafe$1(MetadataStorage.scala:80)"));
-        StackLineAnalyser.Link l = StackLineAnalyser.analyse("at org.enso.compiler.core.ir.MetadataStorage.$anonfun$getUnsafe$1(MetadataStorage.scala:80)");
+        String line = "at org.enso.compiler.core.ir.MetadataStorage.$anonfun$getUnsafe$1(MetadataStorage.scala:80)";
+        assertTrue(StackLineAnalyser.matches(line));
+        StackLineAnalyser.Link l = StackLineAnalyser.analyse(line);
         assertEquals(3, l.getStartOffset());
         assertEquals(91, l.getEndOffset());
         assertEquals(".scala", l.getExtension());
+    }
+
+    @Test
+    public void testMatchesUnknownFileLines() throws Exception {
+        String line = "at org.Unknown(Unknown:80)";
+        assertTrue(StackLineAnalyser.matches(line));
+        StackLineAnalyser.Link l = StackLineAnalyser.analyse(line);
+        assertEquals(3, l.getStartOffset());
+        assertEquals(26, l.getEndOffset());
+        assertEquals(null, l.getExtension());
+    }
+
+    @Test
+    public void testMatchesWithNoPackage() throws Exception {
+        String line = "\tat NewClass.main(NewClass.java:12)";
+        assertTrue(StackLineAnalyser.matches(line));
+        StackLineAnalyser.Link l = StackLineAnalyser.analyse(line);
+        assertEquals(4, l.getStartOffset());
+        assertEquals(35, l.getEndOffset());
+        assertEquals(".java", l.getExtension());
     }
 
     @Test
@@ -85,6 +108,9 @@ public class StackLineAnalyserTest extends NbTestCase {
         l = StackLineAnalyser.analyse(" at java.base/java.lang.String.lastIndexOf(String.java:1627)");
         assertEquals(4, l.getStartOffset());
         assertEquals(60, l.getEndOffset());
+        l = StackLineAnalyser.analyse("    at java.util.zip.ZipFile$CleanableResource.<init> (ZipFile.java:742)");
+        assertEquals(7, l.getStartOffset());
+        assertEquals(72, l.getEndOffset());
     }
 
     @Test


### PR DESCRIPTION
   - update matcher to be more forgiving when traces are pasted from ANSI decorated sources (some loggers use colors for exception elements) related: #6843
   - some loggers add extra spaces to stack trace lines (fixed it upstream for maven 4 https://github.com/apache/maven/pull/1342 / [MNG-7970](https://issues.apache.org/jira/browse/MNG-7970))
   - properly escape angle brackets in cell renderer
   - some indentation fixes for lines which are rendered without link
     (e.g native code calls)
   - avoid using deprecated methods


example: this trace isn't parsed properly NB 20 (note: the space before '('):
```
java.util.zip.ZipException: zip file is empty
    at java.util.zip.ZipFile$Source.zerror (ZipFile.java:1769)
    at java.util.zip.ZipFile$Source.findEND (ZipFile.java:1565)
    at java.util.zip.ZipFile$Source.initCEN (ZipFile.java:1659)
    at java.util.zip.ZipFile$Source.<init> (ZipFile.java:1463)
    at java.util.zip.ZipFile$Source.get (ZipFile.java:1426)
    at java.util.zip.ZipFile$CleanableResource.<init> (ZipFile.java:742)
    at java.util.zip.ZipFile$CleanableResource.get (ZipFile.java:859)
    at java.util.zip.ZipFile.<init> (ZipFile.java:257)
    at java.util.zip.ZipFile.<init> (ZipFile.java:186)
    at java.util.zip.ZipFile.<init> (ZipFile.java:200)
```
![image](https://github.com/apache/netbeans/assets/114367/fb1f934b-b454-4aa9-a38f-83380be39f80)

even if the space is manually removed the result could be better (missing `<init>`, broken indentation on at-lines which can't be linked):
![image](https://github.com/apache/netbeans/assets/114367/daa73add-4029-4452-8ab1-7b5038249435)



with this PR applied:
![image](https://github.com/apache/netbeans/assets/114367/ae2448d6-9e23-4e35-bbc0-ab547cefd339)
