### PR TITLE
Improve magic methods generation 

### DIFF
--- a/php/php.api.phpmodule/manifest.mf
+++ b/php/php.api.phpmodule/manifest.mf
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.php.api.phpmodule
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/api/phpmodule/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.94
+OpenIDE-Module-Specification-Version: 2.95

--- a/php/php.api.phpmodule/src/org/netbeans/modules/php/api/PhpVersion.java
+++ b/php/php.api.phpmodule/src/org/netbeans/modules/php/api/PhpVersion.java
@@ -201,6 +201,17 @@ public enum PhpVersion {
     }
 
     /**
+     * Check whether this version supports an object type.
+     *
+     * @return {@code true} if this version supports an object type,
+     * {@code false} otherwise
+     * @since 2.95
+     */
+    public boolean hasObjectType() {
+        return this.compareTo(PhpVersion.PHP_72) >= 0;
+    }
+
+    /**
      * Check whether this version supports typed properties.
      *
      * @return {@code true} if this version supports typed properties,

--- a/php/php.editor/nbproject/project.properties
+++ b/php/php.editor/nbproject/project.properties
@@ -18,7 +18,7 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 nbjavac.ignore.missing.enclosing=**/CUP$ASTPHP5Parser$actions.class
 nbm.needs.restart=true
-spec.version.base=2.34.0
+spec.version.base=2.35.0
 release.external/predefined_vars-1.0.zip=docs/predefined_vars.zip
 sigtest.gen.fail.on.error=false
 

--- a/php/php.editor/nbproject/project.xml
+++ b/php/php.editor/nbproject/project.xml
@@ -304,7 +304,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>2.94</specification-version>
+                        <specification-version>2.95</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/php/php.editor/src/org/netbeans/modules/php/editor/api/elements/ParameterElement.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/api/elements/ParameterElement.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.php.editor.api.elements;
 import java.util.Set;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.modules.csl.api.OffsetRange;
+import org.netbeans.modules.php.api.PhpVersion;
 
 /**
  * @author Radek Matous
@@ -30,6 +31,7 @@ public interface ParameterElement {
     String getName();
     String asString(OutputType outputType);
     String asString(OutputType outputType, TypeNameResolver typeNameResolver);
+    String asString(OutputType outputType, TypeNameResolver typeNameResolver, PhpVersion phpVersion);
     boolean isReference();
     boolean isVariadic();
     boolean isUnionType();

--- a/php/php.editor/src/org/netbeans/modules/php/editor/codegen/CGSInfo.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/codegen/CGSInfo.java
@@ -108,7 +108,8 @@ public final class CGSInfo {
     private boolean generateDoc;
     private boolean fluentSetter;
     private boolean isPublicModifier;
-
+    @NullAllowed
+    private Index index;
 
     private CGSInfo(JTextComponent textComp, PhpVersion phpVersion) {
         properties = new ArrayList<>();
@@ -215,6 +216,11 @@ public final class CGSInfo {
         return phpVersion;
     }
 
+    @CheckForNull
+    public Index getIndex() {
+        return index;
+    }
+
     public TypeNameResolver createTypeNameResolver(MethodElement method) {
         TypeNameResolver result;
         if (method.getParameters().isEmpty()) {
@@ -260,7 +266,7 @@ public final class CGSInfo {
                 className = getTypeName(typeDecl);
                 if (className != null) {
                     FileObject fileObject = info.getSnapshot().getSource().getFileObject();
-                    Index index = ElementQueryFactory.getIndexQuery(info);
+                    index = ElementQueryFactory.getIndexQuery(info);
                     final ElementFilter forFilesFilter = ElementFilter.forFiles(fileObject);
                     QualifiedName fullyQualifiedName = VariousUtils.getFullyQualifiedName(
                             QualifiedName.create(className),
@@ -513,12 +519,12 @@ public final class CGSInfo {
          */
         private List<String> getAllPossibleProperties(String possibleProperty) {
             List<String> allPossibleProperties = new LinkedList<>();
-            possibleProperty = possibleProperty.toLowerCase();
-            allPossibleProperties.add(possibleProperty);
-            if (possibleProperty.startsWith("_")) { // NOI18N
-                allPossibleProperties.add(possibleProperty.substring(1));
+            String lowerCasePossibleProperty = possibleProperty.toLowerCase(Locale.ROOT);
+            allPossibleProperties.add(lowerCasePossibleProperty);
+            if (lowerCasePossibleProperty.startsWith("_")) { // NOI18N
+                allPossibleProperties.add(lowerCasePossibleProperty.substring(1));
             } else {
-                allPossibleProperties.add("_" + possibleProperty); // NOI18N
+                allPossibleProperties.add("_" + lowerCasePossibleProperty); // NOI18N
             }
             return allPossibleProperties;
         }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/codegen/CGSInfo.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/codegen/CGSInfo.java
@@ -283,7 +283,7 @@ public final class CGSInfo {
                         final Set<MethodElement> methods = ElementFilter.forMembersOfTypes(preferedTypes).filter(accessibleMethods);
                         for (final MethodElement methodElement : methods) {
                             if (!methodElement.isFinal()) {
-                                methodProperties.add(new MethodProperty(methodElement, enclosingType));
+                                methodProperties.add(new MethodProperty(methodElement, enclosingType, phpVersion));
                             }
                         }
                         Collections.<MethodProperty>sort(methodProperties, MethodProperty.getComparator());

--- a/php/php.editor/src/org/netbeans/modules/php/editor/codegen/SinglePropertyMethodCreator.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/codegen/SinglePropertyMethodCreator.java
@@ -61,6 +61,12 @@ public interface SinglePropertyMethodCreator<T extends Property> {
                         BaseFunctionElement.PrintAs.DeclarationWithEmptyBody,
                         cgsInfo.createTypeNameResolver(method),
                         cgsInfo.getPhpVersion()).replace("abstract ", CodeUtils.EMPTY_STRING)); //NOI18N;
+                if (ElementUtils.isToStringMagicMethod(method)) {
+                    // GH-6783
+                    inheritedMethod.deleteCharAt(inheritedMethod.length() - 1); // delete "}"
+                    inheritedMethod.append(ElementUtils.getToStringMagicMethodBody(method.getType(), cgsInfo.getIndex()));
+                    inheritedMethod.append("\n}"); // NOI18N
+                }
             } else {
                 inheritedMethod.append(method.asString(
                         BaseFunctionElement.PrintAs.DeclarationWithParentCallInBody,

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCompletionItem.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCompletionItem.java
@@ -1324,7 +1324,9 @@ public abstract class PHPCompletionItem implements CompletionProposal {
             MethodElement method = (MethodElement) getBaseFunctionElement();
             TypeElement type = method.getType();
             Collection<TypeResolver> returnTypes = getBaseFunctionElement().getReturnTypes();
-            if (isMagic() || type.isInterface() || method.isAbstract() || type.isTrait() || ElementUtils.isVoidOrNeverType(returnTypes)) {
+            if (ElementUtils.isToStringMagicMethod(method)) {
+                template.append(getToStringMethodBody(type)).append("${cursor}\n"); // NOI18N
+            } else if (isMagic() || type.isInterface() || method.isAbstract() || type.isTrait() || ElementUtils.isVoidOrNeverType(returnTypes)) {
                 template.append("${cursor};\n"); //NOI18N
             } else {
                 if (returnTypes.size() == 1 || getBaseFunctionElement().isReturnUnionType()) {
@@ -1334,6 +1336,13 @@ public abstract class PHPCompletionItem implements CompletionProposal {
                 }
             }
             return template.toString();
+        }
+
+        private String getToStringMethodBody(TypeElement type) {
+            if (request != null) {
+                return ElementUtils.getToStringMagicMethodBody(type, request.index);
+            }
+            return CodeUtils.EMPTY_STRING;
         }
 
         private String getSignature() {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCompletionItem.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCompletionItem.java
@@ -1264,17 +1264,19 @@ public abstract class PHPCompletionItem implements CompletionProposal {
         }
 
         protected String getNameAndFunctionBodyForTemplate() {
+            FileObject fileObject = null;
+            if (request != null) {
+                fileObject = request.result.getSnapshot().getSource().getFileObject();
+            }
+            PhpVersion phpVersion = getPhpVersion(fileObject);
             StringBuilder template = new StringBuilder();
             TypeNameResolver typeNameResolver = getBaseFunctionElement().getParameters().isEmpty() || request == null
                     ? TypeNameResolverImpl.forNull()
                     : CodegenUtils.createSmarterTypeNameResolver(getBaseFunctionElement(), request.result.getModel(), request.anchor);
-            template.append(getBaseFunctionElement().asString(PrintAs.NameAndParamsDeclaration, typeNameResolver));
+            template.append(getBaseFunctionElement().asString(PrintAs.NameAndParamsDeclaration, typeNameResolver, phpVersion));
             // #270237
-            FileObject fileObject = null;
             if (request != null) {
                 // resquest is null if completion items are used in the IntroduceSuggestion hint
-                fileObject = request.result.getSnapshot().getSource().getFileObject();
-                PhpVersion phpVersion = getPhpVersion(fileObject);
                 if (phpVersion != null
                         && phpVersion.compareTo(PhpVersion.PHP_70) >= 0) {
                     Collection<TypeResolver> returnTypes = getBaseFunctionElement().getReturnTypes();

--- a/php/php.editor/src/org/netbeans/modules/php/editor/elements/ElementUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/elements/ElementUtils.java
@@ -18,8 +18,13 @@
  */
 package org.netbeans.modules.php.editor.elements;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import org.netbeans.modules.php.editor.api.ElementQuery.Index;
+import org.netbeans.modules.php.editor.api.elements.FieldElement;
 import org.netbeans.modules.php.editor.api.elements.MethodElement;
+import org.netbeans.modules.php.editor.api.elements.TypeElement;
 import org.netbeans.modules.php.editor.api.elements.TypeResolver;
 import org.netbeans.modules.php.editor.model.impl.Type;
 
@@ -42,5 +47,36 @@ public final class ElementUtils {
             }
         }
         return false;
+    }
+
+    public static boolean isToStringMagicMethod(MethodElement method) {
+        return method.getName().equals("__toString"); // NOI18N
+    }
+
+    public static String getToStringMagicMethodBody(TypeElement type, Index index) {
+        StringBuilder sb = new StringBuilder();
+        if (index != null) {
+            List<FieldElement> allFields = new ArrayList<>(index.getAlllFields(type));
+            allFields.sort((f1, f2) -> Integer.compare(f1.getOffset(), f2.getOffset()));
+            sb.append("return \"").append(type.getName()).append("["); // NOI18N
+            if (allFields.isEmpty()) {
+                sb.append("]\";"); // NOI18N
+            } else {
+                boolean isFirst = true;
+                for (FieldElement field : allFields) {
+                    if (field.isStatic()) {
+                        continue;
+                    }
+                    if (isFirst) {
+                        isFirst = false;
+                    } else {
+                        sb.append("\n. \", "); // NOI18N
+                    }
+                    sb.append(field.getName(false)).append("=\"").append(" . $this->").append(field.getName(false));
+                }
+                sb.append("\n. \"]\";"); // NOI18N
+            }
+        }
+        return sb.toString();
     }
 }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/Type.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/Type.java
@@ -284,4 +284,37 @@ public final class Type {
     public static String toTypeTemplate(String typeDeclaration) {
         return CodeUtils.TYPE_NAMES_IN_TYPE_DECLARATION_PATTERN.matcher(typeDeclaration.replace(" ", "")).replaceAll("%s"); // NOI18N
     }
+
+    /**
+     * Check whether a declaration type is a union type.
+     *
+     * @param typeDeclaration a type declaration
+     * @return {@code true} if it's a union type, {@code false} otherwise
+     */
+    public static boolean isUnionType(@NullAllowed String typeDeclaration) {
+        return typeDeclaration != null
+                && typeDeclaration.contains(SEPARATOR);
+    }
+
+    /**
+     * Check whether a declaration type is an intersection type.
+     *
+     * @param typeDeclaration a type declaration
+     * @return {@code true} if it's an intersection type, {@code false}
+     * otherwise
+     */
+    public static boolean isIntersectionType(@NullAllowed String typeDeclaration) {
+        return typeDeclaration != null
+                && typeDeclaration.contains(SEPARATOR_INTERSECTION);
+    }
+
+    /**
+     * Check whether a declaration type is a DNF type.
+     *
+     * @param typeDeclaration a type declaration
+     * @return {@code true} if it's a DNF type, {@code false} otherwise
+     */
+    public static boolean isDNFType(@NullAllowed String typeDeclaration) {
+        return isUnionType(typeDeclaration) && isIntersectionType(typeDeclaration);
+    }
 }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/IntroduceSuggestion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/IntroduceSuggestion.java
@@ -1055,7 +1055,7 @@ public class IntroduceSuggestion extends SuggestionRule {
 
     private static PHPCompletionItem.MethodDeclarationItem createMethodDeclarationItem(final TypeScope typeScope, final MethodInvocation node) {
         final String methodName = CodeUtils.extractFunctionName(node.getMethod());
-        final MethodElement method = MethodElementImpl.createMagicMethod(typeScope,
+        final MethodElement method = MethodElementImpl.forIntroduceHint(typeScope,
                 methodName, 0, getParameters(node.getMethod().getParameters()));
         return typeScope.isInterface()
                 ? PHPCompletionItem.MethodDeclarationItem.forIntroduceInterfaceHint(method, null)
@@ -1064,7 +1064,7 @@ public class IntroduceSuggestion extends SuggestionRule {
 
     private static PHPCompletionItem.MethodDeclarationItem createMethodDeclarationItem(final TypeScope typeScope, final StaticMethodInvocation node) {
         final String methodName = CodeUtils.extractFunctionName(node.getMethod());
-        final MethodElement method = MethodElementImpl.createMagicMethod(typeScope, methodName,
+        final MethodElement method = MethodElementImpl.forIntroduceHint(typeScope, methodName,
                 Modifier.STATIC, getParameters(node.getMethod().getParameters()));
         return PHPCompletionItem.MethodDeclarationItem.forIntroduceHint(method, null);
     }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethodToString01/testMagicMethodToString01.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethodToString01/testMagicMethodToString01.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class TestMagicMethodToString {
+    public string $name;
+    private int $age;
+    protected string $phoneNumber;
+    private string $emailAddress;
+    // test
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethodToString01/testMagicMethodToString01.php.testMagicMethodToString01_PHP83.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethodToString01/testMagicMethodToString01.php.testMagicMethodToString01_PHP83.codegen
@@ -1,0 +1,7 @@
+public function __toString(): string{
+return "TestMagicMethodToString[name=" . $this->name
+. ", age=" . $this->age
+. ", phoneNumber=" . $this->phoneNumber
+. ", emailAddress=" . $this->emailAddress
+. "]";
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethodToString02/testMagicMethodToString02.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethodToString02/testMagicMethodToString02.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class TestMagicMethodToString {
+
+    public const CONSTANT1 = 1;
+    protected const CONSTANT2 = 2;
+    private const CONSTANT3 = 3;
+
+    public string $name;
+    private int $age;
+    protected string $phoneNumber;
+    private string $emailAddress;
+
+    public static int $static1;
+    private static int $static2;
+    protected static int $static3;
+
+    // test
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethodToString02/testMagicMethodToString02.php.testMagicMethodToString02_PHP83.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethodToString02/testMagicMethodToString02.php.testMagicMethodToString02_PHP83.codegen
@@ -1,0 +1,7 @@
+public function __toString(): string{
+return "TestMagicMethodToString[name=" . $this->name
+. ", age=" . $this->age
+. ", phoneNumber=" . $this->phoneNumber
+. ", emailAddress=" . $this->emailAddress
+. "]";
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class TestMagicMethods {
+    // test
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP56.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP56.codegen
@@ -1,0 +1,34 @@
+public function __construct(){
+}
+public function __call(string $name, array $arguments){
+}
+public static function __callStatic(string $name, array $arguments){
+}
+public function __clone(){
+}
+public function __debugInfo(){
+}
+public function __destruct(){
+}
+public function __get(string $name){
+}
+public function __invoke(){
+}
+public function __isset(string $name){
+}
+public function __serialize(){
+}
+public function __set(string $name, $value){
+}
+public static function __set_state(array $properties){
+}
+public function __sleep(){
+}
+public function __toString(){
+}
+public function __unserialize(array $data){
+}
+public function __unset(string $name){
+}
+public function __wakeup(){
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP56.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP56.codegen
@@ -25,6 +25,7 @@ public static function __set_state(array $properties){
 public function __sleep(){
 }
 public function __toString(){
+return "TestMagicMethods[]";
 }
 public function __unserialize(array $data){
 }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP70.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP70.codegen
@@ -25,6 +25,7 @@ public static function __set_state(array $properties){
 public function __sleep(): array{
 }
 public function __toString(): string{
+return "TestMagicMethods[]";
 }
 public function __unserialize(array $data){
 }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP70.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP70.codegen
@@ -1,0 +1,34 @@
+public function __construct(){
+}
+public function __call(string $name, array $arguments){
+}
+public static function __callStatic(string $name, array $arguments){
+}
+public function __clone(){
+}
+public function __debugInfo(): array{
+}
+public function __destruct(){
+}
+public function __get(string $name){
+}
+public function __invoke(){
+}
+public function __isset(string $name): bool{
+}
+public function __serialize(): array{
+}
+public function __set(string $name, $value){
+}
+public static function __set_state(array $properties){
+}
+public function __sleep(): array{
+}
+public function __toString(): string{
+}
+public function __unserialize(array $data){
+}
+public function __unset(string $name){
+}
+public function __wakeup(){
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP71.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP71.codegen
@@ -1,0 +1,34 @@
+public function __construct(){
+}
+public function __call(string $name, array $arguments){
+}
+public static function __callStatic(string $name, array $arguments){
+}
+public function __clone(): void{
+}
+public function __debugInfo(): array{
+}
+public function __destruct(){
+}
+public function __get(string $name){
+}
+public function __invoke(){
+}
+public function __isset(string $name): bool{
+}
+public function __serialize(): array{
+}
+public function __set(string $name, $value): void{
+}
+public static function __set_state(array $properties){
+}
+public function __sleep(): array{
+}
+public function __toString(): string{
+}
+public function __unserialize(array $data): void{
+}
+public function __unset(string $name): void{
+}
+public function __wakeup(): void{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP71.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP71.codegen
@@ -25,6 +25,7 @@ public static function __set_state(array $properties){
 public function __sleep(): array{
 }
 public function __toString(): string{
+return "TestMagicMethods[]";
 }
 public function __unserialize(array $data): void{
 }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP72.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP72.codegen
@@ -1,0 +1,34 @@
+public function __construct(){
+}
+public function __call(string $name, array $arguments){
+}
+public static function __callStatic(string $name, array $arguments){
+}
+public function __clone(): void{
+}
+public function __debugInfo(): array{
+}
+public function __destruct(){
+}
+public function __get(string $name){
+}
+public function __invoke(){
+}
+public function __isset(string $name): bool{
+}
+public function __serialize(): array{
+}
+public function __set(string $name, $value): void{
+}
+public static function __set_state(array $properties): object{
+}
+public function __sleep(): array{
+}
+public function __toString(): string{
+}
+public function __unserialize(array $data): void{
+}
+public function __unset(string $name): void{
+}
+public function __wakeup(): void{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP72.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP72.codegen
@@ -25,6 +25,7 @@ public static function __set_state(array $properties): object{
 public function __sleep(): array{
 }
 public function __toString(): string{
+return "TestMagicMethods[]";
 }
 public function __unserialize(array $data): void{
 }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP73.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP73.codegen
@@ -1,0 +1,34 @@
+public function __construct(){
+}
+public function __call(string $name, array $arguments){
+}
+public static function __callStatic(string $name, array $arguments){
+}
+public function __clone(): void{
+}
+public function __debugInfo(): array{
+}
+public function __destruct(){
+}
+public function __get(string $name){
+}
+public function __invoke(){
+}
+public function __isset(string $name): bool{
+}
+public function __serialize(): array{
+}
+public function __set(string $name, $value): void{
+}
+public static function __set_state(array $properties): object{
+}
+public function __sleep(): array{
+}
+public function __toString(): string{
+}
+public function __unserialize(array $data): void{
+}
+public function __unset(string $name): void{
+}
+public function __wakeup(): void{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP73.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP73.codegen
@@ -25,6 +25,7 @@ public static function __set_state(array $properties): object{
 public function __sleep(): array{
 }
 public function __toString(): string{
+return "TestMagicMethods[]";
 }
 public function __unserialize(array $data): void{
 }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP74.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP74.codegen
@@ -1,0 +1,34 @@
+public function __construct(){
+}
+public function __call(string $name, array $arguments){
+}
+public static function __callStatic(string $name, array $arguments){
+}
+public function __clone(): void{
+}
+public function __debugInfo(): array{
+}
+public function __destruct(){
+}
+public function __get(string $name){
+}
+public function __invoke(){
+}
+public function __isset(string $name): bool{
+}
+public function __serialize(): array{
+}
+public function __set(string $name, $value): void{
+}
+public static function __set_state(array $properties): object{
+}
+public function __sleep(): array{
+}
+public function __toString(): string{
+}
+public function __unserialize(array $data): void{
+}
+public function __unset(string $name): void{
+}
+public function __wakeup(): void{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP74.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP74.codegen
@@ -25,6 +25,7 @@ public static function __set_state(array $properties): object{
 public function __sleep(): array{
 }
 public function __toString(): string{
+return "TestMagicMethods[]";
 }
 public function __unserialize(array $data): void{
 }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP80.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP80.codegen
@@ -25,6 +25,7 @@ public static function __set_state(array $properties): object{
 public function __sleep(): array{
 }
 public function __toString(): string{
+return "TestMagicMethods[]";
 }
 public function __unserialize(array $data): void{
 }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP80.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP80.codegen
@@ -1,0 +1,34 @@
+public function __construct(){
+}
+public function __call(string $name, array $arguments): mixed{
+}
+public static function __callStatic(string $name, array $arguments): mixed{
+}
+public function __clone(): void{
+}
+public function __debugInfo(): array{
+}
+public function __destruct(){
+}
+public function __get(string $name): mixed{
+}
+public function __invoke(): mixed{
+}
+public function __isset(string $name): bool{
+}
+public function __serialize(): array{
+}
+public function __set(string $name, mixed $value): void{
+}
+public static function __set_state(array $properties): object{
+}
+public function __sleep(): array{
+}
+public function __toString(): string{
+}
+public function __unserialize(array $data): void{
+}
+public function __unset(string $name): void{
+}
+public function __wakeup(): void{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP81.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP81.codegen
@@ -25,6 +25,7 @@ public static function __set_state(array $properties): object{
 public function __sleep(): array{
 }
 public function __toString(): string{
+return "TestMagicMethods[]";
 }
 public function __unserialize(array $data): void{
 }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP81.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP81.codegen
@@ -1,0 +1,34 @@
+public function __construct(){
+}
+public function __call(string $name, array $arguments): mixed{
+}
+public static function __callStatic(string $name, array $arguments): mixed{
+}
+public function __clone(): void{
+}
+public function __debugInfo(): array{
+}
+public function __destruct(){
+}
+public function __get(string $name): mixed{
+}
+public function __invoke(): mixed{
+}
+public function __isset(string $name): bool{
+}
+public function __serialize(): array{
+}
+public function __set(string $name, mixed $value): void{
+}
+public static function __set_state(array $properties): object{
+}
+public function __sleep(): array{
+}
+public function __toString(): string{
+}
+public function __unserialize(array $data): void{
+}
+public function __unset(string $name): void{
+}
+public function __wakeup(): void{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP82.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP82.codegen
@@ -25,6 +25,7 @@ public static function __set_state(array $properties): object{
 public function __sleep(): array{
 }
 public function __toString(): string{
+return "TestMagicMethods[]";
 }
 public function __unserialize(array $data): void{
 }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP82.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP82.codegen
@@ -1,0 +1,34 @@
+public function __construct(){
+}
+public function __call(string $name, array $arguments): mixed{
+}
+public static function __callStatic(string $name, array $arguments): mixed{
+}
+public function __clone(): void{
+}
+public function __debugInfo(): array{
+}
+public function __destruct(){
+}
+public function __get(string $name): mixed{
+}
+public function __invoke(): mixed{
+}
+public function __isset(string $name): bool{
+}
+public function __serialize(): array{
+}
+public function __set(string $name, mixed $value): void{
+}
+public static function __set_state(array $properties): object{
+}
+public function __sleep(): array{
+}
+public function __toString(): string{
+}
+public function __unserialize(array $data): void{
+}
+public function __unset(string $name): void{
+}
+public function __wakeup(): void{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP83.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP83.codegen
@@ -25,6 +25,7 @@ public static function __set_state(array $properties): object{
 public function __sleep(): array{
 }
 public function __toString(): string{
+return "TestMagicMethods[]";
 }
 public function __unserialize(array $data): void{
 }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP83.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testMagicMethods01/testMagicMethods01.php.testMagicMethods01_PHP83.codegen
@@ -1,0 +1,34 @@
+public function __construct(){
+}
+public function __call(string $name, array $arguments): mixed{
+}
+public static function __callStatic(string $name, array $arguments): mixed{
+}
+public function __clone(): void{
+}
+public function __debugInfo(): array{
+}
+public function __destruct(){
+}
+public function __get(string $name): mixed{
+}
+public function __invoke(): mixed{
+}
+public function __isset(string $name): bool{
+}
+public function __serialize(): array{
+}
+public function __set(string $name, mixed $value): void{
+}
+public static function __set_state(array $properties): object{
+}
+public function __sleep(): array{
+}
+public function __toString(): string{
+}
+public function __unserialize(array $data): void{
+}
+public function __unset(string $name): void{
+}
+public function __wakeup(): void{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testOverrideAttributeEnum01/testOverrideAttributeEnum01.php.testOverrideAttributeEnum01.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testOverrideAttributeEnum01/testOverrideAttributeEnum01.php.testOverrideAttributeEnum01.codegen
@@ -21,9 +21,9 @@ public function testInterfaceMethod(): void{
 }
 public function testTraitMethod(): void{
 }
-public function __call($name, $arguments){
+public function __call(string $name, array $arguments): mixed{
 }
-public static function __callStatic($name, $arguments){
+public static function __callStatic(string $name, array $arguments): mixed{
 }
-public function __invoke(){
+public function __invoke(): mixed{
 }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testOverrideAttributeEnum01/testOverrideAttributeEnum01.php.testOverrideAttributeEnum01_PHP82.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testOverrideAttributeEnum01/testOverrideAttributeEnum01.php.testOverrideAttributeEnum01_PHP82.codegen
@@ -14,9 +14,9 @@ public function testInterfaceMethod(): void{
 }
 public function testTraitMethod(): void{
 }
-public function __call($name, $arguments){
+public function __call(string $name, array $arguments): mixed{
 }
-public static function __callStatic($name, $arguments){
+public static function __callStatic(string $name, array $arguments): mixed{
 }
-public function __invoke(){
+public function __invoke(): mixed{
 }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testSerializeUnserializeMagicMethod/testSerializeUnserializeMagicMethod.php.testSerializeUnserializeMagicMethod.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testSerializeUnserializeMagicMethod/testSerializeUnserializeMagicMethod.php.testSerializeUnserializeMagicMethod.codegen
@@ -1,4 +1,4 @@
-public function __serialize(){
+public function __serialize(): array{
 }
-public function __unserialize(array $data){
+public function __unserialize(array $data): void{
 }

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/insideClass.php.testInsideClass_2.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/insideClass.php.testInsideClass_2.completion
@@ -2,17 +2,18 @@ Code completion result for source line:
 public function |setFld($fld) {
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
-METHOD     __call($name, $arguments) - ge  [PUBLIC]   Magic Method
-METHOD     __callStatic($name, $arguments  [STATIC]   Magic Method
+METHOD     __call(string $name, array $ar  [PUBLIC]   Magic Method
+METHOD     __callStatic(string $name, arr  [STATIC]   Magic Method
 METHOD     __clone() - generate            [PUBLIC]   Magic Method
-METHOD     __get($name) - generate         [PUBLIC]   Magic Method
+METHOD     __debugInfo() - generate        [PUBLIC]   Magic Method
+METHOD     __get(string $name) - generate  [PUBLIC]   Magic Method
 METHOD     __invoke() - generate           [PUBLIC]   Magic Method
-METHOD     __isset($name) - generate       [PUBLIC]   Magic Method
+METHOD     __isset(string $name) - genera  [PUBLIC]   Magic Method
 METHOD     __serialize() - generate        [PUBLIC]   Magic Method
-METHOD     __set($name, $value) - generat  [PUBLIC]   Magic Method
-METHOD     __set_state($array) - generate  [STATIC]   Magic Method
+METHOD     __set(string $name, mixed $val  [PUBLIC]   Magic Method
+METHOD     __set_state(array $properties)  [STATIC]   Magic Method
 METHOD     __sleep() - generate            [PUBLIC]   Magic Method
 METHOD     __toString() - generate         [PUBLIC]   Magic Method
 METHOD     __unserialize(array $data) - g  [PUBLIC]   Magic Method
-METHOD     __unset($name) - generate       [PUBLIC]   Magic Method
+METHOD     __unset(string $name) - genera  [PUBLIC]   Magic Method
 METHOD     __wakeup() - generate           [PUBLIC]   Magic Method

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class MagicMethods {
+    __
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP56.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP56.cccustomtpl
@@ -1,0 +1,84 @@
+Name: __call
+public function __call(string $name, array $arguments) {
+${cursor};
+}
+
+Name: __callStatic
+public static function __callStatic(string $name, array $arguments) {
+${cursor};
+}
+
+Name: __clone
+public function __clone() {
+${cursor};
+}
+
+Name: __construct
+public function __construct() {
+${cursor};
+}
+
+Name: __debugInfo
+public function __debugInfo() {
+${cursor};
+}
+
+Name: __destruct
+public function __destruct() {
+${cursor};
+}
+
+Name: __get
+public function __get(string $name) {
+${cursor};
+}
+
+Name: __invoke
+public function __invoke() {
+${cursor};
+}
+
+Name: __isset
+public function __isset(string $name) {
+${cursor};
+}
+
+Name: __serialize
+public function __serialize() {
+${cursor};
+}
+
+Name: __set
+public function __set(string $name, $value) {
+${cursor};
+}
+
+Name: __set_state
+public static function __set_state(array $properties) {
+${cursor};
+}
+
+Name: __sleep
+public function __sleep() {
+${cursor};
+}
+
+Name: __toString
+public function __toString() {
+${cursor};
+}
+
+Name: __unserialize
+public function __unserialize(array $data) {
+${cursor};
+}
+
+Name: __unset
+public function __unset(string $name) {
+${cursor};
+}
+
+Name: __wakeup
+public function __wakeup() {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP56.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP56.cccustomtpl
@@ -65,7 +65,7 @@ ${cursor};
 
 Name: __toString
 public function __toString() {
-${cursor};
+return "MagicMethods[]";${cursor}
 }
 
 Name: __unserialize

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP70.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP70.cccustomtpl
@@ -1,0 +1,84 @@
+Name: __call
+public function __call(string $name, array $arguments) {
+${cursor};
+}
+
+Name: __callStatic
+public static function __callStatic(string $name, array $arguments) {
+${cursor};
+}
+
+Name: __clone
+public function __clone() {
+${cursor};
+}
+
+Name: __construct
+public function __construct() {
+${cursor};
+}
+
+Name: __debugInfo
+public function __debugInfo(): array {
+${cursor};
+}
+
+Name: __destruct
+public function __destruct() {
+${cursor};
+}
+
+Name: __get
+public function __get(string $name) {
+${cursor};
+}
+
+Name: __invoke
+public function __invoke() {
+${cursor};
+}
+
+Name: __isset
+public function __isset(string $name): bool {
+${cursor};
+}
+
+Name: __serialize
+public function __serialize(): array {
+${cursor};
+}
+
+Name: __set
+public function __set(string $name, $value) {
+${cursor};
+}
+
+Name: __set_state
+public static function __set_state(array $properties) {
+${cursor};
+}
+
+Name: __sleep
+public function __sleep(): array {
+${cursor};
+}
+
+Name: __toString
+public function __toString(): string {
+${cursor};
+}
+
+Name: __unserialize
+public function __unserialize(array $data) {
+${cursor};
+}
+
+Name: __unset
+public function __unset(string $name) {
+${cursor};
+}
+
+Name: __wakeup
+public function __wakeup() {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP70.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP70.cccustomtpl
@@ -65,7 +65,7 @@ ${cursor};
 
 Name: __toString
 public function __toString(): string {
-${cursor};
+return "MagicMethods[]";${cursor}
 }
 
 Name: __unserialize

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP71.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP71.cccustomtpl
@@ -1,0 +1,84 @@
+Name: __call
+public function __call(string $name, array $arguments) {
+${cursor};
+}
+
+Name: __callStatic
+public static function __callStatic(string $name, array $arguments) {
+${cursor};
+}
+
+Name: __clone
+public function __clone(): void {
+${cursor};
+}
+
+Name: __construct
+public function __construct() {
+${cursor};
+}
+
+Name: __debugInfo
+public function __debugInfo(): array {
+${cursor};
+}
+
+Name: __destruct
+public function __destruct() {
+${cursor};
+}
+
+Name: __get
+public function __get(string $name) {
+${cursor};
+}
+
+Name: __invoke
+public function __invoke() {
+${cursor};
+}
+
+Name: __isset
+public function __isset(string $name): bool {
+${cursor};
+}
+
+Name: __serialize
+public function __serialize(): array {
+${cursor};
+}
+
+Name: __set
+public function __set(string $name, $value): void {
+${cursor};
+}
+
+Name: __set_state
+public static function __set_state(array $properties) {
+${cursor};
+}
+
+Name: __sleep
+public function __sleep(): array {
+${cursor};
+}
+
+Name: __toString
+public function __toString(): string {
+${cursor};
+}
+
+Name: __unserialize
+public function __unserialize(array $data): void {
+${cursor};
+}
+
+Name: __unset
+public function __unset(string $name): void {
+${cursor};
+}
+
+Name: __wakeup
+public function __wakeup(): void {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP71.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP71.cccustomtpl
@@ -65,7 +65,7 @@ ${cursor};
 
 Name: __toString
 public function __toString(): string {
-${cursor};
+return "MagicMethods[]";${cursor}
 }
 
 Name: __unserialize

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP72.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP72.cccustomtpl
@@ -1,0 +1,84 @@
+Name: __call
+public function __call(string $name, array $arguments) {
+${cursor};
+}
+
+Name: __callStatic
+public static function __callStatic(string $name, array $arguments) {
+${cursor};
+}
+
+Name: __clone
+public function __clone(): void {
+${cursor};
+}
+
+Name: __construct
+public function __construct() {
+${cursor};
+}
+
+Name: __debugInfo
+public function __debugInfo(): array {
+${cursor};
+}
+
+Name: __destruct
+public function __destruct() {
+${cursor};
+}
+
+Name: __get
+public function __get(string $name) {
+${cursor};
+}
+
+Name: __invoke
+public function __invoke() {
+${cursor};
+}
+
+Name: __isset
+public function __isset(string $name): bool {
+${cursor};
+}
+
+Name: __serialize
+public function __serialize(): array {
+${cursor};
+}
+
+Name: __set
+public function __set(string $name, $value): void {
+${cursor};
+}
+
+Name: __set_state
+public static function __set_state(array $properties): object {
+${cursor};
+}
+
+Name: __sleep
+public function __sleep(): array {
+${cursor};
+}
+
+Name: __toString
+public function __toString(): string {
+${cursor};
+}
+
+Name: __unserialize
+public function __unserialize(array $data): void {
+${cursor};
+}
+
+Name: __unset
+public function __unset(string $name): void {
+${cursor};
+}
+
+Name: __wakeup
+public function __wakeup(): void {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP72.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP72.cccustomtpl
@@ -65,7 +65,7 @@ ${cursor};
 
 Name: __toString
 public function __toString(): string {
-${cursor};
+return "MagicMethods[]";${cursor}
 }
 
 Name: __unserialize

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP73.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP73.cccustomtpl
@@ -1,0 +1,84 @@
+Name: __call
+public function __call(string $name, array $arguments) {
+${cursor};
+}
+
+Name: __callStatic
+public static function __callStatic(string $name, array $arguments) {
+${cursor};
+}
+
+Name: __clone
+public function __clone(): void {
+${cursor};
+}
+
+Name: __construct
+public function __construct() {
+${cursor};
+}
+
+Name: __debugInfo
+public function __debugInfo(): array {
+${cursor};
+}
+
+Name: __destruct
+public function __destruct() {
+${cursor};
+}
+
+Name: __get
+public function __get(string $name) {
+${cursor};
+}
+
+Name: __invoke
+public function __invoke() {
+${cursor};
+}
+
+Name: __isset
+public function __isset(string $name): bool {
+${cursor};
+}
+
+Name: __serialize
+public function __serialize(): array {
+${cursor};
+}
+
+Name: __set
+public function __set(string $name, $value): void {
+${cursor};
+}
+
+Name: __set_state
+public static function __set_state(array $properties): object {
+${cursor};
+}
+
+Name: __sleep
+public function __sleep(): array {
+${cursor};
+}
+
+Name: __toString
+public function __toString(): string {
+${cursor};
+}
+
+Name: __unserialize
+public function __unserialize(array $data): void {
+${cursor};
+}
+
+Name: __unset
+public function __unset(string $name): void {
+${cursor};
+}
+
+Name: __wakeup
+public function __wakeup(): void {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP73.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP73.cccustomtpl
@@ -65,7 +65,7 @@ ${cursor};
 
 Name: __toString
 public function __toString(): string {
-${cursor};
+return "MagicMethods[]";${cursor}
 }
 
 Name: __unserialize

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP74.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP74.cccustomtpl
@@ -1,0 +1,84 @@
+Name: __call
+public function __call(string $name, array $arguments) {
+${cursor};
+}
+
+Name: __callStatic
+public static function __callStatic(string $name, array $arguments) {
+${cursor};
+}
+
+Name: __clone
+public function __clone(): void {
+${cursor};
+}
+
+Name: __construct
+public function __construct() {
+${cursor};
+}
+
+Name: __debugInfo
+public function __debugInfo(): array {
+${cursor};
+}
+
+Name: __destruct
+public function __destruct() {
+${cursor};
+}
+
+Name: __get
+public function __get(string $name) {
+${cursor};
+}
+
+Name: __invoke
+public function __invoke() {
+${cursor};
+}
+
+Name: __isset
+public function __isset(string $name): bool {
+${cursor};
+}
+
+Name: __serialize
+public function __serialize(): array {
+${cursor};
+}
+
+Name: __set
+public function __set(string $name, $value): void {
+${cursor};
+}
+
+Name: __set_state
+public static function __set_state(array $properties): object {
+${cursor};
+}
+
+Name: __sleep
+public function __sleep(): array {
+${cursor};
+}
+
+Name: __toString
+public function __toString(): string {
+${cursor};
+}
+
+Name: __unserialize
+public function __unserialize(array $data): void {
+${cursor};
+}
+
+Name: __unset
+public function __unset(string $name): void {
+${cursor};
+}
+
+Name: __wakeup
+public function __wakeup(): void {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP74.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP74.cccustomtpl
@@ -65,7 +65,7 @@ ${cursor};
 
 Name: __toString
 public function __toString(): string {
-${cursor};
+return "MagicMethods[]";${cursor}
 }
 
 Name: __unserialize

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP80.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP80.cccustomtpl
@@ -65,7 +65,7 @@ ${cursor};
 
 Name: __toString
 public function __toString(): string {
-${cursor};
+return "MagicMethods[]";${cursor}
 }
 
 Name: __unserialize

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP80.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP80.cccustomtpl
@@ -1,0 +1,84 @@
+Name: __call
+public function __call(string $name, array $arguments): mixed {
+${cursor};
+}
+
+Name: __callStatic
+public static function __callStatic(string $name, array $arguments): mixed {
+${cursor};
+}
+
+Name: __clone
+public function __clone(): void {
+${cursor};
+}
+
+Name: __construct
+public function __construct() {
+${cursor};
+}
+
+Name: __debugInfo
+public function __debugInfo(): array {
+${cursor};
+}
+
+Name: __destruct
+public function __destruct() {
+${cursor};
+}
+
+Name: __get
+public function __get(string $name): mixed {
+${cursor};
+}
+
+Name: __invoke
+public function __invoke(): mixed {
+${cursor};
+}
+
+Name: __isset
+public function __isset(string $name): bool {
+${cursor};
+}
+
+Name: __serialize
+public function __serialize(): array {
+${cursor};
+}
+
+Name: __set
+public function __set(string $name, mixed $value): void {
+${cursor};
+}
+
+Name: __set_state
+public static function __set_state(array $properties): object {
+${cursor};
+}
+
+Name: __sleep
+public function __sleep(): array {
+${cursor};
+}
+
+Name: __toString
+public function __toString(): string {
+${cursor};
+}
+
+Name: __unserialize
+public function __unserialize(array $data): void {
+${cursor};
+}
+
+Name: __unset
+public function __unset(string $name): void {
+${cursor};
+}
+
+Name: __wakeup
+public function __wakeup(): void {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP81.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP81.cccustomtpl
@@ -65,7 +65,7 @@ ${cursor};
 
 Name: __toString
 public function __toString(): string {
-${cursor};
+return "MagicMethods[]";${cursor}
 }
 
 Name: __unserialize

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP81.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP81.cccustomtpl
@@ -1,0 +1,84 @@
+Name: __call
+public function __call(string $name, array $arguments): mixed {
+${cursor};
+}
+
+Name: __callStatic
+public static function __callStatic(string $name, array $arguments): mixed {
+${cursor};
+}
+
+Name: __clone
+public function __clone(): void {
+${cursor};
+}
+
+Name: __construct
+public function __construct() {
+${cursor};
+}
+
+Name: __debugInfo
+public function __debugInfo(): array {
+${cursor};
+}
+
+Name: __destruct
+public function __destruct() {
+${cursor};
+}
+
+Name: __get
+public function __get(string $name): mixed {
+${cursor};
+}
+
+Name: __invoke
+public function __invoke(): mixed {
+${cursor};
+}
+
+Name: __isset
+public function __isset(string $name): bool {
+${cursor};
+}
+
+Name: __serialize
+public function __serialize(): array {
+${cursor};
+}
+
+Name: __set
+public function __set(string $name, mixed $value): void {
+${cursor};
+}
+
+Name: __set_state
+public static function __set_state(array $properties): object {
+${cursor};
+}
+
+Name: __sleep
+public function __sleep(): array {
+${cursor};
+}
+
+Name: __toString
+public function __toString(): string {
+${cursor};
+}
+
+Name: __unserialize
+public function __unserialize(array $data): void {
+${cursor};
+}
+
+Name: __unset
+public function __unset(string $name): void {
+${cursor};
+}
+
+Name: __wakeup
+public function __wakeup(): void {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP82.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP82.cccustomtpl
@@ -65,7 +65,7 @@ ${cursor};
 
 Name: __toString
 public function __toString(): string {
-${cursor};
+return "MagicMethods[]";${cursor}
 }
 
 Name: __unserialize

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP82.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP82.cccustomtpl
@@ -1,0 +1,84 @@
+Name: __call
+public function __call(string $name, array $arguments): mixed {
+${cursor};
+}
+
+Name: __callStatic
+public static function __callStatic(string $name, array $arguments): mixed {
+${cursor};
+}
+
+Name: __clone
+public function __clone(): void {
+${cursor};
+}
+
+Name: __construct
+public function __construct() {
+${cursor};
+}
+
+Name: __debugInfo
+public function __debugInfo(): array {
+${cursor};
+}
+
+Name: __destruct
+public function __destruct() {
+${cursor};
+}
+
+Name: __get
+public function __get(string $name): mixed {
+${cursor};
+}
+
+Name: __invoke
+public function __invoke(): mixed {
+${cursor};
+}
+
+Name: __isset
+public function __isset(string $name): bool {
+${cursor};
+}
+
+Name: __serialize
+public function __serialize(): array {
+${cursor};
+}
+
+Name: __set
+public function __set(string $name, mixed $value): void {
+${cursor};
+}
+
+Name: __set_state
+public static function __set_state(array $properties): object {
+${cursor};
+}
+
+Name: __sleep
+public function __sleep(): array {
+${cursor};
+}
+
+Name: __toString
+public function __toString(): string {
+${cursor};
+}
+
+Name: __unserialize
+public function __unserialize(array $data): void {
+${cursor};
+}
+
+Name: __unset
+public function __unset(string $name): void {
+${cursor};
+}
+
+Name: __wakeup
+public function __wakeup(): void {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP83.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP83.cccustomtpl
@@ -65,7 +65,7 @@ ${cursor};
 
 Name: __toString
 public function __toString(): string {
-${cursor};
+return "MagicMethods[]";${cursor}
 }
 
 Name: __unserialize

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP83.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodsCustomTemplate/magicMethods.php.testMagicMethodsCustomTemplate_PHP83.cccustomtpl
@@ -1,0 +1,84 @@
+Name: __call
+public function __call(string $name, array $arguments): mixed {
+${cursor};
+}
+
+Name: __callStatic
+public static function __callStatic(string $name, array $arguments): mixed {
+${cursor};
+}
+
+Name: __clone
+public function __clone(): void {
+${cursor};
+}
+
+Name: __construct
+public function __construct() {
+${cursor};
+}
+
+Name: __debugInfo
+public function __debugInfo(): array {
+${cursor};
+}
+
+Name: __destruct
+public function __destruct() {
+${cursor};
+}
+
+Name: __get
+public function __get(string $name): mixed {
+${cursor};
+}
+
+Name: __invoke
+public function __invoke(): mixed {
+${cursor};
+}
+
+Name: __isset
+public function __isset(string $name): bool {
+${cursor};
+}
+
+Name: __serialize
+public function __serialize(): array {
+${cursor};
+}
+
+Name: __set
+public function __set(string $name, mixed $value): void {
+${cursor};
+}
+
+Name: __set_state
+public static function __set_state(array $properties): object {
+${cursor};
+}
+
+Name: __sleep
+public function __sleep(): array {
+${cursor};
+}
+
+Name: __toString
+public function __toString(): string {
+${cursor};
+}
+
+Name: __unserialize
+public function __unserialize(array $data): void {
+${cursor};
+}
+
+Name: __unset
+public function __unset(string $name): void {
+${cursor};
+}
+
+Name: __wakeup
+public function __wakeup(): void {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testToStringCustomTemplate/toString01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testToStringCustomTemplate/toString01.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class TestMagicMethodToString {
+
+    public string $name;
+    private int $age;
+    protected string $phoneNumber;
+    private string $emailAddress;
+
+    __
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testToStringCustomTemplate/toString01.php.testToStringCustomTemplate_01_PHP83.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testToStringCustomTemplate/toString01.php.testToStringCustomTemplate_01_PHP83.cccustomtpl
@@ -1,0 +1,8 @@
+Name: __toString
+public function __toString(): string {
+return "TestMagicMethodToString[name=" . $this->name
+. ", age=" . $this->age
+. ", phoneNumber=" . $this->phoneNumber
+. ", emailAddress=" . $this->emailAddress
+. "]";${cursor}
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testToStringCustomTemplate/toString02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testToStringCustomTemplate/toString02.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class TestMagicMethodToString {
+
+    public const CONSTANT1 = 1;
+    protected const CONSTANT2 = 2;
+    private const CONSTANT3 = 3;
+
+    public string $name;
+    private int $age;
+    protected string $phoneNumber;
+    private string $emailAddress;
+
+    public static int $static1;
+    private static int $static2;
+    protected static int $static3;
+
+    __
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testToStringCustomTemplate/toString02.php.testToStringCustomTemplate_02_PHP83.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testToStringCustomTemplate/toString02.php.testToStringCustomTemplate_02_PHP83.cccustomtpl
@@ -1,0 +1,8 @@
+Name: __toString
+public function __toString(): string {
+return "TestMagicMethodToString[name=" . $this->name
+. ", age=" . $this->age
+. ", phoneNumber=" . $this->phoneNumber
+. ", emailAddress=" . $this->emailAddress
+. "]";${cursor}
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/anonymousClass01.php.testAnonymousClass01h.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/anonymousClass01.php.testAnonymousClass01h.completion
@@ -2,21 +2,22 @@ Code completion result for source line:
 |// magic methods
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
-METHOD     __call($name, $arguments) - ge  [PUBLIC]   Magic Method
-METHOD     __callStatic($name, $arguments  [STATIC]   Magic Method
+METHOD     __call(string $name, array $ar  [PUBLIC]   Magic Method
+METHOD     __callStatic(string $name, arr  [STATIC]   Magic Method
 METHOD     __clone() - generate            [PUBLIC]   Magic Method
 METHOD     __construct() - generate        [PUBLIC]   Magic Method
+METHOD     __debugInfo() - generate        [PUBLIC]   Magic Method
 METHOD     __destruct() - generate         [PUBLIC]   Magic Method
-METHOD     __get($name) - generate         [PUBLIC]   Magic Method
+METHOD     __get(string $name) - generate  [PUBLIC]   Magic Method
 METHOD     __invoke() - generate           [PUBLIC]   Magic Method
-METHOD     __isset($name) - generate       [PUBLIC]   Magic Method
+METHOD     __isset(string $name) - genera  [PUBLIC]   Magic Method
 METHOD     __serialize() - generate        [PUBLIC]   Magic Method
-METHOD     __set($name, $value) - generat  [PUBLIC]   Magic Method
-METHOD     __set_state($array) - generate  [STATIC]   Magic Method
+METHOD     __set(string $name, mixed $val  [PUBLIC]   Magic Method
+METHOD     __set_state(array $properties)  [STATIC]   Magic Method
 METHOD     __sleep() - generate            [PUBLIC]   Magic Method
 METHOD     __toString() - generate         [PUBLIC]   Magic Method
 METHOD     __unserialize(array $data) - g  [PUBLIC]   Magic Method
-METHOD     __unset($name) - generate       [PUBLIC]   Magic Method
+METHOD     __unset(string $name) - genera  [PUBLIC]   Magic Method
 METHOD     __wakeup() - generate           [PUBLIC]   Magic Method
 KEYWORD    abstract                                   null
 KEYWORD    const                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSerializeUnserialize/serializeUnserialize.php.testSerializeUnserialize_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSerializeUnserialize/serializeUnserialize.php.testSerializeUnserialize_01.completion
@@ -2,19 +2,20 @@ Code completion result for source line:
 __|
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
-METHOD     __call($name, $arguments) - ge  [PUBLIC]   Magic Method
-METHOD     __callStatic($name, $arguments  [STATIC]   Magic Method
+METHOD     __call(string $name, array $ar  [PUBLIC]   Magic Method
+METHOD     __callStatic(string $name, arr  [STATIC]   Magic Method
 METHOD     __clone() - generate            [PUBLIC]   Magic Method
 METHOD     __construct() - generate        [PUBLIC]   Magic Method
+METHOD     __debugInfo() - generate        [PUBLIC]   Magic Method
 METHOD     __destruct() - generate         [PUBLIC]   Magic Method
-METHOD     __get($name) - generate         [PUBLIC]   Magic Method
+METHOD     __get(string $name) - generate  [PUBLIC]   Magic Method
 METHOD     __invoke() - generate           [PUBLIC]   Magic Method
-METHOD     __isset($name) - generate       [PUBLIC]   Magic Method
+METHOD     __isset(string $name) - genera  [PUBLIC]   Magic Method
 METHOD     __serialize() - generate        [PUBLIC]   Magic Method
-METHOD     __set($name, $value) - generat  [PUBLIC]   Magic Method
-METHOD     __set_state($array) - generate  [STATIC]   Magic Method
+METHOD     __set(string $name, mixed $val  [PUBLIC]   Magic Method
+METHOD     __set_state(array $properties)  [STATIC]   Magic Method
 METHOD     __sleep() - generate            [PUBLIC]   Magic Method
 METHOD     __toString() - generate         [PUBLIC]   Magic Method
 METHOD     __unserialize(array $data) - g  [PUBLIC]   Magic Method
-METHOD     __unset($name) - generate       [PUBLIC]   Magic Method
+METHOD     __unset(string $name) - genera  [PUBLIC]   Magic Method
 METHOD     __wakeup() - generate           [PUBLIC]   Magic Method

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPropertiesTyping01/readonlyPropertiesTyping01.php.testReadonlyPropertiesTyping01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPropertiesTyping01/readonlyPropertiesTyping01.php.testReadonlyPropertiesTyping01.completion
@@ -2,21 +2,22 @@ Code completion result for source line:
 |// test
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
-METHOD     __call($name, $arguments) - ge  [PUBLIC]   Magic Method
-METHOD     __callStatic($name, $arguments  [STATIC]   Magic Method
+METHOD     __call(string $name, array $ar  [PUBLIC]   Magic Method
+METHOD     __callStatic(string $name, arr  [STATIC]   Magic Method
 METHOD     __clone() - generate            [PUBLIC]   Magic Method
 METHOD     __construct() - generate        [PUBLIC]   Magic Method
+METHOD     __debugInfo() - generate        [PUBLIC]   Magic Method
 METHOD     __destruct() - generate         [PUBLIC]   Magic Method
-METHOD     __get($name) - generate         [PUBLIC]   Magic Method
+METHOD     __get(string $name) - generate  [PUBLIC]   Magic Method
 METHOD     __invoke() - generate           [PUBLIC]   Magic Method
-METHOD     __isset($name) - generate       [PUBLIC]   Magic Method
+METHOD     __isset(string $name) - genera  [PUBLIC]   Magic Method
 METHOD     __serialize() - generate        [PUBLIC]   Magic Method
-METHOD     __set($name, $value) - generat  [PUBLIC]   Magic Method
-METHOD     __set_state($array) - generate  [STATIC]   Magic Method
+METHOD     __set(string $name, mixed $val  [PUBLIC]   Magic Method
+METHOD     __set_state(array $properties)  [STATIC]   Magic Method
 METHOD     __sleep() - generate            [PUBLIC]   Magic Method
 METHOD     __toString() - generate         [PUBLIC]   Magic Method
 METHOD     __unserialize(array $data) - g  [PUBLIC]   Magic Method
-METHOD     __unset($name) - generate       [PUBLIC]   Magic Method
+METHOD     __unset(string $name) - genera  [PUBLIC]   Magic Method
 METHOD     __wakeup() - generate           [PUBLIC]   Magic Method
 KEYWORD    abstract                                   null
 KEYWORD    const                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/test209117/issue209117.php.testUseCase1.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/test209117/issue209117.php.testUseCase1.completion
@@ -3,21 +3,22 @@ Code completion result for source line:
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 METHOD     baseClassfunctionName() - over  [PROTECTE  \FrontSpace\BaseClass
 ------------------------------------
-METHOD     __call($name, $arguments) - ge  [PUBLIC]   Magic Method
-METHOD     __callStatic($name, $arguments  [STATIC]   Magic Method
+METHOD     __call(string $name, array $ar  [PUBLIC]   Magic Method
+METHOD     __callStatic(string $name, arr  [STATIC]   Magic Method
 METHOD     __clone() - generate            [PUBLIC]   Magic Method
 METHOD     __construct() - generate        [PUBLIC]   Magic Method
+METHOD     __debugInfo() - generate        [PUBLIC]   Magic Method
 METHOD     __destruct() - generate         [PUBLIC]   Magic Method
-METHOD     __get($name) - generate         [PUBLIC]   Magic Method
+METHOD     __get(string $name) - generate  [PUBLIC]   Magic Method
 METHOD     __invoke() - generate           [PUBLIC]   Magic Method
-METHOD     __isset($name) - generate       [PUBLIC]   Magic Method
+METHOD     __isset(string $name) - genera  [PUBLIC]   Magic Method
 METHOD     __serialize() - generate        [PUBLIC]   Magic Method
-METHOD     __set($name, $value) - generat  [PUBLIC]   Magic Method
-METHOD     __set_state($array) - generate  [STATIC]   Magic Method
+METHOD     __set(string $name, mixed $val  [PUBLIC]   Magic Method
+METHOD     __set_state(array $properties)  [STATIC]   Magic Method
 METHOD     __sleep() - generate            [PUBLIC]   Magic Method
 METHOD     __toString() - generate         [PUBLIC]   Magic Method
 METHOD     __unserialize(array $data) - g  [PUBLIC]   Magic Method
-METHOD     __unset($name) - generate       [PUBLIC]   Magic Method
+METHOD     __unset(string $name) - genera  [PUBLIC]   Magic Method
 METHOD     __wakeup() - generate           [PUBLIC]   Magic Method
 KEYWORD    abstract                                   null
 KEYWORD    const                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/test233756/issue233756.php.testUseCase1.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/test233756/issue233756.php.testUseCase1.completion
@@ -5,21 +5,22 @@ METHOD     __construct($foo) - override    [PUBLIC]   Foo
 METHOD     bat() - override                [PUBLIC]   Foo
 METHOD     baz() - generate                [PUBLIC,   Foo
 ------------------------------------
-METHOD     __call($name, $arguments) - ge  [PUBLIC]   Magic Method
-METHOD     __callStatic($name, $arguments  [STATIC]   Magic Method
+METHOD     __call(string $name, array $ar  [PUBLIC]   Magic Method
+METHOD     __callStatic(string $name, arr  [STATIC]   Magic Method
 METHOD     __clone() - generate            [PUBLIC]   Magic Method
 METHOD     __construct() - generate        [PUBLIC]   Magic Method
+METHOD     __debugInfo() - generate        [PUBLIC]   Magic Method
 METHOD     __destruct() - generate         [PUBLIC]   Magic Method
-METHOD     __get($name) - generate         [PUBLIC]   Magic Method
+METHOD     __get(string $name) - generate  [PUBLIC]   Magic Method
 METHOD     __invoke() - generate           [PUBLIC]   Magic Method
-METHOD     __isset($name) - generate       [PUBLIC]   Magic Method
+METHOD     __isset(string $name) - genera  [PUBLIC]   Magic Method
 METHOD     __serialize() - generate        [PUBLIC]   Magic Method
-METHOD     __set($name, $value) - generat  [PUBLIC]   Magic Method
-METHOD     __set_state($array) - generate  [STATIC]   Magic Method
+METHOD     __set(string $name, mixed $val  [PUBLIC]   Magic Method
+METHOD     __set_state(array $properties)  [STATIC]   Magic Method
 METHOD     __sleep() - generate            [PUBLIC]   Magic Method
 METHOD     __toString() - generate         [PUBLIC]   Magic Method
 METHOD     __unserialize(array $data) - g  [PUBLIC]   Magic Method
-METHOD     __unset($name) - generate       [PUBLIC]   Magic Method
+METHOD     __unset(string $name) - genera  [PUBLIC]   Magic Method
 METHOD     __wakeup() - generate           [PUBLIC]   Magic Method
 KEYWORD    abstract                                   null
 KEYWORD    const                                      null

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
@@ -971,4 +971,20 @@ public class SelectedPropertyMethodsCreatorTest extends PHPTestBase {
                 new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
         ));
     }
+
+    public void testMagicMethodToString01_PHP83() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("    // test^", PhpVersion.PHP_83);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "__toString"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testMagicMethodToString02_PHP83() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("    // test^", PhpVersion.PHP_83);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "__toString"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
 }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
@@ -891,4 +891,84 @@ public class SelectedPropertyMethodsCreatorTest extends PHPTestBase {
                 new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
         ));
     }
+
+    public void testMagicMethods01_PHP56() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("    // test^", PhpVersion.PHP_56);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), ""),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testMagicMethods01_PHP70() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("    // test^", PhpVersion.PHP_70);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), ""),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testMagicMethods01_PHP71() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("    // test^", PhpVersion.PHP_71);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), ""),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testMagicMethods01_PHP72() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("    // test^", PhpVersion.PHP_72);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), ""),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testMagicMethods01_PHP73() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("    // test^", PhpVersion.PHP_73);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), ""),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testMagicMethods01_PHP74() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("    // test^", PhpVersion.PHP_74);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), ""),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testMagicMethods01_PHP80() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("    // test^", PhpVersion.PHP_80);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), ""),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testMagicMethods01_PHP81() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("    // test^", PhpVersion.PHP_81);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), ""),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testMagicMethods01_PHP82() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("    // test^", PhpVersion.PHP_82);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), ""),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testMagicMethods01_PHP83() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("    // test^", PhpVersion.PHP_83);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), ""),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
 }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionMagicMethodTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionMagicMethodTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.api.PhpVersion;
+import org.netbeans.modules.php.project.api.PhpSourcePath;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class PHPCodeCompletionMagicMethodTest extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionMagicMethodTest(String testName) {
+        super(testName);
+    }
+
+    public void testMagicMethodsCustomTemplate_PHP56() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("magicMethods"), "    __^",
+                new DefaultFilter(PhpVersion.PHP_56, "__"), true);
+    }
+
+    public void testMagicMethodsCustomTemplate_PHP70() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("magicMethods"), "    __^",
+                new DefaultFilter(PhpVersion.PHP_70, "__"), true);
+    }
+
+    public void testMagicMethodsCustomTemplate_PHP71() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("magicMethods"), "    __^",
+                new DefaultFilter(PhpVersion.PHP_71, "__"), true);
+    }
+
+    public void testMagicMethodsCustomTemplate_PHP72() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("magicMethods"), "    __^",
+                new DefaultFilter(PhpVersion.PHP_72, "__"), true);
+    }
+
+    public void testMagicMethodsCustomTemplate_PHP73() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("magicMethods"), "    __^",
+                new DefaultFilter(PhpVersion.PHP_73, "__"), true);
+    }
+
+    public void testMagicMethodsCustomTemplate_PHP74() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("magicMethods"), "    __^",
+                new DefaultFilter(PhpVersion.PHP_74, "__"), true);
+    }
+
+    public void testMagicMethodsCustomTemplate_PHP80() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("magicMethods"), "    __^",
+                new DefaultFilter(PhpVersion.PHP_80, "__"), true);
+    }
+
+    public void testMagicMethodsCustomTemplate_PHP81() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("magicMethods"), "    __^",
+                new DefaultFilter(PhpVersion.PHP_81, "__"), true);
+    }
+
+    public void testMagicMethodsCustomTemplate_PHP82() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("magicMethods"), "    __^",
+                new DefaultFilter(PhpVersion.PHP_82, "__"), true);
+    }
+
+    public void testMagicMethodsCustomTemplate_PHP83() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("magicMethods"), "    __^",
+                new DefaultFilter(PhpVersion.PHP_83, "__"), true);
+    }
+
+    @Override
+    protected Map<String, ClassPath> createClassPathsForTest() {
+        return Collections.singletonMap(
+            PhpSourcePath.SOURCE_CP,
+            ClassPathSupport.createClassPath(new FileObject[]{
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/magicMethods/" + getTestDirName()))
+            })
+        );
+    }
+
+    private String getTestDirName() {
+        String name = getName();
+        int indexOf = name.indexOf("_");
+        if (indexOf != -1) {
+            name = name.substring(0, indexOf);
+        }
+        return name;
+    }
+
+    private String getTestPath(String fileName) {
+        return String.format("testfiles/completion/lib/magicMethods/%s/%s.php", getTestDirName(), fileName);
+    }
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionMagicMethodTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionMagicMethodTest.java
@@ -84,6 +84,16 @@ public class PHPCodeCompletionMagicMethodTest extends PHPCodeCompletionTestBase 
                 new DefaultFilter(PhpVersion.PHP_83, "__"), true);
     }
 
+    public void testToStringCustomTemplate_01_PHP83() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("toString01"), "    __^",
+                new DefaultFilter(PhpVersion.PHP_83, "__toString"), true);
+    }
+
+    public void testToStringCustomTemplate_02_PHP83() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("toString02"), "    __^",
+                new DefaultFilter(PhpVersion.PHP_83, "__toString"), true);
+    }
+
     @Override
     protected Map<String, ClassPath> createClassPathsForTest() {
         return Collections.singletonMap(


### PR DESCRIPTION
### Improve magic methods generation 

- Add `__debugInfo()`
- Add parameter and return types
- Add/Fix unit tests
- https://www.php.net/manual/en/language.oop5.magic.php

### Generate __toString() magic method with all fields #6783 

- #6783
- Add/Fix unit tests

Example:
```php
class Person {
    public string $name;
    private int $age;
    protected string $phoneNumber;
    private string $emailAddress;
}
```

Result:
```php
class Person {
    public string $name;
    private int $age;
    protected string $phoneNumber;
    private string $emailAddress;
    public function __toString(): string {
        return "Person[name=" . $this->name
                . ", age=" . $this->age
                . ", phoneNumber=" . $this->phoneNumber
                . ", emailAddress=" . $this->emailAddress
                . "]";
    }
}
```
![nb-php-gh-6783](https://github.com/apache/netbeans/assets/738383/bf98b1cd-593a-45d8-adbf-c08500400b33)

