### PR TITLE
asyncOpenSelectedProjects will return project that correspond to the candidates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2653,7 +2653,7 @@ jobs:
       - name: test-vscode-ext
         run: |
           cd java/java.lsp.server
-          ant $OPTS test-vscode-ext
+          env "netbeans.extra.options=-J-Dnetbeans.logger.console=true" ant $OPTS test-vscode-ext
  
 
 # last job depends on everything so that it is forced to run last even if a long job fails early

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/LspServerState.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/LspServerState.java
@@ -48,6 +48,9 @@ public interface LspServerState {
      * Asynchronously opens projects that contain the passed files. Completes with the list
      * of opened projects, in no particular order. File owners will be registered as opened in the 
      * workspace.
+     * <p>
+     * For each input FileObject, the resulting array will contain its owning projects at the corresponding array index,
+     * or {@code null}, if the FileObject is not owned by any recognized project.
      * @param fileCandidates reference / owned files
      * @return opened projects.
      */
@@ -60,10 +63,12 @@ public interface LspServerState {
      * of opened projects, in no particular order. addWorkspace controls if the projects will
      * be registered as a part of client workspace. Content of workspace project and their subprojects are 
      * trusted, no questions are asked about opening.
-     * 
+     * <p>
+     * For each input FileObject, the resulting array will contain its owning projects at the corresponding array index,
+     * or {@code null}, if the FileObject is not owned by any recognized project.
      * @param addWorkspace register projects as part of client workspace.
      * @param fileCandidates reference / owned files
-     * @return opened projects.
+     * @return opened projects, in the same order as the input FileObjects.
      */
     public CompletableFuture<Project[]>   asyncOpenSelectedProjects(List<FileObject> fileCandidates, boolean addWorkspace);
     

--- a/java/java.lsp.server/vscode/src/nbcode.ts
+++ b/java/java.lsp.server/vscode/src/nbcode.ts
@@ -71,10 +71,10 @@ export function launch(
     }
     ideArgs.push(`-J-Dnetbeans.extra.dirs=${clusterPath}`)
     if (env['netbeans.extra.options']) {
-        ideArgs.push(env['netbeans.extra.options']);
+        ideArgs.push(...env['netbeans.extra.options'].split(' '));
     }
     ideArgs.push(...extraArgs);
-    
+    ideArgs.push(...['-J-Dnetbeans.logger.console=true', '-J-Dorg.netbeans.modules.java.lsp.server.protocol.level=300']);
     if (env['netbeans_debug'] && extraArgs && extraArgs.find(s => s.includes("--list"))) {
         ideArgs.push(...['-J-Dnetbeans.logger.console=true', '-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000']);
     }

--- a/java/java.lsp.server/vscode/src/nbcode.ts
+++ b/java/java.lsp.server/vscode/src/nbcode.ts
@@ -74,7 +74,6 @@ export function launch(
         ideArgs.push(...env['netbeans.extra.options'].split(' '));
     }
     ideArgs.push(...extraArgs);
-    ideArgs.push(...['-J-Dnetbeans.logger.console=true', '-J-Dorg.netbeans.modules.java.lsp.server.protocol.level=300']);
     if (env['netbeans_debug'] && extraArgs && extraArgs.find(s => s.includes("--list"))) {
         ideArgs.push(...['-J-Dnetbeans.logger.console=true', '-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000']);
     }

--- a/java/java.lsp.server/vscode/src/test/runTest.ts
+++ b/java/java.lsp.server/vscode/src/test/runTest.ts
@@ -52,7 +52,7 @@ async function main() {
             extensionTestsPath,
             extensionTestsEnv: {
                 'ENABLE_CONSOLE_LOG' : 'true',
-                "netbeans.extra.options" : `-J-Dproject.limitScanRoot=${outRoot}`
+                "netbeans.extra.options" : `-J-Dproject.limitScanRoot=${outRoot} -J-Dnetbeans.logger.console=true`
             },
             launchArgs: [
                 '--disable-extensions',


### PR DESCRIPTION
From an offline report:

Open a Maven GCN project in VSCode with NBLS installed (no RH Java). Go to 'Projects' view an try to invoke 'Compile Project' action on the top level project's node. The following exception is thrown

```
WARNING [org.netbeans.modules.java.lsp.server.protocol.Server]: Error occurred during LSP message dispatch
java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
	at java.base/java.util.Objects.checkIndex(Objects.java:359)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at org.netbeans.modules.java.lsp.server.protocol.WorkspaceServiceImpl.lambda$executeCommand$3(WorkspaceServiceImpl.java:226)
	at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1150)
Caused: java.util.concurrent.CompletionException
```

This exception happes because if a multiproject root directory (or a file with the root project itself, not a subproject) is passed, NBLS opens all contained projects - and returns the whole subtree. The original code attempted to match the projects against the input fileobjects and failed since there were more projects opened than the input fileobjects. 

The original intention of `asyncOpenSelectedProjects` was to return projects that correspond to the candidates after their open / prime. This PR changes the behaviour so that `asyncOpenSeelectedProjects` will return Project objects that correspond to individual input FileObjects, in the same order. If a FileObject is not part of any project, its corresponding array slot will be `null`.  I adjusted the callers to check for `null` values, hopefully.
