### PR TITLE
Fix incorrect code completion with the same member names as semi-type prefixes #6909

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/VariousUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/VariousUtils.java
@@ -116,16 +116,18 @@ public final class VariousUtils {
     public static final String PRE_OPERATION_TYPE_DELIMITER = "@"; //NOI18N
     public static final String POST_OPERATION_TYPE_DELIMITER = ":"; //NOI18N
     public static final String POST_OPERATION_TYPE_DELIMITER_SUBS = "_POTD_"; //NOI18N
-    public static final String CONSTRUCTOR_TYPE_PREFIX = "constuct" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
-    public static final String FUNCTION_TYPE_PREFIX = "fn" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
-    public static final String METHOD_TYPE_PREFIX = "mtd" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
-    public static final String STATIC_METHOD_TYPE_PREFIX = "static.mtd" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
-    public static final String FIELD_TYPE_PREFIX = "fld" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
-    public static final String STATIC_FIELD_TYPE_PREFIX = "static.fld" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
-    public static final String STATIC_CONSTANT_TYPE_PREFIX = "static.constant" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
-    public static final String VAR_TYPE_PREFIX = "var" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
-    public static final String ARRAY_TYPE_PREFIX = "array" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
-    public static final String TYPE_TYPE_PREFIX = "type" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
+    // GH-6909 To avoid conflicting with member names, add "-type" suffix
+    // because "-" can not be contained to member names
+    public static final String CONSTRUCTOR_TYPE_PREFIX = "constuct-type" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
+    public static final String FUNCTION_TYPE_PREFIX = "fn-type" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
+    public static final String METHOD_TYPE_PREFIX = "mtd-type" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
+    public static final String STATIC_METHOD_TYPE_PREFIX = "static.mtd-type" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
+    public static final String FIELD_TYPE_PREFIX = "fld-type" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
+    public static final String STATIC_FIELD_TYPE_PREFIX = "static.fld-type" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
+    public static final String STATIC_CONSTANT_TYPE_PREFIX = "static.constant-type" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
+    public static final String VAR_TYPE_PREFIX = "var-type" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
+    public static final String ARRAY_TYPE_PREFIX = "array-type" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
+    public static final String TYPE_TYPE_PREFIX = "type-type" + POST_OPERATION_TYPE_DELIMITER; //NOI18N
     private static final Collection<String> SPECIAL_CLASS_NAMES = new LinkedList<>();
     private static final Collection<String> STATIC_CLASS_NAMES = new LinkedList<>();
     private static final String VAR_TYPE_COMMENT_PREFIX = "@var"; //NOI18N

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class GH6909Instance {
+    public function Type(): int {
+        return 0;
+    }
+
+    public function test(): void {
+        $this->Type()->test;
+        $this->mtd()->test;
+        $this->fn()->test;
+        $this->fld()->test;
+        $this->var()->test;
+        $this->array()->test;
+        $this->type->test;
+    }
+}
+
+class GH6909Static {
+    public static function type(): int {
+        return 0;
+    }
+
+    public function test(): void {
+        self::type()->test;
+        self::mtd()->test;
+        self::fn()->test;
+        self::fld()->test;
+        GH6909Static::var()->test;
+        static::array()->test;
+    }
+}
+
+class GH6909InstanceReturnType {
+    public function Type(): ExampleClass {
+        return new Example();
+    }
+
+    public function test(): void {
+        $this->Type()->example;
+        $this->Type()::EXAMPLE;
+    }
+}
+
+class GH6909StaticReturnType {
+    public static function Type(): ExampleClass {
+        return new Example();
+    }
+
+    public function test(): void {
+        self::Type()->example;
+        self::Type()::EXAMPLE;
+    }
+}
+
+class GH6909FieldType {
+    private ExampleClass $type;
+
+    public function test(): void {
+        $this->type->example;
+    }
+}
+
+class ExampleClass {
+    public int $example;
+    public const EXAMPLE = 1;
+    public function method(): void {}
+    public static function staticMethod(): void {}
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_FieldType01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_FieldType01.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+$this->type->|example;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     method()                        [PUBLIC]   ExampleClass
+METHOD     staticMethod()                  [STATIC]   ExampleClass
+VARIABLE   int example                     [PUBLIC]   ExampleClass

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Instance01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Instance01.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+$this->Type()->|test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Instance02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Instance02.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+$this->mtd()->|test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Instance03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Instance03.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+$this->fn()->|test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Instance04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Instance04.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+$this->fld()->|test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Instance05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Instance05.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+$this->var()->|test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Instance06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Instance06.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+$this->array()->|test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Instance07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Instance07.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+$this->type->|test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_InstanceReturnType01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_InstanceReturnType01.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+$this->Type()->|example;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     method()                        [PUBLIC]   ExampleClass
+METHOD     staticMethod()                  [STATIC]   ExampleClass
+VARIABLE   int example                     [PUBLIC]   ExampleClass

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_InstanceReturnType02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_InstanceReturnType02.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+$this->Type()::|EXAMPLE;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     staticMethod()                  [STATIC]   ExampleClass
+CONSTANT   EXAMPLE 1                       [PUBLIC]   ExampleClass
+CONSTANT   class \ExampleClass             [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Static01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Static01.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+self::type()->|test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Static02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Static02.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+self::mtd()->|test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Static03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Static03.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+self::fn()->|test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Static04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Static04.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+self::fld()->|test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Static05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Static05.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+GH6909Static::var()->|test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Static06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_Static06.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+static::array()->|test;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_StaticReturnType01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_StaticReturnType01.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+self::Type()->|example;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     method()                        [PUBLIC]   ExampleClass
+METHOD     staticMethod()                  [STATIC]   ExampleClass
+VARIABLE   int example                     [PUBLIC]   ExampleClass

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_StaticReturnType02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh6909/gh6909.php.testGH6909_StaticReturnType02.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+self::Type()::|EXAMPLE;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     staticMethod()                  [STATIC]   ExampleClass
+CONSTANT   EXAMPLE 1                       [PUBLIC]   ExampleClass
+CONSTANT   class \ExampleClass             [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/index/testPHP83TypedClassConstants/testPHP83TypedClassConstants.php.indexed
+++ b/php/php.editor/test/unit/data/testfiles/index/testPHP83TypedClassConstants/testPHP83TypedClassConstants.php.indexed
@@ -3,7 +3,7 @@
 Document 0
 Searchable Keys:
   clz : a;A;820;;;Stringable|\Stringable;1;;0;<TESTURL>/testPHP83TypedClassConstants.php;;
-  method : __tostring;__toString;866;;@static.constant:static.class;1;0;<TESTURL>/testPHP83TypedClassConstants.php;0;0;;
+  method : __tostring;__toString;866;;@static.constant-type:static.class;1;0;<TESTURL>/testPHP83TypedClassConstants.php;0;0;;
   superiface : stringable;Stringable;
   top : a
 

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionGH6909Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionGH6909Test.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.project.api.PhpSourcePath;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class PHPCodeCompletionGH6909Test extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionGH6909Test(String testName) {
+        super(testName);
+    }
+
+    public void testGH6909_Instance01() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        $this->Type()->^test;", false);
+    }
+
+    public void testGH6909_Instance02() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        $this->mtd()->^test;", false);
+    }
+
+    public void testGH6909_Instance03() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        $this->fn()->^test;", false);
+    }
+
+    public void testGH6909_Instance04() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        $this->fld()->^test;", false);
+    }
+
+    public void testGH6909_Instance05() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        $this->var()->^test;", false);
+    }
+
+    public void testGH6909_Instance06() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        $this->array()->^test;", false);
+    }
+
+    public void testGH6909_Instance07() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        $this->type->^test;", false);
+    }
+
+    public void testGH6909_Static01() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        self::type()->^test;", false);
+    }
+
+    public void testGH6909_Static02() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        self::mtd()->^test;", false);
+    }
+
+    public void testGH6909_Static03() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        self::fn()->^test;", false);
+    }
+
+    public void testGH6909_Static04() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        self::fld()->^test;", false);
+    }
+
+    public void testGH6909_Static05() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        GH6909Static::var()->^test;", false);
+    }
+
+    public void testGH6909_Static06() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        static::array()->^test;", false);
+    }
+
+    public void testGH6909_InstanceReturnType01() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        $this->Type()->^example;", false);
+    }
+
+    public void testGH6909_InstanceReturnType02() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        $this->Type()::^EXAMPLE;", false);
+    }
+
+    public void testGH6909_StaticReturnType01() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        self::Type()->^example;", false);
+    }
+
+    public void testGH6909_StaticReturnType02() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        self::Type()::^EXAMPLE;", false);
+    }
+
+    public void testGH6909_FieldType01() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh6909/gh6909.php", "        $this->type->^example;", false);
+    }
+
+    @Override
+    protected Map<String, ClassPath> createClassPathsForTest() {
+        return Collections.singletonMap(
+            PhpSourcePath.SOURCE_CP,
+            ClassPathSupport.createClassPath(new FileObject[] {
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/gh6909"))
+            })
+        );
+    }
+}


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/6909
- To avoid conflicting with member names, add `-type` suffix to semi-type prefixes because "-" can not be contained to member names
- Add unit tests

Example:
```php
class Example {
    public function Type(): int {
        return 0;
    }

    public function test(): void {
        $this->Type()-> // before: Example members(`Type()`, `test()`) are shown
                        // after : no items
    }
}
```