### PR TITLE
Allow to instruct the client to save a document.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientWrapper.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientWrapper.java
@@ -219,4 +219,8 @@ class NbCodeClientWrapper implements NbCodeLanguageClient {
         return remote.configurationUpdate(params);
     }
     
+    @Override
+    public CompletableFuture<Boolean> requestDocumentSave(SaveDocumentRequestParams documentUris) {
+        return remote.requestDocumentSave(documentUris);
+    }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeLanguageClient.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeLanguageClient.java
@@ -151,4 +151,7 @@ public interface NbCodeLanguageClient extends LanguageClient {
     @JsonRequest("config/update")
     public CompletableFuture<Void> configurationUpdate(@NonNull UpdateConfigParams params);
     
+    @JsonRequest("window/documentSave")
+    public CompletableFuture<Boolean> requestDocumentSave(@NonNull SaveDocumentRequestParams documentUri);
+    
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/SaveDocumentRequestParams.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/SaveDocumentRequestParams.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import java.util.List;
+import org.eclipse.xtext.xbase.lib.Pure;
+
+/**
+ *
+ * @author sdedic
+ */
+public class SaveDocumentRequestParams {
+    private List<String> documents;
+
+    public SaveDocumentRequestParams() {
+    }
+
+    public SaveDocumentRequestParams(List<String> documents) {
+        this.documents = documents;
+    }
+
+    @Pure
+    public List<String> getDocuments() {
+        return documents;
+    }
+
+    public void setDocuments(List<String> documents) {
+        this.documents = documents;
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -1233,6 +1233,12 @@ public final class Server {
             logWarning(params);
             return CompletableFuture.completedFuture(null);
         }
+
+        @Override
+        public CompletableFuture<Boolean> requestDocumentSave(SaveDocumentRequestParams documentUris) {
+            logWarning(Arrays.asList(documentUris));
+            return CompletableFuture.completedFuture(false);
+        }
     };
 
 

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/TestCodeLanguageClient.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/TestCodeLanguageClient.java
@@ -43,6 +43,7 @@ import org.netbeans.modules.java.lsp.server.protocol.SetTextEditorDecorationPara
 import org.netbeans.modules.java.lsp.server.input.ShowInputBoxParams;
 import org.netbeans.modules.java.lsp.server.input.ShowMutliStepInputParams;
 import org.netbeans.modules.java.lsp.server.input.ShowQuickPickParams;
+import org.netbeans.modules.java.lsp.server.protocol.SaveDocumentRequestParams;
 import org.netbeans.modules.java.lsp.server.protocol.ShowStatusMessageParams;
 import org.netbeans.modules.java.lsp.server.protocol.TestProgressParams;
 import org.netbeans.modules.java.lsp.server.protocol.UpdateConfigParams;
@@ -155,4 +156,8 @@ public abstract class TestCodeLanguageClient implements NbCodeLanguageClient {
         throw new UnsupportedOperationException();
     }
     
+    @Override
+    public CompletableFuture<Boolean> requestDocumentSave(SaveDocumentRequestParams documentUris) {
+        return CompletableFuture.completedFuture(false);
+    }
 }

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/ProjectViewTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/ProjectViewTest.java
@@ -76,6 +76,7 @@ import org.netbeans.modules.java.lsp.server.input.QuickPickItem;
 import org.netbeans.modules.java.lsp.server.input.ShowInputBoxParams;
 import org.netbeans.modules.java.lsp.server.input.ShowMutliStepInputParams;
 import org.netbeans.modules.java.lsp.server.input.ShowQuickPickParams;
+import org.netbeans.modules.java.lsp.server.protocol.SaveDocumentRequestParams;
 import org.netbeans.modules.java.lsp.server.protocol.SetTextEditorDecorationParams;
 import org.netbeans.modules.java.lsp.server.protocol.ShowStatusMessageParams;
 import org.netbeans.modules.java.lsp.server.protocol.TestProgressParams;
@@ -277,6 +278,11 @@ public class ProjectViewTest extends NbTestCase {
         @Override
         public CompletableFuture<Void> configurationUpdate(UpdateConfigParams params) {
             return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletableFuture<Boolean> requestDocumentSave(SaveDocumentRequestParams documentUris) {
+            return CompletableFuture.completedFuture(false);
         }
     }
 

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/progress/TestProgressHandlerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/progress/TestProgressHandlerTest.java
@@ -46,6 +46,7 @@ import org.netbeans.modules.java.lsp.server.input.QuickPickItem;
 import org.netbeans.modules.java.lsp.server.protocol.SetTextEditorDecorationParams;
 import org.netbeans.modules.java.lsp.server.input.ShowInputBoxParams;
 import org.netbeans.modules.java.lsp.server.input.ShowQuickPickParams;
+import org.netbeans.modules.java.lsp.server.protocol.SaveDocumentRequestParams;
 import org.netbeans.modules.java.lsp.server.protocol.ShowStatusMessageParams;
 import org.netbeans.modules.java.lsp.server.protocol.TestProgressParams;
 import org.netbeans.modules.java.lsp.server.protocol.TestSuiteInfo;
@@ -221,6 +222,5 @@ public class TestProgressHandlerTest extends NbTestCase {
         public CompletableFuture<Void> configurationUpdate(UpdateConfigParams params) {
             return CompletableFuture.completedFuture(null);
         }
-
     }
 }

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -51,7 +51,7 @@ import * as launcher from './nbcode';
 import {NbTestAdapter} from './testAdapter';
 import { asRanges, StatusMessageRequest, ShowStatusMessageParams, QuickPickRequest, InputBoxRequest, MutliStepInputRequest, TestProgressNotification, DebugConnector,
          TextEditorDecorationCreateRequest, TextEditorDecorationSetNotification, TextEditorDecorationDisposeNotification, HtmlPageRequest, HtmlPageParams,
-         ExecInHtmlPageRequest, SetTextEditorDecorationParams, ProjectActionParams, UpdateConfigurationRequest, QuickPickStep, InputBoxStep
+         ExecInHtmlPageRequest, SetTextEditorDecorationParams, ProjectActionParams, UpdateConfigurationRequest, QuickPickStep, InputBoxStep, SaveDocumentsRequest, SaveDocumentRequestParams
 } from './protocol';
 import * as launchConfigurations from './launchConfigurations';
 import { createTreeViewService, TreeViewService, TreeItemDecorator, Visualizer, CustomizableTreeDataProvider } from './explorer';
@@ -1052,6 +1052,14 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
             c.onRequest(UpdateConfigurationRequest.type, async (param) => {
                 await vscode.workspace.getConfiguration(param.section).update(param.key, param.value);
                 runConfigurationUpdateAll();
+            });
+            c.onRequest(SaveDocumentsRequest.type, async (request : SaveDocumentRequestParams) => {
+                for (let ed of window.visibleTextEditors) {
+                    if (request.documents.includes(ed.document.uri.toString())) {
+                        await vscode.commands.executeCommand('workbench.action.files.save', ed.document.uri);
+                    }
+                }
+                return true;
             });
             c.onRequest(InputBoxRequest.type, async param => {
                 return await window.showInputBox({ title: param.title, prompt: param.prompt, value: param.value, password: param.password });

--- a/java/java.lsp.server/vscode/src/protocol.ts
+++ b/java/java.lsp.server/vscode/src/protocol.ts
@@ -204,6 +204,14 @@ export namespace TextEditorDecorationDisposeNotification {
     export const type = new ProtocolNotificationType<string, void>('window/disposeTextEditorDecoration');
 }
 
+export interface SaveDocumentRequestParams {
+    documents: string[];
+}
+
+export namespace SaveDocumentsRequest {
+    export const type = new ProtocolRequestType<SaveDocumentRequestParams, boolean, never, void, void>('window/documentSave');
+}
+
 export interface NodeChangedParams {
     rootId : number;
     nodeId : number | null;


### PR DESCRIPTION
The LSP client can be instructed to perform edits on certain files, but NBLS may need to force the client to commit its bufers to disk - in particular if the project build / metadata files are modified, so it can reload the up-to-date project state.

The message that forces the client to save the document is missing from the official LSP protocol. This PR adds a `window/saveDocument` request that instructs the client to save specified documents.
