### PR TITLE
Github actions version bumps.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
     steps:
         
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
@@ -142,10 +142,11 @@ jobs:
 
       - name: Upload Workspace
         if: ${{ (matrix.java == '11') && success() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: /tmp/build.tar.zst
+          compression-level: 0
           retention-days: 2
           if-no-files-found: error
           
@@ -155,10 +156,11 @@ jobs:
 
       - name: Upload Dev Build
         if: ${{ matrix.java == '11' && contains(github.event.pull_request.labels.*.name, 'ci:dev-build') && success() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dev-build
           path: nbbuild/NetBeans-*.zip
+          compression-level: 0
           retention-days: 7
           if-no-files-found: error
 
@@ -177,7 +179,7 @@ jobs:
           show-progress: false
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
             distribution: ${{ env.default_java_distribution }}
             java-version: 11
@@ -215,7 +217,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
@@ -227,7 +229,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -275,7 +277,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
@@ -308,7 +310,7 @@ jobs:
 
       - name: Download Build
         if: ${{ needs.base-build.result == 'success' && !cancelled() }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -340,13 +342,13 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -373,13 +375,13 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -408,13 +410,13 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -466,7 +468,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: ${{ env.default_java_distribution }}
@@ -477,7 +479,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -823,7 +825,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: ${{ env.default_java_distribution }}
@@ -834,7 +836,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -897,7 +899,7 @@ jobs:
 
       - name: Set up JDK 17 for JDK 21 incompatible tests
         if: ${{ matrix.java == '21' }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: ${{ env.default_java_distribution }}
@@ -936,7 +938,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: ${{ env.default_java_distribution }}
@@ -947,7 +949,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -1069,7 +1071,7 @@ jobs:
         run: ant $OPTS -f platform/o.n.swing.tabcontrol test
 
       - name: Set up JDK 8 for incompatibe tests
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: ${{ env.default_java_distribution }}
@@ -1117,13 +1119,13 @@ jobs:
     steps:
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: ${{ env.default_java_distribution }}
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: ${{ env.default_java_distribution }}
@@ -1134,7 +1136,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -1257,7 +1259,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: ${{ env.default_java_distribution }}
@@ -1268,7 +1270,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -1323,7 +1325,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
@@ -1334,7 +1336,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -1511,7 +1513,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: ${{ env.default_java_distribution }}
@@ -1522,7 +1524,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -1566,7 +1568,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
@@ -1577,7 +1579,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -1616,7 +1618,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: ${{ env.default_java_distribution }}
@@ -1627,7 +1629,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -1673,7 +1675,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: ${{ env.default_java_distribution }}
@@ -1684,7 +1686,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -1715,7 +1717,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: ${{ env.default_java_distribution }}
@@ -1726,7 +1728,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -1851,7 +1853,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
@@ -1862,7 +1864,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -1895,7 +1897,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
@@ -1906,7 +1908,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -1951,7 +1953,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
@@ -1962,7 +1964,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -1996,7 +1998,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
@@ -2007,7 +2009,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -2213,7 +2215,7 @@ jobs:
         run: ant $OPTS -f enterprise/websvc.wsstackapi test
 
       - name: Set up JDK 8 for incompatible tests
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: ${{ env.default_java_distribution }}
@@ -2225,7 +2227,7 @@ jobs:
         run: ant $OPTS -f enterprise/j2ee.dd.webservice test
 
       - name: Set up JDK 17 for tests that are not compatible with JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: ${{ env.default_java_distribution }}
@@ -2251,7 +2253,7 @@ jobs:
 
     steps:
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
@@ -2262,7 +2264,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -2326,7 +2328,7 @@ jobs:
 
     steps:
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
@@ -2337,7 +2339,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -2377,7 +2379,7 @@ jobs:
     steps:
 
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
@@ -2398,7 +2400,7 @@ jobs:
       # - - -
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -2517,7 +2519,7 @@ jobs:
 
     steps:
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: ${{ env.default_java_distribution }}
@@ -2528,7 +2530,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -2564,7 +2566,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 
@@ -2622,7 +2624,7 @@ jobs:
 
     steps:
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: ${{ env.default_java_distribution }}
@@ -2638,7 +2640,7 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
 

--- a/.github/workflows/native-binary-build-dlight.nativeexecution.yml
+++ b/.github/workflows/native-binary-build-dlight.nativeexecution.yml
@@ -94,7 +94,7 @@ jobs:
           ls -l -R ${SOURCES}
 
       - name: Upload native sources
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nativeexecution-external-sources
           path: ide/dlight.nativeexecution/build/sources/
@@ -110,7 +110,7 @@ jobs:
     steps:
 
       - name: Download sources
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nativeexecution-external-sources
 
@@ -126,7 +126,7 @@ jobs:
         working-directory: ide/dlight.nativeexecution/tools
 
       - name: Upload artifact Linux 64 bit
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Linux-x86_64
           path: ide/dlight.nativeexecution/tools/buildall/
@@ -144,7 +144,7 @@ jobs:
 #    steps:
 #
 #      - name: Download sources
-#        uses: actions/download-artifact@v3
+#        uses: actions/download-artifact@v4
 #        with:
 #          name: nativeexecution-external-sources
 #
@@ -158,7 +158,7 @@ jobs:
 #        shell: bash
 #        working-directory: ide/dlight.nativeexecution/tools
 #      - name: Upload artifact Windows 64 bit
-#        uses: actions/upload-artifact@v3
+#        uses: actions/upload-artifact@v4
 #        with:
 #          name: Windows-x86_64
 #          path: ide/dlight.nativeexecution/tools/buildall/
@@ -174,7 +174,7 @@ jobs:
     steps:
 
       - name: Download sources
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nativeexecution-external-sources
 
@@ -188,7 +188,7 @@ jobs:
         working-directory: ide/dlight.nativeexecution/tools
 
       - name: Upload artifact macOS x86_64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: MacOSX-x86_64
           path: ide/dlight.nativeexecution/tools/buildall/
@@ -203,7 +203,7 @@ jobs:
     steps:
 
       - name: Download sources
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nativeexecution-external-sources
 
@@ -217,7 +217,7 @@ jobs:
         working-directory: ide/dlight.nativeexecution/tools
 
       - name: Upload artifact macOS arm64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: MacOSX-arm_64
           path: ide/dlight.nativeexecution/tools/buildall/
@@ -238,7 +238,7 @@ jobs:
       run: mkdir -p myfiles/
 
     - name: Download artifacts from predecessor jobs
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: myfiles/
 
@@ -267,7 +267,7 @@ jobs:
          echo ""                                                               >> "$BUILDINFO"
 
     - name: Upload bundle
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: nativeexecution-external-binaries
         path: myfiles/

--- a/.github/workflows/native-binary-build-launcher.yml
+++ b/.github/workflows/native-binary-build-launcher.yml
@@ -86,7 +86,7 @@ jobs:
           ls -l -R ${SOURCES}
 
       - name: Upload native sources
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: launcher-external-sources
           path: nbbuild/build/native/launcher/sources/
@@ -105,7 +105,7 @@ jobs:
         run: sudo apt install mingw-w64 mingw-w64-tools
 
       - name: Download sources
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: launcher-external-sources
 
@@ -119,7 +119,7 @@ jobs:
         working-directory: platform/o.n.bootstrap/launcher/windows/
 
       - name: Upload bootstrap artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: launcher-bootstrap-bin
           path: platform/o.n.bootstrap/launcher/windows/build/
@@ -135,7 +135,7 @@ jobs:
         working-directory: harness/apisupport.harness/windows-launcher-src
 
       - name: Upload harness artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: launcher-harness-bin
           path: harness/apisupport.harness/windows-launcher-src/build/
@@ -151,7 +151,7 @@ jobs:
         working-directory: nb/ide.launcher/windows
 
       - name: Upload IDE artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: launcher-ide-bin
           path: nb/ide.launcher/windows/build/
@@ -171,7 +171,7 @@ jobs:
       run: mkdir -p myfiles/
 
     - name: Download artifacts from predecessor jobs
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: myfiles/
 
@@ -203,7 +203,7 @@ jobs:
          echo ""                                                               >> "$BUILDINFO"
 
     - name: Upload bundle
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: launcher-external-binaries
         path: myfiles/

--- a/.github/workflows/native-binary-build-lib.profiler.yml
+++ b/.github/workflows/native-binary-build-lib.profiler.yml
@@ -118,7 +118,7 @@ jobs:
           cp NOTICE ${SOURCES}/NOTICE
           ls -l -R ${SOURCES}
       - name: Upload native sources 
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: profiler-external-sources-ASF
           path: profiler/lib.profiler/build/sources/
@@ -134,7 +134,7 @@ jobs:
     steps:
 
       - name: Download sources
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: profiler-external-sources-ASF
         
@@ -171,13 +171,13 @@ jobs:
       #   Upload interim build artifacts to GitHub
       #
       - name: Upload artifact Linux 64 bit
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-amd64
           path: profiler/lib.profiler/release/lib/deployed/jdk16/linux-amd64/
           if-no-files-found: error
       - name: Upload artifact Linux 32 bit
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux
           path: profiler/lib.profiler/release/lib/deployed/jdk16/linux/
@@ -195,7 +195,7 @@ jobs:
     steps:
 
       - name: Download sources
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: profiler-external-sources-ASF
 
@@ -246,13 +246,13 @@ jobs:
       #   Upload interim build artifacts to GitHub
       #
       - name: Upload artifact Windows 64 bit
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-amd64
           path: profiler/lib.profiler/release/lib/deployed/jdk16/windows-amd64/
           if-no-files-found: error
       - name: Upload artifact Windows 32 bit
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows
           path: profiler/lib.profiler/release/lib/deployed/jdk16/windows/
@@ -268,7 +268,7 @@ jobs:
     steps:
 
       - name: Download sources
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: profiler-external-sources-ASF
 
@@ -292,7 +292,7 @@ jobs:
       #   Upload interim build artifacts to GitHub
       #
       - name: Upload artifact MacOS 64 bit
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mac
           path: profiler/lib.profiler/release/lib/deployed/jdk16/mac/
@@ -313,7 +313,7 @@ jobs:
       run: mkdir -p myfiles/lib/deployed/jdk16
 
     - name: Download artifacts from predecessor jobs
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: myfiles/lib/deployed/jdk16
         
@@ -343,7 +343,7 @@ jobs:
 
 
     - name: Upload bundle
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: profiler-external-binaries-ASF
         path: myfiles/


### PR DESCRIPTION
 - upload/download action v3 to v4
 - setup-java action v3 to v4

upload/download actions got some usability improvements

 - artifacts will now be available for manual dl right after the job finishes
 - release claims [upload](https://github.com/actions/upload-artifact/tree/v4.0.0#improvements)/[download](https://github.com/actions/download-artifact/tree/v4.0.0#improvements) speed improvements
 - compression level is configurable, I set it to 0 for big, already compressed artifacts

edit:
 - upload workspace improved from 7m20s -> 8s
 - download workspace seems to be about the same ~20s-70s (maybe due to the fact that so many jobs download it in parallel)