### PR TITLE
Allow invocation of annotation Processor's getCompletions even if process fails.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/APTUtils.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/APTUtils.java
@@ -958,7 +958,8 @@ public class APTUtils implements ChangeListener, PropertyChangeListener {
 
         private final Processor delegate;
         private ProcessingEnvironment processingEnv;
-        private boolean valid = true;
+        private boolean initFailed = false;
+        private boolean processFailed = false;
 
         public ErrorToleratingProcessor(Processor delegate) {
             this.delegate = delegate;
@@ -966,7 +967,7 @@ public class APTUtils implements ChangeListener, PropertyChangeListener {
 
         @Override
         public Set<String> getSupportedOptions() {
-            if (!valid) {
+            if (initFailed) {
                 return Collections.emptySet();
             }
             return delegate.getSupportedOptions();
@@ -974,7 +975,7 @@ public class APTUtils implements ChangeListener, PropertyChangeListener {
 
         @Override
         public Set<String> getSupportedAnnotationTypes() {
-            if (!valid) {
+            if (initFailed) {
                 return Collections.emptySet();
             }
             return delegate.getSupportedAnnotationTypes();
@@ -982,7 +983,7 @@ public class APTUtils implements ChangeListener, PropertyChangeListener {
 
         @Override
         public SourceVersion getSupportedSourceVersion() {
-            if (!valid) {
+            if (initFailed) {
                 return SourceVersion.latest();
             }
             return delegate.getSupportedSourceVersion();
@@ -993,10 +994,10 @@ public class APTUtils implements ChangeListener, PropertyChangeListener {
             try {
                 delegate.init(processingEnv);
             } catch (ClientCodeException | ThreadDeath | Abort err) {
-                valid = false;
+                initFailed = true;
                 throw err;
             } catch (Throwable t) {
-                valid = false;
+                initFailed = true;
                 StringBuilder exception = new StringBuilder();
                 exception.append(t.getMessage()).append("\n");
                 for (StackTraceElement ste : t.getStackTrace()) {
@@ -1010,16 +1011,16 @@ public class APTUtils implements ChangeListener, PropertyChangeListener {
         @Override
         @Messages("ERR_ProcessorException=Annotation processor {0} failed with an exception: {1}")
         public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-            if (!valid) {
+            if (initFailed || processFailed) {
                 return false;
             }
             try {
                 return delegate.process(annotations, roundEnv);
             } catch (ClientCodeException | ThreadDeath | Abort err) {
-                valid = false;
+                processFailed = true;
                 throw err;
             } catch (Throwable t) {
-                valid = false;
+                processFailed = true;
                 Element el = roundEnv.getRootElements().isEmpty() ? null : roundEnv.getRootElements().iterator().next();
                 StringBuilder exception = new StringBuilder();
                 exception.append(t.getMessage()).append("\n");
@@ -1033,12 +1034,11 @@ public class APTUtils implements ChangeListener, PropertyChangeListener {
 
         @Override
         public Iterable<? extends Completion> getCompletions(Element element, AnnotationMirror annotation, ExecutableElement member, String userText) {
-            if (!valid) {
+            if (initFailed) {
                 return Collections.emptySet();
             }
             return delegate.getCompletions(element, annotation, member, userText);
         }
 
     }
-
 }


### PR DESCRIPTION
Writing code along these lines:
```
@ServiceProvider(service=|)
public class Test implements Runnable {
...
}
```

Code completion invoked at the place `|` does not contain options like `Runnable`. The reason is that the `ServiceProviderProcessor.process` will fail (due to the incomplete code), and then `APTUtils.ErrorToleratingProcessor` ignores even the `getCompletions` invocation.

The proposal is to split the `valid` flag in `APTUtils.ErrorToleratingProcessor` into two: one will be set if `init` fails, and this will block all the methods of the target processor, and one will be set when `process` fails, and that will only block the `process` method. As long as `init` passes, the `getCompletions` method may still be able to produce meaningful results, I think.
