### PR TITLE
fix apidocs for NB21

### DIFF
--- a/ide/libs.git/apichanges.xml
+++ b/ide/libs.git/apichanges.xml
@@ -102,7 +102,8 @@ is the proper place.
                     </li>
                 </ul>
             </description>
-            <class package="org.netbeans.libs.git.jgit.commands" name="PushCommand"/>
+             <!-- PushCommand is not in apidoc -->
+            <class package="org.netbeans.libs.git.jgit.commands" name="PushCommand" link="no"/>
         </change>
         <change>
             <api name="gitlibrary_api"/>

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
@@ -144,7 +144,7 @@ public class CheckLinks extends MatchingTask {
         JUnitReportWriter.writeReport(this, null, report, Collections.singletonMap("testBrokenLinks", testMessage));
     }
     
-    private static Pattern hrefOrAnchor = Pattern.compile("<(a|img|link|h3)(\\s+shape=\"rect\")?(?:\\s+rel=\"stylesheet\")?\\s+(href|name|id|src)=\"([^\"#]*)(#[^\"$]+)?\"(\\s+shape=\"rect\")?(?:\\s+type=\"text/css\")?\\s*/?>", Pattern.CASE_INSENSITIVE);
+    private static Pattern hrefOrAnchor = Pattern.compile("<(a|img|link|h3|span)(\\s+shape=\"rect\")?(?:\\s+rel=\"stylesheet\")?\\s+(href|name|id|src)=\"([^\"#]*)(#[^\"$]+)?\"(\\s+shape=\"rect\")?(?:\\s+type=\"text/css\")?\\s*/?>", Pattern.CASE_INSENSITIVE);
     private static Pattern lineBreak = Pattern.compile("^", Pattern.MULTILINE);
     
     /**


### PR DESCRIPTION
Need to scan for span element to get id ref.

PushCommand is not in apidoc, so adjusted to link="no"