### PR TITLE
Return root node even though everything is filtered.

### DIFF
--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/Scope.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/Scope.java
@@ -86,7 +86,7 @@ public abstract class Scope {
         if (obj == null) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!(obj instanceof Scope)) {
             return false;
         }
         final Scope other = (Scope) obj;

--- a/java/maven/src/org/netbeans/modules/maven/queries/MavenDependenciesImplementation.java
+++ b/java/maven/src/org/netbeans/modules/maven/queries/MavenDependenciesImplementation.java
@@ -264,10 +264,10 @@ public class MavenDependenciesImplementation implements ProjectDependenciesImple
     private Dependency convertDependencies(org.apache.maven.shared.dependency.tree.DependencyNode n, Dependency.Filter filter, Set<ArtifactSpec> broken) {
         Map<String, List<org.apache.maven.shared.dependency.tree.DependencyNode>> realNodes = new HashMap<>();
         findRealNodes(n, realNodes);
-        return convert2(n, filter, realNodes, broken);
+        return convert2(true, n, filter, realNodes, broken);
     }
     
-    private Dependency convert2(org.apache.maven.shared.dependency.tree.DependencyNode n, Dependency.Filter filter, Map<String, List<org.apache.maven.shared.dependency.tree.DependencyNode>> realNodes, Set<ArtifactSpec> broken) {
+    private Dependency convert2(boolean root, org.apache.maven.shared.dependency.tree.DependencyNode n, Dependency.Filter filter, Map<String, List<org.apache.maven.shared.dependency.tree.DependencyNode>> realNodes, Set<ArtifactSpec> broken) {
         List<Dependency> ch = new ArrayList<>();
         
         List<org.apache.maven.shared.dependency.tree.DependencyNode> children = null;
@@ -286,7 +286,7 @@ public class MavenDependenciesImplementation implements ProjectDependenciesImple
         }
         
         for (org.apache.maven.shared.dependency.tree.DependencyNode c : children) {
-            Dependency cd = convert2(c, filter, realNodes, broken);
+            Dependency cd = convert2(false, c, filter, realNodes, broken);
             if (cd != null) {
                 ch.add(cd);
             }
@@ -303,7 +303,7 @@ public class MavenDependenciesImplementation implements ProjectDependenciesImple
         }
         Scope s = scope(a);
         
-        if (!filter.accept(s, aspec)) {
+        if (!root && !filter.accept(s, aspec)) {
             return null;
         }
         


### PR DESCRIPTION
Two fixes:
-  first, the `Scope` was designed to be equals based on its `name` only; the implementation Class was checked by mistake.
- maven implementation happily filters out even the root of the project when scope filter is active. This is bad, because all data under the root are lost. This PR handles the root conversion specially - root corresponds to the project itself and needs to be present always, so the filter is disabled for it.