### PR TITLE
Formatting for the group multiline alignment for match arm arrows #6074

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/CodeStyle.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/CodeStyle.java
@@ -576,12 +576,16 @@ public final class CodeStyle {
         return preferences.getBoolean(PLACE_NEW_LINE_AFTER_MODIFIERS, getDefaultAsBoolean(PLACE_NEW_LINE_AFTER_MODIFIERS));
     }
 
-    public boolean groupMulitlineAssignment() {
+    public boolean groupMultilineAssignment() {
         return preferences.getBoolean(GROUP_ALIGNMENT_ASSIGNMENT, getDefaultAsBoolean(GROUP_ALIGNMENT_ASSIGNMENT));
     }
 
-    public boolean groupMulitlineArrayInit() {
+    public boolean groupMultilineArrayInit() {
         return preferences.getBoolean(GROUP_ALIGNMENT_ARRAY_INIT, getDefaultAsBoolean(GROUP_ALIGNMENT_ARRAY_INIT));
+    }
+
+    public boolean groupMultilineMatchArmArrow() {
+        return preferences.getBoolean(GROUP_ALIGNMENT_MATCH_ARM_ARROW, getDefaultAsBoolean(GROUP_ALIGNMENT_MATCH_ARM_ARROW));
     }
 
     // Wrapping ----------------------------------------------------------------

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FmtOptions.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FmtOptions.java
@@ -195,6 +195,7 @@ public final class FmtOptions {
     public static final String ALIGN_MULTILINE_ARRAY_INIT = "alignMultilineArrayInit"; //NOI18N
     public static final String GROUP_ALIGNMENT_ASSIGNMENT = "groupAlignmentAssignment"; //NOI18N
     public static final String GROUP_ALIGNMENT_ARRAY_INIT = "groupAlignmentArrayInit"; //NOI18N
+    public static final String GROUP_ALIGNMENT_MATCH_ARM_ARROW = "groupAlignmentMatchArmArrow"; //NOI18N
     public static final String WRAP_GROUP_USE_LIST = "wrapGroupUseList"; //NOI18N
     public static final String WRAP_EXTENDS_IMPLEMENTS_KEYWORD = "wrapExtendsImplementsKeyword"; //NOI18N
     public static final String WRAP_EXTENDS_IMPLEMENTS_LIST = "wrapExtendsImplementsList"; //NOI18N
@@ -392,6 +393,7 @@ public final class FmtOptions {
             {PLACE_NEW_LINE_AFTER_MODIFIERS, FALSE}, //NOI18N
 
             {GROUP_ALIGNMENT_ARRAY_INIT, FALSE},
+            {GROUP_ALIGNMENT_MATCH_ARM_ARROW, FALSE},
             {GROUP_ALIGNMENT_ASSIGNMENT, FALSE},
             {WRAP_GROUP_USE_LIST, WRAP_ALWAYS},
             {WRAP_EXTENDS_IMPLEMENTS_KEYWORD, WRAP_NEVER}, //NOI18N

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatToken.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatToken.java
@@ -297,6 +297,12 @@ public class FormatToken {
      */
     public static class AssignmentAnchorToken extends FormatToken {
 
+        public enum Type {
+            ASSIGNMENT, // "="
+            ARRAY, // "=>"
+            MATCH_ARM, // "=>"
+        }
+
         /**
          * length of the identifier that is before the aligned operator
          */
@@ -315,22 +321,28 @@ public class FormatToken {
          */
         private AssignmentAnchorToken previous;
         private final boolean multilined;
+        private final Type type;
 
         public AssignmentAnchorToken(int offset, boolean multilined) {
+            this(offset, multilined, Type.ASSIGNMENT);
+        }
+
+        public AssignmentAnchorToken(int offset, boolean multilined, Type type) {
             super(Kind.ASSIGNMENT_ANCHOR, offset);
             length = -1;
             maxLength = -1;
             previous = null;
             isInGroup = false;
             this.multilined = multilined;
+            this.type = type;
         }
 
-        public int getLenght() {
+        public int getLength() {
             return length;
         }
 
-        public void setLenght(int lenght) {
-            this.length = lenght;
+        public void setLength(int length) {
+            this.length = length;
         }
 
         public int getMaxLength() {
@@ -361,6 +373,9 @@ public class FormatToken {
             return multilined;
         }
 
+        public Type getType() {
+            return type;
+        }
     }
 
     public static class UnbreakableSequenceToken extends FormatToken {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/TokenFormatter.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/TokenFormatter.java
@@ -37,6 +37,7 @@ import org.netbeans.modules.csl.spi.GsfUtilities;
 import org.netbeans.modules.csl.spi.ParserResult;
 import org.netbeans.modules.editor.indent.spi.Context;
 import org.netbeans.modules.php.editor.CodeUtils;
+import org.netbeans.modules.php.editor.indent.FormatToken.AssignmentAnchorToken;
 import org.netbeans.modules.php.editor.lexer.LexUtilities;
 import org.netbeans.modules.php.editor.lexer.PHPTokenId;
 import org.netbeans.modules.php.editor.parser.PHPParseResult;
@@ -216,8 +217,9 @@ public class TokenFormatter {
         public boolean alignMultilineFor; // not implemented yet
         @org.netbeans.api.annotations.common.SuppressWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
         public boolean alignMultilineArrayInit; //not implemented yet
-        public boolean groupMulitilineAssignment;
-        public boolean groupMulitilineArrayInit;
+        public boolean groupMultilineAssignment;
+        public boolean groupMultilineArrayInit;
+        public boolean groupMultilineMatchArmArrow;
 
         boolean wrapNeverKeepLines = Boolean.getBoolean("nb.php.editor.formatting.never.keep.lines"); // NOI18N
 
@@ -382,8 +384,9 @@ public class TokenFormatter {
             alignMultilineAssignment = codeStyle.alignMultilineAssignment();
             alignMultilineFor = codeStyle.alignMultilineFor();
             alignMultilineArrayInit = codeStyle.alignMultilineArrayInit();
-            groupMulitilineArrayInit = codeStyle.groupMulitlineArrayInit();
-            groupMulitilineAssignment = codeStyle.groupMulitlineAssignment();
+            groupMultilineArrayInit = codeStyle.groupMultilineArrayInit();
+            groupMultilineMatchArmArrow = codeStyle.groupMultilineMatchArmArrow();
+            groupMultilineAssignment = codeStyle.groupMultilineAssignment();
         }
 
     }
@@ -1199,12 +1202,17 @@ public class TokenFormatter {
                                     case WHITESPACE_BEFORE_ASSIGN_OP:
                                         indentRule = true;
                                         countSpaces = 0;
-                                        if (index > 0 && docOptions.groupMulitilineAssignment
+                                        boolean addSpaceBeforeAssign = true;
+                                        if (index > 0 && docOptions.groupMultilineAssignment
                                                 && formatTokens.get(index - 1).getId() == FormatToken.Kind.ASSIGNMENT_ANCHOR) {
                                             FormatToken.AssignmentAnchorToken aaToken = (FormatToken.AssignmentAnchorToken) formatTokens.get(index - 1);
+                                            // space of options is added if the token is grouped and tab is not expanded
                                             countSpaces = new SpacesCounter(docOptions).count(aaToken);
+                                            addSpaceBeforeAssign = addSpaceAroundAssignment(aaToken, docOptions);
                                         }
-                                        countSpaces = countSpaces + (docOptions.spaceAroundAssignOps ? 1 : 0);
+                                        if (addSpaceBeforeAssign) {
+                                            countSpaces += (docOptions.spaceAroundAssignOps ? 1 : 0);
+                                        }
                                         newLines = 0;
                                         if (!docOptions.wrapAfterAssignOps) {
                                             switch (docOptions.wrapAssignOps) {
@@ -1228,12 +1236,17 @@ public class TokenFormatter {
                                     case WHITESPACE_AFTER_ASSIGN_OP:
                                         indentRule = true;
                                         countSpaces = 0;
-                                        if (index > 0 && docOptions.groupMulitilineAssignment
+                                        boolean addSpaceAfterAssign = true;
+                                        if (index > 0 && docOptions.groupMultilineAssignment
                                                 && formatTokens.get(index - 1).getId() == FormatToken.Kind.ASSIGNMENT_ANCHOR) {
                                             FormatToken.AssignmentAnchorToken aaToken = (FormatToken.AssignmentAnchorToken) formatTokens.get(index - 1);
+                                            // space of options is added if the token is grouped and tab is not expanded
                                             countSpaces = new SpacesCounter(docOptions).count(aaToken);
+                                            addSpaceAfterAssign = addSpaceAroundAssignment(aaToken, docOptions);
                                         }
-                                        countSpaces = countSpaces + (docOptions.spaceAroundAssignOps ? 1 : 0);
+                                        if (addSpaceAfterAssign) {
+                                            countSpaces += (docOptions.spaceAroundAssignOps ? 1 : 0);
+                                        }
                                         newLines = 0;
                                         if (docOptions.wrapAfterAssignOps) {
                                             switch (docOptions.wrapAssignOps) {
@@ -1256,14 +1269,30 @@ public class TokenFormatter {
                                         break;
                                     case WHITESPACE_AROUND_KEY_VALUE_OP:
                                         countSpaces = 0;
-                                        FormatToken lastToken = formatTokens.get(index - 1);
-                                        if (index > 0 && docOptions.groupMulitilineArrayInit && lastToken.getId() == FormatToken.Kind.ASSIGNMENT_ANCHOR) {
-                                            FormatToken.AssignmentAnchorToken anchorToken = (FormatToken.AssignmentAnchorToken) lastToken;
-                                            if (docOptions.wrapArrayInit == CodeStyle.WrapStyle.WRAP_ALWAYS || anchorToken.isMultilined()) {
-                                                countSpaces = new SpacesCounter(docOptions).count(anchorToken);
+                                        FormatToken lastToken = null;
+                                        if (index > 0) {
+                                            lastToken = formatTokens.get(index - 1);
+                                        }
+                                        boolean addSpaceAroundKeyValue = true;
+                                        if (lastToken != null && lastToken.getId() == FormatToken.Kind.ASSIGNMENT_ANCHOR) {
+                                            AssignmentAnchorToken anchorToken = (AssignmentAnchorToken) lastToken;
+                                            if (anchorToken.getType() == AssignmentAnchorToken.Type.ARRAY && docOptions.groupMultilineArrayInit) {
+                                                if (docOptions.wrapArrayInit == CodeStyle.WrapStyle.WRAP_ALWAYS || anchorToken.isMultilined()) {
+                                                    // space of options is added if the token is grouped and tab is not expanded
+                                                    countSpaces = new SpacesCounter(docOptions).count(anchorToken);
+                                                    addSpaceAroundKeyValue = addSpaceAroundAssignment(anchorToken, docOptions);
+                                                }
+                                            } else if (anchorToken.getType() == AssignmentAnchorToken.Type.MATCH_ARM && docOptions.groupMultilineMatchArmArrow) {
+                                                if (anchorToken.isMultilined()) {
+                                                    // space of options is added if the token is grouped and tab is not expanded
+                                                    countSpaces = new SpacesCounter(docOptions).count(anchorToken);
+                                                    addSpaceAroundKeyValue = addSpaceAroundAssignment(anchorToken, docOptions);
+                                                }
                                             }
                                         }
-                                        countSpaces = countSpaces + (docOptions.spaceAroundKeyValueOps ? 1 : 0);
+                                        if (addSpaceAroundKeyValue) {
+                                            countSpaces += docOptions.spaceAroundKeyValueOps ? 1 : 0;
+                                        }
                                         break;
                                     case WHITESPACE_BEFORE_ANONYMOUS_CLASS_PAREN:
                                         countSpaces = docOptions.spaceBeforeAnonymousClassParen ? 1 : 0;
@@ -3184,6 +3213,10 @@ public class TokenFormatter {
         return lineEndings;
     }
 
+    private boolean addSpaceAroundAssignment(AssignmentAnchorToken token, DocumentOptions docOption) {
+        return docOption.expandTabsToSpaces || !token.isInGroup();
+    }
+
     private static final class SpacesCounter {
         private final DocumentOptions documentOptions;
 
@@ -3202,7 +3235,7 @@ public class TokenFormatter {
         private int countSpacesForGroupedToken(final FormatToken.AssignmentAnchorToken token) {
             int spaces;
             if (documentOptions.expandTabsToSpaces) {
-                spaces = token.getMaxLength() - token.getLenght();
+                spaces = token.getMaxLength() - token.getLength();
             } else {
                 spaces = countSpacesWhenNotExpandingTabs(token);
             }
@@ -3211,53 +3244,71 @@ public class TokenFormatter {
 
         private int countSpacesWhenNotExpandingTabs(final FormatToken.AssignmentAnchorToken token) {
             int spaces;
+            int spaceAroundAssignment = getSpaceAroundAssignment(token);
+            // consider also the space around assinment here
+            // to avoid adding extra spaces before assignment
+            final int maxLength = token.getMaxLength() + spaceAroundAssignment;
+            final int tokenLength = token.getLength();
             // 1 tabSize will be reduced to tabWidthToComplete...
-            int tabWidthToCompleteMaxLengthToTab = documentOptions.tabSize - (token.getMaxLength() % documentOptions.tabSize);
-            int tabWidthToCompleteLengthToTab = documentOptions.tabSize - (token.getLenght() % documentOptions.tabSize);
-            if (tabWidthToCompleteMaxLengthToTab == documentOptions.tabSize) {
-                // the biggest item of the group doesn't have to be expanded by one Tab
-                tabWidthToCompleteMaxLengthToTab = 0;
-            }
+            int tabWidthToCompleteLengthToTab = documentOptions.tabSize - (tokenLength % documentOptions.tabSize);
             if (tabWidthToCompleteLengthToTab == documentOptions.tabSize) {
                 // current item is on the Tab offset
                 tabWidthToCompleteLengthToTab = 0;
             }
+            boolean hasIncompleteTab = tabWidthToCompleteLengthToTab != 0;
 
-            if (token.getLenght() == token.getMaxLength()) {
-                spaces = countSpacesForBiggestItem(tabWidthToCompleteLengthToTab);
+            if (tokenLength == token.getMaxLength()) {
+                spaces = spaceAroundAssignment;
             } else {
-                spaces = countSpacesForCommonItem(token, tabWidthToCompleteLengthToTab, tabWidthToCompleteMaxLengthToTab);
-            }
-            return spaces;
-        }
-
-        private int countSpacesForBiggestItem(final int tabWidthToCompleteLengthToTab) {
-            int spaces = 0;
-            if (tabWidthToCompleteLengthToTab != 0) {
-                // and this biggest item has to be expanded by one tab
-                spaces = documentOptions.tabSize;
-            }
-            return spaces;
-        }
-
-        private int countSpacesForCommonItem(final FormatToken.AssignmentAnchorToken token, final int tabWidthToCompleteLengthToTab, final int tabWidthToCompleteMaxLengthToTab) {
-            int spaces;
-            if (tabWidthToCompleteMaxLengthToTab == 0) {
-                if (tabWidthToCompleteLengthToTab == 0) {
-                    spaces = token.getMaxLength() - token.getLenght();
+                spaces = maxLength - tabWidthToCompleteLengthToTab - tokenLength;
+                // e.g. tab size: 4, spaceAroundKeyValueOps: true
+                // match ($cond) {
+                //     666666 => 6,
+                //     22 => 2,
+                // };
+                //     666666 =>
+                //     ^^^^^^^
+                //     maxLength = 7
+                //     22
+                //       ^^
+                //       tabWidthToCompleteLengthToTab = 2 (has incomplete tab, i.e. must add 4(tab size) instead of 2)
+                //     ^^
+                //     tokenLength = 2
+                //     666666 =>
+                //     22
+                //         ^^^
+                //         spaces = 3 = 7 - 2 - 2
+                if (spaces < 0) {
+                    // e.g. tab size: 4, spaceAroundKeyValueOps: true, spaces = -1
+                    // in this case, add maxLength - tokenLength = 2
+                    // match ($cond) {
+                    //     22 => 1, // max length = 3
+                    //     1 => 0, // tabWidthToCompleteLengthToTab = 3, token length = 1
+                    // };
+                    spaces = maxLength - tokenLength;
                 } else {
-                    spaces = (token.getMaxLength() - token.getLenght()) - tabWidthToCompleteLengthToTab + documentOptions.tabSize;
-                }
-            } else {
-                if (tabWidthToCompleteLengthToTab == 0) {
-                    spaces = (token.getMaxLength() + tabWidthToCompleteMaxLengthToTab) - token.getLenght();
-                } else {
-                    spaces = (token.getMaxLength() + tabWidthToCompleteMaxLengthToTab) - (token.getLenght() + tabWidthToCompleteLengthToTab) + documentOptions.tabSize;
+                    if (hasIncompleteTab) {
+                        spaces += documentOptions.tabSize;
+                    }
                 }
             }
             return spaces;
         }
 
+        private int getSpaceAroundAssignment(AssignmentAnchorToken token) {
+            int space = 0;
+            switch (token.getType()) {
+                case ARRAY: // no break
+                case MATCH_ARM:
+                    space = documentOptions.spaceAroundKeyValueOps ? 1 : 0;
+                    break;
+                case ASSIGNMENT:
+                    space = documentOptions.spaceAroundAssignOps ? 1 : 0;
+                    break;
+                default:
+                    assert false : "Unhandled AssignmentAnchorToken.Type: " + token.getType(); // NOI18N
+            }
+            return space;
+        }
     }
-
 }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/Bundle.properties
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/Bundle.properties
@@ -459,3 +459,4 @@ FmtUses.putInPSR12OrderCheckBox.text=Put in PSR-12 &Order
 FmtUses.keepExistingUseTypeOrderCheckBox.text=&Keep Existing Order of Use Types(types, functions, constants) If Possible
 FmtBlankLines.afterUseTraitLabel.text=After U&se Trait:
 FmtBlankLines.afterUseTraitTextField.text=
+FmtAlignment.gmlMatchArmArrowCheckBox.text=Match Arm Arro&w

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/FmtAlignment.form
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/FmtAlignment.form
@@ -55,67 +55,80 @@
               <Group type="103" groupAlignment="0" attributes="0">
                   <Group type="102" attributes="0">
                       <EmptySpace max="-2" attributes="0"/>
+                      <Component id="multilineAlignmentLabel" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="jSeparator2" max="32767" attributes="1"/>
+                  </Group>
+                  <Group type="102" alignment="0" attributes="0">
+                      <EmptySpace max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
-                          <Group type="102" alignment="0" attributes="0">
+                          <Group type="102" attributes="0">
                               <Component id="newLinesLabel" min="-2" max="-2" attributes="0"/>
                               <EmptySpace max="-2" attributes="0"/>
-                              <Component id="jSeparator1" pref="305" max="32767" attributes="0"/>
+                              <Component id="jSeparator1" max="32767" attributes="0"/>
                           </Group>
-                          <Group type="102" alignment="0" attributes="0">
-                              <Component id="groupMultilineAlignmentLabel" min="-2" max="-2" attributes="0"/>
-                              <EmptySpace max="-2" attributes="0"/>
-                              <Component id="jSeparator3" pref="195" max="32767" attributes="1"/>
-                          </Group>
-                          <Group type="102" alignment="0" attributes="0">
-                              <Component id="multilineAlignmentLabel" min="-2" pref="147" max="-2" attributes="0"/>
-                              <EmptySpace max="-2" attributes="0"/>
-                              <Component id="jSeparator2" pref="231" max="32767" attributes="1"/>
+                          <Group type="102" attributes="0">
+                              <Group type="103" groupAlignment="0" attributes="0">
+                                  <Group type="102" attributes="0">
+                                      <EmptySpace min="6" pref="6" max="-2" attributes="0"/>
+                                      <Group type="103" groupAlignment="0" attributes="0">
+                                          <Component id="nlWhileCheckBox" min="-2" max="-2" attributes="0"/>
+                                          <Component id="nlElseCheckBox" min="-2" max="-2" attributes="0"/>
+                                          <Component id="nlFinallyCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
+                                          <Component id="amMethodParamsCheckBox" alignment="0" min="-2" max="-2" attributes="1"/>
+                                          <Component id="amImplementsCheckBox1" alignment="0" min="-2" max="-2" attributes="0"/>
+                                          <Component id="amAssignCheckBox1" alignment="0" min="-2" max="-2" attributes="0"/>
+                                          <Component id="amParenthesizedCheckBox1" alignment="0" min="-2" max="-2" attributes="0"/>
+                                          <Component id="amForCheckBox1" alignment="0" min="-2" max="-2" attributes="0"/>
+                                      </Group>
+                                      <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                                      <Group type="103" groupAlignment="0" attributes="0">
+                                          <Component id="nlCatchCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
+                                          <Component id="nlModifiersCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
+                                          <Component id="gmlArrayInitializerCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
+                                      </Group>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <EmptySpace min="167" pref="167" max="-2" attributes="0"/>
+                                      <Component id="amCallArgsCheckBox" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" attributes="0">
+                                      <EmptySpace min="167" pref="167" max="-2" attributes="0"/>
+                                      <Component id="amBinaryOpCheckBox1" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" attributes="0">
+                                      <EmptySpace min="167" pref="167" max="-2" attributes="0"/>
+                                      <Component id="amArrayInitCheckBox1" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" attributes="0">
+                                      <EmptySpace min="167" pref="167" max="-2" attributes="0"/>
+                                      <Component id="amTernaryOpCheckBox1" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                              </Group>
+                              <EmptySpace pref="6" max="32767" attributes="0"/>
                           </Group>
                       </Group>
                   </Group>
-                  <Group type="102" attributes="0">
+                  <Group type="102" alignment="0" attributes="0">
+                      <EmptySpace min="6" pref="6" max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
-                          <Group type="102" alignment="0" attributes="0">
-                              <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="nlWhileCheckBox" min="-2" max="-2" attributes="0"/>
-                                  <Component id="nlElseCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
-                              </Group>
-                              <EmptySpace min="-2" pref="71" max="-2" attributes="0"/>
-                              <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="nlCatchCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
-                                  <Component id="nlModifiersCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
-                              </Group>
-                          </Group>
-                          <Group type="102" alignment="0" attributes="0">
-                              <Component id="gmlAssignmentCheckBox" min="-2" max="-2" attributes="0"/>
-                              <EmptySpace min="-2" pref="93" max="-2" attributes="0"/>
-                              <Component id="gmlArrayInitializerCheckBox" min="-2" max="-2" attributes="0"/>
-                          </Group>
-                          <Group type="102" alignment="0" attributes="0">
-                              <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="amMethodParamsCheckBox" min="-2" max="-2" attributes="1"/>
-                                  <Component id="amParenthesizedCheckBox1" alignment="0" min="-2" max="-2" attributes="0"/>
-                                  <Component id="amAssignCheckBox1" alignment="0" min="-2" max="-2" attributes="0"/>
-                                  <Component id="amForCheckBox1" alignment="0" min="-2" max="-2" attributes="0"/>
-                                  <Component id="amImplementsCheckBox1" alignment="0" min="-2" max="-2" attributes="0"/>
-                              </Group>
+                          <Group type="102" attributes="0">
+                              <Component id="groupMultilineAlignmentLabel" min="-2" max="-2" attributes="0"/>
                               <EmptySpace max="-2" attributes="0"/>
+                              <Component id="jSeparator3" max="32767" attributes="1"/>
+                          </Group>
+                          <Group type="102" alignment="0" attributes="0">
+                              <EmptySpace min="6" pref="6" max="-2" attributes="0"/>
                               <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="amBinaryOpCheckBox1" alignment="0" min="-2" max="-2" attributes="0"/>
-                                  <Component id="amTernaryOpCheckBox1" alignment="0" min="-2" max="-2" attributes="0"/>
-                                  <Component id="amArrayInitCheckBox1" alignment="0" min="-2" max="-2" attributes="0"/>
-                                  <Component id="amCallArgsCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
+                                  <Component id="gmlMatchArmArrowCheckBox" min="-2" max="-2" attributes="0"/>
+                                  <Component id="gmlAssignmentCheckBox" min="-2" max="-2" attributes="0"/>
                               </Group>
+                              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                           </Group>
                       </Group>
-                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                   </Group>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
-          </Group>
-          <Group type="102" attributes="0">
-              <Component id="nlFinallyCheckBox" min="-2" max="-2" attributes="0"/>
-              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
           </Group>
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
@@ -127,30 +140,25 @@
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" attributes="0">
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Component id="newLinesLabel" min="-2" max="-2" attributes="1"/>
-                  </Group>
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace min="-2" pref="17" max="-2" attributes="0"/>
-                      <Component id="jSeparator1" min="-2" pref="10" max="-2" attributes="0"/>
-                  </Group>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="1" attributes="0">
+                  <Component id="newLinesLabel" min="-2" max="-2" attributes="1"/>
+                  <Component id="jSeparator1" min="-2" pref="10" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="nlModifiersCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="nlElseCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="nlElseCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
-                  <Component id="nlModifiersCheckBox" min="-2" max="-2" attributes="0"/>
-              </Group>
+              <Component id="nlWhileCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
-                  <Component id="nlWhileCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="nlFinallyCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="nlCatchCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="nlFinallyCheckBox" min="-2" max="-2" attributes="0"/>
-              <EmptySpace min="-2" pref="18" max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="0" attributes="0">
+              <EmptySpace type="unrelated" min="-2" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="1" attributes="0">
                   <Component id="groupMultilineAlignmentLabel" min="-2" max="-2" attributes="0"/>
                   <Component id="jSeparator3" min="-2" pref="10" max="-2" attributes="0"/>
               </Group>
@@ -159,44 +167,38 @@
                   <Component id="gmlAssignmentCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="gmlArrayInitializerCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="gmlMatchArmArrowCheckBox" min="-2" max="-2" attributes="0"/>
+              <EmptySpace type="unrelated" min="-2" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                      <Component id="multilineAlignmentLabel" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace min="-2" pref="14" max="-2" attributes="0"/>
-                      <Component id="jSeparator2" min="-2" pref="10" max="-2" attributes="0"/>
-                  </Group>
+                  <Component id="multilineAlignmentLabel" alignment="1" min="-2" max="-2" attributes="0"/>
+                  <Component id="jSeparator2" alignment="1" min="-2" pref="10" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="amMethodParamsCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="amCallArgsCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace min="-2" pref="20" max="-2" attributes="0"/>
-                      <Component id="amArrayInitCheckBox1" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Component id="amTernaryOpCheckBox1" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <Group type="102" alignment="0" attributes="0">
-                      <Group type="103" groupAlignment="3" attributes="0">
-                          <Component id="amImplementsCheckBox1" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="amBinaryOpCheckBox1" alignment="3" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Component id="amAssignCheckBox1" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace min="-2" max="-2" attributes="0"/>
-                      <Component id="amParenthesizedCheckBox1" min="-2" max="-2" attributes="0"/>
-                  </Group>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="amImplementsCheckBox1" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="amBinaryOpCheckBox1" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="amAssignCheckBox1" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="amArrayInitCheckBox1" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="amParenthesizedCheckBox1" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="amTernaryOpCheckBox1" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="amForCheckBox1" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Component id="noteLabel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="26" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -526,6 +528,13 @@
           <Border info="org.netbeans.modules.form.compat2.border.EmptyBorderInfo">
             <EmptyBorder/>
           </Border>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="gmlMatchArmArrowCheckBox">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/php/editor/indent/ui/Bundle.properties" key="FmtAlignment.gmlMatchArmArrowCheckBox.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/FmtAlignment.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/FmtAlignment.java
@@ -22,7 +22,9 @@ package org.netbeans.modules.php.editor.indent.ui;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.netbeans.api.annotations.common.StaticResource;
 import org.netbeans.modules.options.editor.spi.PreferencesCustomizer;
+import org.netbeans.modules.php.editor.CodeUtils;
 import static org.netbeans.modules.php.editor.indent.FmtOptions.*;
 import org.netbeans.modules.php.editor.indent.FmtOptions.CategorySupport;
 import static org.netbeans.modules.php.editor.indent.FmtOptions.CategorySupport.OPTION_ID;
@@ -34,6 +36,8 @@ import static org.netbeans.modules.php.editor.indent.FmtOptions.CategorySupport.
  */
 public class FmtAlignment extends javax.swing.JPanel {
 
+    @StaticResource
+    private static final String PREVIEW_FILE = "org/netbeans/modules/php/editor/indent/ui/Spaces.php"; // NOI18N
     private static final Logger LOGGER = Logger.getLogger(FmtAlignment.class.getName());
 
     public FmtAlignment() {
@@ -62,17 +66,17 @@ public class FmtAlignment extends javax.swing.JPanel {
 
         gmlAssignmentCheckBox.putClientProperty(OPTION_ID, GROUP_ALIGNMENT_ASSIGNMENT);
         gmlArrayInitializerCheckBox.putClientProperty(OPTION_ID, GROUP_ALIGNMENT_ARRAY_INIT);
+        gmlMatchArmArrowCheckBox.putClientProperty(OPTION_ID, GROUP_ALIGNMENT_MATCH_ARM_ARROW);
     }
 
     public static PreferencesCustomizer.Factory getController() {
-        String preview = "";
+        String preview = CodeUtils.EMPTY_STRING;
         try {
-            preview = Utils.loadPreviewText(FmtBlankLines.class.getClassLoader().getResourceAsStream("org/netbeans/modules/php/editor/indent/ui/Spaces.php"));
+            preview = Utils.loadPreviewText(FmtBlankLines.class.getClassLoader().getResourceAsStream(PREVIEW_FILE));
         } catch (IOException ex) {
             LOGGER.log(Level.WARNING, null, ex);
         }
-        return new CategorySupport.Factory("alignment", FmtAlignment.class, //NOI18N
-                preview);
+        return new CategorySupport.Factory("alignment", FmtAlignment.class, preview); // NOI18N
 //        return new CategorySupport.Factory("alignment", FmtAlignment.class, //NOI18N
 //                org.openide.util.NbBundle.getMessage(FmtAlignment.class, "SAMPLE_AlignBraces"), // NOI18N
 //                new String[] { FmtOptions.wrapAnnotations, WrapStyle.WRAP_ALWAYS.name() },
@@ -126,6 +130,7 @@ public class FmtAlignment extends javax.swing.JPanel {
         jSeparator3 = new javax.swing.JSeparator();
         gmlAssignmentCheckBox = new javax.swing.JCheckBox();
         gmlArrayInitializerCheckBox = new javax.swing.JCheckBox();
+        gmlMatchArmArrowCheckBox = new javax.swing.JCheckBox();
         nlFinallyCheckBox = new javax.swing.JCheckBox();
         noteLabel = new javax.swing.JLabel();
 
@@ -183,6 +188,8 @@ public class FmtAlignment extends javax.swing.JPanel {
         org.openide.awt.Mnemonics.setLocalizedText(gmlArrayInitializerCheckBox, org.openide.util.NbBundle.getMessage(FmtAlignment.class, "FmtAlignment.gmlArrayInitializerCheckBox.text")); // NOI18N
         gmlArrayInitializerCheckBox.setBorder(javax.swing.BorderFactory.createEmptyBorder(1, 1, 1, 1));
 
+        org.openide.awt.Mnemonics.setLocalizedText(gmlMatchArmArrowCheckBox, org.openide.util.NbBundle.getMessage(FmtAlignment.class, "FmtAlignment.gmlMatchArmArrowCheckBox.text")); // NOI18N
+
         org.openide.awt.Mnemonics.setLocalizedText(nlFinallyCheckBox, org.openide.util.NbBundle.getMessage(FmtAlignment.class, "FmtAlignment.nlFinallyCheckBox.text")); // NOI18N
         nlFinallyCheckBox.setBorder(javax.swing.BorderFactory.createEmptyBorder(1, 1, 1, 1));
 
@@ -196,114 +203,118 @@ public class FmtAlignment extends javax.swing.JPanel {
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(layout.createSequentialGroup()
                         .addContainerGap()
+                        .addComponent(multilineAlignmentLabel)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(jSeparator2))
+                    .addGroup(layout.createSequentialGroup()
+                        .addContainerGap()
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addGroup(layout.createSequentialGroup()
                                 .addComponent(newLinesLabel)
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(jSeparator1, javax.swing.GroupLayout.DEFAULT_SIZE, 305, Short.MAX_VALUE))
+                                .addComponent(jSeparator1))
+                            .addGroup(layout.createSequentialGroup()
+                                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                    .addGroup(layout.createSequentialGroup()
+                                        .addGap(6, 6, 6)
+                                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                            .addComponent(nlWhileCheckBox)
+                                            .addComponent(nlElseCheckBox)
+                                            .addComponent(nlFinallyCheckBox)
+                                            .addComponent(amMethodParamsCheckBox)
+                                            .addComponent(amImplementsCheckBox1)
+                                            .addComponent(amAssignCheckBox1)
+                                            .addComponent(amParenthesizedCheckBox1)
+                                            .addComponent(amForCheckBox1))
+                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                            .addComponent(nlCatchCheckBox)
+                                            .addComponent(nlModifiersCheckBox)
+                                            .addComponent(gmlArrayInitializerCheckBox)))
+                                    .addGroup(layout.createSequentialGroup()
+                                        .addGap(167, 167, 167)
+                                        .addComponent(amCallArgsCheckBox))
+                                    .addGroup(layout.createSequentialGroup()
+                                        .addGap(167, 167, 167)
+                                        .addComponent(amBinaryOpCheckBox1))
+                                    .addGroup(layout.createSequentialGroup()
+                                        .addGap(167, 167, 167)
+                                        .addComponent(amArrayInitCheckBox1))
+                                    .addGroup(layout.createSequentialGroup()
+                                        .addGap(167, 167, 167)
+                                        .addComponent(amTernaryOpCheckBox1)))
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 6, Short.MAX_VALUE))))
+                    .addGroup(layout.createSequentialGroup()
+                        .addGap(6, 6, 6)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addGroup(layout.createSequentialGroup()
                                 .addComponent(groupMultilineAlignmentLabel)
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(jSeparator3, javax.swing.GroupLayout.DEFAULT_SIZE, 195, Short.MAX_VALUE))
+                                .addComponent(jSeparator3))
                             .addGroup(layout.createSequentialGroup()
-                                .addComponent(multilineAlignmentLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 147, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(jSeparator2, javax.swing.GroupLayout.DEFAULT_SIZE, 231, Short.MAX_VALUE))))
-                    .addGroup(layout.createSequentialGroup()
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addGroup(layout.createSequentialGroup()
+                                .addGap(6, 6, 6)
                                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                                    .addComponent(nlWhileCheckBox)
-                                    .addComponent(nlElseCheckBox))
-                                .addGap(71, 71, 71)
-                                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                                    .addComponent(nlCatchCheckBox)
-                                    .addComponent(nlModifiersCheckBox)))
-                            .addGroup(layout.createSequentialGroup()
-                                .addComponent(gmlAssignmentCheckBox)
-                                .addGap(93, 93, 93)
-                                .addComponent(gmlArrayInitializerCheckBox))
-                            .addGroup(layout.createSequentialGroup()
-                                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                                    .addComponent(amMethodParamsCheckBox)
-                                    .addComponent(amParenthesizedCheckBox1)
-                                    .addComponent(amAssignCheckBox1)
-                                    .addComponent(amForCheckBox1)
-                                    .addComponent(amImplementsCheckBox1))
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                                    .addComponent(amBinaryOpCheckBox1)
-                                    .addComponent(amTernaryOpCheckBox1)
-                                    .addComponent(amArrayInitCheckBox1)
-                                    .addComponent(amCallArgsCheckBox))))
-                        .addGap(0, 0, Short.MAX_VALUE)))
+                                    .addComponent(gmlMatchArmArrowCheckBox)
+                                    .addComponent(gmlAssignmentCheckBox))
+                                .addGap(0, 0, Short.MAX_VALUE)))))
                 .addContainerGap())
             .addGroup(layout.createSequentialGroup()
-                .addComponent(nlFinallyCheckBox)
-                .addGap(0, 0, Short.MAX_VALUE))
-            .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
-                .addComponent(noteLabel)
+                .addComponent(noteLabel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(layout.createSequentialGroup()
-                        .addContainerGap()
-                        .addComponent(newLinesLabel))
-                    .addGroup(layout.createSequentialGroup()
-                        .addGap(17, 17, 17)
-                        .addComponent(jSeparator1, javax.swing.GroupLayout.PREFERRED_SIZE, 10, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                .addContainerGap()
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                    .addComponent(newLinesLabel)
+                    .addComponent(jSeparator1, javax.swing.GroupLayout.PREFERRED_SIZE, 10, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(nlModifiersCheckBox)
+                    .addComponent(nlElseCheckBox))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(nlElseCheckBox)
-                    .addComponent(nlModifiersCheckBox))
+                .addComponent(nlWhileCheckBox)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(nlWhileCheckBox)
+                    .addComponent(nlFinallyCheckBox)
                     .addComponent(nlCatchCheckBox))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(nlFinallyCheckBox)
-                .addGap(18, 18, 18)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
                     .addComponent(groupMultilineAlignmentLabel)
                     .addComponent(jSeparator3, javax.swing.GroupLayout.PREFERRED_SIZE, 10, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(gmlAssignmentCheckBox)
                     .addComponent(gmlArrayInitializerCheckBox))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(gmlMatchArmArrowCheckBox)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(layout.createSequentialGroup()
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                        .addComponent(multilineAlignmentLabel))
-                    .addGroup(layout.createSequentialGroup()
-                        .addGap(14, 14, 14)
-                        .addComponent(jSeparator2, javax.swing.GroupLayout.PREFERRED_SIZE, 10, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                    .addComponent(multilineAlignmentLabel, javax.swing.GroupLayout.Alignment.TRAILING)
+                    .addComponent(jSeparator2, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.PREFERRED_SIZE, 10, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(amMethodParamsCheckBox)
                     .addComponent(amCallArgsCheckBox))
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(layout.createSequentialGroup()
-                        .addGap(20, 20, 20)
-                        .addComponent(amArrayInitCheckBox1)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(amTernaryOpCheckBox1))
-                    .addGroup(layout.createSequentialGroup()
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                            .addComponent(amImplementsCheckBox1)
-                            .addComponent(amBinaryOpCheckBox1))
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(amAssignCheckBox1)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(amParenthesizedCheckBox1)))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(amImplementsCheckBox1)
+                    .addComponent(amBinaryOpCheckBox1))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(amAssignCheckBox1)
+                    .addComponent(amArrayInitCheckBox1))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(amParenthesizedCheckBox1)
+                    .addComponent(amTernaryOpCheckBox1))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(amForCheckBox1)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(noteLabel)
-                .addContainerGap(26, Short.MAX_VALUE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(noteLabel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         newLinesLabel.getAccessibleContext().setAccessibleName(org.openide.util.NbBundle.getMessage(FmtAlignment.class, "FmtAlignment.newLinesLabel.AccessibleContext.accessibleName")); // NOI18N
@@ -354,6 +365,7 @@ public class FmtAlignment extends javax.swing.JPanel {
     private javax.swing.JCheckBox amTernaryOpCheckBox1;
     private javax.swing.JCheckBox gmlArrayInitializerCheckBox;
     private javax.swing.JCheckBox gmlAssignmentCheckBox;
+    private javax.swing.JCheckBox gmlMatchArmArrowCheckBox;
     private javax.swing.JLabel groupMultilineAlignmentLabel;
     private javax.swing.JSeparator jSeparator1;
     private javax.swing.JSeparator jSeparator2;

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/Spaces.php
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/Spaces.php
@@ -150,4 +150,8 @@ $data=[
 'very_looong_key'=>100,
 ];
 
-?>
+$match = match ($type) {
+    "condition" => 1,
+    "loooooong condition" => 2,
+    default => 0,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_01.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_01.php
@@ -1,0 +1,209 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$type1 = "test";
+$type2 = 1;
+match ($type1) {
+    'min' => 'min', 'maxLength' => 'maxLength', default => null,
+};
+
+$m = match ($type1) {
+     'maxLength' => 'maxLength', 'min' => 'min', default => null,
+};
+
+match ($type1) {
+    'min' => 'min', 'maxLength' => 'maxLength',
+    default => null,
+};
+
+match ($type1) {
+    'maxLength' => 'maxLength',
+    'min' => 'mim',
+    default => null,
+};
+match ($type1) {
+    'min' => 'min',
+    'maxLength' => 'maxLength',
+    default => null,
+};
+
+match ($type1) {
+    'maxLength', 'min' => 'min',
+    'test' => 'test',
+    default => null,
+};
+
+match ($type1) {
+    'maxLength', 'test' => 'maxLength',
+    'min' => match ($type2) {
+        1, 2 => "nested",
+        3 => "nested",
+        4 => "nested",
+    },
+    default => null,
+};
+
+match ($type1) {
+    'min' => 'min',
+    'maxLength' => match ($type2) {
+        1 => "nested",
+        "maxLength" => "nested", "test" => "test",
+        4 => "nested",
+    },
+    default => null,
+};
+
+
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    11111111111 => '11',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    11111111111 => '11',
+    122222222222 => '12',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    11111111111 => '11',
+    122222222222 => '12',
+    1333333333333 => '13',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    11111111111 => '11',
+    122222222222 => '12',
+    1333333333333 => '13',
+    14444444444444 => '14',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    11111111111 => '11',
+    122222222222 => '12',
+    1333333333333 => '13',
+    14444444444444 => '14',
+    155555555555555 => '15',
+    default => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_01.php.testGroupAlignmentMatchArmArrow_Spaces01a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_01.php.testGroupAlignmentMatchArmArrow_Spaces01a.formatted
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$type1 = "test";
+$type2 = 1;
+match ($type1) {
+    'min' => 'min', 'maxLength' => 'maxLength', default => null,
+};
+
+$m = match ($type1) {
+    'maxLength' => 'maxLength', 'min' => 'min', default => null,
+};
+
+match ($type1) {
+    'min'   => 'min', 'maxLength' => 'maxLength',
+    default => null,
+};
+
+match ($type1) {
+    'maxLength' => 'maxLength',
+    'min'       => 'mim',
+    default     => null,
+};
+match ($type1) {
+    'min'       => 'min',
+    'maxLength' => 'maxLength',
+    default     => null,
+};
+
+match ($type1) {
+    'maxLength', 'min' => 'min',
+    'test'             => 'test',
+    default            => null,
+};
+
+match ($type1) {
+    'maxLength', 'test' => 'maxLength',
+    'min'               => match ($type2) {
+        1, 2 => "nested",
+        3    => "nested",
+        4    => "nested",
+    },
+    default             => null,
+};
+
+match ($type1) {
+    'min'       => 'min',
+    'maxLength' => match ($type2) {
+        1           => "nested",
+        "maxLength" => "nested", "test" => "test",
+        4           => "nested",
+    },
+    default     => null,
+};
+
+match ($type1) {
+    1       => '1',
+    22      => '2',
+    333     => '3',
+    4444    => '4',
+    55555   => '5',
+    666666  => '6',
+    7777777 => '7',
+    default => null,
+};
+
+match ($type1) {
+    1        => '1',
+    22       => '2',
+    333      => '3',
+    4444     => '4',
+    55555    => '5',
+    666666   => '6',
+    7777777  => '7',
+    88888888 => '8',
+    default  => null,
+};
+
+match ($type1) {
+    1         => '1',
+    22        => '2',
+    333       => '3',
+    4444      => '4',
+    55555     => '5',
+    666666    => '6',
+    7777777   => '7',
+    88888888  => '8',
+    999999999 => '9',
+    default   => null,
+};
+
+match ($type1) {
+    1          => '1',
+    22         => '2',
+    333        => '3',
+    4444       => '4',
+    55555      => '5',
+    666666     => '6',
+    7777777    => '7',
+    88888888   => '8',
+    999999999  => '9',
+    1000000000 => '10',
+    default    => null,
+};
+
+match ($type1) {
+    1           => '1',
+    22          => '2',
+    333         => '3',
+    4444        => '4',
+    55555       => '5',
+    666666      => '6',
+    7777777     => '7',
+    88888888    => '8',
+    999999999   => '9',
+    1000000000  => '10',
+    11111111111 => '11',
+    default     => null,
+};
+
+match ($type1) {
+    1            => '1',
+    22           => '2',
+    333          => '3',
+    4444         => '4',
+    55555        => '5',
+    666666       => '6',
+    7777777      => '7',
+    88888888     => '8',
+    999999999    => '9',
+    1000000000   => '10',
+    11111111111  => '11',
+    122222222222 => '12',
+    default      => null,
+};
+
+match ($type1) {
+    1             => '1',
+    22            => '2',
+    333           => '3',
+    4444          => '4',
+    55555         => '5',
+    666666        => '6',
+    7777777       => '7',
+    88888888      => '8',
+    999999999     => '9',
+    1000000000    => '10',
+    11111111111   => '11',
+    122222222222  => '12',
+    1333333333333 => '13',
+    default       => null,
+};
+
+match ($type1) {
+    1              => '1',
+    22             => '2',
+    333            => '3',
+    4444           => '4',
+    55555          => '5',
+    666666         => '6',
+    7777777        => '7',
+    88888888       => '8',
+    999999999      => '9',
+    1000000000     => '10',
+    11111111111    => '11',
+    122222222222   => '12',
+    1333333333333  => '13',
+    14444444444444 => '14',
+    default        => null,
+};
+
+match ($type1) {
+    1               => '1',
+    22              => '2',
+    333             => '3',
+    4444            => '4',
+    55555           => '5',
+    666666          => '6',
+    7777777         => '7',
+    88888888        => '8',
+    999999999       => '9',
+    1000000000      => '10',
+    11111111111     => '11',
+    122222222222    => '12',
+    1333333333333   => '13',
+    14444444444444  => '14',
+    155555555555555 => '15',
+    default         => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_01.php.testGroupAlignmentMatchArmArrow_Spaces01b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_01.php.testGroupAlignmentMatchArmArrow_Spaces01b.formatted
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$type1 = "test";
+$type2 = 1;
+match ($type1) {
+    'min' => 'min', 'maxLength' => 'maxLength', default => null,
+};
+
+$m = match ($type1) {
+    'maxLength' => 'maxLength', 'min' => 'min', default => null,
+};
+
+match ($type1) {
+    'min' => 'min', 'maxLength' => 'maxLength',
+    default => null,
+};
+
+match ($type1) {
+    'maxLength' => 'maxLength',
+    'min' => 'mim',
+    default => null,
+};
+match ($type1) {
+    'min' => 'min',
+    'maxLength' => 'maxLength',
+    default => null,
+};
+
+match ($type1) {
+    'maxLength', 'min' => 'min',
+    'test' => 'test',
+    default => null,
+};
+
+match ($type1) {
+    'maxLength', 'test' => 'maxLength',
+    'min' => match ($type2) {
+        1, 2 => "nested",
+        3 => "nested",
+        4 => "nested",
+    },
+    default => null,
+};
+
+match ($type1) {
+    'min' => 'min',
+    'maxLength' => match ($type2) {
+        1 => "nested",
+        "maxLength" => "nested", "test" => "test",
+        4 => "nested",
+    },
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    11111111111 => '11',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    11111111111 => '11',
+    122222222222 => '12',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    11111111111 => '11',
+    122222222222 => '12',
+    1333333333333 => '13',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    11111111111 => '11',
+    122222222222 => '12',
+    1333333333333 => '13',
+    14444444444444 => '14',
+    default => null,
+};
+
+match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    11111111111 => '11',
+    122222222222 => '12',
+    1333333333333 => '13',
+    14444444444444 => '14',
+    155555555555555 => '15',
+    default => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_01.php.testGroupAlignmentMatchArmArrow_Tab01_Size4a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_01.php.testGroupAlignmentMatchArmArrow_Tab01_Size4a.formatted
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$type1 = "test";
+$type2 = 1;
+match ($type1) {
+	'min' => 'min', 'maxLength' => 'maxLength', default => null,
+};
+
+$m = match ($type1) {
+	'maxLength' => 'maxLength', 'min' => 'min', default => null,
+};
+
+match ($type1) {
+	'min'	=> 'min', 'maxLength' => 'maxLength',
+	default => null,
+};
+
+match ($type1) {
+	'maxLength' => 'maxLength',
+	'min'		=> 'mim',
+	default		=> null,
+};
+match ($type1) {
+	'min'		=> 'min',
+	'maxLength' => 'maxLength',
+	default		=> null,
+};
+
+match ($type1) {
+	'maxLength', 'min' => 'min',
+	'test'			   => 'test',
+	default			   => null,
+};
+
+match ($type1) {
+	'maxLength', 'test' => 'maxLength',
+	'min'				=> match ($type2) {
+		1, 2 => "nested",
+		3	 => "nested",
+		4	 => "nested",
+	},
+	default				=> null,
+};
+
+match ($type1) {
+	'min'		=> 'min',
+	'maxLength' => match ($type2) {
+		1			=> "nested",
+		"maxLength" => "nested", "test" => "test",
+		4			=> "nested",
+	},
+	default		=> null,
+};
+
+match ($type1) {
+	1		=> '1',
+	22		=> '2',
+	333		=> '3',
+	4444	=> '4',
+	55555	=> '5',
+	666666	=> '6',
+	7777777 => '7',
+	default => null,
+};
+
+match ($type1) {
+	1		 => '1',
+	22		 => '2',
+	333		 => '3',
+	4444	 => '4',
+	55555	 => '5',
+	666666	 => '6',
+	7777777	 => '7',
+	88888888 => '8',
+	default	 => null,
+};
+
+match ($type1) {
+	1		  => '1',
+	22		  => '2',
+	333		  => '3',
+	4444	  => '4',
+	55555	  => '5',
+	666666	  => '6',
+	7777777	  => '7',
+	88888888  => '8',
+	999999999 => '9',
+	default	  => null,
+};
+
+match ($type1) {
+	1		   => '1',
+	22		   => '2',
+	333		   => '3',
+	4444	   => '4',
+	55555	   => '5',
+	666666	   => '6',
+	7777777	   => '7',
+	88888888   => '8',
+	999999999  => '9',
+	1000000000 => '10',
+	default	   => null,
+};
+
+match ($type1) {
+	1			=> '1',
+	22			=> '2',
+	333			=> '3',
+	4444		=> '4',
+	55555		=> '5',
+	666666		=> '6',
+	7777777		=> '7',
+	88888888	=> '8',
+	999999999	=> '9',
+	1000000000	=> '10',
+	11111111111 => '11',
+	default		=> null,
+};
+
+match ($type1) {
+	1			 => '1',
+	22			 => '2',
+	333			 => '3',
+	4444		 => '4',
+	55555		 => '5',
+	666666		 => '6',
+	7777777		 => '7',
+	88888888	 => '8',
+	999999999	 => '9',
+	1000000000	 => '10',
+	11111111111	 => '11',
+	122222222222 => '12',
+	default		 => null,
+};
+
+match ($type1) {
+	1			  => '1',
+	22			  => '2',
+	333			  => '3',
+	4444		  => '4',
+	55555		  => '5',
+	666666		  => '6',
+	7777777		  => '7',
+	88888888	  => '8',
+	999999999	  => '9',
+	1000000000	  => '10',
+	11111111111	  => '11',
+	122222222222  => '12',
+	1333333333333 => '13',
+	default		  => null,
+};
+
+match ($type1) {
+	1			   => '1',
+	22			   => '2',
+	333			   => '3',
+	4444		   => '4',
+	55555		   => '5',
+	666666		   => '6',
+	7777777		   => '7',
+	88888888	   => '8',
+	999999999	   => '9',
+	1000000000	   => '10',
+	11111111111	   => '11',
+	122222222222   => '12',
+	1333333333333  => '13',
+	14444444444444 => '14',
+	default		   => null,
+};
+
+match ($type1) {
+	1				=> '1',
+	22				=> '2',
+	333				=> '3',
+	4444			=> '4',
+	55555			=> '5',
+	666666			=> '6',
+	7777777			=> '7',
+	88888888		=> '8',
+	999999999		=> '9',
+	1000000000		=> '10',
+	11111111111		=> '11',
+	122222222222	=> '12',
+	1333333333333	=> '13',
+	14444444444444	=> '14',
+	155555555555555 => '15',
+	default			=> null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_01.php.testGroupAlignmentMatchArmArrow_Tab01_Size4b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_01.php.testGroupAlignmentMatchArmArrow_Tab01_Size4b.formatted
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$type1 = "test";
+$type2 = 1;
+match ($type1) {
+	'min' => 'min', 'maxLength' => 'maxLength', default => null,
+};
+
+$m = match ($type1) {
+	'maxLength' => 'maxLength', 'min' => 'min', default => null,
+};
+
+match ($type1) {
+	'min' => 'min', 'maxLength' => 'maxLength',
+	default => null,
+};
+
+match ($type1) {
+	'maxLength' => 'maxLength',
+	'min' => 'mim',
+	default => null,
+};
+match ($type1) {
+	'min' => 'min',
+	'maxLength' => 'maxLength',
+	default => null,
+};
+
+match ($type1) {
+	'maxLength', 'min' => 'min',
+	'test' => 'test',
+	default => null,
+};
+
+match ($type1) {
+	'maxLength', 'test' => 'maxLength',
+	'min' => match ($type2) {
+		1, 2 => "nested",
+		3 => "nested",
+		4 => "nested",
+	},
+	default => null,
+};
+
+match ($type1) {
+	'min' => 'min',
+	'maxLength' => match ($type2) {
+		1 => "nested",
+		"maxLength" => "nested", "test" => "test",
+		4 => "nested",
+	},
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	11111111111 => '11',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	11111111111 => '11',
+	122222222222 => '12',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	11111111111 => '11',
+	122222222222 => '12',
+	1333333333333 => '13',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	11111111111 => '11',
+	122222222222 => '12',
+	1333333333333 => '13',
+	14444444444444 => '14',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	11111111111 => '11',
+	122222222222 => '12',
+	1333333333333 => '13',
+	14444444444444 => '14',
+	155555555555555 => '15',
+	default => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_01.php.testGroupAlignmentMatchArmArrow_Tab01_Size8a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_01.php.testGroupAlignmentMatchArmArrow_Tab01_Size8a.formatted
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$type1 = "test";
+$type2 = 1;
+match ($type1) {
+	'min' => 'min', 'maxLength' => 'maxLength', default => null,
+};
+
+$m = match ($type1) {
+	'maxLength' => 'maxLength', 'min' => 'min', default => null,
+};
+
+match ($type1) {
+	'min'	=> 'min', 'maxLength' => 'maxLength',
+	default => null,
+};
+
+match ($type1) {
+	'maxLength' => 'maxLength',
+	'min'	    => 'mim',
+	default	    => null,
+};
+match ($type1) {
+	'min'	    => 'min',
+	'maxLength' => 'maxLength',
+	default	    => null,
+};
+
+match ($type1) {
+	'maxLength', 'min' => 'min',
+	'test'		   => 'test',
+	default		   => null,
+};
+
+match ($type1) {
+	'maxLength', 'test' => 'maxLength',
+	'min'		    => match ($type2) {
+		1, 2 => "nested",
+		3    => "nested",
+		4    => "nested",
+	},
+	default		    => null,
+};
+
+match ($type1) {
+	'min'	    => 'min',
+	'maxLength' => match ($type2) {
+		1	    => "nested",
+		"maxLength" => "nested", "test" => "test",
+		4	    => "nested",
+	},
+	default	    => null,
+};
+
+match ($type1) {
+	1	=> '1',
+	22	=> '2',
+	333	=> '3',
+	4444	=> '4',
+	55555	=> '5',
+	666666	=> '6',
+	7777777 => '7',
+	default => null,
+};
+
+match ($type1) {
+	1	 => '1',
+	22	 => '2',
+	333	 => '3',
+	4444	 => '4',
+	55555	 => '5',
+	666666	 => '6',
+	7777777	 => '7',
+	88888888 => '8',
+	default	 => null,
+};
+
+match ($type1) {
+	1	  => '1',
+	22	  => '2',
+	333	  => '3',
+	4444	  => '4',
+	55555	  => '5',
+	666666	  => '6',
+	7777777	  => '7',
+	88888888  => '8',
+	999999999 => '9',
+	default	  => null,
+};
+
+match ($type1) {
+	1	   => '1',
+	22	   => '2',
+	333	   => '3',
+	4444	   => '4',
+	55555	   => '5',
+	666666	   => '6',
+	7777777	   => '7',
+	88888888   => '8',
+	999999999  => '9',
+	1000000000 => '10',
+	default	   => null,
+};
+
+match ($type1) {
+	1	    => '1',
+	22	    => '2',
+	333	    => '3',
+	4444	    => '4',
+	55555	    => '5',
+	666666	    => '6',
+	7777777	    => '7',
+	88888888    => '8',
+	999999999   => '9',
+	1000000000  => '10',
+	11111111111 => '11',
+	default	    => null,
+};
+
+match ($type1) {
+	1	     => '1',
+	22	     => '2',
+	333	     => '3',
+	4444	     => '4',
+	55555	     => '5',
+	666666	     => '6',
+	7777777	     => '7',
+	88888888     => '8',
+	999999999    => '9',
+	1000000000   => '10',
+	11111111111  => '11',
+	122222222222 => '12',
+	default	     => null,
+};
+
+match ($type1) {
+	1	      => '1',
+	22	      => '2',
+	333	      => '3',
+	4444	      => '4',
+	55555	      => '5',
+	666666	      => '6',
+	7777777	      => '7',
+	88888888      => '8',
+	999999999     => '9',
+	1000000000    => '10',
+	11111111111   => '11',
+	122222222222  => '12',
+	1333333333333 => '13',
+	default	      => null,
+};
+
+match ($type1) {
+	1	       => '1',
+	22	       => '2',
+	333	       => '3',
+	4444	       => '4',
+	55555	       => '5',
+	666666	       => '6',
+	7777777	       => '7',
+	88888888       => '8',
+	999999999      => '9',
+	1000000000     => '10',
+	11111111111    => '11',
+	122222222222   => '12',
+	1333333333333  => '13',
+	14444444444444 => '14',
+	default	       => null,
+};
+
+match ($type1) {
+	1		=> '1',
+	22		=> '2',
+	333		=> '3',
+	4444		=> '4',
+	55555		=> '5',
+	666666		=> '6',
+	7777777		=> '7',
+	88888888	=> '8',
+	999999999	=> '9',
+	1000000000	=> '10',
+	11111111111	=> '11',
+	122222222222	=> '12',
+	1333333333333	=> '13',
+	14444444444444	=> '14',
+	155555555555555 => '15',
+	default		=> null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_01.php.testGroupAlignmentMatchArmArrow_Tab01_Size8b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_01.php.testGroupAlignmentMatchArmArrow_Tab01_Size8b.formatted
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$type1 = "test";
+$type2 = 1;
+match ($type1) {
+	'min' => 'min', 'maxLength' => 'maxLength', default => null,
+};
+
+$m = match ($type1) {
+	'maxLength' => 'maxLength', 'min' => 'min', default => null,
+};
+
+match ($type1) {
+	'min' => 'min', 'maxLength' => 'maxLength',
+	default => null,
+};
+
+match ($type1) {
+	'maxLength' => 'maxLength',
+	'min' => 'mim',
+	default => null,
+};
+match ($type1) {
+	'min' => 'min',
+	'maxLength' => 'maxLength',
+	default => null,
+};
+
+match ($type1) {
+	'maxLength', 'min' => 'min',
+	'test' => 'test',
+	default => null,
+};
+
+match ($type1) {
+	'maxLength', 'test' => 'maxLength',
+	'min' => match ($type2) {
+		1, 2 => "nested",
+		3 => "nested",
+		4 => "nested",
+	},
+	default => null,
+};
+
+match ($type1) {
+	'min' => 'min',
+	'maxLength' => match ($type2) {
+		1 => "nested",
+		"maxLength" => "nested", "test" => "test",
+		4 => "nested",
+	},
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	11111111111 => '11',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	11111111111 => '11',
+	122222222222 => '12',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	11111111111 => '11',
+	122222222222 => '12',
+	1333333333333 => '13',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	11111111111 => '11',
+	122222222222 => '12',
+	1333333333333 => '13',
+	14444444444444 => '14',
+	default => null,
+};
+
+match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	11111111111 => '11',
+	122222222222 => '12',
+	1333333333333 => '13',
+	14444444444444 => '14',
+	155555555555555 => '15',
+	default => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = match ($type1) {
+        1 => '1',
+        22 => '2',
+        333 => '3',
+        4444 => '4',
+        55555 => '5',
+        666666 => '6',
+        7777777 => '7',
+        88888888 => '8',
+        999999999 => '9',
+        1000000000 => '10',
+    'maxLength' => [
+        '1' => 1,
+        'test' => [
+            'nested' => "nested",
+            'nested2' => "nested",
+            'nestedMaxLength' => "nested",
+            'nested3' => "nested",
+            'nestedTest' => "nested",
+        ],
+        1 => '1',
+        22 => '2',
+        333 => '3',
+        4444 => '4',
+        55555 => '5',
+        666666 => '6',
+        7777777 => '7',
+        88888888 => '8',
+        999999999 => '9',
+        1000000000 => '10',
+    ],
+    default => null,
+};
+
+$result = match ($type1) {
+        1 => '1',
+        22 => '2',
+        333 => '3',
+        4444 => '4',
+        55555 => '5',
+        666666 => '6',
+        7777777 => '7',
+        88888888 => '8',
+        999999999 => '9',
+        1000000000 => '10',
+    'maxLength' => [
+        '1' => 1,
+        'test' => [
+            'nested' => "nested",
+            'nested2' => "nested",
+            'nestedMaxLength' => "nested",
+            'nested3' => "nested",
+            'nestedTest' => "nested",
+        ],
+        1 => '1',
+        22 => '2',
+        333 => '3',
+        4444 => '4',
+        55555 => '5',
+        666666 => '6',
+        7777777 => '7',
+        88888888 => '8',
+        999999999 => '9',
+        1000000000 => '10',
+    ],
+11111111111 => '11',
+122222222222 => '12',
+1333333333333 => '13',
+    default => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Spaces02a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Spaces02a.formatted
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = match ($type1) {
+    1           => '1',
+    22          => '2',
+    333         => '3',
+    4444        => '4',
+    55555       => '5',
+    666666      => '6',
+    7777777     => '7',
+    88888888    => '8',
+    999999999   => '9',
+    1000000000  => '10',
+    'maxLength' => [
+        '1'        => 1,
+        'test'     => [
+            'nested'          => "nested",
+            'nested2'         => "nested",
+            'nestedMaxLength' => "nested",
+            'nested3'         => "nested",
+            'nestedTest'      => "nested",
+        ],
+        1          => '1',
+        22         => '2',
+        333        => '3',
+        4444       => '4',
+        55555      => '5',
+        666666     => '6',
+        7777777    => '7',
+        88888888   => '8',
+        999999999  => '9',
+        1000000000 => '10',
+    ],
+    default     => null,
+};
+
+$result = match ($type1) {
+    1             => '1',
+    22            => '2',
+    333           => '3',
+    4444          => '4',
+    55555         => '5',
+    666666        => '6',
+    7777777       => '7',
+    88888888      => '8',
+    999999999     => '9',
+    1000000000    => '10',
+    'maxLength'   => [
+        '1'        => 1,
+        'test'     => [
+            'nested'          => "nested",
+            'nested2'         => "nested",
+            'nestedMaxLength' => "nested",
+            'nested3'         => "nested",
+            'nestedTest'      => "nested",
+        ],
+        1          => '1',
+        22         => '2',
+        333        => '3',
+        4444       => '4',
+        55555      => '5',
+        666666     => '6',
+        7777777    => '7',
+        88888888   => '8',
+        999999999  => '9',
+        1000000000 => '10',
+    ],
+    11111111111   => '11',
+    122222222222  => '12',
+    1333333333333 => '13',
+    default       => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Spaces02b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Spaces02b.formatted
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    'maxLength' => [
+        '1'        => 1,
+        'test'     => [
+            'nested'          => "nested",
+            'nested2'         => "nested",
+            'nestedMaxLength' => "nested",
+            'nested3'         => "nested",
+            'nestedTest'      => "nested",
+        ],
+        1          => '1',
+        22         => '2',
+        333        => '3',
+        4444       => '4',
+        55555      => '5',
+        666666     => '6',
+        7777777    => '7',
+        88888888   => '8',
+        999999999  => '9',
+        1000000000 => '10',
+    ],
+    default => null,
+};
+
+$result = match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    'maxLength' => [
+        '1'        => 1,
+        'test'     => [
+            'nested'          => "nested",
+            'nested2'         => "nested",
+            'nestedMaxLength' => "nested",
+            'nested3'         => "nested",
+            'nestedTest'      => "nested",
+        ],
+        1          => '1',
+        22         => '2',
+        333        => '3',
+        4444       => '4',
+        55555      => '5',
+        666666     => '6',
+        7777777    => '7',
+        88888888   => '8',
+        999999999  => '9',
+        1000000000 => '10',
+    ],
+    11111111111 => '11',
+    122222222222 => '12',
+    1333333333333 => '13',
+    default => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Spaces02c.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Spaces02c.formatted
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = match ($type1) {
+    1           => '1',
+    22          => '2',
+    333         => '3',
+    4444        => '4',
+    55555       => '5',
+    666666      => '6',
+    7777777     => '7',
+    88888888    => '8',
+    999999999   => '9',
+    1000000000  => '10',
+    'maxLength' => [
+        '1' => 1,
+        'test' => [
+            'nested' => "nested",
+            'nested2' => "nested",
+            'nestedMaxLength' => "nested",
+            'nested3' => "nested",
+            'nestedTest' => "nested",
+        ],
+        1 => '1',
+        22 => '2',
+        333 => '3',
+        4444 => '4',
+        55555 => '5',
+        666666 => '6',
+        7777777 => '7',
+        88888888 => '8',
+        999999999 => '9',
+        1000000000 => '10',
+    ],
+    default     => null,
+};
+
+$result = match ($type1) {
+    1             => '1',
+    22            => '2',
+    333           => '3',
+    4444          => '4',
+    55555         => '5',
+    666666        => '6',
+    7777777       => '7',
+    88888888      => '8',
+    999999999     => '9',
+    1000000000    => '10',
+    'maxLength'   => [
+        '1' => 1,
+        'test' => [
+            'nested' => "nested",
+            'nested2' => "nested",
+            'nestedMaxLength' => "nested",
+            'nested3' => "nested",
+            'nestedTest' => "nested",
+        ],
+        1 => '1',
+        22 => '2',
+        333 => '3',
+        4444 => '4',
+        55555 => '5',
+        666666 => '6',
+        7777777 => '7',
+        88888888 => '8',
+        999999999 => '9',
+        1000000000 => '10',
+    ],
+    11111111111   => '11',
+    122222222222  => '12',
+    1333333333333 => '13',
+    default       => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Spaces02d.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Spaces02d.formatted
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    'maxLength' => [
+        '1' => 1,
+        'test' => [
+            'nested' => "nested",
+            'nested2' => "nested",
+            'nestedMaxLength' => "nested",
+            'nested3' => "nested",
+            'nestedTest' => "nested",
+        ],
+        1 => '1',
+        22 => '2',
+        333 => '3',
+        4444 => '4',
+        55555 => '5',
+        666666 => '6',
+        7777777 => '7',
+        88888888 => '8',
+        999999999 => '9',
+        1000000000 => '10',
+    ],
+    default => null,
+};
+
+$result = match ($type1) {
+    1 => '1',
+    22 => '2',
+    333 => '3',
+    4444 => '4',
+    55555 => '5',
+    666666 => '6',
+    7777777 => '7',
+    88888888 => '8',
+    999999999 => '9',
+    1000000000 => '10',
+    'maxLength' => [
+        '1' => 1,
+        'test' => [
+            'nested' => "nested",
+            'nested2' => "nested",
+            'nestedMaxLength' => "nested",
+            'nested3' => "nested",
+            'nestedTest' => "nested",
+        ],
+        1 => '1',
+        22 => '2',
+        333 => '3',
+        4444 => '4',
+        55555 => '5',
+        666666 => '6',
+        7777777 => '7',
+        88888888 => '8',
+        999999999 => '9',
+        1000000000 => '10',
+    ],
+    11111111111 => '11',
+    122222222222 => '12',
+    1333333333333 => '13',
+    default => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size4a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size4a.formatted
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = match ($type1) {
+	1			=> '1',
+	22			=> '2',
+	333			=> '3',
+	4444		=> '4',
+	55555		=> '5',
+	666666		=> '6',
+	7777777		=> '7',
+	88888888	=> '8',
+	999999999	=> '9',
+	1000000000	=> '10',
+	'maxLength' => [
+		'1'		   => 1,
+		'test'	   => [
+			'nested'		  => "nested",
+			'nested2'		  => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3'		  => "nested",
+			'nestedTest'	  => "nested",
+		],
+		1		   => '1',
+		22		   => '2',
+		333		   => '3',
+		4444	   => '4',
+		55555	   => '5',
+		666666	   => '6',
+		7777777	   => '7',
+		88888888   => '8',
+		999999999  => '9',
+		1000000000 => '10',
+	],
+	default		=> null,
+};
+
+$result = match ($type1) {
+	1			  => '1',
+	22			  => '2',
+	333			  => '3',
+	4444		  => '4',
+	55555		  => '5',
+	666666		  => '6',
+	7777777		  => '7',
+	88888888	  => '8',
+	999999999	  => '9',
+	1000000000	  => '10',
+	'maxLength'	  => [
+		'1'		   => 1,
+		'test'	   => [
+			'nested'		  => "nested",
+			'nested2'		  => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3'		  => "nested",
+			'nestedTest'	  => "nested",
+		],
+		1		   => '1',
+		22		   => '2',
+		333		   => '3',
+		4444	   => '4',
+		55555	   => '5',
+		666666	   => '6',
+		7777777	   => '7',
+		88888888   => '8',
+		999999999  => '9',
+		1000000000 => '10',
+	],
+	11111111111	  => '11',
+	122222222222  => '12',
+	1333333333333 => '13',
+	default		  => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size4b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size4b.formatted
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = match ($type1) {
+	1			=> '1',
+	22			=> '2',
+	333			=> '3',
+	4444		=> '4',
+	55555		=> '5',
+	666666		=> '6',
+	7777777		=> '7',
+	88888888	=> '8',
+	999999999	=> '9',
+	1000000000	=> '10',
+	'maxLength' => [
+		'1' => 1,
+		'test' => [
+			'nested' => "nested",
+			'nested2' => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3' => "nested",
+			'nestedTest' => "nested",
+		],
+		1 => '1',
+		22 => '2',
+		333 => '3',
+		4444 => '4',
+		55555 => '5',
+		666666 => '6',
+		7777777 => '7',
+		88888888 => '8',
+		999999999 => '9',
+		1000000000 => '10',
+	],
+	default		=> null,
+};
+
+$result = match ($type1) {
+	1			  => '1',
+	22			  => '2',
+	333			  => '3',
+	4444		  => '4',
+	55555		  => '5',
+	666666		  => '6',
+	7777777		  => '7',
+	88888888	  => '8',
+	999999999	  => '9',
+	1000000000	  => '10',
+	'maxLength'	  => [
+		'1' => 1,
+		'test' => [
+			'nested' => "nested",
+			'nested2' => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3' => "nested",
+			'nestedTest' => "nested",
+		],
+		1 => '1',
+		22 => '2',
+		333 => '3',
+		4444 => '4',
+		55555 => '5',
+		666666 => '6',
+		7777777 => '7',
+		88888888 => '8',
+		999999999 => '9',
+		1000000000 => '10',
+	],
+	11111111111	  => '11',
+	122222222222  => '12',
+	1333333333333 => '13',
+	default		  => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size4c.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size4c.formatted
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	'maxLength' => [
+		'1'		   => 1,
+		'test'	   => [
+			'nested'		  => "nested",
+			'nested2'		  => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3'		  => "nested",
+			'nestedTest'	  => "nested",
+		],
+		1		   => '1',
+		22		   => '2',
+		333		   => '3',
+		4444	   => '4',
+		55555	   => '5',
+		666666	   => '6',
+		7777777	   => '7',
+		88888888   => '8',
+		999999999  => '9',
+		1000000000 => '10',
+	],
+	default => null,
+};
+
+$result = match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	'maxLength' => [
+		'1'		   => 1,
+		'test'	   => [
+			'nested'		  => "nested",
+			'nested2'		  => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3'		  => "nested",
+			'nestedTest'	  => "nested",
+		],
+		1		   => '1',
+		22		   => '2',
+		333		   => '3',
+		4444	   => '4',
+		55555	   => '5',
+		666666	   => '6',
+		7777777	   => '7',
+		88888888   => '8',
+		999999999  => '9',
+		1000000000 => '10',
+	],
+	11111111111 => '11',
+	122222222222 => '12',
+	1333333333333 => '13',
+	default => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size4d.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size4d.formatted
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	'maxLength' => [
+		'1' => 1,
+		'test' => [
+			'nested' => "nested",
+			'nested2' => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3' => "nested",
+			'nestedTest' => "nested",
+		],
+		1 => '1',
+		22 => '2',
+		333 => '3',
+		4444 => '4',
+		55555 => '5',
+		666666 => '6',
+		7777777 => '7',
+		88888888 => '8',
+		999999999 => '9',
+		1000000000 => '10',
+	],
+	default => null,
+};
+
+$result = match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	'maxLength' => [
+		'1' => 1,
+		'test' => [
+			'nested' => "nested",
+			'nested2' => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3' => "nested",
+			'nestedTest' => "nested",
+		],
+		1 => '1',
+		22 => '2',
+		333 => '3',
+		4444 => '4',
+		55555 => '5',
+		666666 => '6',
+		7777777 => '7',
+		88888888 => '8',
+		999999999 => '9',
+		1000000000 => '10',
+	],
+	11111111111 => '11',
+	122222222222 => '12',
+	1333333333333 => '13',
+	default => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size8a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size8a.formatted
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = match ($type1) {
+	1	    => '1',
+	22	    => '2',
+	333	    => '3',
+	4444	    => '4',
+	55555	    => '5',
+	666666	    => '6',
+	7777777	    => '7',
+	88888888    => '8',
+	999999999   => '9',
+	1000000000  => '10',
+	'maxLength' => [
+		'1'	   => 1,
+		'test'	   => [
+			'nested'	  => "nested",
+			'nested2'	  => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3'	  => "nested",
+			'nestedTest'	  => "nested",
+		],
+		1	   => '1',
+		22	   => '2',
+		333	   => '3',
+		4444	   => '4',
+		55555	   => '5',
+		666666	   => '6',
+		7777777	   => '7',
+		88888888   => '8',
+		999999999  => '9',
+		1000000000 => '10',
+	],
+	default	    => null,
+};
+
+$result = match ($type1) {
+	1	      => '1',
+	22	      => '2',
+	333	      => '3',
+	4444	      => '4',
+	55555	      => '5',
+	666666	      => '6',
+	7777777	      => '7',
+	88888888      => '8',
+	999999999     => '9',
+	1000000000    => '10',
+	'maxLength'   => [
+		'1'	   => 1,
+		'test'	   => [
+			'nested'	  => "nested",
+			'nested2'	  => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3'	  => "nested",
+			'nestedTest'	  => "nested",
+		],
+		1	   => '1',
+		22	   => '2',
+		333	   => '3',
+		4444	   => '4',
+		55555	   => '5',
+		666666	   => '6',
+		7777777	   => '7',
+		88888888   => '8',
+		999999999  => '9',
+		1000000000 => '10',
+	],
+	11111111111   => '11',
+	122222222222  => '12',
+	1333333333333 => '13',
+	default	      => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size8b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size8b.formatted
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = match ($type1) {
+	1	    => '1',
+	22	    => '2',
+	333	    => '3',
+	4444	    => '4',
+	55555	    => '5',
+	666666	    => '6',
+	7777777	    => '7',
+	88888888    => '8',
+	999999999   => '9',
+	1000000000  => '10',
+	'maxLength' => [
+		'1' => 1,
+		'test' => [
+			'nested' => "nested",
+			'nested2' => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3' => "nested",
+			'nestedTest' => "nested",
+		],
+		1 => '1',
+		22 => '2',
+		333 => '3',
+		4444 => '4',
+		55555 => '5',
+		666666 => '6',
+		7777777 => '7',
+		88888888 => '8',
+		999999999 => '9',
+		1000000000 => '10',
+	],
+	default	    => null,
+};
+
+$result = match ($type1) {
+	1	      => '1',
+	22	      => '2',
+	333	      => '3',
+	4444	      => '4',
+	55555	      => '5',
+	666666	      => '6',
+	7777777	      => '7',
+	88888888      => '8',
+	999999999     => '9',
+	1000000000    => '10',
+	'maxLength'   => [
+		'1' => 1,
+		'test' => [
+			'nested' => "nested",
+			'nested2' => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3' => "nested",
+			'nestedTest' => "nested",
+		],
+		1 => '1',
+		22 => '2',
+		333 => '3',
+		4444 => '4',
+		55555 => '5',
+		666666 => '6',
+		7777777 => '7',
+		88888888 => '8',
+		999999999 => '9',
+		1000000000 => '10',
+	],
+	11111111111   => '11',
+	122222222222  => '12',
+	1333333333333 => '13',
+	default	      => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size8c.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size8c.formatted
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	'maxLength' => [
+		'1'	   => 1,
+		'test'	   => [
+			'nested'	  => "nested",
+			'nested2'	  => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3'	  => "nested",
+			'nestedTest'	  => "nested",
+		],
+		1	   => '1',
+		22	   => '2',
+		333	   => '3',
+		4444	   => '4',
+		55555	   => '5',
+		666666	   => '6',
+		7777777	   => '7',
+		88888888   => '8',
+		999999999  => '9',
+		1000000000 => '10',
+	],
+	default => null,
+};
+
+$result = match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	'maxLength' => [
+		'1'	   => 1,
+		'test'	   => [
+			'nested'	  => "nested",
+			'nested2'	  => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3'	  => "nested",
+			'nestedTest'	  => "nested",
+		],
+		1	   => '1',
+		22	   => '2',
+		333	   => '3',
+		4444	   => '4',
+		55555	   => '5',
+		666666	   => '6',
+		7777777	   => '7',
+		88888888   => '8',
+		999999999  => '9',
+		1000000000 => '10',
+	],
+	11111111111 => '11',
+	122222222222 => '12',
+	1333333333333 => '13',
+	default => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size8d.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentMatchArmArrow_02.php.testGroupAlignmentMatchArmArrow_Tab02_Size8d.formatted
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$result = match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	'maxLength' => [
+		'1' => 1,
+		'test' => [
+			'nested' => "nested",
+			'nested2' => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3' => "nested",
+			'nestedTest' => "nested",
+		],
+		1 => '1',
+		22 => '2',
+		333 => '3',
+		4444 => '4',
+		55555 => '5',
+		666666 => '6',
+		7777777 => '7',
+		88888888 => '8',
+		999999999 => '9',
+		1000000000 => '10',
+	],
+	default => null,
+};
+
+$result = match ($type1) {
+	1 => '1',
+	22 => '2',
+	333 => '3',
+	4444 => '4',
+	55555 => '5',
+	666666 => '6',
+	7777777 => '7',
+	88888888 => '8',
+	999999999 => '9',
+	1000000000 => '10',
+	'maxLength' => [
+		'1' => 1,
+		'test' => [
+			'nested' => "nested",
+			'nested2' => "nested",
+			'nestedMaxLength' => "nested",
+			'nested3' => "nested",
+			'nestedTest' => "nested",
+		],
+		1 => '1',
+		22 => '2',
+		333 => '3',
+		4444 => '4',
+		55555 => '5',
+		666666 => '6',
+		7777777 => '7',
+		88888888 => '8',
+		999999999 => '9',
+		1000000000 => '10',
+	],
+	11111111111 => '11',
+	122222222222 => '12',
+	1333333333333 => '13',
+	default => null,
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/issue210617.php.testIssue210617_TabSize8.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/issue210617.php.testIssue210617_TabSize8.formatted
@@ -4,31 +4,31 @@ $v = 'test';
 
 $va = 'test';
 
-$v			 = 'test';
-$va			 = 'test';
-$var		 = 'test';
-$var1		 = 'test';
-$var11		 = 'test';
-$var111		 = 'test';
-$var1111	 = 'test';
-$var11111	 = 'test';
-$var111111	 = 'test';
-$var1111111	 = 'test';
+$v	     = 'test';
+$va	     = 'test';
+$var	     = 'test';
+$var1	     = 'test';
+$var11	     = 'test';
+$var111	     = 'test';
+$var1111     = 'test';
+$var11111    = 'test';
+$var111111   = 'test';
+$var1111111  = 'test';
 $longVarName = 'test';
 
-$v			= 'test';
-$va			= 'test';
-$var		= 'test';
-$var1		= 'test';
-$var11		= 'test';
-$var111		= 'test';
-$var1111	= 'test';
-$var11111	= 'test';
-$var111111	= 'test';
+$v	    = 'test';
+$va	    = 'test';
+$var	    = 'test';
+$var1	    = 'test';
+$var11	    = 'test';
+$var111	    = 'test';
+$var1111    = 'test';
+$var11111   = 'test';
+$var111111  = 'test';
 $var1111111 = 'test';
 
-$v		   = 'test';
-$va		   = 'test';
+$v	   = 'test';
+$va	   = 'test';
 $var	   = 'test';
 $var1	   = 'test';
 $var11	   = 'test';
@@ -37,8 +37,8 @@ $var1111   = 'test';
 $var11111  = 'test';
 $var111111 = 'test';
 
-$v		  = 'test';
-$va		  = 'test';
+$v	  = 'test';
+$va	  = 'test';
 $var	  = 'test';
 $var1	  = 'test';
 $var11	  = 'test';
@@ -46,37 +46,37 @@ $var111	  = 'test';
 $var1111  = 'test';
 $var11111 = 'test';
 
-$v		 = 'test';
-$va		 = 'test';
+$v	 = 'test';
+$va	 = 'test';
 $var	 = 'test';
 $var1	 = 'test';
 $var11	 = 'test';
 $var111	 = 'test';
 $var1111 = 'test';
 
-$v		= 'test';
-$va		= 'test';
+$v	= 'test';
+$va	= 'test';
 $var	= 'test';
 $var1	= 'test';
 $var11	= 'test';
 $var111 = 'test';
 
-$v	   = 'test';
-$va	   = 'test';
+$v     = 'test';
+$va    = 'test';
 $var   = 'test';
 $var1  = 'test';
 $var11 = 'test';
 
-$v	  = 'test';
-$va	  = 'test';
+$v    = 'test';
+$va   = 'test';
 $var  = 'test';
 $var1 = 'test';
 
-$v	 = 'test';
-$va	 = 'test';
+$v   = 'test';
+$va  = 'test';
 $var = 'test';
 
-$v	= 'test';
+$v  = 'test';
 $va = 'test';
 
 $short	 = 'test';
@@ -113,6 +113,6 @@ $var1 = 'test';
 $var	  = 'test';
 $var11111 = 'test';
 
-$v			 = 'test';
+$v	     = 'test';
 $longVarName = 'test';
 ?>

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterAlignmentTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterAlignmentTest.java
@@ -315,4 +315,183 @@ public class PHPFormatterAlignmentTest extends PHPFormatterTestBase {
         reformatFileContents(getTestFilePath("gh6714_02.php"), options, false, true);
     }
 
+    public void testGroupAlignmentMatchArmArrow_Spaces01a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, true);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, true);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_01.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Spaces01b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, true);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, false);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_01.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Tab01_Size4a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        options.put(FmtOptions.TAB_SIZE, 4);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, true);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_01.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Tab01_Size4b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        options.put(FmtOptions.TAB_SIZE, 4);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, false);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_01.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Tab01_Size8a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        options.put(FmtOptions.TAB_SIZE, 8);
+        options.put(FmtOptions.INDENT_SIZE, 8);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 8);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, true);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_01.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Tab01_Size8b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        options.put(FmtOptions.TAB_SIZE, 8);
+        options.put(FmtOptions.INDENT_SIZE, 8);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 8);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, false);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_01.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Spaces02a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, true);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, true);
+        options.put(FmtOptions.GROUP_ALIGNMENT_ARRAY_INIT, true);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_02.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Spaces02b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, true);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, false);
+        options.put(FmtOptions.GROUP_ALIGNMENT_ARRAY_INIT, true);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_02.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Spaces02c() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, true);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, true);
+        options.put(FmtOptions.GROUP_ALIGNMENT_ARRAY_INIT, false);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_02.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Spaces02d() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, true);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, false);
+        options.put(FmtOptions.GROUP_ALIGNMENT_ARRAY_INIT, false);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_02.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Tab02_Size4a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        options.put(FmtOptions.TAB_SIZE, 4);
+        options.put(FmtOptions.INDENT_SIZE, 4);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, true);
+        options.put(FmtOptions.ITEMS_IN_ARRAY_DECLARATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.GROUP_ALIGNMENT_ARRAY_INIT, true);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_02.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Tab02_Size4b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        options.put(FmtOptions.TAB_SIZE, 4);
+        options.put(FmtOptions.INDENT_SIZE, 4);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, true);
+        options.put(FmtOptions.ITEMS_IN_ARRAY_DECLARATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.GROUP_ALIGNMENT_ARRAY_INIT, false);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_02.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Tab02_Size4c() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        options.put(FmtOptions.TAB_SIZE, 4);
+        options.put(FmtOptions.INDENT_SIZE, 4);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, false);
+        options.put(FmtOptions.ITEMS_IN_ARRAY_DECLARATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.GROUP_ALIGNMENT_ARRAY_INIT, true);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_02.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Tab02_Size4d() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        options.put(FmtOptions.TAB_SIZE, 4);
+        options.put(FmtOptions.INDENT_SIZE, 4);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, false);
+        options.put(FmtOptions.ITEMS_IN_ARRAY_DECLARATION_INDENT_SIZE, 4);
+        options.put(FmtOptions.GROUP_ALIGNMENT_ARRAY_INIT, false);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_02.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Tab02_Size8a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        options.put(FmtOptions.TAB_SIZE, 8);
+        options.put(FmtOptions.INDENT_SIZE, 8);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 8);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, true);
+        options.put(FmtOptions.ITEMS_IN_ARRAY_DECLARATION_INDENT_SIZE, 8);
+        options.put(FmtOptions.GROUP_ALIGNMENT_ARRAY_INIT, true);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_02.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Tab02_Size8b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        options.put(FmtOptions.TAB_SIZE, 8);
+        options.put(FmtOptions.INDENT_SIZE, 8);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 8);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, true);
+        options.put(FmtOptions.ITEMS_IN_ARRAY_DECLARATION_INDENT_SIZE, 8);
+        options.put(FmtOptions.GROUP_ALIGNMENT_ARRAY_INIT, false);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_02.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Tab02_Size8c() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        options.put(FmtOptions.TAB_SIZE, 8);
+        options.put(FmtOptions.INDENT_SIZE, 8);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 8);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, false);
+        options.put(FmtOptions.ITEMS_IN_ARRAY_DECLARATION_INDENT_SIZE, 8);
+        options.put(FmtOptions.GROUP_ALIGNMENT_ARRAY_INIT, true);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_02.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentMatchArmArrow_Tab02_Size8d() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        options.put(FmtOptions.TAB_SIZE, 8);
+        options.put(FmtOptions.INDENT_SIZE, 8);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 8);
+        options.put(FmtOptions.GROUP_ALIGNMENT_MATCH_ARM_ARROW, false);
+        options.put(FmtOptions.ITEMS_IN_ARRAY_DECLARATION_INDENT_SIZE, 8);
+        options.put(FmtOptions.GROUP_ALIGNMENT_ARRAY_INIT, false);
+        reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_02.php"), options, false, true);
+    }
 }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterSpacesTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterSpacesTest.java
@@ -236,6 +236,18 @@ public class PHPFormatterSpacesTest extends PHPFormatterTestBase {
         reformatFileContents("testfiles/formatting/alignment/issue210617.php", options);
     }
 
+    public void testIssue210617_TabSize8() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.GROUP_ALIGNMENT_ARRAY_INIT, true);
+        options.put(FmtOptions.GROUP_ALIGNMENT_ASSIGNMENT, true);
+        options.put(FmtOptions.EXPAND_TAB_TO_SPACES, false);
+        options.put(FmtOptions.TAB_SIZE, 8);
+        options.put(FmtOptions.INDENT_SIZE, 8);
+        options.put(FmtOptions.ITEMS_IN_ARRAY_DECLARATION_INDENT_SIZE, 8);
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 8);
+        reformatFileContents("testfiles/formatting/alignment/issue210617.php", options, false, true);
+    }
+
     public void testIssue181624_01() throws Exception {
         HashMap<String, Object> options = new HashMap<String, Object>(FmtOptions.getDefaults());
         reformatFileContents("testfiles/formatting/spaces/issue181624_01.php", options);


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/6074
- Add "Match Arm Arrow" as an alignment option
- Add/Fix unit tests

Example:
```php
match ($type1) {
    'integer', 'test' => 'test',
    'string' => match ($type2) {
        1, 2 => "test",
        3 => "test",
        4 => "test",
    },
    default => null,
};
```

Result:

```php
match ($type1) {
    'integer', 'test' => 'test',
    'string'          => match ($type2) {
        1, 2 => "test",
        3    => "test",
        4    => "test",
    },
    default           => null,
};
```
![nb-php-gh-6074-match-arm-arrow-alignment-option](https://github.com/apache/netbeans/assets/738383/0a4e2297-e13e-4e13-91bf-f4888629b0ba)

