### PR TITLE
Update to JGit 6.8 and Bouncy Castle 1.77

### DIFF
--- a/ide/bcpg/external/bcpg-jdk18on-1.77-license.txt
+++ b/ide/bcpg/external/bcpg-jdk18on-1.77-license.txt
@@ -1,5 +1,5 @@
-Name: Bouncy Castle Java Provider
-Version: 1.76
+Name: Bouncy Castle Java OpenPGP/BCPG
+Version: 1.77
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcpg/external/binaries-list
+++ b/ide/bcpg/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-D5C23D0470261254D0E84DDE1D4237D228540298 org.bouncycastle:bcpg-jdk18on:1.76
+BB0BE51E8B378BAAE6E0D86F5282CD3887066539 org.bouncycastle:bcpg-jdk18on:1.77

--- a/ide/bcpg/nbproject/project.properties
+++ b/ide/bcpg/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcpg-jdk18on-1.76.jar=modules/bcpg.jar
+release.external/bcpg-jdk18on-1.77.jar=modules/bcpg.jar
 is.autoload=true

--- a/ide/bcpg/nbproject/project.xml
+++ b/ide/bcpg/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcpg.jar</runtime-relative-path>
-                <binary-origin>external/bcpg-jdk18on-1.76.jar</binary-origin>
+                <binary-origin>external/bcpg-jdk18on-1.77.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/bcpkix/external/bcpkix-jdk18on-1.77-license.txt
+++ b/ide/bcpkix/external/bcpkix-jdk18on-1.77-license.txt
@@ -1,5 +1,5 @@
-Name: Bouncy Castle Java OpenPGP/BCPG
-Version: 1.76
+Name: Bouncy Castle Java Provider
+Version: 1.77
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcpkix/external/binaries-list
+++ b/ide/bcpkix/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-10C9CF5C1B4D64ABEDA28EE32FBADE3B74373622 org.bouncycastle:bcpkix-jdk18on:1.76
+ED953791BA0229747DD0FD9911E3D76A462ACFD3 org.bouncycastle:bcpkix-jdk18on:1.77

--- a/ide/bcpkix/nbproject/project.properties
+++ b/ide/bcpkix/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcpkix-jdk18on-1.76.jar=modules/bcpkix.jar
+release.external/bcpkix-jdk18on-1.77.jar=modules/bcpkix.jar
 is.autoload=true

--- a/ide/bcpkix/nbproject/project.xml
+++ b/ide/bcpkix/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcpkix.jar</runtime-relative-path>
-                <binary-origin>external/bcpkix-jdk18on-1.76.jar</binary-origin>
+                <binary-origin>external/bcpkix-jdk18on-1.77.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/bcprov/external/bcprov-jdk18on-1.77-license.txt
+++ b/ide/bcprov/external/bcprov-jdk18on-1.77-license.txt
@@ -1,5 +1,5 @@
-Name: Bouncy Castle ASN.1 Extension and Utility APIs
-Version: 1.76
+Name: Bouncy Castle Java Provider
+Version: 1.77
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcprov/external/binaries-list
+++ b/ide/bcprov/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-3A785D0B41806865AD7E311162BFA3FA60B3965B org.bouncycastle:bcprov-jdk18on:1.76
+2CC971B6C20949C1FF98D1A4BC741EE848A09523 org.bouncycastle:bcprov-jdk18on:1.77

--- a/ide/bcprov/nbproject/project.properties
+++ b/ide/bcprov/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcprov-jdk18on-1.76.jar=modules/bcprov.jar
+release.external/bcprov-jdk18on-1.77.jar=modules/bcprov.jar
 is.autoload=true

--- a/ide/bcprov/nbproject/project.xml
+++ b/ide/bcprov/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcprov.jar</runtime-relative-path>
-                <binary-origin>external/bcprov-jdk18on-1.76.jar</binary-origin>
+                <binary-origin>external/bcprov-jdk18on-1.77.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/bcutil/external/bcutil-jdk18on-1.77-license.txt
+++ b/ide/bcutil/external/bcutil-jdk18on-1.77-license.txt
@@ -1,5 +1,5 @@
-Name: Bouncy Castle Java Provider
-Version: 1.76
+Name: Bouncy Castle ASN.1 Extension and Utility APIs
+Version: 1.77
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcutil/external/binaries-list
+++ b/ide/bcutil/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-8C7594E651A278BCDE18E038D8AB55B1F97F4D31 org.bouncycastle:bcutil-jdk18on:1.76
+DE3EAEF351545FE8562CF29DDFF4A403A45B49B7 org.bouncycastle:bcutil-jdk18on:1.77

--- a/ide/bcutil/nbproject/project.properties
+++ b/ide/bcutil/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcutil-jdk18on-1.76.jar=modules/bcutil.jar
+release.external/bcutil-jdk18on-1.77.jar=modules/bcutil.jar
 is.autoload=true

--- a/ide/bcutil/nbproject/project.xml
+++ b/ide/bcutil/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcutil.jar</runtime-relative-path>
-                <binary-origin>external/bcutil-jdk18on-1.76.jar</binary-origin>
+                <binary-origin>external/bcutil-jdk18on-1.77.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/o.eclipse.jgit.gpg.bc/external/binaries-list
+++ b/ide/o.eclipse.jgit.gpg.bc/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-598B2D4E3677D82FB281BEA8AD8DC636D3624BAE org.eclipse.jgit:org.eclipse.jgit.gpg.bc:6.7.0.202309050840-r
+DD10A2BDED9F560D9D816FA9B61CB3226CCD6BCF org.eclipse.jgit:org.eclipse.jgit.gpg.bc:6.8.0.202311291450-r

--- a/ide/o.eclipse.jgit.gpg.bc/external/org.eclipse.jgit.gpg.bc-6.8.0.202311291450-r-license.txt
+++ b/ide/o.eclipse.jgit.gpg.bc/external/org.eclipse.jgit.gpg.bc-6.8.0.202311291450-r-license.txt
@@ -1,6 +1,6 @@
 Name: JGit Library
 Origin: Eclipse
-Version: 6.7.0.202309050840-r
+Version: 6.8.0.202311291450-r
 Description: Integration library for Git client
 License: EDL-1.0-jgit
 URL: http://www.eclipse.org/jgit/download/

--- a/ide/o.eclipse.jgit.gpg.bc/nbproject/project.properties
+++ b/ide/o.eclipse.jgit.gpg.bc/nbproject/project.properties
@@ -17,4 +17,4 @@
 
 is.autoload=true
 
-release.external/org.eclipse.jgit.gpg.bc-6.7.0.202309050840-r.jar=modules/org-eclipse-jgit-gpg-bc.jar
+release.external/org.eclipse.jgit.gpg.bc-6.8.0.202311291450-r.jar=modules/org-eclipse-jgit-gpg-bc.jar

--- a/ide/o.eclipse.jgit.gpg.bc/nbproject/project.xml
+++ b/ide/o.eclipse.jgit.gpg.bc/nbproject/project.xml
@@ -65,7 +65,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>org-eclipse-jgit-gpg-bc.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.jgit.gpg.bc-6.7.0.202309050840-r.jar</binary-origin>
+                <binary-origin>external/org.eclipse.jgit.gpg.bc-6.8.0.202311291450-r.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/o.eclipse.jgit.lfs/external/binaries-list
+++ b/ide/o.eclipse.jgit.lfs/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-59B2627DE4CCDB433582EB28FA6C4B842948074A org.eclipse.jgit:org.eclipse.jgit.lfs:6.7.0.202309050840-r
+8206F2DF2FB704B3D36CAC725E3D127FAC3F0329 org.eclipse.jgit:org.eclipse.jgit.lfs:6.8.0.202311291450-r

--- a/ide/o.eclipse.jgit.lfs/external/org.eclipse.jgit.lfs-6.8.0.202311291450-r-license.txt
+++ b/ide/o.eclipse.jgit.lfs/external/org.eclipse.jgit.lfs-6.8.0.202311291450-r-license.txt
@@ -1,6 +1,6 @@
 Name: JGit Library
 Origin: Eclipse
-Version: 6.7.0.202309050840-r
+Version: 6.8.0.202311291450-r
 Description: Integration library for Git client
 License: EDL-1.0-jgit
 URL: http://www.eclipse.org/jgit/download/

--- a/ide/o.eclipse.jgit.lfs/nbproject/project.properties
+++ b/ide/o.eclipse.jgit.lfs/nbproject/project.properties
@@ -17,4 +17,4 @@
 
 is.autoload=true
 
-release.external/org.eclipse.jgit.lfs-6.7.0.202309050840-r.jar=modules/org-eclipse-jgit-lfs.jar
+release.external/org.eclipse.jgit.lfs-6.8.0.202311291450-r.jar=modules/org-eclipse-jgit-lfs.jar

--- a/ide/o.eclipse.jgit.lfs/nbproject/project.xml
+++ b/ide/o.eclipse.jgit.lfs/nbproject/project.xml
@@ -60,7 +60,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>org-eclipse-jgit-lfs.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.jgit.lfs-6.7.0.202309050840-r.jar</binary-origin>
+                <binary-origin>external/org.eclipse.jgit.lfs-6.8.0.202311291450-r.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/o.eclipse.jgit.ssh.jsch/external/binaries-list
+++ b/ide/o.eclipse.jgit.ssh.jsch/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-F437425BEAAB4073554ADE72A7F0C633312D249A org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:6.7.0.202309050840-r
+47BC32A1B7CCDB2093E0B9FF8D78598B82F49B21 org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:6.8.0.202311291450-r

--- a/ide/o.eclipse.jgit.ssh.jsch/external/org.eclipse.jgit.ssh.jsch-6.8.0.202311291450-r-license.txt
+++ b/ide/o.eclipse.jgit.ssh.jsch/external/org.eclipse.jgit.ssh.jsch-6.8.0.202311291450-r-license.txt
@@ -1,6 +1,6 @@
 Name: JGit Library
 Origin: Eclipse
-Version: 6.7.0.202309050840-r
+Version: 6.8.0.202311291450-r
 Description: Integration library for Git client
 License: EDL-1.0-jgit
 URL: http://www.eclipse.org/jgit/download/

--- a/ide/o.eclipse.jgit.ssh.jsch/nbproject/project.properties
+++ b/ide/o.eclipse.jgit.ssh.jsch/nbproject/project.properties
@@ -17,4 +17,4 @@
 
 is.autoload=true
 
-release.external/org.eclipse.jgit.ssh.jsch-6.7.0.202309050840-r.jar=modules/org-eclipse-jgit-ssh-jsch.jar
+release.external/org.eclipse.jgit.ssh.jsch-6.8.0.202311291450-r.jar=modules/org-eclipse-jgit-ssh-jsch.jar

--- a/ide/o.eclipse.jgit.ssh.jsch/nbproject/project.xml
+++ b/ide/o.eclipse.jgit.ssh.jsch/nbproject/project.xml
@@ -54,7 +54,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>org-eclipse-jgit-ssh-jsch.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.jgit.ssh.jsch-6.7.0.202309050840-r.jar</binary-origin>
+                <binary-origin>external/org.eclipse.jgit.ssh.jsch-6.8.0.202311291450-r.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/o.eclipse.jgit/external/binaries-list
+++ b/ide/o.eclipse.jgit/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-30599F446ABE09AB51CFE24D3433170F2599F9CC org.eclipse.jgit:org.eclipse.jgit:6.7.0.202309050840-r
+A665A8AD3A3FBEAEE292D5927D204FFE8F6AA23D org.eclipse.jgit:org.eclipse.jgit:6.8.0.202311291450-r

--- a/ide/o.eclipse.jgit/external/org.eclipse.jgit-6.8.0.202311291450-r-license.txt
+++ b/ide/o.eclipse.jgit/external/org.eclipse.jgit-6.8.0.202311291450-r-license.txt
@@ -1,6 +1,6 @@
 Name: JGit Library
 Origin: Eclipse
-Version: 6.7.0.202309050840-r
+Version: 6.8.0.202311291450-r
 Description: Integration library for Git client
 License: EDL-1.0-jgit
 URL: http://www.eclipse.org/jgit/download/

--- a/ide/o.eclipse.jgit/nbproject/project.properties
+++ b/ide/o.eclipse.jgit/nbproject/project.properties
@@ -17,4 +17,4 @@
 
 is.autoload=true
 
-release.external/org.eclipse.jgit-6.7.0.202309050840-r.jar=modules/org-eclipse-jgit.jar
+release.external/org.eclipse.jgit-6.8.0.202311291450-r.jar=modules/org-eclipse-jgit.jar

--- a/ide/o.eclipse.jgit/nbproject/project.xml
+++ b/ide/o.eclipse.jgit/nbproject/project.xml
@@ -52,7 +52,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>org-eclipse-jgit.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.jgit-6.7.0.202309050840-r.jar</binary-origin>
+                <binary-origin>external/org.eclipse.jgit-6.8.0.202311291450-r.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
 - jgit 6.7 to 6.8  -> https://projects.eclipse.org/projects/technology.jgit/releases/6.8.0
 - bc 1.76 to 1.77 -> https://www.bouncycastle.org/releasenotes.html#r1rv77

tested: init, commit, history, clone