### PR TITLE
Fix incorrect formatting after use statements #6980

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/TokenFormatter.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/TokenFormatter.java
@@ -1770,6 +1770,14 @@ public class TokenFormatter {
                                         countSpaces = ws.spaces;
                                         break;
                                     case WHITESPACE_INDENT:
+                                        if (formatTokens.get(index - 1).getId() == FormatToken.Kind.WHITESPACE_AFTER_USE) {
+                                            // GH-6980
+                                            // namespace {
+                                            //     use Vendor\Package\ExampleClass;
+                                            //     $variable = 1; // add indent spaces here
+                                            // }
+                                            countSpaces = indent;
+                                        }
                                         indentLine = true;
                                         break;
                                     case INDENT:

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_01.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_01.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+    use Vendor\Package\Example;
+
+    $test = 1;

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_01.php.testGH6980_01.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_01.php.testGH6980_01.formatted
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use Vendor\Package\Example;
+
+$test = 1;

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_02.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_02.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+    use Vendor\Package\Example;
+
+    class Example {
+        
+    }

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_02.php.testGH6980_02.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_02.php.testGH6980_02.formatted
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use Vendor\Package\Example;
+
+class Example {
+    
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_03.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_03.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+    use Vendor\Package\ {
+        Example1,
+        Example2,
+    };
+
+    $test = 1;

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_03.php.testGH6980_03.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_03.php.testGH6980_03.formatted
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use Vendor\Package\{
+    Example1,
+    Example2,
+};
+
+$test = 1;

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_NSWithBlock01.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_NSWithBlock01.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace {
+    use Vendor\Package\Example;
+
+$test = 1;
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_NSWithBlock01.php.testGH6980_NSWithBlock01.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_NSWithBlock01.php.testGH6980_NSWithBlock01.formatted
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace {
+
+    use Vendor\Package\Example;
+
+    $test = 1;
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_NSWithBlock02.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_NSWithBlock02.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace {
+    use Vendor\Package\Example;
+
+    class Example {
+        
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_NSWithBlock02.php.testGH6980_NSWithBlock02.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_NSWithBlock02.php.testGH6980_NSWithBlock02.formatted
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace {
+
+    use Vendor\Package\Example;
+
+    class Example {
+        
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_NSWithBlock03.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_NSWithBlock03.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace {
+    use Vendor\Package\ {
+        Example1,
+        Example2,
+    };
+
+    $test = 1;
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_NSWithBlock03.php.testGH6980_NSWithBlock03.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/issueGH6980_NSWithBlock03.php.testGH6980_NSWithBlock03.formatted
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace {
+
+    use Vendor\Package\{
+        Example1,
+        Example2,
+    };
+
+    $test = 1;
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterBlankLinesTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterBlankLinesTest.java
@@ -2035,4 +2035,40 @@ public class PHPFormatterBlankLinesTest extends PHPFormatterTestBase {
         reformatFileContents("testfiles/formatting/blankLines/AfterUseTrait_01.php", options, false, true);
     }
 
+    public void testGH6980_NSWithBlock01() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.BLANK_LINES_AFTER_USE, 1);
+        reformatFileContents("testfiles/formatting/blankLines/issueGH6980_NSWithBlock01.php", options, false, true);
+    }
+
+    public void testGH6980_NSWithBlock02() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.BLANK_LINES_AFTER_USE, 1);
+        reformatFileContents("testfiles/formatting/blankLines/issueGH6980_NSWithBlock02.php", options, false, true);
+    }
+
+    public void testGH6980_NSWithBlock03() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.BLANK_LINES_AFTER_USE, 1);
+        reformatFileContents("testfiles/formatting/blankLines/issueGH6980_NSWithBlock03.php", options, false, true);
+    }
+
+    public void testGH6980_01() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.BLANK_LINES_AFTER_USE, 1);
+        reformatFileContents("testfiles/formatting/blankLines/issueGH6980_01.php", options, false, true);
+    }
+
+    public void testGH6980_02() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.BLANK_LINES_AFTER_USE, 1);
+        reformatFileContents("testfiles/formatting/blankLines/issueGH6980_02.php", options, false, true);
+    }
+
+    public void testGH6980_03() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.BLANK_LINES_AFTER_USE, 1);
+        reformatFileContents("testfiles/formatting/blankLines/issueGH6980_03.php", options, false, true);
+    }
+
 }


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/6980
- Fix the below case
- Add unit tests

Example:

```php
<?php
namespace {
    use Vendor\Class1;
    $test = 1;
}
```

Before:

```php
<?php

namespace {

    use Vendor\Class1;

$test = 1;
}
```

After:

```php
<?php

namespace {

    use Vendor\Class1;

    $test = 1;
}
```

