### PR TITLE
Fix the code completion for predefined attributes

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/CodeUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/CodeUtils.java
@@ -89,8 +89,6 @@ public final class CodeUtils {
     public static final String NULLABLE_TYPE_PREFIX = "?"; // NOI18N
     public static final String ELLIPSIS = "..."; // NOI18N
     public static final String VAR_TAG = "@var"; // NOI18N
-    public static final String ATTRIBUTE_ATTRIBUTE_NAME = "Attribute"; // NOI18N
-    public static final String ATTRIBUTE_ATTRIBUTE_FQ_NAME = "\\" + ATTRIBUTE_ATTRIBUTE_NAME; // NOI18N
     public static final String OVERRIDE_ATTRIBUTE_NAME = "Override"; // NOI18N
     public static final String OVERRIDE_ATTRIBUTE_FQ_NAME = "\\" + OVERRIDE_ATTRIBUTE_NAME; // NOI18N
     public static final String OVERRIDE_ATTRIBUTE = "#[" + OVERRIDE_ATTRIBUTE_FQ_NAME + "]"; // NOI18N

--- a/php/php.editor/src/org/netbeans/modules/php/editor/CodeUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/CodeUtils.java
@@ -89,9 +89,6 @@ public final class CodeUtils {
     public static final String NULLABLE_TYPE_PREFIX = "?"; // NOI18N
     public static final String ELLIPSIS = "..."; // NOI18N
     public static final String VAR_TAG = "@var"; // NOI18N
-    public static final String OVERRIDE_ATTRIBUTE_NAME = "Override"; // NOI18N
-    public static final String OVERRIDE_ATTRIBUTE_FQ_NAME = "\\" + OVERRIDE_ATTRIBUTE_NAME; // NOI18N
-    public static final String OVERRIDE_ATTRIBUTE = "#[" + OVERRIDE_ATTRIBUTE_FQ_NAME + "]"; // NOI18N
     public static final String EMPTY_STRING = ""; // NOI18N
     public static final String NEW_LINE = "\n"; // NOI18N
     public static final String THIS_VARIABLE = "$this"; // NOI18N

--- a/php/php.editor/src/org/netbeans/modules/php/editor/PredefinedSymbols.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/PredefinedSymbols.java
@@ -107,12 +107,57 @@ public final class PredefinedSymbols {
                 "__unserialize", // NOI18N PHP 7.4
             })));
 
+    public static final Set<String> ATTRIBUTE_NAMES = Collections.unmodifiableSet(Attributes.ATTRIBUTE_NAMES);
+    public static final Set<String> ATTRIBUTE_FQ_NAMES = Collections.unmodifiableSet(Attributes.ATTRIBUTE_FQ_NAMES);
+
     public static enum VariableKind {
         STANDARD,
         THIS,
         SELF,
         PARENT
     };
+
+    // https://www.php.net/manual/en/reserved.attributes.php
+    public static enum Attributes {
+        ATTRIBUTE("Attribute"), // NOI18N
+        ALLOW_DYNAMIC_PROPERTIES("AllowDynamicProperties"), // NOI18N
+        OVERRIDE("Override"), // NOI18N
+        RETURN_TYPE_WILL_CHANGE("ReturnTypeWillChange"), // NOI18N
+        SENSITIVE_PARAMETER("SensitiveParameter"), // NOI18N
+        ;
+
+        private static final Set<String> ATTRIBUTE_NAMES = new HashSet<>();
+        private static final Set<String> ATTRIBUTE_FQ_NAMES = new HashSet<>();
+
+        private final String name;
+        private final String fqName;
+        private final String asAttributeExpression;
+
+        static {
+            for (Attributes attribute : Attributes.values()) {
+                ATTRIBUTE_NAMES.add(attribute.getName());
+                ATTRIBUTE_FQ_NAMES.add(attribute.getFqName());
+            }
+        }
+
+        private Attributes(String name) {
+            this.name = name;
+            this.fqName = "\\" + name; // NOI18N
+            this.asAttributeExpression = String.format("#[%s]", fqName); // NOI18N
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getFqName() {
+            return fqName;
+        }
+
+        public String asAttributeExpression() {
+            return asAttributeExpression;
+        }
+    }
 
     private static String docURLBase;
 

--- a/php/php.editor/src/org/netbeans/modules/php/editor/codegen/SinglePropertyMethodCreator.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/codegen/SinglePropertyMethodCreator.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import org.netbeans.modules.php.api.PhpVersion;
 import org.netbeans.modules.php.editor.CodeUtils;
+import static org.netbeans.modules.php.editor.PredefinedSymbols.Attributes.OVERRIDE;
 import org.netbeans.modules.php.editor.api.elements.BaseFunctionElement;
 import org.netbeans.modules.php.editor.api.elements.MethodElement;
 import org.netbeans.modules.php.editor.api.elements.TypeResolver;
@@ -81,7 +82,7 @@ public interface SinglePropertyMethodCreator<T extends Property> {
             if (!method.isMagic()
                     && (!method.getType().isTrait() || ElementUtils.isAbstractTraitMethod(method))
                     && cgsInfo.getPhpVersion().hasOverrideAttribute()) {
-                return CodeUtils.OVERRIDE_ATTRIBUTE + CodeUtils.NEW_LINE;
+                return OVERRIDE.asAttributeExpression() + CodeUtils.NEW_LINE;
             }
             return CodeUtils.EMPTY_STRING;
         }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCompletionItem.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCompletionItem.java
@@ -102,6 +102,7 @@ import org.netbeans.modules.php.editor.model.impl.Type;
 import org.netbeans.modules.php.editor.model.impl.VariousUtils;
 import org.netbeans.modules.php.editor.model.nodes.NamespaceDeclarationInfo;
 import org.netbeans.modules.php.editor.NavUtils;
+import static org.netbeans.modules.php.editor.PredefinedSymbols.Attributes.OVERRIDE;
 import org.netbeans.modules.php.editor.api.elements.EnumCaseElement;
 import org.netbeans.modules.php.editor.api.elements.EnumElement;
 import org.netbeans.modules.php.editor.elements.ElementUtils;
@@ -1283,7 +1284,7 @@ public abstract class PHPCompletionItem implements CompletionProposal {
                 FileObject fileObject = request.result.getSnapshot().getSource().getFileObject();
                 PhpVersion phpVersion = getPhpVersion(fileObject);
                 if (phpVersion.hasOverrideAttribute()) {
-                    return CodeUtils.OVERRIDE_ATTRIBUTE + CodeUtils.NEW_LINE;
+                    return OVERRIDE.asAttributeExpression() + CodeUtils.NEW_LINE;
                 }
             }
             return CodeUtils.EMPTY_STRING;

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/ClassScopeImpl.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/ClassScopeImpl.java
@@ -31,6 +31,7 @@ import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.modules.parsing.spi.indexing.support.IndexDocument;
 import org.netbeans.modules.php.api.util.StringUtils;
 import org.netbeans.modules.php.editor.CodeUtils;
+import org.netbeans.modules.php.editor.PredefinedSymbols;
 import org.netbeans.modules.php.editor.api.ElementQuery;
 import org.netbeans.modules.php.editor.api.PhpElementKind;
 import org.netbeans.modules.php.editor.api.QualifiedName;
@@ -172,10 +173,8 @@ class ClassScopeImpl extends TypeScopeImpl implements ClassScope, VariableNameFa
     private boolean isAttributeClass(ClassDeclarationInfo nodeInfo, NamespaceScope namespaceScope) {
         String className = nodeInfo.getName();
         int offset = nodeInfo.getOriginalNode().getStartOffset();
-        if (CodeUtils.ATTRIBUTE_ATTRIBUTE_NAME.equals(className)) {
-            if (isAttributeAttribute(className, offset, namespaceScope)) {
-                return true;
-            }
+        if (isPredefinedAttribute(className, offset, namespaceScope)) {
+            return true;
         }
         for (Attribute attribute : nodeInfo.getAttributes()) {
             for (AttributeDeclaration attributeDeclaration : attribute.getAttributeDeclarations()) {
@@ -190,14 +189,22 @@ class ClassScopeImpl extends TypeScopeImpl implements ClassScope, VariableNameFa
     }
 
     private boolean isAttributeAttribute(String attributeName, int offset, NamespaceScope namespaceScope) {
-        if (CodeUtils.ATTRIBUTE_ATTRIBUTE_FQ_NAME.equals(attributeName)) {
+        if (PredefinedSymbols.Attributes.ATTRIBUTE.getFqName().equals(attributeName)) {
             return true;
         }
-        if (CodeUtils.ATTRIBUTE_ATTRIBUTE_NAME.equals(attributeName)) {
+        return PredefinedSymbols.Attributes.ATTRIBUTE.getName().equals(attributeName)
+                && isPredefinedAttribute(attributeName, offset, namespaceScope);
+    }
+
+    private boolean isPredefinedAttribute(String attributeName, int offset, NamespaceScope namespaceScope) {
+        if (PredefinedSymbols.ATTRIBUTE_FQ_NAMES.contains(attributeName)) {
+            return true;
+        }
+        if (PredefinedSymbols.ATTRIBUTE_NAMES.contains(attributeName)) {
             if (namespaceScope != null) {
-                // check FQ name because there may be `use Attribute;`
-                QualifiedName fullyQualifiedName = VariousUtils.getFullyQualifiedName(QualifiedName.create(CodeUtils.ATTRIBUTE_ATTRIBUTE_NAME), offset, namespaceScope);
-                if (CodeUtils.ATTRIBUTE_ATTRIBUTE_FQ_NAME.equals(fullyQualifiedName.toString())) {
+                // check FQ name because there may be use statement (e.g. `use Attribute;`)
+                QualifiedName fullyQualifiedName = VariousUtils.getFullyQualifiedName(QualifiedName.create(attributeName), offset, namespaceScope);
+                if (PredefinedSymbols.ATTRIBUTE_FQ_NAMES.contains(fullyQualifiedName.toString())) {
                     return true;
                 }
             }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/AddOverrideAttributeHint.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/AddOverrideAttributeHint.java
@@ -42,6 +42,7 @@ import org.netbeans.modules.csl.spi.support.CancelSupport;
 import org.netbeans.modules.php.api.PhpVersion;
 import org.netbeans.modules.php.api.util.StringUtils;
 import org.netbeans.modules.php.editor.CodeUtils;
+import static org.netbeans.modules.php.editor.PredefinedSymbols.Attributes.OVERRIDE;
 import org.netbeans.modules.php.editor.api.ElementQuery;
 import org.netbeans.modules.php.editor.api.QualifiedName;
 import org.netbeans.modules.php.editor.api.elements.ElementFilter;
@@ -433,10 +434,10 @@ public class AddOverrideAttributeHint extends HintRule {
         }
 
         private boolean isOverrideAttibute(String attributeName, int offset) {
-            if (CodeUtils.OVERRIDE_ATTRIBUTE_FQ_NAME.equals(attributeName)) {
+            if (OVERRIDE.getFqName().equals(attributeName)) {
                 return true;
             }
-            if (CodeUtils.OVERRIDE_ATTRIBUTE_NAME.equals(attributeName)) {
+            if (OVERRIDE.getName().equals(attributeName)) {
                 Collection<? extends NamespaceScope> declaredNamespaces = fileScope.getDeclaredNamespaces();
                 if (isGlobalNamespace()) {
                     return true;
@@ -453,8 +454,8 @@ public class AddOverrideAttributeHint extends HintRule {
                 }
                 if (namespaceScope != null) {
                     // check FQ name because there may be `use \Override;`
-                    QualifiedName fullyQualifiedName = VariousUtils.getFullyQualifiedName(QualifiedName.create(CodeUtils.OVERRIDE_ATTRIBUTE_NAME), offset, namespaceScope);
-                    if (CodeUtils.OVERRIDE_ATTRIBUTE_FQ_NAME.equals(fullyQualifiedName.toString())) {
+                    QualifiedName fullyQualifiedName = VariousUtils.getFullyQualifiedName(QualifiedName.create(OVERRIDE.getName()), offset, namespaceScope);
+                    if (OVERRIDE.getFqName().equals(fullyQualifiedName.toString())) {
                         return true;
                     }
                 }
@@ -551,7 +552,7 @@ public class AddOverrideAttributeHint extends HintRule {
                 }
             }
             if (attributes.isEmpty()) {
-                edits.replace(offset, 0, CodeUtils.OVERRIDE_ATTRIBUTE + CodeUtils.NEW_LINE + indent, false, 0);
+                edits.replace(offset, 0, OVERRIDE.asAttributeExpression() + CodeUtils.NEW_LINE + indent, false, 0);
             } else {
                 // #[Attr] // comment
                 // #[\Override]
@@ -565,7 +566,7 @@ public class AddOverrideAttributeHint extends HintRule {
                         offset = ts.offset();
                     }
                 }
-                edits.replace(offset, 0, CodeUtils.OVERRIDE_ATTRIBUTE + CodeUtils.NEW_LINE + indent, false, 0);
+                edits.replace(offset, 0, OVERRIDE.asAttributeExpression() + CodeUtils.NEW_LINE + indent, false, 0);
             }
             edits.apply();
         }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/ImplementAbstractMethodsHintError.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/ImplementAbstractMethodsHintError.java
@@ -48,6 +48,7 @@ import org.netbeans.modules.parsing.spi.Parser.Result;
 import org.netbeans.modules.php.api.PhpVersion;
 import org.netbeans.modules.php.api.util.StringUtils;
 import org.netbeans.modules.php.editor.CodeUtils;
+import static org.netbeans.modules.php.editor.PredefinedSymbols.Attributes.OVERRIDE;
 import org.netbeans.modules.php.editor.api.ElementQuery.Index;
 import org.netbeans.modules.php.editor.api.PhpElementKind;
 import org.netbeans.modules.php.editor.api.elements.BaseFunctionElement.PrintAs;
@@ -193,7 +194,7 @@ public class ImplementAbstractMethodsHintError extends HintErrorRule {
                             TypeNameResolver typeNameResolver = TypeNameResolverImpl.forChainOf(typeNameResolvers);
                             String skeleton = methodElement.asString(PrintAs.DeclarationWithEmptyBody, typeNameResolver, phpVersion);
                             if (phpVersion.hasOverrideAttribute()) {
-                                skeleton = CodeUtils.OVERRIDE_ATTRIBUTE + CodeUtils.NEW_LINE + skeleton; // PHP 8.3
+                                skeleton = OVERRIDE.asAttributeExpression() + CodeUtils.NEW_LINE + skeleton; // PHP 8.3
                             }
                             skeleton = skeleton.replace(ABSTRACT_PREFIX, CodeUtils.EMPTY_STRING);
                             methodSkeletons.add(skeleton);

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testAttributesPredefined/testAttributesPredefined.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testAttributesPredefined/testAttributesPredefined.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace {
+    final class Attribute {}
+    final class AllowDynamicProperties {}
+    final class Override {}
+    final class ReturnTypeWillChange {}
+    final class SensitiveParameter {}
+    final class NotAttribute {}
+}
+
+namespace Predefined\Attributes {
+    #[]
+    class PredefinedAttributes {}
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testAttributesPredefined/testAttributesPredefined.php.testAttributesPredefined_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testAttributesPredefined/testAttributesPredefined.php.testAttributesPredefined_01.completion
@@ -1,0 +1,16 @@
+Code completion result for source line:
+#[|]
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTRUCTO AllowDynamicProperties          [PUBLIC]   testAttributesPredefined.php
+CONSTRUCTO AllowDynamicProperties()        [PUBLIC]   AllowDynamicProperties
+CONSTRUCTO Attribute                       [PUBLIC]   testAttributesPredefined.php
+CONSTRUCTO Attribute()                     [PUBLIC]   Attribute
+CONSTRUCTO Override                        [PUBLIC]   testAttributesPredefined.php
+CONSTRUCTO Override()                      [PUBLIC]   Override
+CONSTRUCTO ReturnTypeWillChange            [PUBLIC]   testAttributesPredefined.php
+CONSTRUCTO ReturnTypeWillChange()          [PUBLIC]   ReturnTypeWillChange
+CONSTRUCTO SensitiveParameter              [PUBLIC]   testAttributesPredefined.php
+CONSTRUCTO SensitiveParameter()            [PUBLIC]   SensitiveParameter
+PACKAGE    Predefined                      [PUBLIC]   null
+------------------------------------
+PACKAGE    Attributes                      [PUBLIC]   Predefined

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHP80CodeCompletionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHP80CodeCompletionTest.java
@@ -1668,4 +1668,8 @@ public class PHP80CodeCompletionTest extends PHPCodeCompletionTestBase {
         checkCompletion(getTestPath(), "    $annon = new #[Attr1(int: 500, stri^ng: \"anon\")] class() {};", false);
     }
 
+    public void testAttributesPredefined_01() throws Exception {
+        checkCompletion(getTestPath(), "    #[^]", false);
+    }
+
 }


### PR DESCRIPTION
- https://www.php.net/manual/en/reserved.attributes.php
- Add all predefined attributes to `PredefinedSymbols` as enum
- Add a unit test

Example:

```php
 #[^]
 class Example {
 }
```

Before:

```php
 #[^] // predefined attributes are not shown except for the Attribute attribute
 class Example {
 }
```

After:

```php
 #[^] // all predefined attributes are shown
 class Example {
 }
```