### PR TITLE
Not registering the LSP's SingleFileOptionsQueryImpl in java.lsp.server, but only in nbcode

### DIFF
--- a/java/java.file.launcher/nbproject/project.xml
+++ b/java/java.file.launcher/nbproject/project.xml
@@ -260,6 +260,7 @@
             </test-dependencies>
             <friend-packages>
                 <friend>org.netbeans.modules.java.lsp.server</friend>
+                <friend>org.netbeans.modules.nbcode.integration</friend>
                 <friend>org.netbeans.modules.refactoring.java</friend>
                 <package>org.netbeans.modules.java.file.launcher.api</package>
                 <package>org.netbeans.modules.java.file.launcher.spi</package>

--- a/java/java.lsp.server/nbcode/integration/nbproject/project.xml
+++ b/java/java.lsp.server/nbcode/integration/nbproject/project.xml
@@ -102,6 +102,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.java.file.launcher</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.0</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.java.lsp.server</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspSingleFileOptionsQueryImpl.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspSingleFileOptionsQueryImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.nbcode.integration;
+
+import org.netbeans.modules.java.file.launcher.spi.SingleFileOptionsQueryImplementation;
+import org.netbeans.modules.java.lsp.server.singlesourcefile.SingleFileOptionsQueryImpl;
+import org.openide.util.lookup.ServiceProvider;
+
+@ServiceProvider(service=SingleFileOptionsQueryImplementation.class, position=100)
+public class LspSingleFileOptionsQueryImpl extends SingleFileOptionsQueryImpl {
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -1128,28 +1128,30 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
         CompletableFuture<CodeAction> future = new CompletableFuture<>();
         BACKGROUND_TASKS.post(() -> {
             JsonObject data = (JsonObject) unresolved.getData();
-            if (data.has(CodeActionsProvider.CODE_ACTIONS_PROVIDER_CLASS)) {
-                String providerClass = data.getAsJsonPrimitive(CodeActionsProvider.CODE_ACTIONS_PROVIDER_CLASS).getAsString();
-                for (CodeActionsProvider codeGenerator : Lookup.getDefault().lookupAll(CodeActionsProvider.class)) {
-                    if (codeGenerator.getClass().getName().equals(providerClass)) {
+            if (data != null) {
+                if (data.has(CodeActionsProvider.CODE_ACTIONS_PROVIDER_CLASS)) {
+                    String providerClass = data.getAsJsonPrimitive(CodeActionsProvider.CODE_ACTIONS_PROVIDER_CLASS).getAsString();
+                    for (CodeActionsProvider codeGenerator : Lookup.getDefault().lookupAll(CodeActionsProvider.class)) {
+                        if (codeGenerator.getClass().getName().equals(providerClass)) {
+                            try {
+                                codeGenerator.resolve(client, unresolved, data.get(CodeActionsProvider.DATA)).thenAccept(action -> {
+                                    future.complete(action);
+                                });
+                            } catch (Exception e) {
+                                future.completeExceptionally(e);
+                            }
+                            return;
+                        }
+                    }
+                } else if (data.has(URL) && data.has(INDEX)) {
+                    LazyCodeAction inputAction = lastCodeActions.get(data.getAsJsonPrimitive(INDEX).getAsInt());
+                    if (inputAction != null) {
                         try {
-                            codeGenerator.resolve(client, unresolved, data.get(CodeActionsProvider.DATA)).thenAccept(action -> {
-                                future.complete(action);
-                            });
+                            unresolved.setEdit(fromAPI(inputAction.getLazyEdit().get(), data.getAsJsonPrimitive(URL).getAsString(), client));
                         } catch (Exception e) {
                             future.completeExceptionally(e);
+                            return;
                         }
-                        return;
-                    }
-                }
-            } else if (data.has(URL) && data.has(INDEX)) {
-                LazyCodeAction inputAction = lastCodeActions.get(data.getAsJsonPrimitive(INDEX).getAsInt());
-                if (inputAction != null) {
-                    try {
-                        unresolved.setEdit(fromAPI(inputAction.getLazyEdit().get(), data.getAsJsonPrimitive(URL).getAsString(), client));
-                    } catch (Exception e) {
-                        future.completeExceptionally(e);
-                        return;
                     }
                 }
             }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/singlesourcefile/SingleFileOptionsQueryImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/singlesourcefile/SingleFileOptionsQueryImpl.java
@@ -32,10 +32,8 @@ import org.netbeans.modules.java.lsp.server.protocol.NbCodeLanguageClient;
 import org.openide.filesystems.FileObject;
 import org.openide.util.ChangeSupport;
 import org.openide.util.Lookup;
-import org.openide.util.lookup.ServiceProvider;
 
-@ServiceProvider(service=SingleFileOptionsQueryImplementation.class, position=100)
-public class SingleFileOptionsQueryImpl implements SingleFileOptionsQueryImplementation {
+public abstract class SingleFileOptionsQueryImpl implements SingleFileOptionsQueryImplementation {
 
     private final Map<NbCodeLanguageClient, ResultImpl> client2Options = new WeakHashMap<>();
     private final GlobalResultImpl globalOptions = new GlobalResultImpl();


### PR DESCRIPTION
As noted here:
https://github.com/apache/netbeans/pull/6329#issuecomment-1857867731
the compiler options set a VM Options for a source-file launcher are not working in the NetBeans GUI. The reason is that the provider from `java.lsp.server` overrides the default provider.

This patch moves the registration into nbcode, which, I believe, is what has been done in similar cases.

Also, in `TextDocumentServiceImpl.resolveCodeAction`, the data may be `null`, I believe (like for the "Enable Preview" action), adding a null check.
