### PR TITLE
Ignore scope inheritance for configs not present in the project.

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleScopesBuilder.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleScopesBuilder.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.gradle.api.GradleBaseProject;
@@ -118,10 +119,10 @@ public final class GradleScopesBuilder {
             
             extendsFrom.getOrDefault(gs.name(), Collections.emptyList()).
                     stream().
-                    map(scopes::get).forEach(data.extendsFrom::add);
+                    map(scopes::get).filter(Objects::nonNull).forEach(data.extendsFrom::add);
             inheritedInto.getOrDefault(gs.name(), Collections.emptyList()).
                     stream().
-                    map(scopes::get).forEach(data.inheritedInto::add);
+                    map(scopes::get).filter(Objects::nonNull).forEach(data.inheritedInto::add);
         }
 
         return new GradleScopes(project, scopes);


### PR DESCRIPTION
This PR just adds NPE check to `GradleScopeBuilder`, as there are pre-defined 'abstract' scopes that inherit from Gradle configurations ... but they do not need to be present at all in a gradle project.

During investigation of a bug I've added some more logging to gradle dependency implementation, I'd retain it.

Finally, from the inception of Vulnerability Audit implementation, and introduction of `Diagnostic.ReporterControl`, there is a potential race on write to `TextDocumentService.diagnosticTasks`; simple synchronize() should solve that. I've been 'just lucky' to encounter it during development.
