### PR TITLE
Fix the problem that inccorect indentation is added after an attribute(e.g. `#[Attr(1, 2)]`)

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/IndentationCounter.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/IndentationCounter.java
@@ -766,8 +766,9 @@ public class IndentationCounter {
             }
         }
         if (result) {
-            // check whether there is tokens other than whitespace for parameters, anonymous function/class
-            int lineStart = LineDocumentUtils.getLineStart(doc, LineDocumentUtils.getLineStart(doc, ts.offset()) - 1);
+            // check for non-whitespace tokens before an attribute of parameters, anonymous function/class
+            // not `ts.offset() - 1` but `ts.offset()` to avoid getting the start position of the previous line
+            int lineStart = LineDocumentUtils.getLineStart(doc, LineDocumentUtils.getLineStart(doc, ts.offset()));
             while (ts.movePrevious() && ts.offset() >= lineStart) {
                 if (ts.token().id() != PHPTokenId.WHITESPACE) {
                     result = false;

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_09.php
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_09.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$closure = function(#[Attr(1, 2)]^ $param) {};

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_09.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_09.php.indented
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$closure = function(#[Attr(1, 2)]
+        ^$param) {};

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_10.php
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_10.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$closure = function(#[Attr]^ $param) {};

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_10.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_10.php.indented
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$closure = function(#[Attr]
+        ^$param) {};

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_11.php
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_11.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$closure = #[Attr]^ function(#[Attr] $param) {};

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_11.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_11.php.indented
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$closure = #[Attr]
+        ^function(#[Attr] $param) {};

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_12.php
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_12.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$arrow = #[Attr]^ fn(#[Attr] $param) => 1;

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_12.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_12.php.indented
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$arrow = #[Attr]
+        ^fn(#[Attr] $param) => 1;

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_13.php
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_13.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$arrow = #[Attr] fn(#[Attr]^ $param) => 1;

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_13.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_13.php.indented
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$arrow = #[Attr] fn(#[Attr]
+        ^$param) => 1;

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_14.php
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_14.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$anon = new #[Attr(1, 2)]^ class () {
+};

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_14.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_14.php.indented
@@ -1,0 +1,23 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$anon = new #[Attr(1, 2)]
+        ^class () {
+};

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_15.php
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_15.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#[Attr1(1, 2)]
+#[Attr2("test", "test")]^
+class AttributedClass {
+    
+}

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_15.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_15.php.indented
@@ -1,0 +1,26 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#[Attr1(1, 2)]
+#[Attr2("test", "test")]
+^
+class AttributedClass {
+    
+}

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_16.php
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_16.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#[Attr1(1, 2)]
+#[Attr2("test", "test")]
+class AttributedClass {
+
+    #[Attr1(1, 2)]
+    #[Attr2("test", "test")]^
+    public function method(): void {
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_16.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/indent/php80/attributeSyntax_16.php.indented
@@ -1,0 +1,30 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#[Attr1(1, 2)]
+#[Attr2("test", "test")]
+class AttributedClass {
+
+    #[Attr1(1, 2)]
+    #[Attr2("test", "test")]
+    ^
+    public function method(): void {
+    }
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPNewLineIndenterTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPNewLineIndenterTest.java
@@ -1178,6 +1178,38 @@ public class PHPNewLineIndenterTest extends PHPTestBase {
         testIndentInFile("testfiles/indent/php80/attributeSyntax_08.php");
     }
 
+    public void testAttributeSyntax_09() throws Exception {
+        testIndentInFile("testfiles/indent/php80/attributeSyntax_09.php");
+    }
+
+    public void testAttributeSyntax_10() throws Exception {
+        testIndentInFile("testfiles/indent/php80/attributeSyntax_10.php");
+    }
+
+    public void testAttributeSyntax_11() throws Exception {
+        testIndentInFile("testfiles/indent/php80/attributeSyntax_11.php");
+    }
+
+    public void testAttributeSyntax_12() throws Exception {
+        testIndentInFile("testfiles/indent/php80/attributeSyntax_12.php");
+    }
+
+    public void testAttributeSyntax_13() throws Exception {
+        testIndentInFile("testfiles/indent/php80/attributeSyntax_13.php");
+    }
+
+    public void testAttributeSyntax_14() throws Exception {
+        testIndentInFile("testfiles/indent/php80/attributeSyntax_14.php");
+    }
+
+    public void testAttributeSyntax_15() throws Exception {
+        testIndentInFile("testfiles/indent/php80/attributeSyntax_15.php");
+    }
+
+    public void testAttributeSyntax_16() throws Exception {
+        testIndentInFile("testfiles/indent/php80/attributeSyntax_16.php");
+    }
+
     public void testConstructorPropertyPromotion_01() throws Exception {
         testIndentInFile("testfiles/indent/php80/constructorPropertyPromotion_01.php");
     }


### PR DESCRIPTION
Example:
```php
 #[Attr1(1, 2)]
 #[Attr2("test", "test")]^ // type enter key here
 class AttributedClass {

     #[Attr1(1, 2)]
     #[Attr2("test", "test")]^ // type enter key here
     public function method(): void {
     }
 }
```

Before:
```php
 #[Attr1(1, 2)]
 #[Attr2("test", "test")]
         ^// incorrect indent
 class AttributedClass {

     #[Attr1(1, 2)]
     #[Attr2("test", "test")]
             ^// incorrect indent
     public function method(): void {
     }
 }
```

After:
```php
 #[Attr1(1, 2)]
 #[Attr2("test", "test")]
 ^// correct indent
 class AttributedClass {

     #[Attr1(1, 2)]
     #[Attr2("test", "test")]
     ^// correct indent
     public function method(): void {
     }
 }
```
