### PR TITLE
PHP: New way to set the current breakpoint

### DIFF
--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/FeatureGetCommand.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/FeatureGetCommand.java
@@ -36,6 +36,7 @@ public class FeatureGetCommand extends DbgpCommand {
         DATA_ENCODING,
         BREAKPOINT_LANGUAGES,
         BREAKPOINT_TYPES,
+        BREAKPOINT_DETAILS,
         MULTIPLE_SESSIONS,
         MAX_CHILDREN,
         MAX_DATA,
@@ -86,6 +87,10 @@ public class FeatureGetCommand extends DbgpCommand {
 
     public void setFeature(String name) {
         myName = name;
+    }
+
+    public String getFeature() {
+        return myName;
     }
 
     @Override

--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/InitMessage.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/InitMessage.java
@@ -58,6 +58,7 @@ public class InitMessage extends DbgpMessage {
         setMaxDepth(session);
         setMaxChildren(session);
         setMaxDataSize(session);
+        setBreakpointDetails(session);
         setBreakpoints(session);
         negotiateOutputStream(session);
         negotiateRequestedUrls(session);
@@ -80,6 +81,10 @@ public class InitMessage extends DbgpMessage {
 
     private void setShowHidden(DebugSession session) {
         setFeature(session, Feature.SHOW_HIDDEN, "1"); //NOI18N
+    }
+
+    private void setBreakpointDetails(DebugSession session) {
+        setFeature(session, Feature.BREAKPOINT_DETAILS, "1"); //NOI18N
     }
 
     private void setBreakpointResolution(DebugSession session) {

--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/MessageBuilder.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/MessageBuilder.java
@@ -50,13 +50,14 @@ final class MessageBuilder {
 
     static DbgpMessage createResponse(Node node) {
         String command = DbgpMessage.getAttribute(node, DbgpResponse.COMMAND);
-        if (RunCommand.RUN.equals(command)
-                || StatusCommand.STATUS.equals(command)
+        if (StatusCommand.STATUS.equals(command)
                 || StepOutCommand.STEP_OUT.equals(command)
                 || StepOverCommand.STEP_OVER.equals(command)
                 || StepIntoCommand.STEP_INTO.equals(command)
                 || StopCommand.COMMAND.equals(command)) {
             return new StatusResponse(node);
+        } else if (RunCommand.RUN.equals(command)) {
+            return new RunResponse(node);
         } else if (BrkpntSetCommand.BREAKPOINT_SET.equals(command)) {
             return new BrkpntSetResponse(node);
         } else if (BrkpntUpdateCommand.UPDATE.equals(command)) {

--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/StackGetResponse.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/StackGetResponse.java
@@ -96,7 +96,7 @@ public class StackGetResponse extends DbgpResponse {
         IDESessionBridge bridge = session.getBridge();
         if (bridge != null) {
             BreakpointModel breakpointModel = bridge.getBreakpointModel();
-            if (breakpointModel != null) {
+            if (breakpointModel != null && !breakpointModel.isSearchCurrentBreakpointById()) {
                 breakpointModel.setCurrentStack(
                         stacks.get(0), session);
             }


### PR DESCRIPTION
Now the logic of determining the current breakpoint is based on the information received from xdebug's response to the `stack_get` command, which is not always used to correctly determine the current breakpoint.

Since version 3.1.0 xdebug provides possibility to get information about current breakpoint.
To do this you need to enable `breakpoint_details` feature.
https://bugs.xdebug.org/bug_view_page.php?bug_id=00001969

In this PR I implemented the use of this feature, with fallback to the old logic, in case xdebug does not support this feature.

Examples before and after (using xdebug version 3.1.6):

1) 
- Write code:
```php
<?php

echo 'Hi!';

function x()
{
    echo 'Hello';
    return 12;
}

$x = x();
```

- Set two `method breakpoints` on the `x()` function: one with `stop on call`, the other with `stop on return`

behavior before:

https://github.com/apache/netbeans/assets/9607501/32cf74f3-9471-4ee9-af61-c8fd5114569d


behavior after:


https://github.com/apache/netbeans/assets/9607501/eeca1c63-b843-457a-a44b-350650c6a960


2)
- Write code:
```php
<?php

echo 'Hi!';

class MethodBreakpoint
{
    public function x()
    {
            echo 'Hello';
            return 12;
    }
}

$cls = new MethodBreakpoint();

$x = $cls->x();
```
- Set two `method breakpoints` on the `x()` method: one with `stop on call`, the other with `stop on return`

behavior before:

https://github.com/apache/netbeans/assets/9607501/b67193a3-ff7d-4640-bc1e-f3a0bce9a2d0


behavior after:


https://github.com/apache/netbeans/assets/9607501/80a9f1cf-76b2-469d-9380-c22bb849abc8

3)
- Write code:
```php
<?php

echo 'Hi!';

$foo = $bar['foo'];
```

- Set `exception breakpoint` on `Notice`

behavior before:

https://github.com/apache/netbeans/assets/9607501/b61db462-1b7a-4508-96f1-088f5c0881f0


behavior after:


https://github.com/apache/netbeans/assets/9607501/ddccd736-8a0b-46fa-81ba-c12d98aa2559


4)
- Write code:
```php
<?php

echo 'Hi';

$s = 12;

echo 'Hello';
```
- Put two breakpoints on the line `echo 'Hello';` with different conditions (the order in which the breakpoints are set is important!):
    - first `$s == 4`
    - then `$s == 12`

behavior before:

https://github.com/apache/netbeans/assets/9607501/539bb786-e87b-4b82-9fba-62fb59d01bff


behavior after:


https://github.com/apache/netbeans/assets/9607501/4332706f-4b31-439e-aceb-f478dc7e94c7

