### PR TITLE
Disable ANSI decorations for default (embedded) maven logger.

### DIFF
--- a/java/maven.embedder/nbproject/project.xml
+++ b/java/maven.embedder/nbproject/project.xml
@@ -319,9 +319,14 @@
             <class-path-extension>
                 <runtime-relative-path>../maven/lib/httpcore-4.4.16.jar</runtime-relative-path>
             </class-path-extension>
+            <!--
+            disable Maven's ANSI CLI decorations
+            maven-slf4j-provider injects MavenSimpleLogger which decorates the output for terminal use
+            this causes problems in log files, tests etc which don't expect or cant display them properly
             <class-path-extension>
                 <runtime-relative-path>../maven/lib/jansi-2.4.0.jar</runtime-relative-path>
             </class-path-extension>
+            -->
             <class-path-extension>
                 <runtime-relative-path>../maven/lib/javax.annotation-api-1.3.2.jar</runtime-relative-path>
             </class-path-extension>


### PR DESCRIPTION
`maven-slf4j-provider` injects `MavenSimpleLogger` which decorates the output for terminal use. This causes problems in log files, tests etc which don't expect or cant display them properly.

a quick way to test this:
run `NexusRepositoryIndexerImplTest#testFilterPluginGroupIdsRepositoryQueries` directly from NB and check that there is no color in the stack trace. The `TEST-org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImplTest.xml` should also have no escaped ANSI symbols in it.

long way to test would be to run NB and check that the log file is clean.
this is how it should _not_ look:
![image](https://github.com/apache/netbeans/assets/114367/44c412be-403c-4fcb-8cde-cbd00adef61a)
