### PR TITLE
FlatLAF properties fallback to Openable for rcp apps without editors

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.Properties;
 import javax.swing.UIManager;
 import org.netbeans.api.actions.Editable;
+import org.netbeans.api.actions.Openable;
 import org.netbeans.spi.options.OptionsPanelController;
 import org.openide.LifecycleManager;
 import org.openide.awt.Notification;
@@ -299,7 +300,13 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
                 }
                 DataObject dob = DataObject.find(customProp);
                 Editable editable = dob.getLookup().lookup(Editable.class);
-                editable.edit();
+                if (editable != null) {
+                  editable.edit();
+                } else {
+                  // fallback to openable for platform apps without editor modules
+                  Openable openable = dob.getLookup().lookup(Openable.class);
+                  openable.open();
+                }
             } catch (Exception ex) {
                 Exceptions.printStackTrace(ex);
             }


### PR DESCRIPTION

As @trixon pointed out on the [dev mailing list](https://lists.apache.org/thread/g5yhcmy7pjfsk0z03m971zstm0jp4psn), the FlatLAF properties button can result in a null pointer if a Platform application does include the editor modules as part of the application.

This PR adds logic which fallbacks to an Openable object to view the properties file if the Editable object is null.

