### PR TITLE
Fix the formatting for the method call arguments alignment option #6714

### DIFF
--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_01.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_01.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace NS\GH6714;
+
+use Vendor\Package\TestClass1;
+use function Vendor\Package\ {
+            function1,
+            function2,
+};
+use function Vendor\Package\ {
+            function3,
+            function4,
+};
+use const Vendor\Package\CONSTANT1;
+
+class GH6714 implements Interface1,
+Interface2,
+Interface3
+{
+	public array $x = [];
+	public array $y = [];
+
+	public function test1()
+	{
+		return something1(
+			$this->x,
+   $this->y,
+		);
+	}
+
+	public function test2(
+  $param1,
+     $param2,
+    $param3,
+        )
+	{
+            nestedCall(
+			$this->testMethod($arg1),
+$this->x,
+		$this->y,
+		);
+		return nestedCall(
+			$this->testMethod($arg1),
+$this->x,
+		$this->y,
+		);
+	}
+}
+
+array_merge(
+	$x,
+$y,
+);
+
+nestedCall(
+	something(
+				$arg1,
+			$arg2,
+		C::something(
+					$x,
+					$y,
+				$z,
+		)
+	),
+			$y,
+		$z,
+);

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_01.php.testGH6714WithSpaces_01a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_01.php.testGH6714WithSpaces_01a.formatted
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\GH6714;
+
+use Vendor\Package\TestClass1;
+use function Vendor\Package\{
+    function1,
+    function2,
+};
+use function Vendor\Package\{
+    function3,
+    function4,
+};
+use const Vendor\Package\CONSTANT1;
+
+class GH6714 implements Interface1,
+                        Interface2,
+                        Interface3 {
+
+    public array $x = [];
+    public array $y = [];
+
+    public function test1() {
+        return something1(
+            $this->x,
+            $this->y,
+        );
+    }
+
+    public function test2(
+        $param1,
+        $param2,
+        $param3,
+    ) {
+        nestedCall(
+            $this->testMethod($arg1),
+            $this->x,
+            $this->y,
+        );
+        return nestedCall(
+            $this->testMethod($arg1),
+            $this->x,
+            $this->y,
+        );
+    }
+}
+
+array_merge(
+    $x,
+    $y,
+);
+
+nestedCall(
+    something(
+        $arg1,
+        $arg2,
+        C::something(
+            $x,
+            $y,
+            $z,
+        )
+    ),
+    $y,
+    $z,
+);

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_01.php.testGH6714WithSpaces_01b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_01.php.testGH6714WithSpaces_01b.formatted
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\GH6714;
+
+use Vendor\Package\TestClass1;
+use function Vendor\Package\{
+    function1,
+    function2,
+};
+use function Vendor\Package\{
+    function3,
+    function4,
+};
+use const Vendor\Package\CONSTANT1;
+
+class GH6714 implements Interface1,
+                        Interface2,
+                        Interface3 {
+
+    public array $x = [];
+    public array $y = [];
+
+    public function test1() {
+        return something1(
+            $this->x,
+            $this->y,
+        );
+    }
+
+    public function test2(
+        $param1,
+        $param2,
+        $param3,
+    ) {
+        nestedCall(
+            $this->testMethod($arg1),
+            $this->x,
+            $this->y,
+        );
+        return nestedCall(
+            $this->testMethod($arg1),
+            $this->x,
+            $this->y,
+        );
+    }
+}
+
+array_merge(
+    $x,
+    $y,
+);
+
+nestedCall(
+    something(
+        $arg1,
+        $arg2,
+        C::something(
+            $x,
+            $y,
+            $z,
+        )
+    ),
+    $y,
+    $z,
+);

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_01.php.testGH6714WithTab_01a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_01.php.testGH6714WithTab_01a.formatted
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\GH6714;
+
+use Vendor\Package\TestClass1;
+use function Vendor\Package\{
+	function1,
+	function2,
+};
+use function Vendor\Package\{
+	function3,
+	function4,
+};
+use const Vendor\Package\CONSTANT1;
+
+class GH6714 implements Interface1,
+						Interface2,
+						Interface3 {
+
+	public array $x = [];
+	public array $y = [];
+
+	public function test1() {
+		return something1(
+			$this->x,
+			$this->y,
+		);
+	}
+
+	public function test2(
+		$param1,
+		$param2,
+		$param3,
+	) {
+		nestedCall(
+			$this->testMethod($arg1),
+			$this->x,
+			$this->y,
+		);
+		return nestedCall(
+			$this->testMethod($arg1),
+			$this->x,
+			$this->y,
+		);
+	}
+}
+
+array_merge(
+	$x,
+	$y,
+);
+
+nestedCall(
+	something(
+		$arg1,
+		$arg2,
+		C::something(
+			$x,
+			$y,
+			$z,
+		)
+	),
+	$y,
+	$z,
+);

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_01.php.testGH6714WithTab_01b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_01.php.testGH6714WithTab_01b.formatted
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\GH6714;
+
+use Vendor\Package\TestClass1;
+use function Vendor\Package\{
+	function1,
+	function2,
+};
+use function Vendor\Package\{
+	function3,
+	function4,
+};
+use const Vendor\Package\CONSTANT1;
+
+class GH6714 implements Interface1,
+						Interface2,
+						Interface3 {
+
+	public array $x = [];
+	public array $y = [];
+
+	public function test1() {
+		return something1(
+			$this->x,
+			$this->y,
+		);
+	}
+
+	public function test2(
+		$param1,
+		$param2,
+		$param3,
+	) {
+		nestedCall(
+			$this->testMethod($arg1),
+			$this->x,
+			$this->y,
+		);
+		return nestedCall(
+			$this->testMethod($arg1),
+			$this->x,
+			$this->y,
+		);
+	}
+}
+
+array_merge(
+	$x,
+	$y,
+);
+
+nestedCall(
+	something(
+		$arg1,
+		$arg2,
+		C::something(
+			$x,
+			$y,
+			$z,
+		)
+	),
+	$y,
+	$z,
+);

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_02.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_02.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\GH6714;
+
+use Vendor\Package\TestClass1;
+use function Vendor\Package\ {
+            function1,
+            function2,
+};
+use function Vendor\Package\ {
+            function3,
+            function4,
+};
+use const Vendor\Package\CONSTANT1;
+
+class GH6714 implements Interface1,
+                        Interface2,
+                        Interface3 {
+
+    public array $x = [];
+    public array $y = [];
+
+    public function test1() {
+        return something1(
+            $this->x,
+            $this->y,
+        );
+    }
+
+    public function test2(
+        $param1,
+        $param2,
+        $param3,
+    ) {
+        nestedCall(
+            $this->testMethod($arg1),
+            $this->x,
+            $this->y,
+        );
+        return nestedCall(
+            $this->testMethod($arg1),
+            $this->x,
+            $this->y,
+        );
+    }
+}
+
+array_merge(
+    $x,
+    $y,
+);
+
+nestedCall(
+    something(
+        $arg1,
+        $arg2,
+        C::something(
+            $x,
+            $y,
+            $z,
+        )
+    ),
+    $y,
+    $z,
+);

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_02.php.testGH6714WithSpaces_02a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_02.php.testGH6714WithSpaces_02a.formatted
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\GH6714;
+
+use Vendor\Package\TestClass1;
+use function Vendor\Package\{
+    function1,
+    function2,
+};
+use function Vendor\Package\{
+    function3,
+    function4,
+};
+use const Vendor\Package\CONSTANT1;
+
+class GH6714 implements Interface1,
+                        Interface2,
+                        Interface3 {
+
+    public array $x = [];
+    public array $y = [];
+
+    public function test1() {
+        return something1(
+            $this->x,
+            $this->y,
+        );
+    }
+
+    public function test2(
+        $param1,
+        $param2,
+        $param3,
+    ) {
+        nestedCall(
+            $this->testMethod($arg1),
+            $this->x,
+            $this->y,
+        );
+        return nestedCall(
+            $this->testMethod($arg1),
+            $this->x,
+            $this->y,
+        );
+    }
+}
+
+array_merge(
+    $x,
+    $y,
+);
+
+nestedCall(
+    something(
+        $arg1,
+        $arg2,
+        C::something(
+            $x,
+            $y,
+            $z,
+        )
+    ),
+    $y,
+    $z,
+);

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_02.php.testGH6714WithSpaces_02b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_02.php.testGH6714WithSpaces_02b.formatted
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\GH6714;
+
+use Vendor\Package\TestClass1;
+use function Vendor\Package\{
+    function1,
+    function2,
+};
+use function Vendor\Package\{
+    function3,
+    function4,
+};
+use const Vendor\Package\CONSTANT1;
+
+class GH6714 implements Interface1,
+                        Interface2,
+                        Interface3 {
+
+    public array $x = [];
+    public array $y = [];
+
+    public function test1() {
+        return something1(
+            $this->x,
+            $this->y,
+        );
+    }
+
+    public function test2(
+        $param1,
+        $param2,
+        $param3,
+    ) {
+        nestedCall(
+            $this->testMethod($arg1),
+            $this->x,
+            $this->y,
+        );
+        return nestedCall(
+            $this->testMethod($arg1),
+            $this->x,
+            $this->y,
+        );
+    }
+}
+
+array_merge(
+    $x,
+    $y,
+);
+
+nestedCall(
+    something(
+        $arg1,
+        $arg2,
+        C::something(
+            $x,
+            $y,
+            $z,
+        )
+    ),
+    $y,
+    $z,
+);

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_02.php.testGH6714WithTab_02a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_02.php.testGH6714WithTab_02a.formatted
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\GH6714;
+
+use Vendor\Package\TestClass1;
+use function Vendor\Package\{
+	function1,
+	function2,
+};
+use function Vendor\Package\{
+	function3,
+	function4,
+};
+use const Vendor\Package\CONSTANT1;
+
+class GH6714 implements Interface1,
+						Interface2,
+						Interface3 {
+
+	public array $x = [];
+	public array $y = [];
+
+	public function test1() {
+		return something1(
+			$this->x,
+			$this->y,
+		);
+	}
+
+	public function test2(
+		$param1,
+		$param2,
+		$param3,
+	) {
+		nestedCall(
+			$this->testMethod($arg1),
+			$this->x,
+			$this->y,
+		);
+		return nestedCall(
+			$this->testMethod($arg1),
+			$this->x,
+			$this->y,
+		);
+	}
+}
+
+array_merge(
+	$x,
+	$y,
+);
+
+nestedCall(
+	something(
+		$arg1,
+		$arg2,
+		C::something(
+			$x,
+			$y,
+			$z,
+		)
+	),
+	$y,
+	$z,
+);

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_02.php.testGH6714WithTab_02b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/gh6714_02.php.testGH6714WithTab_02b.formatted
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS\GH6714;
+
+use Vendor\Package\TestClass1;
+use function Vendor\Package\{
+	function1,
+	function2,
+};
+use function Vendor\Package\{
+	function3,
+	function4,
+};
+use const Vendor\Package\CONSTANT1;
+
+class GH6714 implements Interface1,
+						Interface2,
+						Interface3 {
+
+	public array $x = [];
+	public array $y = [];
+
+	public function test1() {
+		return something1(
+			$this->x,
+			$this->y,
+		);
+	}
+
+	public function test2(
+		$param1,
+		$param2,
+		$param3,
+	) {
+		nestedCall(
+			$this->testMethod($arg1),
+			$this->x,
+			$this->y,
+		);
+		return nestedCall(
+			$this->testMethod($arg1),
+			$this->x,
+			$this->y,
+		);
+	}
+}
+
+array_merge(
+	$x,
+	$y,
+);
+
+nestedCall(
+	something(
+		$arg1,
+		$arg2,
+		C::something(
+			$x,
+			$y,
+			$z,
+		)
+	),
+	$y,
+	$z,
+);

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterAlignmentTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterAlignmentTest.java
@@ -26,8 +26,14 @@ import java.util.HashMap;
  */
 public class PHPFormatterAlignmentTest extends PHPFormatterTestBase {
 
+    private static final String TEST_DIRECTORY_PATH = "testfiles/formatting/alignment/";
+
     public PHPFormatterAlignmentTest(String testName) {
         super(testName);
+    }
+
+    private String getTestFilePath(String fileName) {
+        return TEST_DIRECTORY_PATH + fileName;
     }
 
     public void testAlignmentKeywords01() throws Exception {
@@ -211,6 +217,102 @@ public class PHPFormatterAlignmentTest extends PHPFormatterTestBase {
         HashMap<String, Object> options = new HashMap<String, Object>(FmtOptions.getDefaults());
         options.put(FmtOptions.GROUP_ALIGNMENT_ASSIGNMENT, true);
         reformatFileContents("testfiles/formatting/alignment/issue244566.php", options);
+    }
+
+    public void testGH6714WithTab_01a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.ALIGN_MULTILINE_CALL_ARGS, true);
+        options.put(FmtOptions.ALIGN_MULTILINE_IMPLEMENTS, true);
+        options.put(FmtOptions.WRAP_EXTENDS_IMPLEMENTS_LIST, CodeStyle.WrapStyle.WRAP_ALWAYS);
+        options.put(FmtOptions.ALIGN_MULTILINE_METHOD_PARAMS, true);
+        options.put(FmtOptions.TAB_SIZE, 4);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        reformatFileContents(getTestFilePath("gh6714_01.php"), options, false, true);
+    }
+
+    public void testGH6714WithTab_01b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.ALIGN_MULTILINE_CALL_ARGS, false);
+        options.put(FmtOptions.WRAP_EXTENDS_IMPLEMENTS_LIST, CodeStyle.WrapStyle.WRAP_ALWAYS);
+        options.put(FmtOptions.ALIGN_MULTILINE_IMPLEMENTS, true);
+        options.put(FmtOptions.ALIGN_MULTILINE_METHOD_PARAMS, true);
+        options.put(FmtOptions.TAB_SIZE, 4);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        reformatFileContents(getTestFilePath("gh6714_01.php"), options, false, true);
+    }
+
+    public void testGH6714WithTab_02a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.ALIGN_MULTILINE_CALL_ARGS, true);
+        options.put(FmtOptions.WRAP_EXTENDS_IMPLEMENTS_LIST, CodeStyle.WrapStyle.WRAP_ALWAYS);
+        options.put(FmtOptions.ALIGN_MULTILINE_IMPLEMENTS, true);
+        options.put(FmtOptions.ALIGN_MULTILINE_METHOD_PARAMS, true);
+        options.put(FmtOptions.TAB_SIZE, 4);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        reformatFileContents(getTestFilePath("gh6714_02.php"), options, false, true);
+    }
+
+    public void testGH6714WithTab_02b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.ALIGN_MULTILINE_CALL_ARGS, false);
+        options.put(FmtOptions.WRAP_EXTENDS_IMPLEMENTS_LIST, CodeStyle.WrapStyle.WRAP_ALWAYS);
+        options.put(FmtOptions.ALIGN_MULTILINE_IMPLEMENTS, true);
+        options.put(FmtOptions.ALIGN_MULTILINE_METHOD_PARAMS, true);
+        options.put(FmtOptions.TAB_SIZE, 4);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        reformatFileContents(getTestFilePath("gh6714_02.php"), options, false, true);
+    }
+
+    public void testGH6714WithSpaces_01a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.ALIGN_MULTILINE_CALL_ARGS, true);
+        options.put(FmtOptions.WRAP_EXTENDS_IMPLEMENTS_LIST, CodeStyle.WrapStyle.WRAP_ALWAYS);
+        options.put(FmtOptions.ALIGN_MULTILINE_IMPLEMENTS, true);
+        options.put(FmtOptions.ALIGN_MULTILINE_METHOD_PARAMS, true);
+        options.put(FmtOptions.TAB_SIZE, 4);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, true);
+        reformatFileContents(getTestFilePath("gh6714_01.php"), options, false, true);
+    }
+
+    public void testGH6714WithSpaces_01b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.ALIGN_MULTILINE_CALL_ARGS, false);
+        options.put(FmtOptions.WRAP_EXTENDS_IMPLEMENTS_LIST, CodeStyle.WrapStyle.WRAP_ALWAYS);
+        options.put(FmtOptions.ALIGN_MULTILINE_IMPLEMENTS, true);
+        options.put(FmtOptions.ALIGN_MULTILINE_METHOD_PARAMS, true);
+        options.put(FmtOptions.TAB_SIZE, 4);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, true);
+        reformatFileContents(getTestFilePath("gh6714_01.php"), options, false, true);
+    }
+
+    public void testGH6714WithSpaces_02a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.ALIGN_MULTILINE_CALL_ARGS, true);
+        options.put(FmtOptions.WRAP_EXTENDS_IMPLEMENTS_LIST, CodeStyle.WrapStyle.WRAP_ALWAYS);
+        options.put(FmtOptions.ALIGN_MULTILINE_IMPLEMENTS, true);
+        options.put(FmtOptions.ALIGN_MULTILINE_METHOD_PARAMS, true);
+        options.put(FmtOptions.TAB_SIZE, 4);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, true);
+        reformatFileContents(getTestFilePath("gh6714_02.php"), options, false, true);
+    }
+
+    public void testGH6714WithSpaces_02b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.ALIGN_MULTILINE_CALL_ARGS, false);
+        options.put(FmtOptions.WRAP_EXTENDS_IMPLEMENTS_LIST, CodeStyle.WrapStyle.WRAP_ALWAYS);
+        options.put(FmtOptions.ALIGN_MULTILINE_IMPLEMENTS, true);
+        options.put(FmtOptions.ALIGN_MULTILINE_METHOD_PARAMS, true);
+        options.put(FmtOptions.TAB_SIZE, 4);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, true);
+        reformatFileContents(getTestFilePath("gh6714_02.php"), options, false, true);
     }
 
 }


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/6714
- Consider the TAB size when a column size is got

Example:
```php
array_merge(
	$x,
	$y,
);
```

Before:

```php
array_merge(
	$x,
 $y,
);
```

After:

```php
array_merge(
        $x,
        $y,
);
```

- Keep the last anchor to a stack when a method calls are nested

Example:

```php
nestedCall(
	something(
				$arg1,
			$arg2,
		C::something(
					$x,
					$y,
				$z,
		)
	),
			$y,
		$z,
);
```

Before:

```php
nestedCall(
	something(
		$arg1,
  $arg2,
  C::something(
			$x,
   $y,
   $z,
		)
	),
   $y,
   $z,
);
```

After:

```php
nestedCall(
	something(
		$arg1,
		$arg2,
		C::something(
			$x,
			$y,
			$z,
		)
	),
	$y,
	$z,
);
```

- Add unit tests
