### PR TITLE
[NETBEANS-6881][NETBEANS-6880][NETBEANS-6921] Additional fixes for the multi-file launcher:

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/CustomIndexerImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/CustomIndexerImpl.java
@@ -51,8 +51,13 @@ public class CustomIndexerImpl extends CustomIndexer {
 
     @Override
     protected void index(Iterable<? extends Indexable> files, Context context) {
+        FileObject root = context.getRoot();
+
+        if (root == null) {
+            return ; //ignore
+        }
+
         handleStoredFiles(context, props -> {
-            FileObject root = context.getRoot();
             for (Indexable i : files) {
                 FileObject file = root.getFileObject(i.getRelativePath());
                 if (file != null) {

--- a/java/java.file.launcher/nbproject/project.xml
+++ b/java/java.file.launcher/nbproject/project.xml
@@ -141,6 +141,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.parsing.api</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>9.30</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.parsing.indexing</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -164,6 +173,15 @@
                     <run-dependency>
                         <release-version>1</release-version>
                         <specification-version>1.63</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.spi.editor.hints</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>0</release-version>
+                        <specification-version>1.65</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/AttributeBasedSingleFileOptions.java
+++ b/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/AttributeBasedSingleFileOptions.java
@@ -19,8 +19,6 @@
 package org.netbeans.modules.java.file.launcher;
 
 import javax.swing.event.ChangeListener;
-import org.netbeans.api.project.FileOwnerQuery;
-import org.netbeans.api.project.Project;
 import org.netbeans.modules.java.file.launcher.queries.MultiSourceRootProvider;
 import org.netbeans.modules.java.file.launcher.spi.SingleFileOptionsQueryImplementation;
 import org.openide.filesystems.FileAttributeEvent;
@@ -38,9 +36,7 @@ public class AttributeBasedSingleFileOptions implements SingleFileOptionsQueryIm
 
     @Override
     public Result optionsFor(FileObject file) {
-        Project p = FileOwnerQuery.getOwner(file);
-
-        if (p != null) {
+        if (!SingleSourceFileUtil.isSupportedFile(file)) {
             return null;
         }
 

--- a/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/SharedRootData.java
+++ b/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/SharedRootData.java
@@ -18,16 +18,13 @@
  */
 package org.netbeans.modules.java.file.launcher;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.modules.java.file.launcher.api.SourceLauncher;
 import org.openide.filesystems.FileAttributeEvent;
@@ -36,8 +33,6 @@ import org.openide.filesystems.FileChangeListener;
 import org.openide.filesystems.FileEvent;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
-import org.openide.modules.SpecificationVersion;
-import org.openide.util.Exceptions;
 
 /**
  *
@@ -108,10 +103,7 @@ public class SharedRootData {
         }
         String joinedCommandLine = SourceLauncher.joinCommandLines(options.values());
         try {
-            if (
-                    !root.getFileSystem().isReadOnly() // Skip read-only FSes (like JarFileSystem)
-                    && !joinedCommandLine.equals(root.getAttribute(SingleSourceFileUtil.FILE_VM_OPTIONS))
-            ) {
+            if (!joinedCommandLine.equals(root.getAttribute(SingleSourceFileUtil.FILE_VM_OPTIONS))) {
                 root.setAttribute(SingleSourceFileUtil.FILE_VM_OPTIONS, joinedCommandLine);
             }
         } catch (IOException ex) {

--- a/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/SingleSourceFileUtil.java
+++ b/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/SingleSourceFileUtil.java
@@ -34,6 +34,7 @@ import org.netbeans.modules.java.file.launcher.spi.SingleFileOptionsQueryImpleme
 import org.netbeans.modules.java.file.launcher.spi.SingleFileOptionsQueryImplementation.Result;
 import org.netbeans.spi.java.queries.CompilerOptionsQueryImplementation;
 import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileStateInvalidException;
 import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
 import org.openide.util.Lookup;
@@ -74,13 +75,21 @@ public final class SingleSourceFileUtil {
     }
 
     public static boolean isSingleSourceFile(FileObject fObj) {
-        Project p = FileOwnerQuery.getOwner(fObj);
-        if (p != null || !fObj.getExt().equalsIgnoreCase("java")) { //NOI18N
+        if (!isSupportedFile(fObj) || !fObj.getExt().equalsIgnoreCase("java")) { //NOI18N
             return false;
         }
         return true;
     }
 
+    public static boolean isSupportedFile(FileObject file) {
+        try {
+            return !MultiSourceRootProvider.DISABLE_MULTI_SOURCE_ROOT &&
+                   FileOwnerQuery.getOwner(file) == null &&
+                   !file.getFileSystem().isReadOnly();
+        } catch (FileStateInvalidException ex) {
+            return false;
+        }
+    }
     public static Process compileJavaSource(FileObject fileObject) {
         FileObject javac = JavaPlatformManager.getDefault().getDefaultPlatform().findTool("javac"); //NOI18N
         File javacFile = FileUtil.toFile(javac);

--- a/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/indexer/CompilerOptionsIndexer.java
+++ b/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/indexer/CompilerOptionsIndexer.java
@@ -20,11 +20,12 @@ package org.netbeans.modules.java.file.launcher.indexer;
 
 import org.netbeans.modules.java.file.launcher.SharedRootData;
 import org.netbeans.api.editor.mimelookup.MimeRegistration;
-import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.modules.java.file.launcher.SingleSourceFileUtil;
 import org.netbeans.modules.parsing.spi.indexing.Context;
 import org.netbeans.modules.parsing.spi.indexing.CustomIndexer;
 import org.netbeans.modules.parsing.spi.indexing.CustomIndexerFactory;
 import org.netbeans.modules.parsing.spi.indexing.Indexable;
+import org.openide.filesystems.FileObject;
 
 /**
  *
@@ -35,10 +36,17 @@ public class CompilerOptionsIndexer extends CustomIndexer {
 
     @Override
     protected void index(Iterable<? extends Indexable> files, Context context) {
-        if (FileOwnerQuery.getOwner(context.getRoot()) != null) {
+        FileObject root = context.getRoot();
+
+        if (root == null) {
+            return ; //ignore
+        }
+
+        if (!SingleSourceFileUtil.isSupportedFile(root)) {
             return ; //ignore roots under projects
         }
-        SharedRootData.ensureRootRegistered(context.getRoot());
+
+        SharedRootData.ensureRootRegistered(root);
     }
 
 

--- a/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-java-file-launcher.jar/org/netbeans/modules/java/file/launcher/queries/Bundle.properties
+++ b/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-java-file-launcher.jar/org/netbeans/modules/java/file/launcher/queries/Bundle.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+SETTING_AutoRegisterAsRoot=true

--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/APTUtils.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/APTUtils.java
@@ -135,7 +135,9 @@ public class APTUtils implements ChangeListener, PropertyChangeListener {
         this.root = root;
         bootPath = ClassPath.getClassPath(root, ClassPath.BOOT);
         compilePath = ClassPath.getClassPath(root, ClassPath.COMPILE);
-        compilePath.addPropertyChangeListener(this);
+        if (compilePath != null) {
+            compilePath.addPropertyChangeListener(this);
+        }
         processorPath = new AtomicReference<>(ClassPath.getClassPath(root, JavaClassPathConstants.PROCESSOR_PATH));
         processorModulePath = new AtomicReference<>(ClassPath.getClassPath(root, JavaClassPathConstants.MODULE_PROCESSOR_PATH));
         aptOptions = AnnotationProcessingQuery.getAnnotationProcessingOptions(root);
@@ -360,7 +362,9 @@ public class APTUtils implements ChangeListener, PropertyChangeListener {
                     compilePath.removePropertyChangeListener(this);
                 }
                 compilePath = ClassPath.getClassPath(root, ClassPath.COMPILE);
-                compilePath.addPropertyChangeListener(this);
+                if (compilePath != null) {
+                    compilePath.addPropertyChangeListener(this);
+                }
                 listenOnProcessorPath(pp, this);
                 classLoaderCache = null;
             }


### PR DESCRIPTION
- checking for null return result for getClassPath(COMPILE)
- filtering out directories that belong to a project from the multi-file launcher source path
- more thoroughly prevent creating of the multi-file launcher source ClassPath for files under projects
