### PR TITLE
Update Gradle Tooling API to 8.6

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
@@ -86,7 +86,7 @@ public final class GradleDistributionManager {
     private static final Pattern DIST_VERSION_PATTERN = Pattern.compile(".*(gradle-(\\d+\\.\\d+.*))-(bin|all)\\.zip"); //NOI18N
     private static final Set<String> VERSION_BLACKLIST = new HashSet<>(Arrays.asList("2.3", "2.13")); //NOI18N
     private static final Map<File, GradleDistributionManager> CACHE = new WeakHashMap<>();
-    private static final GradleVersion MINIMUM_SUPPORTED_VERSION = GradleVersion.version("2.0"); //NOI18N
+    private static final GradleVersion MINIMUM_SUPPORTED_VERSION = GradleVersion.version("3.0"); //NOI18N
     private static final GradleVersion[] JDK_COMPAT = new GradleVersion[]{
         GradleVersion.version("4.2.1"), // JDK-9
         GradleVersion.version("4.7"), // JDK-10
@@ -102,6 +102,8 @@ public final class GradleDistributionManager {
         GradleVersion.version("8.3"), // JDK-20
         GradleVersion.version("8.5"), // JDK-21
     };
+
+    private static final GradleVersion LAST_KNOWN_GRADLE = GradleVersion.version("8.6"); //NOI18N
 
     final File gradleUserHome;
 
@@ -496,10 +498,9 @@ public final class GradleDistributionManager {
          */
         public boolean isCompatibleWithJava(int jdkMajorVersion) {
             
-            GradleVersion lastKnown = JDK_COMPAT[JDK_COMPAT.length - 1];
             // Optimistic bias, if the GradleVersion is newer than the last NB
             // knows, we say it's compatible with any JDK
-            return lastKnown.compareTo(version.getBaseVersion()) < 0 
+            return LAST_KNOWN_GRADLE.compareTo(version.getBaseVersion()) < 0
                     || jdkMajorVersion <= lastSupportedJava();
         }
 

--- a/extide/libs.gradle/external/binaries-list
+++ b/extide/libs.gradle/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ADAA3E825C608D2428888126CF4D1DDD5B5203D6 https://repo.gradle.org/artifactory/libs-releases/org/gradle/gradle-tooling-api/8.4/gradle-tooling-api-8.4.jar gradle-tooling-api-8.4.jar
+1B1A733327BD5EFE9813DD0590C21865C0EDC954 https://repo.gradle.org/artifactory/libs-releases/org/gradle/gradle-tooling-api/8.6/gradle-tooling-api-8.6.jar gradle-tooling-api-8.6.jar

--- a/extide/libs.gradle/external/gradle-tooling-api-8.6-license.txt
+++ b/extide/libs.gradle/external/gradle-tooling-api-8.6-license.txt
@@ -1,7 +1,7 @@
 Name: Gradle Tooling API
 Description: Gradle Tooling API
-Version: 8.4
-Files: gradle-tooling-api-8.4.jar
+Version: 8.6
+Files: gradle-tooling-api-8.6.jar
 License: Apache-2.0
 Origin: Gradle Inc.
 URL: https://gradle.org/

--- a/extide/libs.gradle/external/gradle-tooling-api-8.6-notice.txt
+++ b/extide/libs.gradle/external/gradle-tooling-api-8.6-notice.txt
@@ -1,8 +1,8 @@
 Gradle Inc.'s Gradle Tooling API
-Copyright 2007-2023 Gradle Inc.
+Copyright 2007-2024 Gradle Inc.
 
 This product includes software developed at
 Gradle Inc. (https://gradle.org/).
 
 This product includes/uses SLF4J (https://www.slf4j.org/)
-developed by QOS.ch, 2004-2023
+developed by QOS.ch, 2004-2024

--- a/extide/libs.gradle/manifest.mf
+++ b/extide/libs.gradle/manifest.mf
@@ -2,4 +2,4 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.libs.gradle/8
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/libs/gradle/Bundle.properties
-OpenIDE-Module-Specification-Version: 8.5
+OpenIDE-Module-Specification-Version: 8.6

--- a/extide/libs.gradle/nbproject/project.properties
+++ b/extide/libs.gradle/nbproject/project.properties
@@ -22,4 +22,4 @@ javac.compilerargs=-Xlint -Xlint:-serial
 # For more information, please see http://wiki.netbeans.org/SignatureTest
 sigtest.gen.fail.on.error=false
 
-release.external/gradle-tooling-api-8.4.jar=modules/gradle/gradle-tooling-api.jar
+release.external/gradle-tooling-api-8.6.jar=modules/gradle/gradle-tooling-api.jar

--- a/extide/libs.gradle/nbproject/project.xml
+++ b/extide/libs.gradle/nbproject/project.xml
@@ -39,7 +39,7 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path>gradle/gradle-tooling-api.jar</runtime-relative-path>
-                <binary-origin>external/gradle-tooling-api-8.4.jar</binary-origin>
+                <binary-origin>external/gradle-tooling-api-8.6.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
It's quite possible that Gradle 8.6 would be released before NB21, so let's start the upgrade now, and maybe add another PR for the final 8.6 during the RC cycle.
