### PR TITLE
Update FlatLaf from 3.2.5 to 3.3

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-A180D2525801750F8BE57A1FAE71181593C9BB36 com.formdev:flatlaf:3.2.5
+C816DFDF2AC7BD55512597E4605FFCCFF840040D com.formdev:flatlaf:3.3

--- a/platform/libs.flatlaf/external/flatlaf-3.3-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-3.3-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 3.2.5
-Files: flatlaf-3.2.5.jar
+Version: 3.3
+Files: flatlaf-3.3.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/manifest.mf
+++ b/platform/libs.flatlaf/manifest.mf
@@ -4,4 +4,4 @@ OpenIDE-Module: org.netbeans.libs.flatlaf/1
 OpenIDE-Module-Install: org/netbeans/libs/flatlaf/Installer.class
 OpenIDE-Module-Specification-Version: 1.17
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Implementation-Version: 3.2.5
+OpenIDE-Module-Implementation-Version: 3.3

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -31,14 +31,18 @@ spec.version.base.fatal.warning=false
 #
 # So when FlatLaf is updated, the OpenIDE-Module-Implementation-Version entry
 # in manifest.mf needs to be updated to match the new FlatLaf version.
-release.external/flatlaf-3.2.5.jar=modules/ext/flatlaf-3.2.5.jar
+release.external/flatlaf-3.3.jar=modules/ext/flatlaf-3.3.jar
 
-release.external/flatlaf-3.2.5.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
-release.external/flatlaf-3.2.5.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll
-release.external/flatlaf-3.2.5.jar!/com/formdev/flatlaf/natives/flatlaf-windows-arm64.dll=modules/lib/flatlaf-windows-arm64.dll
-release.external/flatlaf-3.2.5.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-x86_64.so=modules/lib/libflatlaf-linux-x86_64.so
+release.external/flatlaf-3.3.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
+release.external/flatlaf-3.3.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll
+release.external/flatlaf-3.3.jar!/com/formdev/flatlaf/natives/flatlaf-windows-arm64.dll=modules/lib/flatlaf-windows-arm64.dll
+release.external/flatlaf-3.3.jar!/com/formdev/flatlaf/natives/libflatlaf-macos-arm64.dylib=modules/lib/libflatlaf-macos-arm64.dylib
+release.external/flatlaf-3.3.jar!/com/formdev/flatlaf/natives/libflatlaf-macos-x86_64.dylib=modules/lib/libflatlaf-macos-x86_64.dylib
+release.external/flatlaf-3.3.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-x86_64.so=modules/lib/libflatlaf-linux-x86_64.so
 jnlp.verify.excludes=\
     modules/lib/flatlaf-windows-x86.dll,\
     modules/lib/flatlaf-windows-x86_64.dll,\
     modules/lib/flatlaf-windows-arm64.dll,\
+    modules/lib/libflatlaf-macos-arm64.dylib,\
+    modules/lib/libflatlaf-macos-x86_64.dylib,\
     modules/lib/libflatlaf-linux-x86_64.so

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -48,8 +48,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-3.2.5.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-3.2.5.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-3.3.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-3.3.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Update FlatLaf to v3.3

Changes: https://github.com/JFormDesigner/FlatLaf/releases/tag/3.3

There are two new native libraries for macOS
(`libflatlaf-macos-arm64.dylib` and `libflatlaf-macos-x86_64.dylib`)
used for rounded borders on popups.

fixes issues #6835 and #6828