### PR TITLE
[GITHUB-6970] MultiSourceRootProvider: reduce logging verbosity

### DIFF
--- a/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/SingleSourceFileUtil.java
+++ b/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/SingleSourceFileUtil.java
@@ -82,10 +82,18 @@ public final class SingleSourceFileUtil {
     }
 
     public static boolean isSupportedFile(FileObject file) {
+        if (file == null) {
+            return false;
+        }
         try {
-            return !MultiSourceRootProvider.DISABLE_MULTI_SOURCE_ROOT &&
-                   FileOwnerQuery.getOwner(file) == null &&
-                   !file.getFileSystem().isReadOnly();
+            FileObject dir = file.getParent();
+            File dirFile = dir != null ? FileUtil.toFile(dir) : null;
+            return !MultiSourceRootProvider.DISABLE_MULTI_SOURCE_ROOT
+                    && FileOwnerQuery.getOwner(file) == null
+                    && !file.getFileSystem().isReadOnly()
+                    && !(dirFile != null
+                    && dirFile.getName().startsWith("vcs-")
+                    && dirFile.getAbsolutePath().startsWith(System.getProperty("java.io.tmpdir")));
         } catch (FileStateInvalidException ex) {
             return false;
         }

--- a/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/queries/MultiSourceRootProvider.java
+++ b/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/queries/MultiSourceRootProvider.java
@@ -21,8 +21,6 @@ package org.netbeans.modules.java.file.launcher.queries;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.IOException;
-import java.lang.ref.Reference;
-import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,6 +33,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.java.classpath.ClassPath;
@@ -50,7 +50,9 @@ import org.netbeans.modules.java.file.launcher.SingleSourceFileUtil;
 import org.netbeans.modules.java.file.launcher.spi.SingleFileOptionsQueryImplementation;
 import org.netbeans.spi.java.classpath.ClassPathFactory;
 import org.netbeans.spi.java.classpath.ClassPathImplementation;
+
 import static org.netbeans.spi.java.classpath.ClassPathImplementation.PROP_RESOURCES;
+
 import org.netbeans.spi.java.classpath.ClassPathProvider;
 import org.netbeans.spi.java.classpath.FilteringPathResourceImplementation;
 import org.netbeans.spi.java.classpath.PathResourceImplementation;
@@ -58,7 +60,6 @@ import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
-import org.openide.util.Exceptions;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
@@ -68,6 +69,8 @@ import org.openide.util.lookup.ServiceProviders;
     @ServiceProvider(service=MultiSourceRootProvider.class)
 })
 public class MultiSourceRootProvider implements ClassPathProvider {
+
+    private static final Logger LOG = Logger.getLogger(MultiSourceRootProvider.class.getName());
 
     public static boolean DISABLE_MULTI_SOURCE_ROOT = false;
 
@@ -130,7 +133,7 @@ public class MultiSourceRootProvider implements ClassPathProvider {
                             return srcCP;
                         });
                     } catch (IOException ex) {
-                        Exceptions.printStackTrace(ex);
+                        LOG.log(Level.FINE, "Failed to read sourcefile " + file, ex);
                     }
                     return null;
                 });

--- a/java/java.file.launcher/test/unit/src/org/netbeans/modules/java/file/launcher/SingleSourceFileUtilTest.java
+++ b/java/java.file.launcher/test/unit/src/org/netbeans/modules/java/file/launcher/SingleSourceFileUtilTest.java
@@ -18,9 +18,13 @@
  */
 package org.netbeans.modules.java.file.launcher;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
+
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Lookup;
@@ -50,5 +54,32 @@ public class SingleSourceFileUtilTest {
         assertNotNull("class created", clazz);
 
         assertTrue("Sibling found", SingleSourceFileUtil.hasClassSibling(java));
+    }
+
+    @Test
+    public void testIsSupportedFile() throws IOException {
+        File vcsDemoDir = null;
+        File supportedFile = null;
+        File unsupportedFile = null;
+        try {
+            vcsDemoDir = Files.createTempDirectory("vcs-dummy").toFile();
+            supportedFile = Files.createTempFile("dummy", ".java").toFile();
+            unsupportedFile = new File(vcsDemoDir, "dummy.java");
+            FileUtil.createData(unsupportedFile);
+
+            assertTrue(SingleSourceFileUtil.isSupportedFile(FileUtil.createData(supportedFile)));
+            assertFalse(SingleSourceFileUtil.isSupportedFile(FileUtil.createData(unsupportedFile)));
+
+        } finally {
+            if(supportedFile != null && supportedFile.exists()) {
+                supportedFile.delete();
+            }
+            if(unsupportedFile != null && unsupportedFile.exists()) {
+                unsupportedFile.delete();
+            }
+            if(vcsDemoDir != null && vcsDemoDir.exists()) {
+                vcsDemoDir.delete();
+            }
+        }
     }
 }


### PR DESCRIPTION
The ClassPathProvider is also invoked for files that are only temporary present. The files are only present for a short time and between the FileObject#isValid call and the FileObject#asBytes call the file is removed leading to an IOException.

This situation is a race condition and happens often enough for users to be annoyed. As this is common and the scanning error is not fatal for normal operation, this should normally not be reported.

Closes: #6970
