### PR TITLE
[GH-6970] Adding a system property to disable the multi source file handling.

### DIFF
--- a/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/queries/MultiSourceRootProvider.java
+++ b/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/queries/MultiSourceRootProvider.java
@@ -72,7 +72,7 @@ public class MultiSourceRootProvider implements ClassPathProvider {
 
     private static final Logger LOG = Logger.getLogger(MultiSourceRootProvider.class.getName());
 
-    public static boolean DISABLE_MULTI_SOURCE_ROOT = false;
+    public static boolean DISABLE_MULTI_SOURCE_ROOT = Boolean.getBoolean("java.disable.multi.source.root");
 
     //TODO: the cache will probably be never cleared, as the ClassPath/value refers to the key(?)
     private Map<FileObject, ClassPath> file2SourceCP = new WeakHashMap<>();


### PR DESCRIPTION
I think the caption says it all. Not only won't the source root be registered, they won't even be computed by default. Which should basically eliminate the effect of the multi source root feature.

Relates to #6970 