### PR TITLE
Forcing restart when to_enable.txt file exists in the Windows launcher.

### DIFF
--- a/platform/o.n.bootstrap/launcher/windows/platformlauncher.cpp
+++ b/platform/o.n.bootstrap/launcher/windows/platformlauncher.cpp
@@ -485,6 +485,15 @@ bool PlatformLauncher::shouldAutoUpdate(bool firstStart, const char *basePath) {
         }
 
         path = basePath;
+        path += "\\update\\deactivate\\to_enable.txt";
+        hFind = FindFirstFile(path.c_str(), &fd);
+        if (hFind != INVALID_HANDLE_VALUE) {
+            logMsg("to_enable.txt found: %s", path.c_str());
+            FindClose(hFind);
+            return true;
+        }
+
+        path = basePath;
         path += "\\update\\deactivate\\to_uninstall.txt";
         hFind = FindFirstFile(path.c_str(), &fd);
         if (hFind != INVALID_HANDLE_VALUE) {


### PR DESCRIPTION
Transferring this PR (only the part with `to_enable.txt`):
https://github.com/apache/netbeans-native-launchers/pull/11
into the main repository. 

It should be eventually used by:
https://github.com/apache/netbeans/pull/6743

Not sure if this should be separate like here (hence the launcher would be updated, and could be released, and then used by 6743), or part of 6743, and the launcher would be updated later. I guess I'd prefer first updating the launcher, so that there's no point where 6743 would not work on Windows, but I can do it differently if desired.
