### PR TITLE
Enabling libs.nbjavacapi for debugger.jpda.truffle tests.

### DIFF
--- a/java/debugger.jpda.truffle/test/unit/src/org/netbeans/modules/debugger/jpda/truffle/JPDATestCase.java
+++ b/java/debugger.jpda.truffle/test/unit/src/org/netbeans/modules/debugger/jpda/truffle/JPDATestCase.java
@@ -47,6 +47,7 @@ public abstract class JPDATestCase extends NbTestCase {
                 failOnException(Level.INFO).
                 enableClasspathModules(false). 
                 clusters(".*").
+                enableModules("org.netbeans.libs.nbjavacapi").
                 suite();
     }
 


### PR DESCRIPTION
Before https://github.com/apache/netbeans/pull/6743 nb-javac was always enabled when it was installed and when `java.source.base` was enabled, due to `OpenIDE-Module-Recommends: org.netbeans.libs.nbjavac` in `java.source.base`'s manifest.

This entry has been removed in 6743, which appears to break `debugger.jpda.truffle` tests. This is an attempt to fix that, by explicitly enabling `libs.nbjavacapi` in the test.
