### PR TITLE
PHP: mark a breakpoint as broken when an error is received when breakpoint_set is executed to set a breakpoint

### DIFF
--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/annotations/BrkpntAnnotation.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/annotations/BrkpntAnnotation.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.php.dbgp.annotations;
 
 import org.netbeans.api.debugger.Breakpoint;
 import org.netbeans.modules.php.dbgp.breakpoints.LineBreakpoint;
+import org.netbeans.modules.php.dbgp.breakpoints.Utils;
 import org.netbeans.spi.debugger.ui.BreakpointAnnotation;
 import org.openide.text.Annotatable;
 import org.openide.util.NbBundle;
@@ -41,8 +42,7 @@ public class BrkpntAnnotation extends BreakpointAnnotation {
 
     @Override
     public String getAnnotationType() {
-        Breakpoint.VALIDITY validity = breakpoint.getValidity();
-        return validity == Breakpoint.VALIDITY.VALID || validity == Breakpoint.VALIDITY.UNKNOWN
+        return Utils.isValid(breakpoint)
                 ? BREAKPOINT_ANNOTATION_TYPE
                 : BREAKPOINT_ANNOTATION_TYPE + "_broken"; //NOI18N
     }

--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/breakpoints/AbstractBreakpoint.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/breakpoints/AbstractBreakpoint.java
@@ -84,6 +84,10 @@ public abstract class AbstractBreakpoint extends Breakpoint {
         setValidity(VALIDITY.INVALID, null);
     }
 
+    public void setInvalid(String reason) {
+        setValidity(VALIDITY.INVALID, reason);
+    }
+
     public void reset() {
         setValidity(VALIDITY.UNKNOWN, null);
         myId = null;

--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/breakpoints/BreakpointModel.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/breakpoints/BreakpointModel.java
@@ -49,6 +49,7 @@ public class BreakpointModel extends ViewModelSupport implements NodeModel {
     public static final String CURRENT_LINE_CONDITIONAL_BREAKPOINT = "org/netbeans/modules/debugger/resources/breakpointsView/ConditionalBreakpointHit"; // NOI18N
     public static final String DISABLED_LINE_CONDITIONAL_BREAKPOINT = "org/netbeans/modules/debugger/resources/breakpointsView/DisabledConditionalBreakpoint"; // NOI18N
     public static final String BROKEN_LINE_BREAKPOINT = "org/netbeans/modules/debugger/resources/breakpointsView/Breakpoint_broken"; // NOI18N
+    public static final String BROKEN_BREAKPOINT = "org/netbeans/modules/debugger/resources/breakpointsView/NonLineBreakpoint_broken"; // NOI18N
     private static final String METHOD = "TXT_Method"; // NOI18N
     private static final String EXCEPTION = "TXT_Exception"; // NOI18N
     private static final String PARENS = "()"; // NOI18N
@@ -99,8 +100,7 @@ public class BreakpointModel extends ViewModelSupport implements NodeModel {
             if (!breakpoint.isEnabled()) {
                 return DISABLED_LINE_BREAKPOINT;
             } else {
-                VALIDITY validity = breakpoint.getValidity();
-                if (validity.equals(VALIDITY.VALID) || validity.equals(VALIDITY.UNKNOWN)) {
+                if (Utils.isValid(breakpoint)) {
                     return LINE_BREAKPOINT;
                 } else {
                     return BROKEN_LINE_BREAKPOINT;
@@ -110,8 +110,13 @@ public class BreakpointModel extends ViewModelSupport implements NodeModel {
             AbstractBreakpoint breakpoint = (AbstractBreakpoint) node;
             if (!breakpoint.isEnabled()) {
                 return DISABLED_BREAKPOINT;
+            } else {
+                if (Utils.isValid(breakpoint)) {
+                    return BREAKPOINT;
+                } else {
+                    return BROKEN_BREAKPOINT;
+                }
             }
-            return BREAKPOINT;
         }
         throw new UnknownTypeException(node);
     }

--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/breakpoints/Utils.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/breakpoints/Utils.java
@@ -23,6 +23,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.debugger.Breakpoint;
+import org.netbeans.api.debugger.Breakpoint.VALIDITY;
 import org.netbeans.api.debugger.DebuggerManager;
 import org.netbeans.api.options.OptionsDisplayer;
 import org.netbeans.modules.php.dbgp.DebugSession;
@@ -238,4 +239,8 @@ public final class Utils {
         return mimeTypesOnLine.contains(MIME_TYPE);
     }
 
+    public static boolean isValid(Breakpoint breakpoint) {
+        VALIDITY validity = breakpoint.getValidity();
+        return validity == VALIDITY.VALID || validity == VALIDITY.UNKNOWN;
+    }
 }

--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/BrkpntSetResponse.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/BrkpntSetResponse.java
@@ -30,6 +30,8 @@ import org.w3c.dom.Node;
 public class BrkpntSetResponse extends DbgpResponse {
     private static final String STATE = "state"; // NOI18N
     private static final String ID = "id"; // NOI18N
+    private static final String ERROR = "error"; // NOI18N
+    private static final String MESSAGE = "message"; // NOI18N
 
     BrkpntSetResponse(Node node) {
         super(node);
@@ -56,6 +58,16 @@ public class BrkpntSetResponse extends DbgpResponse {
             // set f.e. for as temporary ( for run to cursor command ).
             return;
         }
+
+        Node error = getChild(getNode(), ERROR);
+        if (error != null) {
+            Node message = getChild(error, MESSAGE);
+            if (message != null) {
+                breakpoint.setInvalid(message.getTextContent());
+                return;
+            }
+        }
+
         breakpoint.setBreakpointId(getBreakpointId());
         if (getState() == State.DISABLED) {
             breakpoint.disable();


### PR DESCRIPTION
xdebug of different versions behaves differently when setting duplicate breakpoints.
xdebug version 2.5.5 allows you to set a duplicate breakpoint.
xdebug version 3.1.6 and higher does not allow setting a duplicate breakpoint by method.
Since version 3.2.0 it also does not allow setting a duplicate breakpoint by line.

If an attempt is made to set a duplicate breakpoint, xdebug returns an error:
```
<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="141" state="enabled" status="starting" reason="ok">
	<error code="200">
		<message>
			<![CDATA[breakpoint could not be set]]>
		</message>
	</error>
</response>
```

This PR implements this error handling and marks the breakpoint as broken. 
Tested on versions of xdebug: `2.5.5`, `3.1.6`, `3.2.1`, `3.3.0`.

Example for a line breakpoint:

 - Write code
```php
<?php

echo 'Hi';

$s = 12;

echo 'Hello';

```
- Put two breakpoints on the line `echo 'Hello';` with different conditions (the order in which the breakpoints are set is important!):
   - first `$s == 4`
   - then `$s == 12`

- When debugging on xdebug version `2.5.5` or `3.1.6`, it will stop at the point with the condition `$s == 12`.
Everything is fine with this.

- When debugging on version `3.2.0`, stopping at a point with the condition `$s == 12` will not be executed, because the
xdebug will not set the breakpoint. But the breakpoint is shown as normal, which is misleading.

Behavior before PR:

https://github.com/apache/netbeans/assets/9607501/3683035c-adc0-4e7c-9108-f05d0794d7d0

Behavior after PR:

https://github.com/apache/netbeans/assets/9607501/4ea4d04a-1acf-49ee-92c3-1df4fe4ddbbf




