### PR TITLE
PHP 8.0 Support: Attribute Syntax (Part 5)

### DIFF
--- a/php/php.editor/test/unit/data/testfiles/gotodeclaration/php80/testAttributes/testAttributes.php
+++ b/php/php.editor/test/unit/data/testfiles/gotodeclaration/php80/testAttributes/testAttributes.php
@@ -1,0 +1,183 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Attributes;
+
+use Attribute;
+
+const CONST_1 = 1;
+
+#[Attribute]
+class AttributeClass1 {
+    public function __construct(int $int = 0, string $string = "default") {
+    }
+}
+#[Attribute]
+class AttributeClass2 {
+    public function __construct(int $int = 0, string $string = "default", object $object = new \stdClass()) {
+    }
+}
+#[Attribute]
+class AttributeClass3 {
+    public function __construct(int $int = 0, string $string = "default") {
+    }
+}
+
+class Example {
+    public const string CONST_EXAMPLE = "example";
+}
+
+namespace AttributeTest1;
+
+use Attributes\AttributeClass1;
+use Attributes\AttributeClass2;
+use Attributes\AttributeClass3;
+use Attributes\Example;
+
+use const Attributes\CONST_1;
+
+#[AttributeClass1(1, self::CONSTANT_CLASS)]
+#[AttributeClass2(1, "class")]
+class AttributedClass
+{
+    #[AttributeClass1(2, "class const")]
+    #[AttributeClass2(2, "class const", new Example())]
+    public const CONSTANT_CLASS = 'constant';
+
+    #[AttributeClass1(3, "class field")]
+    public int|string $field;
+
+    #[AttributeClass1(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    public $staticField;
+
+    #[AttributeClass1(5, "class method")]
+    public function method(#[AttributeClass1(5, "class method param")] $param1, #[AttributeClass1(5, 'class method param')] int $pram2) {}
+
+    #[\Attributes\AttributeClass1(6, "class static method")]
+    public static function staticMethod(#[\Attributes\AttributeClass1(6, "class static method param")] int|string $param1): bool|int {
+        return false;
+    }
+}
+
+#[AttributeClass1(1, "class child")]
+class AttributedClassChild extends AttributedClass {
+}
+
+#[AttributeClass1(1, "trait")]
+#[AttributeClass2(1, "trait")]
+trait AttributedTrait
+{
+    #[AttributeClass2(2, "trait const")]
+    public const CONSTANT_TRAIT = 'constant';
+
+    #[AttributeClass1(3, "trait field")]
+    public int $field;
+
+    #[AttributeClass1(4, "trait static field")]
+    public $staticField;
+
+    #[AttributeClass1(5, "trait method")]
+    public function traitMethod(#[AttributeClass1(5, "trait method param")] $param1) {}
+
+    #[AttributeClass1(6, "trait static method")]
+    #[AttributeClass2(6, "trait static method")]
+    #[AttributeClass3(6, "trait static method")]
+    public static function staticTraitMethod(#[AttributeClass3] int|string $param1): bool|int {
+        return false;
+    }
+}
+
+$anon = new #[AttributeClass1(1, "anonymous class")] class () {};
+
+$test = 1;
+$anon2 = new #[AttributeClass2(1, "anonymous class")] class ($test) {
+    #[AttributeClass2(2, "anonymous class const")]
+    public const CONSTANT_ANON = 'constant';
+
+    #[AttributeClass2(3, "anonymous class field")]
+    #[AttributeClass3(3, "anonymous class field")]
+    public string $field = 'test';
+
+    #[AttributeClass2(4, "anonymous class static field")]
+    public static int $staticField = 1;
+
+    #[AttributeClass2(5, "anonymous class constructor")]
+    public function __construct(#[AttributeClass2(5, "anonymous class")] $param1) {
+    }
+
+    #[AttributeClass2(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[AttributeClass2(6, "anonymous class method param")] $param1): int|string {
+        return 1;
+    }
+
+    #[AttributeClass1(int: 7, string: "anonymous class static method")]
+    private static function staticMethod(#[AttributeClass2(7, "anonymous class static method param")] int|bool $pram1): int|string {
+        return 1;
+    }
+};
+
+#[AttributeClass1(1, "interface")]
+interface AttributedInterface
+{
+    #[AttributeClass2(2, "interface const")]
+    public const CONSTANT_INTERFACE = 3;
+
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[AttributeClass2(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+
+    #[AttributeClass2(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+}
+
+#[\Attributes\AttributeClass2(1, "enum", new Example)]
+#[\Attributes\AttributeClass3(1, "enum"), AttributeClass1]
+enum AttributedEnum {
+    #[AttributeClass1(2, "enum const")]
+    public const CONSTANT_ENUM = 'constant';
+
+    #[AttributeClass1(3, "enum case")]
+    case Case1;
+
+    #[AttributeClass1(4, "enum method")] #[AttributeClass3()]
+    public function method(#[AttributeClass2(4, "enum method param")] $param1): int|string {
+        return 1;
+    }
+
+    #[AttributeClass1(int: 5, string: "enum static method")]
+    public static function staticMethod(#[AttributeClass3(5, "enum static method param")] int|bool $pram1): int|string {
+        return 1;
+    }
+}
+
+#[
+    AttributeClass1(1, "function"),
+    AttributeClass3(int: CONST_1, string: "function" . Example::class)
+] //group
+function func1() {}
+
+#[AttributeClass2(1, "function")]
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+
+$labmda1 = #[AttributeClass1(1, "closure")] function() {};
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[AttributeClass3(3, "closure")] static function(): void {};
+
+$arrow1 = #[AttributeClass1(1, "arrow")] fn() => 100;
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[AttributeClass1(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php
@@ -1,0 +1,183 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Attributes;
+
+use Attribute;
+
+const CONST_1 = 1;
+
+#[Attribute]
+class AttributeClass1 {
+    public function __construct(int $int = 0, string $string = "default") {
+    }
+}
+#[Attribute]
+class AttributeClass2 {
+    public function __construct(int $int = 0, string $string = "default", object $object = new \stdClass()) {
+    }
+}
+#[Attribute]
+class AttributeClass3 {
+    public function __construct(int $int = 0, string $string = "default") {
+    }
+}
+
+class Example {
+    public const string CONST_EXAMPLE = "example";
+}
+
+namespace AttributeTest1;
+
+use Attributes\AttributeClass1;
+use Attributes\AttributeClass2;
+use Attributes\AttributeClass3;
+use Attributes\Example;
+
+use const Attributes\CONST_1;
+
+#[AttributeClass1(1, self::CONSTANT_CLASS)]
+#[AttributeClass2(1, "class")]
+class AttributedClass
+{
+    #[AttributeClass1(2, "class const")]
+    #[AttributeClass2(2, "class const", new Example())]
+    public const CONSTANT_CLASS = 'constant';
+
+    #[AttributeClass1(3, "class field")]
+    public int|string $field;
+
+    #[AttributeClass1(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    public $staticField;
+
+    #[AttributeClass1(5, "class method")]
+    public function method(#[AttributeClass1(5, "class method param")] $param1, #[AttributeClass1(5, 'class method param')] int $pram2) {}
+
+    #[\Attributes\AttributeClass1(6, "class static method")]
+    public static function staticMethod(#[\Attributes\AttributeClass1(6, "class static method param")] int|string $param1): bool|int {
+        return false;
+    }
+}
+
+#[AttributeClass1(1, "class child")]
+class AttributedClassChild extends AttributedClass {
+}
+
+#[AttributeClass1(1, "trait")]
+#[AttributeClass2(1, "trait")]
+trait AttributedTrait
+{
+    #[AttributeClass2(2, "trait const")]
+    public const CONSTANT_TRAIT = 'constant';
+
+    #[AttributeClass1(3, "trait field")]
+    public int $field;
+
+    #[AttributeClass1(4, "trait static field")]
+    public $staticField;
+
+    #[AttributeClass1(5, "trait method")]
+    public function traitMethod(#[AttributeClass1(5, "trait method param")] $param1) {}
+
+    #[AttributeClass1(6, "trait static method")]
+    #[AttributeClass2(6, "trait static method")]
+    #[AttributeClass3(6, "trait static method")]
+    public static function staticTraitMethod(#[AttributeClass3] int|string $param1): bool|int {
+        return false;
+    }
+}
+
+$anon = new #[AttributeClass1(1, "anonymous class")] class () {};
+
+$test = 1;
+$anon2 = new #[AttributeClass2(1, "anonymous class")] class ($test) {
+    #[AttributeClass2(2, "anonymous class const")]
+    public const CONSTANT_ANON = 'constant';
+
+    #[AttributeClass2(3, "anonymous class field")]
+    #[AttributeClass3(3, "anonymous class field")]
+    public string $field = 'test';
+
+    #[AttributeClass2(4, "anonymous class static field")]
+    public static int $staticField = 1;
+
+    #[AttributeClass2(5, "anonymous class constructor")]
+    public function __construct(#[AttributeClass2(5, "anonymous class")] $param1) {
+    }
+
+    #[AttributeClass2(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[AttributeClass2(6, "anonymous class method param")] $param1): int|string {
+        return 1;
+    }
+
+    #[AttributeClass1(int: 7, string: "anonymous class static method")]
+    private static function staticMethod(#[AttributeClass2(7, "anonymous class static method param")] int|bool $pram1): int|string {
+        return 1;
+    }
+};
+
+#[AttributeClass1(1, "interface")]
+interface AttributedInterface
+{
+    #[AttributeClass2(2, "interface const")]
+    public const CONSTANT_INTERFACE = 3;
+
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[AttributeClass2(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+
+    #[AttributeClass2(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+}
+
+#[\Attributes\AttributeClass2(1, "enum", new Example)]
+#[\Attributes\AttributeClass3(1, "enum"), AttributeClass1]
+enum AttributedEnum {
+    #[AttributeClass1(2, "enum const")]
+    public const CONSTANT_ENUM = 'constant';
+
+    #[AttributeClass1(3, "enum case")]
+    case Case1;
+
+    #[AttributeClass1(4, "enum method")] #[AttributeClass3()]
+    public function method(#[AttributeClass2(4, "enum method param")] $param1): int|string {
+        return 1;
+    }
+
+    #[AttributeClass1(int: 5, string: "enum static method")]
+    public static function staticMethod(#[AttributeClass3(5, "enum static method param")] int|bool $pram1): int|string {
+        return 1;
+    }
+}
+
+#[
+    AttributeClass1(1, "function"),
+    AttributeClass3(int: CONST_1, string: "function" . Example::class)
+] //group
+function func1() {}
+
+#[AttributeClass2(1, "function")]
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+
+$labmda1 = #[AttributeClass1(1, "closure")] function() {};
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[AttributeClass3(3, "closure")] static function(): void {};
+
+$arrow1 = #[AttributeClass1(1, "arrow")] fn() => 100;
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[AttributeClass1(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a01.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeCla^ss1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a02.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeCla^ss1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a03.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a03.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:Attribut^eClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a04.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a04.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeCl^ass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a05.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a05.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeCl^ass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a06.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a06.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeCl^ass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a07.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a07.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeCla^ss1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a08.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a08.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeCl^ass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a09.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a09.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeCla^ss1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a10.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a10.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeCla^ss1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a11.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a11.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeCl^ass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a12.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a12.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeC^lass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a13.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a13.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeC^lass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a14.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a14.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeC^lass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a15.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a15.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeCla^ss1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a16.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a16.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:Attribut^eClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a17.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a17.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:Attribute^Class1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a18.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a18.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:Att^ributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a19.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a19.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:Attri^buteClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a20.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a20.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeCl^ass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a21.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a21.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClas^s1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a22.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a22.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeC^lass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a23.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a23.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeCla^ss1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a24.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a24.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeCla^ss1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a25.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a25.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:Attr^ibuteClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a26.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a26.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:Attribute^Class1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a27.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a27.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:Attri^buteClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a28.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a28.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:Attribut^eClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a29.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a29.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeCl^ass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a30.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a30.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeCl^ass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a31.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a31.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:Attribute^Class1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:AttributeClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a32.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_a32.occurrences
@@ -1,0 +1,30 @@
+class |>MARK_OCCURRENCES:AttributeClass1<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass1<|;
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, self::CONSTANT_CLASS)]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\Example)] // group
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method")]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "class method param")] $param1, #[|>MARK_OCCURRENCES:AttributeClass1<|(5, 'class method param')] int $pram2) {}
+    #[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method")]
+    public static function staticMethod(#[\Attributes\|>MARK_OCCURRENCES:AttributeClass1<|(6, "class static method param")] int|string $param1): bool|int {
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "class child")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "trait field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "trait static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method")]
+    public function traitMethod(#[|>MARK_OCCURRENCES:AttributeClass1<|(5, "trait method param")] $param1) {}
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(6, "trait static method")]
+$anon = new #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "anonymous class")] class () {};
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 7, string: "anonymous class static method")]
+#[|>MARK_OCCURRENCES:AttributeClass1<|(1, "interface")]
+#[\Attributes\AttributeClass3(1, "enum"), |>MARK_OCCURRENCES:AttributeClass1<|]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "enum const")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(3, "enum case")]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(4, "enum method")] #[AttributeClass3()]
+    #[|>MARK_OCCURRENCES:AttributeClass1<|(int: 5, string: "enum static method")]
+    |>MARK_OCCURRENCES:AttributeClass1<|(1, "function"),
+$labmda1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "closure")] function() {};
+$arrow1 = #[|>MARK_OCCURRENCES:AttributeClass1<|(1, "arrow")] fn() => 100;
+$arrow2 = #[|>MARK_OCCURRENCES:AttributeClass1<|(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[|>MARK_OCCURRENCES:AttributeClass1<|(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;
+$arrow3 = #[|>MARK_OCCURRENCES:Attr^ibuteClass1<|(3, string: Example::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b01.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass^2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b02.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:Attribut^eClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b03.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b03.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:Attribu^teClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b04.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b04.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:Attribute^Class2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b05.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b05.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:Attr^ibuteClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b06.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b06.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeCl^ass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b07.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b07.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:Attribut^eClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b08.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b08.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:Attribute^Class2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b09.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b09.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:Attr^ibuteClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b10.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b10.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:Attribute^Class2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b11.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b11.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:At^tributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b12.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b12.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:Att^ributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b13.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b13.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:Att^ributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b14.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b14.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClas^s2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b15.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b15.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:Attribute^Class2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b16.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b16.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:Attrib^uteClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b17.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b17.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:Attribu^teClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b18.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b18.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:Attribut^eClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b19.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b19.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeC^lass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b20.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b20.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:Attribute^Class2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b21.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b21.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:Attribut^eClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b22.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b22.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:Attrib^uteClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b23.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b23.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:Attrib^uteClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b24.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b24.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:Attribu^teClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b25.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b25.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:Attribut^eClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b26.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b26.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:Att^ributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b27.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b27.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:Attribute^Class2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b28.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b28.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:Attrib^uteClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:AttributeClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b29.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_b29.occurrences
@@ -1,0 +1,28 @@
+class |>MARK_OCCURRENCES:AttributeClass2<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass2<|;
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "class")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "class const", new Example())]
+    #[AttributeClass1(4, "class static field"), |>MARK_OCCURRENCES:AttributeClass2<|(4, "class static field", new \Attributes\Example)] // group
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "trait")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "trait const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "trait static method")]
+$anon2 = new #[|>MARK_OCCURRENCES:AttributeClass2<|(1, "anonymous class")] class ($test) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "anonymous class const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(3, "anonymous class field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "anonymous class static field")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class constructor")]
+    public function __construct(#[|>MARK_OCCURRENCES:AttributeClass2<|(5, "anonymous class")] $param1) {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method")] #[AttributeClass3()]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(6, "anonymous class method param")] $param1): int|string {
+    private static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(7, "anonymous class static method param")] int|bool $pram1): int|string {
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "interface const")]
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(self::CONSTANT_INTERFACE, "interface method")] #[AttributeClass3()]
+    public function interfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(AttributedInterface::CONSTANT_INTERFACE, "interface method param")] $param1): int|string;
+    #[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method")] #[AttributeClass3()]
+    public static function staticInterfaceMethod(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "interface static method param" . Example::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass2<|(1, "enum", new Example)]
+    public function method(#[|>MARK_OCCURRENCES:AttributeClass2<|(4, "enum method param")] $param1): int|string {
+#[|>MARK_OCCURRENCES:AttributeClass2<|(1, "function")]
+function func2(#[|>MARK_OCCURRENCES:AttributeClass2<|(1 + \Attributes\CONST_1 + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[|>MARK_OCCURRENCES:AttributeClass2<|(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[|>MARK_OCCURRENCES:AttributeClass2<|(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), |>MARK_OCCURRENCES:Attribut^eClass2<|(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c01.occurrences
@@ -1,0 +1,14 @@
+class |>MARK_OCCURRENCES:Attribute^Class3<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass3<|;
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(6, "trait static method")]
+    public static function staticTraitMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|] int|string $param1): bool|int {
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "anonymous class field")]
+    #[AttributeClass2(6, "anonymous class method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(4, "interface static method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass3<|(1, "enum"), AttributeClass1]
+    #[AttributeClass1(4, "enum method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    public static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|(5, "enum static method param")] int|bool $pram1): int|string {
+    |>MARK_OCCURRENCES:AttributeClass3<|(int: CONST_1, string: "function" . Example::class)
+$labmda2 = #[AttributeClass2(2, "closure")] #[|>MARK_OCCURRENCES:AttributeClass3<|(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "closure")] static function(): void {};

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c02.occurrences
@@ -1,0 +1,14 @@
+class |>MARK_OCCURRENCES:AttributeClass3<| {
+use Attributes\|>MARK_OCCURRENCES:Attribu^teClass3<|;
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(6, "trait static method")]
+    public static function staticTraitMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|] int|string $param1): bool|int {
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "anonymous class field")]
+    #[AttributeClass2(6, "anonymous class method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(4, "interface static method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass3<|(1, "enum"), AttributeClass1]
+    #[AttributeClass1(4, "enum method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    public static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|(5, "enum static method param")] int|bool $pram1): int|string {
+    |>MARK_OCCURRENCES:AttributeClass3<|(int: CONST_1, string: "function" . Example::class)
+$labmda2 = #[AttributeClass2(2, "closure")] #[|>MARK_OCCURRENCES:AttributeClass3<|(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "closure")] static function(): void {};

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c03.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c03.occurrences
@@ -1,0 +1,14 @@
+class |>MARK_OCCURRENCES:AttributeClass3<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass3<|;
+    #[|>MARK_OCCURRENCES:Attribut^eClass3<|(6, "trait static method")]
+    public static function staticTraitMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|] int|string $param1): bool|int {
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "anonymous class field")]
+    #[AttributeClass2(6, "anonymous class method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(4, "interface static method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass3<|(1, "enum"), AttributeClass1]
+    #[AttributeClass1(4, "enum method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    public static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|(5, "enum static method param")] int|bool $pram1): int|string {
+    |>MARK_OCCURRENCES:AttributeClass3<|(int: CONST_1, string: "function" . Example::class)
+$labmda2 = #[AttributeClass2(2, "closure")] #[|>MARK_OCCURRENCES:AttributeClass3<|(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "closure")] static function(): void {};

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c04.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c04.occurrences
@@ -1,0 +1,14 @@
+class |>MARK_OCCURRENCES:AttributeClass3<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass3<|;
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(6, "trait static method")]
+    public static function staticTraitMethod(#[|>MARK_OCCURRENCES:Attribut^eClass3<|] int|string $param1): bool|int {
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "anonymous class field")]
+    #[AttributeClass2(6, "anonymous class method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(4, "interface static method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass3<|(1, "enum"), AttributeClass1]
+    #[AttributeClass1(4, "enum method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    public static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|(5, "enum static method param")] int|bool $pram1): int|string {
+    |>MARK_OCCURRENCES:AttributeClass3<|(int: CONST_1, string: "function" . Example::class)
+$labmda2 = #[AttributeClass2(2, "closure")] #[|>MARK_OCCURRENCES:AttributeClass3<|(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "closure")] static function(): void {};

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c05.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c05.occurrences
@@ -1,0 +1,14 @@
+class |>MARK_OCCURRENCES:AttributeClass3<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass3<|;
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(6, "trait static method")]
+    public static function staticTraitMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|] int|string $param1): bool|int {
+    #[|>MARK_OCCURRENCES:Attrib^uteClass3<|(3, "anonymous class field")]
+    #[AttributeClass2(6, "anonymous class method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(4, "interface static method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass3<|(1, "enum"), AttributeClass1]
+    #[AttributeClass1(4, "enum method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    public static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|(5, "enum static method param")] int|bool $pram1): int|string {
+    |>MARK_OCCURRENCES:AttributeClass3<|(int: CONST_1, string: "function" . Example::class)
+$labmda2 = #[AttributeClass2(2, "closure")] #[|>MARK_OCCURRENCES:AttributeClass3<|(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "closure")] static function(): void {};

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c06.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c06.occurrences
@@ -1,0 +1,14 @@
+class |>MARK_OCCURRENCES:AttributeClass3<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass3<|;
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(6, "trait static method")]
+    public static function staticTraitMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|] int|string $param1): bool|int {
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "anonymous class field")]
+    #[AttributeClass2(6, "anonymous class method")] #[|>MARK_OCCURRENCES:Attribu^teClass3<|()]
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(4, "interface static method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass3<|(1, "enum"), AttributeClass1]
+    #[AttributeClass1(4, "enum method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    public static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|(5, "enum static method param")] int|bool $pram1): int|string {
+    |>MARK_OCCURRENCES:AttributeClass3<|(int: CONST_1, string: "function" . Example::class)
+$labmda2 = #[AttributeClass2(2, "closure")] #[|>MARK_OCCURRENCES:AttributeClass3<|(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "closure")] static function(): void {};

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c07.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c07.occurrences
@@ -1,0 +1,14 @@
+class |>MARK_OCCURRENCES:AttributeClass3<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass3<|;
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(6, "trait static method")]
+    public static function staticTraitMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|] int|string $param1): bool|int {
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "anonymous class field")]
+    #[AttributeClass2(6, "anonymous class method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[|>MARK_OCCURRENCES:Attribu^teClass3<|()]
+    #[AttributeClass2(4, "interface static method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass3<|(1, "enum"), AttributeClass1]
+    #[AttributeClass1(4, "enum method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    public static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|(5, "enum static method param")] int|bool $pram1): int|string {
+    |>MARK_OCCURRENCES:AttributeClass3<|(int: CONST_1, string: "function" . Example::class)
+$labmda2 = #[AttributeClass2(2, "closure")] #[|>MARK_OCCURRENCES:AttributeClass3<|(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "closure")] static function(): void {};

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c08.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c08.occurrences
@@ -1,0 +1,14 @@
+class |>MARK_OCCURRENCES:AttributeClass3<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass3<|;
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(6, "trait static method")]
+    public static function staticTraitMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|] int|string $param1): bool|int {
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "anonymous class field")]
+    #[AttributeClass2(6, "anonymous class method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(4, "interface static method")] #[|>MARK_OCCURRENCES:Attri^buteClass3<|()]
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass3<|(1, "enum"), AttributeClass1]
+    #[AttributeClass1(4, "enum method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    public static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|(5, "enum static method param")] int|bool $pram1): int|string {
+    |>MARK_OCCURRENCES:AttributeClass3<|(int: CONST_1, string: "function" . Example::class)
+$labmda2 = #[AttributeClass2(2, "closure")] #[|>MARK_OCCURRENCES:AttributeClass3<|(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "closure")] static function(): void {};

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c09.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c09.occurrences
@@ -1,0 +1,14 @@
+class |>MARK_OCCURRENCES:AttributeClass3<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass3<|;
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(6, "trait static method")]
+    public static function staticTraitMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|] int|string $param1): bool|int {
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "anonymous class field")]
+    #[AttributeClass2(6, "anonymous class method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(4, "interface static method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+#[\Attributes\|>MARK_OCCURRENCES:Attribut^eClass3<|(1, "enum"), AttributeClass1]
+    #[AttributeClass1(4, "enum method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    public static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|(5, "enum static method param")] int|bool $pram1): int|string {
+    |>MARK_OCCURRENCES:AttributeClass3<|(int: CONST_1, string: "function" . Example::class)
+$labmda2 = #[AttributeClass2(2, "closure")] #[|>MARK_OCCURRENCES:AttributeClass3<|(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "closure")] static function(): void {};

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c10.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c10.occurrences
@@ -1,0 +1,14 @@
+class |>MARK_OCCURRENCES:AttributeClass3<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass3<|;
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(6, "trait static method")]
+    public static function staticTraitMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|] int|string $param1): bool|int {
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "anonymous class field")]
+    #[AttributeClass2(6, "anonymous class method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(4, "interface static method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass3<|(1, "enum"), AttributeClass1]
+    #[AttributeClass1(4, "enum method")] #[|>MARK_OCCURRENCES:AttributeCla^ss3<|()]
+    public static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|(5, "enum static method param")] int|bool $pram1): int|string {
+    |>MARK_OCCURRENCES:AttributeClass3<|(int: CONST_1, string: "function" . Example::class)
+$labmda2 = #[AttributeClass2(2, "closure")] #[|>MARK_OCCURRENCES:AttributeClass3<|(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "closure")] static function(): void {};

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c11.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c11.occurrences
@@ -1,0 +1,14 @@
+class |>MARK_OCCURRENCES:AttributeClass3<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass3<|;
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(6, "trait static method")]
+    public static function staticTraitMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|] int|string $param1): bool|int {
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "anonymous class field")]
+    #[AttributeClass2(6, "anonymous class method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(4, "interface static method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass3<|(1, "enum"), AttributeClass1]
+    #[AttributeClass1(4, "enum method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    public static function staticMethod(#[|>MARK_OCCURRENCES:Attrib^uteClass3<|(5, "enum static method param")] int|bool $pram1): int|string {
+    |>MARK_OCCURRENCES:AttributeClass3<|(int: CONST_1, string: "function" . Example::class)
+$labmda2 = #[AttributeClass2(2, "closure")] #[|>MARK_OCCURRENCES:AttributeClass3<|(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "closure")] static function(): void {};

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c12.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c12.occurrences
@@ -1,0 +1,14 @@
+class |>MARK_OCCURRENCES:AttributeClass3<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass3<|;
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(6, "trait static method")]
+    public static function staticTraitMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|] int|string $param1): bool|int {
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "anonymous class field")]
+    #[AttributeClass2(6, "anonymous class method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(4, "interface static method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass3<|(1, "enum"), AttributeClass1]
+    #[AttributeClass1(4, "enum method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    public static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|(5, "enum static method param")] int|bool $pram1): int|string {
+    |>MARK_OCCURRENCES:Attribu^teClass3<|(int: CONST_1, string: "function" . Example::class)
+$labmda2 = #[AttributeClass2(2, "closure")] #[|>MARK_OCCURRENCES:AttributeClass3<|(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "closure")] static function(): void {};

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c13.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c13.occurrences
@@ -1,0 +1,14 @@
+class |>MARK_OCCURRENCES:AttributeClass3<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass3<|;
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(6, "trait static method")]
+    public static function staticTraitMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|] int|string $param1): bool|int {
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "anonymous class field")]
+    #[AttributeClass2(6, "anonymous class method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(4, "interface static method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass3<|(1, "enum"), AttributeClass1]
+    #[AttributeClass1(4, "enum method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    public static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|(5, "enum static method param")] int|bool $pram1): int|string {
+    |>MARK_OCCURRENCES:AttributeClass3<|(int: CONST_1, string: "function" . Example::class)
+$labmda2 = #[AttributeClass2(2, "closure")] #[|>MARK_OCCURRENCES:Attri^buteClass3<|(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "closure")] static function(): void {};

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c14.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_c14.occurrences
@@ -1,0 +1,14 @@
+class |>MARK_OCCURRENCES:AttributeClass3<| {
+use Attributes\|>MARK_OCCURRENCES:AttributeClass3<|;
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(6, "trait static method")]
+    public static function staticTraitMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|] int|string $param1): bool|int {
+    #[|>MARK_OCCURRENCES:AttributeClass3<|(3, "anonymous class field")]
+    #[AttributeClass2(6, "anonymous class method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(self::CONSTANT_INTERFACE, "interface method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    #[AttributeClass2(4, "interface static method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+#[\Attributes\|>MARK_OCCURRENCES:AttributeClass3<|(1, "enum"), AttributeClass1]
+    #[AttributeClass1(4, "enum method")] #[|>MARK_OCCURRENCES:AttributeClass3<|()]
+    public static function staticMethod(#[|>MARK_OCCURRENCES:AttributeClass3<|(5, "enum static method param")] int|bool $pram1): int|string {
+    |>MARK_OCCURRENCES:AttributeClass3<|(int: CONST_1, string: "function" . Example::class)
+$labmda2 = #[AttributeClass2(2, "closure")] #[|>MARK_OCCURRENCES:AttributeClass3<|(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$labmda3 = #[|>MARK_OCCURRENCES:Attribut^eClass3<|(3, "closure")] static function(): void {};

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_d01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_d01.occurrences
@@ -1,0 +1,6 @@
+const |>MARK_OCCURRENCES:CONS^T_1<| = 1;
+use const Attributes\|>MARK_OCCURRENCES:CONST_1<|;
+    AttributeClass3(int: |>MARK_OCCURRENCES:CONST_1<|, string: "function" . Example::class)
+function func2(#[AttributeClass2(1 + \Attributes\|>MARK_OCCURRENCES:CONST_1<| + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\|>MARK_OCCURRENCES:CONST_1<|, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\|>MARK_OCCURRENCES:CONST_1<| / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_d02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_d02.occurrences
@@ -1,0 +1,6 @@
+const |>MARK_OCCURRENCES:CONST_1<| = 1;
+use const Attributes\|>MARK_OCCURRENCES:CO^NST_1<|;
+    AttributeClass3(int: |>MARK_OCCURRENCES:CONST_1<|, string: "function" . Example::class)
+function func2(#[AttributeClass2(1 + \Attributes\|>MARK_OCCURRENCES:CONST_1<| + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\|>MARK_OCCURRENCES:CONST_1<|, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\|>MARK_OCCURRENCES:CONST_1<| / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_d03.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_d03.occurrences
@@ -1,0 +1,6 @@
+const |>MARK_OCCURRENCES:CONST_1<| = 1;
+use const Attributes\|>MARK_OCCURRENCES:CONST_1<|;
+    AttributeClass3(int: |>MARK_OCCURRENCES:CONST_^1<|, string: "function" . Example::class)
+function func2(#[AttributeClass2(1 + \Attributes\|>MARK_OCCURRENCES:CONST_1<| + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\|>MARK_OCCURRENCES:CONST_1<|, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\|>MARK_OCCURRENCES:CONST_1<| / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_d04.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_d04.occurrences
@@ -1,0 +1,6 @@
+const |>MARK_OCCURRENCES:CONST_1<| = 1;
+use const Attributes\|>MARK_OCCURRENCES:CONST_1<|;
+    AttributeClass3(int: |>MARK_OCCURRENCES:CONST_1<|, string: "function" . Example::class)
+function func2(#[AttributeClass2(1 + \Attributes\|>MARK_OCCURRENCES:CON^ST_1<| + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\|>MARK_OCCURRENCES:CONST_1<|, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\|>MARK_OCCURRENCES:CONST_1<| / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_d05.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_d05.occurrences
@@ -1,0 +1,6 @@
+const |>MARK_OCCURRENCES:CONST_1<| = 1;
+use const Attributes\|>MARK_OCCURRENCES:CONST_1<|;
+    AttributeClass3(int: |>MARK_OCCURRENCES:CONST_1<|, string: "function" . Example::class)
+function func2(#[AttributeClass2(1 + \Attributes\|>MARK_OCCURRENCES:CONST_1<| + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\|>MARK_OCCURRENCES:CON^ST_1<|, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\|>MARK_OCCURRENCES:CONST_1<| / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_d06.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_d06.occurrences
@@ -1,0 +1,6 @@
+const |>MARK_OCCURRENCES:CONST_1<| = 1;
+use const Attributes\|>MARK_OCCURRENCES:CONST_1<|;
+    AttributeClass3(int: |>MARK_OCCURRENCES:CONST_1<|, string: "function" . Example::class)
+function func2(#[AttributeClass2(1 + \Attributes\|>MARK_OCCURRENCES:CONST_1<| + 1, Example::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\|>MARK_OCCURRENCES:CONST_1<|, string: "closure param" . Example::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\|>MARK_OCCURRENCES:CONS^T_1<| / 5, "arrow param" . Example::class)] $test): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e01.occurrences
@@ -1,0 +1,11 @@
+class |>MARK_OCCURRENCES:Ex^ample<| {
+use Attributes\|>MARK_OCCURRENCES:Example<|;
+    #[AttributeClass2(2, "class const", new |>MARK_OCCURRENCES:Example<|())]
+    #[AttributeClass1(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\|>MARK_OCCURRENCES:Example<|)] // group
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\AttributeClass2(1, "enum", new |>MARK_OCCURRENCES:Example<|)]
+    AttributeClass3(int: CONST_1, string: "function" . |>MARK_OCCURRENCES:Example<|::class)
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . |>MARK_OCCURRENCES:Example<|::class)] $test): int|string => 100;
+$arrow3 = #[AttributeClass1(3, string: |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e02.occurrences
@@ -1,0 +1,11 @@
+class |>MARK_OCCURRENCES:Example<| {
+use Attributes\|>MARK_OCCURRENCES:Exa^mple<|;
+    #[AttributeClass2(2, "class const", new |>MARK_OCCURRENCES:Example<|())]
+    #[AttributeClass1(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\|>MARK_OCCURRENCES:Example<|)] // group
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\AttributeClass2(1, "enum", new |>MARK_OCCURRENCES:Example<|)]
+    AttributeClass3(int: CONST_1, string: "function" . |>MARK_OCCURRENCES:Example<|::class)
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . |>MARK_OCCURRENCES:Example<|::class)] $test): int|string => 100;
+$arrow3 = #[AttributeClass1(3, string: |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e03.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e03.occurrences
@@ -1,0 +1,11 @@
+class |>MARK_OCCURRENCES:Example<| {
+use Attributes\|>MARK_OCCURRENCES:Example<|;
+    #[AttributeClass2(2, "class const", new |>MARK_OCCURRENCES:Exa^mple<|())]
+    #[AttributeClass1(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\|>MARK_OCCURRENCES:Example<|)] // group
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\AttributeClass2(1, "enum", new |>MARK_OCCURRENCES:Example<|)]
+    AttributeClass3(int: CONST_1, string: "function" . |>MARK_OCCURRENCES:Example<|::class)
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . |>MARK_OCCURRENCES:Example<|::class)] $test): int|string => 100;
+$arrow3 = #[AttributeClass1(3, string: |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e04.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e04.occurrences
@@ -1,0 +1,11 @@
+class |>MARK_OCCURRENCES:Example<| {
+use Attributes\|>MARK_OCCURRENCES:Example<|;
+    #[AttributeClass2(2, "class const", new |>MARK_OCCURRENCES:Example<|())]
+    #[AttributeClass1(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\|>MARK_OCCURRENCES:Exa^mple<|)] // group
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\AttributeClass2(1, "enum", new |>MARK_OCCURRENCES:Example<|)]
+    AttributeClass3(int: CONST_1, string: "function" . |>MARK_OCCURRENCES:Example<|::class)
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . |>MARK_OCCURRENCES:Example<|::class)] $test): int|string => 100;
+$arrow3 = #[AttributeClass1(3, string: |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e05.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e05.occurrences
@@ -1,0 +1,11 @@
+class |>MARK_OCCURRENCES:Example<| {
+use Attributes\|>MARK_OCCURRENCES:Example<|;
+    #[AttributeClass2(2, "class const", new |>MARK_OCCURRENCES:Example<|())]
+    #[AttributeClass1(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\|>MARK_OCCURRENCES:Example<|)] // group
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . |>MARK_OCCURRENCES:Examp^le<|::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\AttributeClass2(1, "enum", new |>MARK_OCCURRENCES:Example<|)]
+    AttributeClass3(int: CONST_1, string: "function" . |>MARK_OCCURRENCES:Example<|::class)
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . |>MARK_OCCURRENCES:Example<|::class)] $test): int|string => 100;
+$arrow3 = #[AttributeClass1(3, string: |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e06.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e06.occurrences
@@ -1,0 +1,11 @@
+class |>MARK_OCCURRENCES:Example<| {
+use Attributes\|>MARK_OCCURRENCES:Example<|;
+    #[AttributeClass2(2, "class const", new |>MARK_OCCURRENCES:Example<|())]
+    #[AttributeClass1(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\|>MARK_OCCURRENCES:Example<|)] // group
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\AttributeClass2(1, "enum", new |>MARK_OCCURRENCES:E^xample<|)]
+    AttributeClass3(int: CONST_1, string: "function" . |>MARK_OCCURRENCES:Example<|::class)
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . |>MARK_OCCURRENCES:Example<|::class)] $test): int|string => 100;
+$arrow3 = #[AttributeClass1(3, string: |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e07.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e07.occurrences
@@ -1,0 +1,11 @@
+class |>MARK_OCCURRENCES:Example<| {
+use Attributes\|>MARK_OCCURRENCES:Example<|;
+    #[AttributeClass2(2, "class const", new |>MARK_OCCURRENCES:Example<|())]
+    #[AttributeClass1(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\|>MARK_OCCURRENCES:Example<|)] // group
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\AttributeClass2(1, "enum", new |>MARK_OCCURRENCES:Example<|)]
+    AttributeClass3(int: CONST_1, string: "function" . |>MARK_OCCURRENCES:Exa^mple<|::class)
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . |>MARK_OCCURRENCES:Example<|::class)] $test): int|string => 100;
+$arrow3 = #[AttributeClass1(3, string: |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e08.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e08.occurrences
@@ -1,0 +1,11 @@
+class |>MARK_OCCURRENCES:Example<| {
+use Attributes\|>MARK_OCCURRENCES:Example<|;
+    #[AttributeClass2(2, "class const", new |>MARK_OCCURRENCES:Example<|())]
+    #[AttributeClass1(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\|>MARK_OCCURRENCES:Example<|)] // group
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\AttributeClass2(1, "enum", new |>MARK_OCCURRENCES:Example<|)]
+    AttributeClass3(int: CONST_1, string: "function" . |>MARK_OCCURRENCES:Example<|::class)
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, |>MARK_OCCURRENCES:Exam^ple<|::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . |>MARK_OCCURRENCES:Example<|::class)] $test): int|string => 100;
+$arrow3 = #[AttributeClass1(3, string: |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e09.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e09.occurrences
@@ -1,0 +1,11 @@
+class |>MARK_OCCURRENCES:Example<| {
+use Attributes\|>MARK_OCCURRENCES:Example<|;
+    #[AttributeClass2(2, "class const", new |>MARK_OCCURRENCES:Example<|())]
+    #[AttributeClass1(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\|>MARK_OCCURRENCES:Example<|)] // group
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\AttributeClass2(1, "enum", new |>MARK_OCCURRENCES:Example<|)]
+    AttributeClass3(int: CONST_1, string: "function" . |>MARK_OCCURRENCES:Example<|::class)
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . |>MARK_OCCURRENCES:Ex^ample<|::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . |>MARK_OCCURRENCES:Example<|::class)] $test): int|string => 100;
+$arrow3 = #[AttributeClass1(3, string: |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e10.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e10.occurrences
@@ -1,0 +1,11 @@
+class |>MARK_OCCURRENCES:Example<| {
+use Attributes\|>MARK_OCCURRENCES:Example<|;
+    #[AttributeClass2(2, "class const", new |>MARK_OCCURRENCES:Example<|())]
+    #[AttributeClass1(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\|>MARK_OCCURRENCES:Example<|)] // group
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\AttributeClass2(1, "enum", new |>MARK_OCCURRENCES:Example<|)]
+    AttributeClass3(int: CONST_1, string: "function" . |>MARK_OCCURRENCES:Example<|::class)
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . |>MARK_OCCURRENCES:Exam^ple<|::class)] $test): int|string => 100;
+$arrow3 = #[AttributeClass1(3, string: |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e11.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_e11.occurrences
@@ -1,0 +1,11 @@
+class |>MARK_OCCURRENCES:Example<| {
+use Attributes\|>MARK_OCCURRENCES:Example<|;
+    #[AttributeClass2(2, "class const", new |>MARK_OCCURRENCES:Example<|())]
+    #[AttributeClass1(4, "class static field"), AttributeClass2(4, "class static field", new \Attributes\|>MARK_OCCURRENCES:Example<|)] // group
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $param1): int|string;
+#[\Attributes\AttributeClass2(1, "enum", new |>MARK_OCCURRENCES:Example<|)]
+    AttributeClass3(int: CONST_1, string: "function" . |>MARK_OCCURRENCES:Example<|::class)
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . |>MARK_OCCURRENCES:Example<|::CONST_EXAMPLE)] $test): void {};
+$arrow2 = #[AttributeClass1(2, "arrow"), AttributeClass2(2, "arrow")] fn(#[AttributeClass1(\Attributes\CONST_1 / 5, "arrow param" . |>MARK_OCCURRENCES:Example<|::class)] $test): int|string => 100;
+$arrow3 = #[AttributeClass1(3, string: |>MARK_OCCURRENCES:Exa^mple<|::CONST_EXAMPLE . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_f01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_f01.occurrences
@@ -1,0 +1,5 @@
+    public const string |>MARK_OCCURRENCES:CONST_EXAMP^LE<| = "example";
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<|)] $param1): int|string;
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<| . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<|)] $test): void {};
+$arrow3 = #[AttributeClass1(3, string: Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<| . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_f02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_f02.occurrences
@@ -1,0 +1,5 @@
+    public const string |>MARK_OCCURRENCES:CONST_EXAMPLE<| = "example";
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . Example::|>MARK_OCCURRENCES:CONST^_EXAMPLE<|)] $param1): int|string;
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<| . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<|)] $test): void {};
+$arrow3 = #[AttributeClass1(3, string: Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<| . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_f03.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_f03.occurrences
@@ -1,0 +1,5 @@
+    public const string |>MARK_OCCURRENCES:CONST_EXAMPLE<| = "example";
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<|)] $param1): int|string;
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, Example::|>MARK_OCCURRENCES:CONST_EXA^MPLE<| . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<|)] $test): void {};
+$arrow3 = #[AttributeClass1(3, string: Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<| . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_f04.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_f04.occurrences
@@ -1,0 +1,5 @@
+    public const string |>MARK_OCCURRENCES:CONST_EXAMPLE<| = "example";
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<|)] $param1): int|string;
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<| . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::|>MARK_OCCURRENCES:CO^NST_EXAMPLE<|)] $test): void {};
+$arrow3 = #[AttributeClass1(3, string: Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<| . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_f05.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_f05.occurrences
@@ -1,0 +1,5 @@
+    public const string |>MARK_OCCURRENCES:CONST_EXAMPLE<| = "example";
+    public static function staticInterfaceMethod(#[AttributeClass2(4, "interface static method param" . Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<|)] $param1): int|string;
+function func2(#[AttributeClass2(1 + \Attributes\CONST_1 + 1, Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<| . "function param")] int|string $param): void {}
+$labmda2 = #[AttributeClass2(2, "closure")] #[AttributeClass3(2, "closurr")] function(#[AttributeClass2(int: 2 * \Attributes\CONST_1, string: "closure param" . Example::|>MARK_OCCURRENCES:CONST_EXAMPLE<|)] $test): void {};
+$arrow3 = #[AttributeClass1(3, string: Example::|>MARK_OCCURRENCES:CONST_EX^AMPLE<| . "arrow")] static fn(): int|string => 100;

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_g01.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_g01.occurrences
@@ -1,0 +1,2 @@
+#[AttributeClass1(1, self::|>MARK_OCCURRENCES:CONSTANT^_CLASS<|)]
+    public const |>MARK_OCCURRENCES:CONSTANT_CLASS<| = 'constant';

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_g02.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/php80/testAttributes/testAttributes.php.testAttributes_g02.occurrences
@@ -1,0 +1,2 @@
+#[AttributeClass1(1, self::|>MARK_OCCURRENCES:CONSTANT_CLASS<|)]
+    public const |>MARK_OCCURRENCES:CO^NSTANT_CLASS<| = 'constant';

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/GotoDeclarationPHP80Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/GotoDeclarationPHP80Test.java
@@ -317,4 +317,352 @@ public class GotoDeclarationPHP80Test extends GotoDeclarationTestBase {
         checkDeclaration(getTestPath(), "protected int|string|\\Test2\\F^oo $field2,", "    class ^Foo {}");
     }
 
+    public void testAttributes_a01() throws Exception {
+        checkDeclaration(getTestPath(), "#[AttributeCl^ass1(1, self::CONSTANT_CLASS)]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a02() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeClas^s1(2, \"class const\")]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a03() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeCla^ss1(3, \"class field\")]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a04() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeCl^ass1(4, \"class static field\"), AttributeClass2(4, \"class static field\", new \\Attributes\\Example)] // group", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a05() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeCla^ss1(5, \"class method\")]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a06() throws Exception {
+        checkDeclaration(getTestPath(), "    public function method(#[AttributeC^lass1(5, \"class method param\")] $param1, #[AttributeClass1(5, 'class method param')] int $pram2) {}", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a07() throws Exception {
+        checkDeclaration(getTestPath(), "    public function method(#[AttributeClass1(5, \"class method param\")] $param1, #[AttributeCla^ss1(5, 'class method param')] int $pram2) {}", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a08() throws Exception {
+        checkDeclaration(getTestPath(), "    #[\\Attributes\\AttributeClas^s1(6, \"class static method\")]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a09() throws Exception {
+        checkDeclaration(getTestPath(), "    public static function staticMethod(#[\\Attributes\\Attrib^uteClass1(6, \"class static method param\")] int|string $param1): bool|int {", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a10() throws Exception {
+        checkDeclaration(getTestPath(), "#[AttributeC^lass1(1, \"class child\")]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a11() throws Exception {
+        checkDeclaration(getTestPath(), "#[Attribute^Class1(1, \"trait\")]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a12() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeCl^ass1(3, \"trait field\")]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a13() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeCl^ass1(4, \"trait static field\")]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a14() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeCla^ss1(5, \"trait method\")]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a15() throws Exception {
+        checkDeclaration(getTestPath(), "    public function traitMethod(#[AttributeCl^ass1(5, \"trait method param\")] $param1) {}", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a16() throws Exception {
+        checkDeclaration(getTestPath(), "    #[Attri^buteClass1(6, \"trait static method\")]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a17() throws Exception {
+        checkDeclaration(getTestPath(), "$anon = new #[Attribut^eClass1(1, \"anonymous class\")] class () {};", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a18() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeClas^s1(int: 7, string: \"anonymous class static method\")]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a19() throws Exception {
+        checkDeclaration(getTestPath(), "#[Attr^ibuteClass1(1, \"interface\")]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a20() throws Exception {
+        checkDeclaration(getTestPath(), "#[\\Attributes\\AttributeClass3(1, \"enum\"), Attrib^uteClass1]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a21() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeCl^ass1(2, \"enum const\")]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a22() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeC^lass1(3, \"enum case\")]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a23() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeCl^ass1(4, \"enum method\")] #[AttributeClass3()]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a24() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeCl^ass1(int: 5, string: \"enum static method\")]", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a25() throws Exception {
+        checkDeclaration(getTestPath(), "    AttributeCla^ss1(1, \"function\"),", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a26() throws Exception {
+        checkDeclaration(getTestPath(), "$labmda1 = #[Attribut^eClass1(1, \"closure\")] function() {};", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a27() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow1 = #[AttributeCla^ss1(1, \"arrow\")] fn() => 100;", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a28() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow2 = #[AttributeCla^ss1(2, \"arrow\"), AttributeClass2(2, \"arrow\")] fn(#[AttributeClass1(\\Attributes\\CONST_1 / 5, \"arrow param\" . Example::class)] $test): int|string => 100;", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a29() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow2 = #[AttributeClass1(2, \"arrow\"), AttributeClass2(2, \"arrow\")] fn(#[AttributeC^lass1(\\Attributes\\CONST_1 / 5, \"arrow param\" . Example::class)] $test): int|string => 100;", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_a30() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow3 = #[Attribute^Class1(3, string: Example::CONST_EXAMPLE . \"arrow\")] static fn(): int|string => 100;", "class ^AttributeClass1 {");
+    }
+
+    public void testAttributes_b01() throws Exception {
+        checkDeclaration(getTestPath(), "#[AttributeCl^ass2(1, \"class\")]", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b02() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeCla^ss2(2, \"class const\", new Example())]", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b03() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeClass1(4, \"class static field\"), Attribut^eClass2(4, \"class static field\", new \\Attributes\\Example)] // group", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b04() throws Exception {
+        checkDeclaration(getTestPath(), "#[AttributeClas^s2(1, \"trait\")]", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b05() throws Exception {
+        checkDeclaration(getTestPath(), "    #[A^ttributeClass2(2, \"trait const\")]", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b06() throws Exception {
+        checkDeclaration(getTestPath(), "    #[Attr^ibuteClass2(6, \"trait static method\")]", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b07() throws Exception {
+        checkDeclaration(getTestPath(), "$anon2 = new #[At^tributeClass2(1, \"anonymous class\")] class ($test) {", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b08() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeC^lass2(2, \"anonymous class const\")]", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b09() throws Exception {
+        checkDeclaration(getTestPath(), "    #[Att^ributeClass2(3, \"anonymous class field\")]", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b10() throws Exception {
+        checkDeclaration(getTestPath(), "    #[At^tributeClass2(4, \"anonymous class static field\")]", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b11() throws Exception {
+        checkDeclaration(getTestPath(), "    #[Att^ributeClass2(5, \"anonymous class constructor\")]", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b12() throws Exception {
+        checkDeclaration(getTestPath(), "    public function __construct(#[Attr^ibuteClass2(5, \"anonymous class\")] $param1) {", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b13() throws Exception {
+        checkDeclaration(getTestPath(), "    #[A^ttributeClass2(6, \"anonymous class method\")] #[AttributeClass3()]", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b14() throws Exception {
+        checkDeclaration(getTestPath(), "    public function method(#[Attribute^Class2(6, \"anonymous class method param\")] $param1): int|string {", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b15() throws Exception {
+        checkDeclaration(getTestPath(), "    private static function staticMethod(#[AttributeClas^s2(7, \"anonymous class static method param\")] int|bool $pram1): int|string {", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b16() throws Exception {
+        checkDeclaration(getTestPath(), "    #[Attribute^Class2(2, \"interface const\")]", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b17() throws Exception {
+        checkDeclaration(getTestPath(), "    #[Attribut^eClass2(self::CONSTANT_INTERFACE, \"interface method\")] #[AttributeClass3()]", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b18() throws Exception {
+        checkDeclaration(getTestPath(), "    public function interfaceMethod(#[AttributeC^lass2(AttributedInterface::CONSTANT_INTERFACE, \"interface method param\")] $param1): int|string;", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b19() throws Exception {
+        checkDeclaration(getTestPath(), "    #[Att^ributeClass2(4, \"interface static method\")] #[AttributeClass3()]", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b20() throws Exception {
+        checkDeclaration(getTestPath(), "    public static function staticInterfaceMethod(#[Attribu^teClass2(4, \"interface static method param\" . Example::CONST_EXAMPLE)] $param1): int|string;", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b21() throws Exception {
+        checkDeclaration(getTestPath(), "#[\\Attributes\\AttributeCla^ss2(1, \"enum\", new Example)]", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b22() throws Exception {
+        checkDeclaration(getTestPath(), "    public function method(#[Attrib^uteClass2(4, \"enum method param\")] $param1): int|string {", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b23() throws Exception {
+        checkDeclaration(getTestPath(), "#[Attribut^eClass2(1, \"function\")]", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b24() throws Exception {
+        checkDeclaration(getTestPath(), "function func2(#[AttributeC^lass2(1 + \\Attributes\\CONST_1 + 1, Example::CONST_EXAMPLE . \"function param\")] int|string $param): void {}", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b25() throws Exception {
+        checkDeclaration(getTestPath(), "$labmda2 = #[Att^ributeClass2(2, \"closure\")] #[AttributeClass3(2, \"closurr\")] function(#[AttributeClass2(int: 2 * \\Attributes\\CONST_1, string: \"closure param\" . Example::CONST_EXAMPLE)] $test): void {};", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b26() throws Exception {
+        checkDeclaration(getTestPath(), "$labmda2 = #[AttributeClass2(2, \"closure\")] #[AttributeClass3(2, \"closurr\")] function(#[AttributeCla^ss2(int: 2 * \\Attributes\\CONST_1, string: \"closure param\" . Example::CONST_EXAMPLE)] $test): void {};", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_b27() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow2 = #[AttributeClass1(2, \"arrow\"), Attri^buteClass2(2, \"arrow\")] fn(#[AttributeClass1(\\Attributes\\CONST_1 / 5, \"arrow param\" . Example::class)] $test): int|string => 100;", "class ^AttributeClass2 {");
+    }
+
+    public void testAttributes_c01() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeClas^s3(6, \"trait static method\")]", "class ^AttributeClass3 {");
+    }
+
+    public void testAttributes_c02() throws Exception {
+        checkDeclaration(getTestPath(), "    public static function staticTraitMethod(#[At^tributeClass3] int|string $param1): bool|int {", "class ^AttributeClass3 {");
+    }
+
+    public void testAttributes_c03() throws Exception {
+        checkDeclaration(getTestPath(), "    #[At^tributeClass3(3, \"anonymous class field\")]", "class ^AttributeClass3 {");
+    }
+
+    public void testAttributes_c04() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeClass2(6, \"anonymous class method\")] #[A^ttributeClass3()]", "class ^AttributeClass3 {");
+    }
+
+    public void testAttributes_c05() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeClass2(self::CONSTANT_INTERFACE, \"interface method\")] #[Attribu^teClass3()]", "class ^AttributeClass3 {");
+    }
+
+    public void testAttributes_c06() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeClass2(4, \"interface static method\")] #[Attribut^eClass3()]", "class ^AttributeClass3 {");
+    }
+
+    public void testAttributes_c07() throws Exception {
+        checkDeclaration(getTestPath(), "#[\\Attributes\\Attribute^Class3(1, \"enum\"), AttributeClass1]", "class ^AttributeClass3 {");
+    }
+
+    public void testAttributes_c08() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeClass1(4, \"enum method\")] #[Att^ributeClass3()]", "class ^AttributeClass3 {");
+    }
+
+    public void testAttributes_c09() throws Exception {
+        checkDeclaration(getTestPath(), "    public static function staticMethod(#[AttributeC^lass3(5, \"enum static method param\")] int|bool $pram1): int|string {", "class ^AttributeClass3 {");
+    }
+
+    public void testAttributes_c10() throws Exception {
+        checkDeclaration(getTestPath(), "    Att^ributeClass3(int: CONST_1, string: \"function\" . Example::class)", "class ^AttributeClass3 {");
+    }
+
+    public void testAttributes_c11() throws Exception {
+        checkDeclaration(getTestPath(), "$labmda2 = #[AttributeClass2(2, \"closure\")] #[Attr^ibuteClass3(2, \"closurr\")] function(#[AttributeClass2(int: 2 * \\Attributes\\CONST_1, string: \"closure param\" . Example::CONST_EXAMPLE)] $test): void {};", "class ^AttributeClass3 {");
+    }
+
+    public void testAttributes_c12() throws Exception {
+        checkDeclaration(getTestPath(), "$labmda3 = #[Attribute^Class3(3, \"closure\")] static function(): void {};", "class ^AttributeClass3 {");
+    }
+
+    public void testAttributes_d01() throws Exception {
+        checkDeclaration(getTestPath(), "    AttributeClass3(int: CONS^T_1, string: \"function\" . Example::class)", "const ^CONST_1 = 1;");
+    }
+
+    public void testAttributes_d02() throws Exception {
+        checkDeclaration(getTestPath(), "function func2(#[AttributeClass2(1 + \\Attributes\\CONS^T_1 + 1, Example::CONST_EXAMPLE . \"function param\")] int|string $param): void {}", "const ^CONST_1 = 1;");
+    }
+
+    public void testAttributes_d03() throws Exception {
+        checkDeclaration(getTestPath(), "$labmda2 = #[AttributeClass2(2, \"closure\")] #[AttributeClass3(2, \"closurr\")] function(#[AttributeClass2(int: 2 * \\Attributes\\CO^NST_1, string: \"closure param\" . Example::CONST_EXAMPLE)] $test): void {};", "const ^CONST_1 = 1;");
+    }
+
+    public void testAttributes_d04() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow2 = #[AttributeClass1(2, \"arrow\"), AttributeClass2(2, \"arrow\")] fn(#[AttributeClass1(\\Attributes\\C^ONST_1 / 5, \"arrow param\" . Example::class)] $test): int|string => 100;", "const ^CONST_1 = 1;");
+    }
+
+    public void testAttributes_e01() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeClass2(2, \"class const\", new Exa^mple())]", "class ^Example {");
+    }
+
+    public void testAttributes_e02() throws Exception {
+        checkDeclaration(getTestPath(), "    #[AttributeClass1(4, \"class static field\"), AttributeClass2(4, \"class static field\", new \\Attributes\\E^xample)] // group", "class ^Example {");
+    }
+
+    public void testAttributes_e03() throws Exception {
+        checkDeclaration(getTestPath(), "    public static function staticInterfaceMethod(#[AttributeClass2(4, \"interface static method param\" . Ex^ample::CONST_EXAMPLE)] $param1): int|string;", "class ^Example {");
+    }
+
+    public void testAttributes_e04() throws Exception {
+        checkDeclaration(getTestPath(), "#[\\Attributes\\AttributeClass2(1, \"enum\", new E^xample)]", "class ^Example {");
+    }
+
+    public void testAttributes_e05() throws Exception {
+        checkDeclaration(getTestPath(), "    AttributeClass3(int: CONST_1, string: \"function\" . Exam^ple::class)", "class ^Example {");
+    }
+
+    public void testAttributes_e06() throws Exception {
+        checkDeclaration(getTestPath(), "function func2(#[AttributeClass2(1 + \\Attributes\\CONST_1 + 1, Ex^ample::CONST_EXAMPLE . \"function param\")] int|string $param): void {}", "class ^Example {");
+    }
+
+    public void testAttributes_e07() throws Exception {
+        checkDeclaration(getTestPath(), "$labmda2 = #[AttributeClass2(2, \"closure\")] #[AttributeClass3(2, \"closurr\")] function(#[AttributeClass2(int: 2 * \\Attributes\\CONST_1, string: \"closure param\" . E^xample::CONST_EXAMPLE)] $test): void {};", "class ^Example {");
+    }
+
+    public void testAttributes_e08() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow2 = #[AttributeClass1(2, \"arrow\"), AttributeClass2(2, \"arrow\")] fn(#[AttributeClass1(\\Attributes\\CONST_1 / 5, \"arrow param\" . Exa^mple::class)] $test): int|string => 100;", "class ^Example {");
+    }
+
+    public void testAttributes_e09() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow3 = #[AttributeClass1(3, string: E^xample::CONST_EXAMPLE . \"arrow\")] static fn(): int|string => 100;", "class ^Example {");
+    }
+
+    public void testAttributes_f01() throws Exception {
+        checkDeclaration(getTestPath(), "    public static function staticInterfaceMethod(#[AttributeClass2(4, \"interface static method param\" . Example::CONST_EXA^MPLE)] $param1): int|string;", "    public const string ^CONST_EXAMPLE = \"example\";");
+    }
+
+    public void testAttributes_f02() throws Exception {
+        checkDeclaration(getTestPath(), "function func2(#[AttributeClass2(1 + \\Attributes\\CONST_1 + 1, Example::CONS^T_EXAMPLE . \"function param\")] int|string $param): void {}", "    public const string ^CONST_EXAMPLE = \"example\";");
+    }
+
+    public void testAttributes_f03() throws Exception {
+        checkDeclaration(getTestPath(), "$labmda2 = #[AttributeClass2(2, \"closure\")] #[AttributeClass3(2, \"closurr\")] function(#[AttributeClass2(int: 2 * \\Attributes\\CONST_1, string: \"closure param\" . Example::CO^NST_EXAMPLE)] $test): void {};", "    public const string ^CONST_EXAMPLE = \"example\";");
+    }
+
+    public void testAttributes_f04() throws Exception {
+        checkDeclaration(getTestPath(), "$arrow3 = #[AttributeClass1(3, string: Example::CONST_EXAM^PLE . \"arrow\")] static fn(): int|string => 100;", "    public const string ^CONST_EXAMPLE = \"example\";");
+    }
+
+    public void testAttributes_g01() throws Exception {
+        checkDeclaration(getTestPath(), "#[AttributeClass1(1, self::CONSTA^NT_CLASS)]", "    public const ^CONSTANT_CLASS = 'constant';");
+    }
+
 }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImplPHP80Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImplPHP80Test.java
@@ -428,4 +428,400 @@ public class OccurrencesFinderImplPHP80Test extends OccurrencesFinderImplTestBas
         checkOccurrences(getTestPath(), "class F^oo {}", true);
     }
 
+    public void testAttributes_a01() throws Exception {
+        checkOccurrences(getTestPath(), "class AttributeCla^ss1 {", true);
+    }
+
+    public void testAttributes_a02() throws Exception {
+        checkOccurrences(getTestPath(), "use Attributes\\AttributeCla^ss1;", true);
+    }
+
+    public void testAttributes_a03() throws Exception {
+        checkOccurrences(getTestPath(), "#[Attribut^eClass1(1, self::CONSTANT_CLASS)]", true);
+    }
+
+    public void testAttributes_a04() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeCl^ass1(2, \"class const\")]", true);
+    }
+
+    public void testAttributes_a05() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeCl^ass1(3, \"class field\")]", true);
+    }
+
+    public void testAttributes_a06() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeCl^ass1(4, \"class static field\"), AttributeClass2(4, \"class static field\", new \\Attributes\\Example)] // group", true);
+    }
+
+    public void testAttributes_a07() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeCla^ss1(5, \"class method\")]", true);
+    }
+
+    public void testAttributes_a08() throws Exception {
+        checkOccurrences(getTestPath(), "    public function method(#[AttributeCl^ass1(5, \"class method param\")] $param1, #[AttributeClass1(5, 'class method param')] int $pram2) {}", true);
+    }
+
+    public void testAttributes_a09() throws Exception {
+        checkOccurrences(getTestPath(), "    public function method(#[AttributeClass1(5, \"class method param\")] $param1, #[AttributeCla^ss1(5, 'class method param')] int $pram2) {}", true);
+    }
+
+    public void testAttributes_a10() throws Exception {
+        checkOccurrences(getTestPath(), "    #[\\Attributes\\AttributeCla^ss1(6, \"class static method\")]", true);
+    }
+
+    public void testAttributes_a11() throws Exception {
+        checkOccurrences(getTestPath(), "    public static function staticMethod(#[\\Attributes\\AttributeCl^ass1(6, \"class static method param\")] int|string $param1): bool|int {", true);
+    }
+
+    public void testAttributes_a12() throws Exception {
+        checkOccurrences(getTestPath(), "#[AttributeC^lass1(1, \"class child\")]", true);
+    }
+
+    public void testAttributes_a13() throws Exception {
+        checkOccurrences(getTestPath(), "#[AttributeC^lass1(1, \"trait\")]", true);
+    }
+
+    public void testAttributes_a14() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeC^lass1(3, \"trait field\")]", true);
+    }
+
+    public void testAttributes_a15() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeCla^ss1(4, \"trait static field\")]", true);
+    }
+
+    public void testAttributes_a16() throws Exception {
+        checkOccurrences(getTestPath(), "    #[Attribut^eClass1(5, \"trait method\")]", true);
+    }
+
+    public void testAttributes_a17() throws Exception {
+        checkOccurrences(getTestPath(), "    public function traitMethod(#[Attribute^Class1(5, \"trait method param\")] $param1) {}", true);
+    }
+
+    public void testAttributes_a18() throws Exception {
+        checkOccurrences(getTestPath(), "    #[Att^ributeClass1(6, \"trait static method\")]", true);
+    }
+
+    public void testAttributes_a19() throws Exception {
+        checkOccurrences(getTestPath(), "$anon = new #[Attri^buteClass1(1, \"anonymous class\")] class () {};", true);
+    }
+
+    public void testAttributes_a20() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeCl^ass1(int: 7, string: \"anonymous class static method\")]", true);
+    }
+
+    public void testAttributes_a21() throws Exception {
+        checkOccurrences(getTestPath(), "#[AttributeClas^s1(1, \"interface\")]", true);
+    }
+
+    public void testAttributes_a22() throws Exception {
+        checkOccurrences(getTestPath(), "#[\\Attributes\\AttributeClass3(1, \"enum\"), AttributeC^lass1]", true);
+    }
+
+    public void testAttributes_a23() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeCla^ss1(2, \"enum const\")]", true);
+    }
+
+    public void testAttributes_a24() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeCla^ss1(3, \"enum case\")]", true);
+    }
+
+    public void testAttributes_a25() throws Exception {
+        checkOccurrences(getTestPath(), "    #[Attr^ibuteClass1(4, \"enum method\")] #[AttributeClass3()]", true);
+    }
+
+    public void testAttributes_a26() throws Exception {
+        checkOccurrences(getTestPath(), "    #[Attribute^Class1(int: 5, string: \"enum static method\")]", true);
+    }
+
+    public void testAttributes_a27() throws Exception {
+        checkOccurrences(getTestPath(), "    Attri^buteClass1(1, \"function\"),", true);
+    }
+
+    public void testAttributes_a28() throws Exception {
+        checkOccurrences(getTestPath(), "$labmda1 = #[Attribut^eClass1(1, \"closure\")] function() {};", true);
+    }
+
+    public void testAttributes_a29() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow1 = #[AttributeCl^ass1(1, \"arrow\")] fn() => 100;", true);
+    }
+
+    public void testAttributes_a30() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow2 = #[AttributeCl^ass1(2, \"arrow\"), AttributeClass2(2, \"arrow\")] fn(#[AttributeClass1(\\Attributes\\CONST_1 / 5, \"arrow param\" . Example::class)] $test): int|string => 100;", true);
+    }
+
+    public void testAttributes_a31() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow2 = #[AttributeClass1(2, \"arrow\"), AttributeClass2(2, \"arrow\")] fn(#[Attribute^Class1(\\Attributes\\CONST_1 / 5, \"arrow param\" . Example::class)] $test): int|string => 100;", true);
+    }
+
+    public void testAttributes_a32() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow3 = #[Attr^ibuteClass1(3, string: Example::CONST_EXAMPLE . \"arrow\")] static fn(): int|string => 100;", true);
+    }
+
+    public void testAttributes_b01() throws Exception {
+        checkOccurrences(getTestPath(), "class AttributeClass^2 {", true);
+    }
+
+    public void testAttributes_b02() throws Exception {
+        checkOccurrences(getTestPath(), "use Attributes\\Attribut^eClass2;", true);
+    }
+
+    public void testAttributes_b03() throws Exception {
+        checkOccurrences(getTestPath(), "#[Attribu^teClass2(1, \"class\")]", true);
+    }
+
+    public void testAttributes_b04() throws Exception {
+        checkOccurrences(getTestPath(), "    #[Attribute^Class2(2, \"class const\", new Example())]", true);
+    }
+
+    public void testAttributes_b05() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeClass1(4, \"class static field\"), Attr^ibuteClass2(4, \"class static field\", new \\Attributes\\Example)] // group", true);
+    }
+
+    public void testAttributes_b06() throws Exception {
+        checkOccurrences(getTestPath(), "#[AttributeCl^ass2(1, \"trait\")]", true);
+    }
+
+    public void testAttributes_b07() throws Exception {
+        checkOccurrences(getTestPath(), "    #[Attribut^eClass2(2, \"trait const\")]", true);
+    }
+
+    public void testAttributes_b08() throws Exception {
+        checkOccurrences(getTestPath(), "    #[Attribute^Class2(6, \"trait static method\")]", true);
+    }
+
+    public void testAttributes_b09() throws Exception {
+        checkOccurrences(getTestPath(), "$anon2 = new #[Attr^ibuteClass2(1, \"anonymous class\")] class ($test) {", true);
+    }
+
+    public void testAttributes_b10() throws Exception {
+        checkOccurrences(getTestPath(), "    #[Attribute^Class2(2, \"anonymous class const\")]", true);
+    }
+
+    public void testAttributes_b11() throws Exception {
+        checkOccurrences(getTestPath(), "    #[At^tributeClass2(3, \"anonymous class field\")]", true);
+    }
+
+    public void testAttributes_b12() throws Exception {
+        checkOccurrences(getTestPath(), "    #[Att^ributeClass2(4, \"anonymous class static field\")]", true);
+    }
+
+    public void testAttributes_b13() throws Exception {
+        checkOccurrences(getTestPath(), "    #[Att^ributeClass2(5, \"anonymous class constructor\")]", true);
+    }
+
+    public void testAttributes_b14() throws Exception {
+        checkOccurrences(getTestPath(), "    public function __construct(#[AttributeClas^s2(5, \"anonymous class\")] $param1) {", true);
+    }
+
+    public void testAttributes_b15() throws Exception {
+        checkOccurrences(getTestPath(), "    #[Attribute^Class2(6, \"anonymous class method\")] #[AttributeClass3()]", true);
+    }
+
+    public void testAttributes_b16() throws Exception {
+        checkOccurrences(getTestPath(), "    public function method(#[Attrib^uteClass2(6, \"anonymous class method param\")] $param1): int|string {", true);
+    }
+
+    public void testAttributes_b17() throws Exception {
+        checkOccurrences(getTestPath(), "    private static function staticMethod(#[Attribu^teClass2(7, \"anonymous class static method param\")] int|bool $pram1): int|string {", true);
+    }
+
+    public void testAttributes_b18() throws Exception {
+        checkOccurrences(getTestPath(), "    #[Attribut^eClass2(2, \"interface const\")]", true);
+    }
+
+    public void testAttributes_b19() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeC^lass2(self::CONSTANT_INTERFACE, \"interface method\")] #[AttributeClass3()]", true);
+    }
+
+    public void testAttributes_b20() throws Exception {
+        checkOccurrences(getTestPath(), "    public function interfaceMethod(#[Attribute^Class2(AttributedInterface::CONSTANT_INTERFACE, \"interface method param\")] $param1): int|string;", true);
+    }
+
+    public void testAttributes_b21() throws Exception {
+        checkOccurrences(getTestPath(), "    #[Attribut^eClass2(4, \"interface static method\")] #[AttributeClass3()]", true);
+    }
+
+    public void testAttributes_b22() throws Exception {
+        checkOccurrences(getTestPath(), "    public static function staticInterfaceMethod(#[Attrib^uteClass2(4, \"interface static method param\" . Example::CONST_EXAMPLE)] $param1): int|string;", true);
+    }
+
+    public void testAttributes_b23() throws Exception {
+        checkOccurrences(getTestPath(), "#[\\Attributes\\Attrib^uteClass2(1, \"enum\", new Example)]", true);
+    }
+
+    public void testAttributes_b24() throws Exception {
+        checkOccurrences(getTestPath(), "    public function method(#[Attribu^teClass2(4, \"enum method param\")] $param1): int|string {", true);
+    }
+
+    public void testAttributes_b25() throws Exception {
+        checkOccurrences(getTestPath(), "#[Attribut^eClass2(1, \"function\")]", true);
+    }
+
+    public void testAttributes_b26() throws Exception {
+        checkOccurrences(getTestPath(), "function func2(#[Att^ributeClass2(1 + \\Attributes\\CONST_1 + 1, Example::CONST_EXAMPLE . \"function param\")] int|string $param): void {}", true);
+    }
+
+    public void testAttributes_b27() throws Exception {
+        checkOccurrences(getTestPath(), "$labmda2 = #[Attribute^Class2(2, \"closure\")] #[AttributeClass3(2, \"closurr\")] function(#[AttributeClass2(int: 2 * \\Attributes\\CONST_1, string: \"closure param\" . Example::CONST_EXAMPLE)] $test): void {};", true);
+    }
+
+    public void testAttributes_b28() throws Exception {
+        checkOccurrences(getTestPath(), "$labmda2 = #[AttributeClass2(2, \"closure\")] #[AttributeClass3(2, \"closurr\")] function(#[Attrib^uteClass2(int: 2 * \\Attributes\\CONST_1, string: \"closure param\" . Example::CONST_EXAMPLE)] $test): void {};", true);
+    }
+
+    public void testAttributes_b29() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow2 = #[AttributeClass1(2, \"arrow\"), Attribut^eClass2(2, \"arrow\")] fn(#[AttributeClass1(\\Attributes\\CONST_1 / 5, \"arrow param\" . Example::class)] $test): int|string => 100;", true);
+    }
+
+    public void testAttributes_c01() throws Exception {
+        checkOccurrences(getTestPath(), "class Attribute^Class3 {", true);
+    }
+
+    public void testAttributes_c02() throws Exception {
+        checkOccurrences(getTestPath(), "use Attributes\\Attribu^teClass3;", true);
+    }
+
+    public void testAttributes_c03() throws Exception {
+        checkOccurrences(getTestPath(), "    #[Attribut^eClass3(6, \"trait static method\")]", true);
+    }
+
+    public void testAttributes_c04() throws Exception {
+        checkOccurrences(getTestPath(), "    public static function staticTraitMethod(#[Attribut^eClass3] int|string $param1): bool|int {", true);
+    }
+
+    public void testAttributes_c05() throws Exception {
+        checkOccurrences(getTestPath(), "    #[Attrib^uteClass3(3, \"anonymous class field\")]", true);
+    }
+
+    public void testAttributes_c06() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeClass2(6, \"anonymous class method\")] #[Attribu^teClass3()]", true);
+    }
+
+    public void testAttributes_c07() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeClass2(self::CONSTANT_INTERFACE, \"interface method\")] #[Attribu^teClass3()]", true);
+    }
+
+    public void testAttributes_c08() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeClass2(4, \"interface static method\")] #[Attri^buteClass3()]", true);
+    }
+
+    public void testAttributes_c09() throws Exception {
+        checkOccurrences(getTestPath(), "#[\\Attributes\\Attribut^eClass3(1, \"enum\"), AttributeClass1]", true);
+    }
+
+    public void testAttributes_c10() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeClass1(4, \"enum method\")] #[AttributeCla^ss3()]", true);
+    }
+
+    public void testAttributes_c11() throws Exception {
+        checkOccurrences(getTestPath(), "    public static function staticMethod(#[Attrib^uteClass3(5, \"enum static method param\")] int|bool $pram1): int|string {", true);
+    }
+
+    public void testAttributes_c12() throws Exception {
+        checkOccurrences(getTestPath(), "    Attribu^teClass3(int: CONST_1, string: \"function\" . Example::class)", true);
+    }
+
+    public void testAttributes_c13() throws Exception {
+        checkOccurrences(getTestPath(), "$labmda2 = #[AttributeClass2(2, \"closure\")] #[Attri^buteClass3(2, \"closurr\")] function(#[AttributeClass2(int: 2 * \\Attributes\\CONST_1, string: \"closure param\" . Example::CONST_EXAMPLE)] $test): void {};", true);
+    }
+
+    public void testAttributes_c14() throws Exception {
+        checkOccurrences(getTestPath(), "$labmda3 = #[Attribut^eClass3(3, \"closure\")] static function(): void {};", true);
+    }
+
+    public void testAttributes_d01() throws Exception {
+        checkOccurrences(getTestPath(), "const CONS^T_1 = 1;", true);
+    }
+
+    public void testAttributes_d02() throws Exception {
+        checkOccurrences(getTestPath(), "use const Attributes\\CO^NST_1;", true);
+    }
+
+    public void testAttributes_d03() throws Exception {
+        checkOccurrences(getTestPath(), "    AttributeClass3(int: CONST_^1, string: \"function\" . Example::class)", true);
+    }
+
+    public void testAttributes_d04() throws Exception {
+        checkOccurrences(getTestPath(), "function func2(#[AttributeClass2(1 + \\Attributes\\CON^ST_1 + 1, Example::CONST_EXAMPLE . \"function param\")] int|string $param): void {}", true);
+    }
+
+    public void testAttributes_d05() throws Exception {
+        checkOccurrences(getTestPath(), "$labmda2 = #[AttributeClass2(2, \"closure\")] #[AttributeClass3(2, \"closurr\")] function(#[AttributeClass2(int: 2 * \\Attributes\\CON^ST_1, string: \"closure param\" . Example::CONST_EXAMPLE)] $test): void {};", true);
+    }
+
+    public void testAttributes_d06() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow2 = #[AttributeClass1(2, \"arrow\"), AttributeClass2(2, \"arrow\")] fn(#[AttributeClass1(\\Attributes\\CONS^T_1 / 5, \"arrow param\" . Example::class)] $test): int|string => 100;", true);
+    }
+
+    public void testAttributes_e01() throws Exception {
+        checkOccurrences(getTestPath(), "class Ex^ample {", true);
+    }
+
+    public void testAttributes_e02() throws Exception {
+        checkOccurrences(getTestPath(), "use Attributes\\Exa^mple;", true);
+    }
+
+    public void testAttributes_e03() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeClass2(2, \"class const\", new Exa^mple())]", true);
+    }
+
+    public void testAttributes_e04() throws Exception {
+        checkOccurrences(getTestPath(), "    #[AttributeClass1(4, \"class static field\"), AttributeClass2(4, \"class static field\", new \\Attributes\\Exa^mple)] // group", true);
+    }
+
+    public void testAttributes_e05() throws Exception {
+        checkOccurrences(getTestPath(), "    public static function staticInterfaceMethod(#[AttributeClass2(4, \"interface static method param\" . Examp^le::CONST_EXAMPLE)] $param1): int|string;", true);
+    }
+
+    public void testAttributes_e06() throws Exception {
+        checkOccurrences(getTestPath(), "#[\\Attributes\\AttributeClass2(1, \"enum\", new E^xample)]", true);
+    }
+
+    public void testAttributes_e07() throws Exception {
+        checkOccurrences(getTestPath(), "    AttributeClass3(int: CONST_1, string: \"function\" . Exa^mple::class)", true);
+    }
+
+    public void testAttributes_e08() throws Exception {
+        checkOccurrences(getTestPath(), "function func2(#[AttributeClass2(1 + \\Attributes\\CONST_1 + 1, Exam^ple::CONST_EXAMPLE . \"function param\")] int|string $param): void {}", true);
+    }
+
+    public void testAttributes_e09() throws Exception {
+        checkOccurrences(getTestPath(), "$labmda2 = #[AttributeClass2(2, \"closure\")] #[AttributeClass3(2, \"closurr\")] function(#[AttributeClass2(int: 2 * \\Attributes\\CONST_1, string: \"closure param\" . Ex^ample::CONST_EXAMPLE)] $test): void {};", true);
+    }
+
+    public void testAttributes_e10() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow2 = #[AttributeClass1(2, \"arrow\"), AttributeClass2(2, \"arrow\")] fn(#[AttributeClass1(\\Attributes\\CONST_1 / 5, \"arrow param\" . Exam^ple::class)] $test): int|string => 100;", true);
+    }
+
+    public void testAttributes_e11() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow3 = #[AttributeClass1(3, string: Exa^mple::CONST_EXAMPLE . \"arrow\")] static fn(): int|string => 100;", true);
+    }
+
+    public void testAttributes_f01() throws Exception {
+        checkOccurrences(getTestPath(), "    public const string CONST_EXAMP^LE = \"example\";", true);
+    }
+
+    public void testAttributes_f02() throws Exception {
+        checkOccurrences(getTestPath(), "    public static function staticInterfaceMethod(#[AttributeClass2(4, \"interface static method param\" . Example::CONST^_EXAMPLE)] $param1): int|string;", true);
+    }
+
+    public void testAttributes_f03() throws Exception {
+        checkOccurrences(getTestPath(), "function func2(#[AttributeClass2(1 + \\Attributes\\CONST_1 + 1, Example::CONST_EXA^MPLE . \"function param\")] int|string $param): void {}", true);
+    }
+
+    public void testAttributes_f04() throws Exception {
+        checkOccurrences(getTestPath(), "$labmda2 = #[AttributeClass2(2, \"closure\")] #[AttributeClass3(2, \"closurr\")] function(#[AttributeClass2(int: 2 * \\Attributes\\CONST_1, string: \"closure param\" . Example::CO^NST_EXAMPLE)] $test): void {};", true);
+    }
+
+    public void testAttributes_f05() throws Exception {
+        checkOccurrences(getTestPath(), "$arrow3 = #[AttributeClass1(3, string: Example::CONST_EX^AMPLE . \"arrow\")] static fn(): int|string => 100;", true);
+    }
+
+    public void testAttributes_g01() throws Exception {
+        checkOccurrences(getTestPath(), "#[AttributeClass1(1, self::CONSTANT^_CLASS)]", true);
+    }
+
+    public void testAttributes_g02() throws Exception {
+        checkOccurrences(getTestPath(), "    public const CO^NSTANT_CLASS = 'constant';", true);
+    }
+
 }


### PR DESCRIPTION
- https://wiki.php.net/rfc/attributes_v2
- https://wiki.php.net/rfc/shorter_attribute_syntax
- https://wiki.php.net/rfc/shorter_attribute_syntax_change
- Fix the Go to Declaration and the Mark Occurrences features
- Add unit tests

![nb-php-attributes-gotodeclaration](https://github.com/apache/netbeans/assets/738383/0ab5ac1d-a669-4cbd-a0e3-0083d0652652)
