### PR TITLE
Allow user to manipulate Truffle breakpoints

### DIFF
--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/RemoteServices.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/RemoteServices.java
@@ -83,6 +83,7 @@ import org.netbeans.modules.debugger.jpda.jdi.UnsupportedOperationExceptionWrapp
 import org.netbeans.modules.debugger.jpda.jdi.VMDisconnectedExceptionWrapper;
 import org.netbeans.modules.debugger.jpda.jdi.VirtualMachineWrapper;
 import org.netbeans.modules.debugger.jpda.models.JPDAThreadImpl;
+import static org.netbeans.modules.debugger.jpda.truffle.TruffleDebugManager.configureTruffleBreakpoint;
 
 import org.openide.util.Exceptions;
 import org.openide.util.RequestProcessor;
@@ -330,7 +331,7 @@ public final class RemoteServices {
         
         mb.setBreakpointType(MethodBreakpoint.TYPE_METHOD_ENTRY);
         mb.setSuspend(MethodBreakpoint.SUSPEND_EVENT_THREAD);
-        mb.setHidden(true);
+        configureTruffleBreakpoint(mb);
         mb.setThreadFilters(dbg, new JPDAThread[] { awtThread });
         mb.addJPDABreakpointListener(new JPDABreakpointListener() {
             @Override

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/access/TruffleAccess.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/access/TruffleAccess.java
@@ -87,6 +87,7 @@ import org.netbeans.modules.debugger.jpda.models.JPDAThreadImpl;
 import org.netbeans.modules.debugger.jpda.truffle.LanguageName;
 import org.netbeans.modules.debugger.jpda.truffle.RemoteServices;
 import org.netbeans.modules.debugger.jpda.truffle.TruffleDebugManager;
+import static org.netbeans.modules.debugger.jpda.truffle.TruffleDebugManager.configureTruffleBreakpoint;
 import org.netbeans.modules.debugger.jpda.truffle.Utils;
 import org.netbeans.modules.debugger.jpda.truffle.actions.StepActionProvider;
 import org.netbeans.modules.debugger.jpda.truffle.ast.TruffleNode;
@@ -175,7 +176,7 @@ public class TruffleAccess implements JPDABreakpointListener {
     private JPDABreakpoint createBP(String className, String methodName, JPDADebugger debugger) {
         final MethodBreakpoint mb = MethodBreakpoint.create(className, methodName);
         mb.setBreakpointType(MethodBreakpoint.TYPE_METHOD_ENTRY);
-        mb.setHidden(true);
+        configureTruffleBreakpoint(mb);
         mb.setSession(debugger);
         mb.addJPDABreakpointListener(this);
         DebuggerManager.getDebuggerManager().addBreakpoint(mb);
@@ -310,7 +311,7 @@ public class TruffleAccess implements JPDABreakpointListener {
         MethodBreakpoint clearLeakingReferencesBreakpoint = MethodBreakpoint.create(CLEAR_REFERENCES_CLASS, CLEAR_REFERENCES_METHOD);
         clearLeakingReferencesBreakpoint.setBreakpointType(MethodBreakpoint.TYPE_METHOD_ENTRY);
         clearLeakingReferencesBreakpoint.setThreadFilters(debugger, new JPDAThread[] { thread });
-        clearLeakingReferencesBreakpoint.setHidden(true);
+        configureTruffleBreakpoint(clearLeakingReferencesBreakpoint);
         Function<EventSet, Boolean> breakpointEventInterceptor = eventSet -> {
             try {
                 ThreadReference etr = null;

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/actions/StepActionProvider.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/actions/StepActionProvider.java
@@ -51,6 +51,7 @@ import org.netbeans.modules.debugger.jpda.jdi.VMDisconnectedExceptionWrapper;
 import org.netbeans.modules.debugger.jpda.jdi.request.EventRequestManagerWrapper;
 import org.netbeans.modules.debugger.jpda.models.AbstractVariable;
 import org.netbeans.modules.debugger.jpda.models.JPDAThreadImpl;
+import static org.netbeans.modules.debugger.jpda.truffle.TruffleDebugManager.configureTruffleBreakpoint;
 import org.netbeans.modules.debugger.jpda.truffle.access.CurrentPCInfo;
 import org.netbeans.modules.debugger.jpda.truffle.access.TruffleAccess;
 import org.netbeans.modules.debugger.jpda.truffle.access.TruffleStrataProvider;
@@ -178,7 +179,7 @@ public class StepActionProvider extends JPDADebuggerActionProvider {
         MethodBreakpoint stepIntoJavaBreakpoint = MethodBreakpoint.create(STEP2JAVA_CLASS, STEP2JAVA_METHOD);
         stepIntoJavaBreakpoint.setBreakpointType(MethodBreakpoint.TYPE_METHOD_ENTRY);
         stepIntoJavaBreakpoint.setThreadFilters(debugger, new JPDAThread[]{currentThread});
-        stepIntoJavaBreakpoint.setHidden(true);
+        configureTruffleBreakpoint(stepIntoJavaBreakpoint);
         stepIntoJavaBreakpoint.addJPDABreakpointListener(new JPDABreakpointListener() {
             @Override
             public void breakpointReached(JPDABreakpointEvent event) {

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/breakpoints/impl/TruffleBreakpointsHandler.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/breakpoints/impl/TruffleBreakpointsHandler.java
@@ -69,6 +69,7 @@ import org.netbeans.modules.debugger.jpda.jdi.UnsupportedOperationExceptionWrapp
 import org.netbeans.modules.debugger.jpda.jdi.VMDisconnectedExceptionWrapper;
 import org.netbeans.modules.debugger.jpda.models.JPDAThreadImpl;
 import org.netbeans.modules.debugger.jpda.truffle.PersistentValues;
+import static org.netbeans.modules.debugger.jpda.truffle.TruffleDebugManager.configureTruffleBreakpoint;
 import org.netbeans.modules.debugger.jpda.truffle.access.TruffleAccess;
 import org.netbeans.modules.debugger.jpda.truffle.source.Source;
 import org.netbeans.modules.debugger.jpda.truffle.source.SourceBinaryTranslator;
@@ -124,7 +125,7 @@ public class TruffleBreakpointsHandler {
             if (this.breakpointResolvedHandler == null) {
                 MethodBreakpoint methodBreakpoint = MethodBreakpoint.create(accessorClass.name(), ACCESSOR_LINE_BREAKPOINT_RESOLVED);
                 methodBreakpoint.setSession(debugger);
-                methodBreakpoint.setHidden(true);
+                configureTruffleBreakpoint(methodBreakpoint);
                 methodBreakpoint.setSuspend(JPDABreakpoint.SUSPEND_EVENT_THREAD);
                 methodBreakpoint.addJPDABreakpointListener(new JPDABreakpointListener() {
                     @Override


### PR DESCRIPTION
While debugging programs with Truffle based languages it may be useful to disable the Truffle functionality (as it may slow down the debugging a lot - for example running tests on mine [graaljs-websocket](https://github.com/JaroslavTulach/graaljs-websocket/commit/a6f674cec2985f3f26c06e2e0a55c77b51ca4649) is quite slow - looks like the VM runs in interpreter only). Currently the only way to disable Truffle breakpoints is to disable the whole module.

This PR offers a different way: It exposes the Truffle breakpoints to the user (under the group `Truffle`) which can then be disabled as a whole with a single click.

![image](https://github.com/apache/netbeans/assets/1842422/bc3bb3df-56d6-4e5b-b0ac-3b29145dffd4)

What do you think, @entlicher?
