### PR TITLE
Remove debugging debris preventing extension start.

### DIFF
--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -61,7 +61,6 @@ import { TLSSocket } from 'tls';
 import { InputStep, MultiStepInput } from './utils';
 import { env } from 'process';
 import { PropertiesView } from './propertiesView/propertiesView';
-import { dumpJava } from './test/suite/testutils';
 
 const API_VERSION : string = "1.0";
 export const COMMAND_PREFIX : string = "nbls";
@@ -291,7 +290,6 @@ function wrapCommandWithProgress(lsCommand : string, title : string, log? : vsco
                         if (res) {
                             resolve(res);
                         } else {
-                            dumpJava();
                             if (log) {
                                 handleLog(log, `Command ${lsCommand} takes too long to start`);
                             }


### PR DESCRIPTION
I happened to merge extra `dumpJava` in 6852 -- this prevents the Apache vscode extension from starting. Although I'd like to retain dump for diagnostic purposes, I'd like just to remove the offending lines for the NB21.  