### PR TITLE
LSP: Do not compute text edits in source actions on `resolve` call.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
@@ -549,7 +549,7 @@ public class Utils {
                 String docUri = parts.first().getDocument();
                 try {
                     FileObject file = Utils.fromUri(docUri);
-                    if (file == null) {
+                    if (file == null && uri != null) {
                         file = Utils.fromUri(uri);
                     }
                     FileObject fo = file;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/CodeActionsProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/CodeActionsProvider.java
@@ -69,10 +69,14 @@ public abstract class CodeActionsProvider {
     }
 
     protected CodeAction createCodeAction(NbCodeLanguageClient client, String name, String kind, Object data, String command, Object... commandArgs) {
+        return createCodeAction(client, name, kind, data, command, Arrays.asList(commandArgs));
+    }
+
+    protected CodeAction createCodeAction(NbCodeLanguageClient client, String name, String kind, Object data, String command, List<Object> commandArgs) {
         CodeAction action = new CodeAction(name);
         action.setKind(kind);
         if (command != null) {
-            action.setCommand(new Command(name, Utils.encodeCommand(command, client.getNbCodeCapabilities()), Arrays.asList(commandArgs)));
+            action.setCommand(new Command(name, Utils.encodeCommand(command, client.getNbCodeCapabilities()), commandArgs));
         }
         if (data != null) {
             Map<String, Object> map = new HashMap<>();

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ConstructorGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ConstructorGenerator.java
@@ -77,6 +77,7 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = CodeActionsProvider.class, position = 10)
 public final class ConstructorGenerator extends CodeActionsProvider {
 
+    private static final String GENERATE_CONSTRUCTOR = "nbls.java.generate.constructor";
     private static final String URI =  "uri";
     private static final String OFFSET =  "offset";
     private static final String CONSTRUCTORS =  "constructors";
@@ -187,7 +188,12 @@ public final class ConstructorGenerator extends CodeActionsProvider {
         data.put(OFFSET, startOffset);
         data.put(CONSTRUCTORS, constructors);
         data.put(FIELDS, fields);
-        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateConstructor(), isSource ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, data, "workbench.action.focusActiveEditorGroup"));
+        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateConstructor(), isSource ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, null, "nbls.generate.code", GENERATE_CONSTRUCTOR, data));
+    }
+
+    @Override
+    public Set<String> getCommands() {
+        return Collections.singleton(GENERATE_CONSTRUCTOR);
     }
 
     @Override
@@ -195,19 +201,19 @@ public final class ConstructorGenerator extends CodeActionsProvider {
         "DN_SelectSuperConstructor=Select super constructor",
         "DN_SelectConstructorFields=Select fields to be initialized by constructor",
     })
-    public CompletableFuture<CodeAction> resolve(NbCodeLanguageClient client, CodeAction codeAction, Object data) {
-        CompletableFuture<CodeAction> future = new CompletableFuture<>();
+    public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
+        if (arguments.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        JsonObject data = (JsonObject) arguments.get(0);
+        CompletableFuture<Object> future = new CompletableFuture<>();
         try {
-            String uri = ((JsonObject) data).getAsJsonPrimitive(URI).getAsString();
-            int offset = ((JsonObject) data).getAsJsonPrimitive(OFFSET).getAsInt();
-            List<QuickPickItem> constructors = Arrays.asList(gson.fromJson(((JsonObject) data).get(CONSTRUCTORS), QuickPickItem[].class));
-            List<QuickPickItem> fields = Arrays.asList(gson.fromJson(((JsonObject) data).get(FIELDS), QuickPickItem[].class));
+            String uri = data.getAsJsonPrimitive(URI).getAsString();
+            int offset = data.getAsJsonPrimitive(OFFSET).getAsInt();
+            List<QuickPickItem> constructors = Arrays.asList(gson.fromJson(data.get(CONSTRUCTORS), QuickPickItem[].class));
+            List<QuickPickItem> fields = Arrays.asList(gson.fromJson(data.get(FIELDS), QuickPickItem[].class));
             if (constructors.size() < 2 && fields.isEmpty()) {
-                WorkspaceEdit edit = generate(client, uri, offset, constructors, fields);
-                if (edit != null) {
-                    codeAction.setEdit(edit);
-                }
-                future.complete(codeAction);
+                future.complete(generate(client, uri, offset, constructors, fields));
             } else {
                 InputService.Registry inputServiceRegistry = Lookup.getDefault().lookup(InputService.Registry.class);
                 if (inputServiceRegistry != null) {
@@ -238,18 +244,10 @@ public final class ConstructorGenerator extends CodeActionsProvider {
                     client.showMultiStepInput(new ShowMutliStepInputParams(inputId, Bundle.DN_GenerateConstructor())).thenAccept(result -> {
                         Either<List<QuickPickItem>, String> selectedConstructors = result.get(CONSTRUCTORS);
                         Either<List<QuickPickItem>, String> selectedFields = result.get(FIELDS);
-                        if (selectedFields != null) {
-                            try {
-                                WorkspaceEdit edit = generate(client, uri, offset, selectedConstructors != null ? selectedConstructors.getLeft() : constructors, selectedFields.getLeft());
-                                if (edit != null) {
-                                    codeAction.setEdit(edit);
-                                }
-                                future.complete(codeAction);
-                            } catch (IOException | IllegalArgumentException ex) {
-                                future.completeExceptionally(ex);
-                            }
-                        } else {
-                            future.complete(codeAction);
+                        try {
+                            future.complete(selectedFields != null ? generate(client, uri, offset, selectedConstructors != null ? selectedConstructors.getLeft() : constructors, selectedFields.getLeft()) : null);
+                        } catch (IOException | IllegalArgumentException ex) {
+                            future.completeExceptionally(ex);
                         }
                     });
                 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/DelegateMethodGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/DelegateMethodGenerator.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Element;
@@ -73,6 +74,7 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = CodeActionsProvider.class, position = 60)
 public final class DelegateMethodGenerator extends CodeActionsProvider {
 
+    private static final String GENERATE_DELEGATE_METHOD = "nbls.java.generate.delegate";
     private static final String URI =  "uri";
     private static final String OFFSET =  "offset";
     private static final String TYPE =  "type";
@@ -135,7 +137,12 @@ public final class DelegateMethodGenerator extends CodeActionsProvider {
         data.put(OFFSET, offset);
         data.put(TYPE, typeItem);
         data.put(FIELDS, fields);
-        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateDelegateMethod(), CODE_GENERATOR_KIND, data, "workbench.action.focusActiveEditorGroup"));
+        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateDelegateMethod(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_DELEGATE_METHOD, data));
+    }
+
+    @Override
+    public Set<String> getCommands() {
+        return Collections.singleton(GENERATE_DELEGATE_METHOD);
     }
 
     @Override
@@ -143,13 +150,17 @@ public final class DelegateMethodGenerator extends CodeActionsProvider {
         "DN_SelectDelegateMethodField=Select target field to generate delegates for",
         "DN_SelectDelegateMethods=Select methods to generate delegates for",
     })
-    public CompletableFuture<CodeAction> resolve(NbCodeLanguageClient client, CodeAction codeAction, Object data) {
-        CompletableFuture<CodeAction> future = new CompletableFuture<>();
+    public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
+        if (arguments.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        JsonObject data = (JsonObject) arguments.get(0);
+        CompletableFuture<Object> future = new CompletableFuture<>();
         try {
-            String uri = ((JsonObject) data).getAsJsonPrimitive(URI).getAsString();
-            int offset = ((JsonObject) data).getAsJsonPrimitive(OFFSET).getAsInt();
-            QuickPickItem type = gson.fromJson(gson.toJson(((JsonObject) data).get(TYPE)), QuickPickItem.class);
-            List<QuickPickItem> fields = Arrays.asList(gson.fromJson(((JsonObject) data).get(FIELDS), QuickPickItem[].class));
+            String uri = data.getAsJsonPrimitive(URI).getAsString();
+            int offset = data.getAsJsonPrimitive(OFFSET).getAsInt();
+            QuickPickItem type = gson.fromJson(gson.toJson(data.get(TYPE)), QuickPickItem.class);
+            List<QuickPickItem> fields = Arrays.asList(gson.fromJson(data.get(FIELDS), QuickPickItem[].class));
             InputService.Registry inputServiceRegistry = Lookup.getDefault().lookup(InputService.Registry.class);
             if (inputServiceRegistry != null) {
                 int totalSteps = fields.size() > 1 ? 2 : 1;
@@ -220,18 +231,10 @@ public final class DelegateMethodGenerator extends CodeActionsProvider {
                     Either<List<QuickPickItem>, String> selectedFields = result.get(FIELDS);
                     QuickPickItem selectedField = (selectedFields != null ? selectedFields.getLeft() : fields).get(0);
                     Either<List<QuickPickItem>, String> selectedMethods = result.get(METHODS);
-                    if (selectedField != null && selectedMethods != null) {
-                        try {
-                            WorkspaceEdit edit = generate(uri, offset, selectedField, selectedMethods.getLeft());
-                            if (edit != null) {
-                                codeAction.setEdit(edit);
-                            }
-                            future.complete(codeAction);
-                        } catch (IOException | IllegalArgumentException ex) {
-                            future.completeExceptionally(ex);
-                        }
-                    } else {
-                        future.complete(codeAction);
+                    try {
+                        future.complete(selectedField != null && selectedMethods != null ? generate(uri, offset, selectedField, selectedMethods.getLeft()) : null);
+                    } catch (IOException | IllegalArgumentException ex) {
+                        future.completeExceptionally(ex);
                     }
                 });
             }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/EqualsHashCodeGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/EqualsHashCodeGenerator.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.lang.model.element.ElementKind;
@@ -60,6 +61,7 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = CodeActionsProvider.class, position = 40)
 public final class EqualsHashCodeGenerator extends CodeActionsProvider {
 
+    private static final String GENERATE_EQUALS_HASHCODE = "nbls.java.generate.equals.hashCode";
     private static final String KIND =  "kind";
     private static final String URI =  "uri";
     private static final String OFFSET =  "offset";
@@ -113,11 +115,16 @@ public final class EqualsHashCodeGenerator extends CodeActionsProvider {
         String uri = Utils.toUri(info.getFileObject());
         if (equalsHashCode[0] == null) {
             if (equalsHashCode[1] == null) {
-                return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateEqualsHashCode(), CODE_GENERATOR_KIND, data(0, uri, offset, fields), "workbench.action.focusActiveEditorGroup"));
+                return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateEqualsHashCode(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_EQUALS_HASHCODE, data(0, uri, offset, fields)));
             }
-            return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateEquals(), CODE_GENERATOR_KIND, data(EQUALS_ONLY, uri, offset, fields), "workbench.action.focusActiveEditorGroup"));
+            return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateEquals(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_EQUALS_HASHCODE, data(EQUALS_ONLY, uri, offset, fields)));
         }
-        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateHashCode(), CODE_GENERATOR_KIND, data(HASH_CODE_ONLY, uri, offset, fields), "workbench.action.focusActiveEditorGroup"));
+        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateHashCode(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_EQUALS_HASHCODE, data(HASH_CODE_ONLY, uri, offset, fields)));
+    }
+
+    @Override
+    public Set<String> getCommands() {
+        return Collections.singleton(GENERATE_EQUALS_HASHCODE);
     }
 
     @Override
@@ -126,13 +133,17 @@ public final class EqualsHashCodeGenerator extends CodeActionsProvider {
         "DN_SelectHashCode=Select fields to be included in hashCode()",
         "DN_SelectEqualsHashCode=Select fields to be included in equals() and hashCode()",
     })
-    public CompletableFuture<CodeAction> resolve(NbCodeLanguageClient client, CodeAction codeAction, Object data) {
-        CompletableFuture<CodeAction> future = new CompletableFuture<>();
+    public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
+        if (arguments.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        JsonObject data = (JsonObject) arguments.get(0);
+        CompletableFuture<Object> future = new CompletableFuture<>();
         try {
-            int kind = ((JsonObject) data).getAsJsonPrimitive(KIND).getAsInt();
-            String uri = ((JsonObject) data).getAsJsonPrimitive(URI).getAsString();
-            int offset = ((JsonObject) data).getAsJsonPrimitive(OFFSET).getAsInt();
-            List<QuickPickItem> fields = Arrays.asList(gson.fromJson(((JsonObject) data).get(FIELDS), QuickPickItem[].class));
+            int kind = data.getAsJsonPrimitive(KIND).getAsInt();
+            String uri = data.getAsJsonPrimitive(URI).getAsString();
+            int offset = data.getAsJsonPrimitive(OFFSET).getAsInt();
+            List<QuickPickItem> fields = Arrays.asList(gson.fromJson(data.get(FIELDS), QuickPickItem[].class));
             String title;
             String text;
             boolean generateEquals = HASH_CODE_ONLY != kind;
@@ -162,11 +173,10 @@ public final class EqualsHashCodeGenerator extends CodeActionsProvider {
                                 org.netbeans.modules.java.editor.codegen.EqualsHashCodeGenerator.generateEqualsAndHashCode(wc, tp, generateEquals ? selectedFields : null, generateHashCode ? selectedFields : null, -1);
                             }
                         });
-                        if (!edits.isEmpty()) {
-                            codeAction.setEdit(new WorkspaceEdit(Collections.singletonMap(uri, edits)));
-                        }
+                        future.complete(edits.isEmpty() ? null : new WorkspaceEdit(Collections.singletonMap(uri, edits)));
+                    } else {
+                        future.complete(null);
                     }
-                    future.complete(codeAction);
                 } catch (IOException | IllegalArgumentException ex) {
                     future.completeExceptionally(ex);
                 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/GetterSetterGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/GetterSetterGenerator.java
@@ -69,6 +69,7 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = CodeActionsProvider.class, position = 30)
 public final class GetterSetterGenerator extends CodeActionsProvider {
 
+    private static final String GENERATE_GETTER_SETTER = "nbls.java.generate.getter.setter";
     private static final String KIND =  "kind";
     private static final String URI =  "uri";
     private static final String OFFSET =  "offset";
@@ -102,30 +103,35 @@ public final class GetterSetterGenerator extends CodeActionsProvider {
         List<CodeAction> result = new ArrayList<>();
         if (missingGetters) {
             String name = pair.first().size() == 1 ? Bundle.DN_GenerateGetterFor(pair.first().iterator().next().getSimpleName().toString()) : Bundle.DN_GenerateGetters();
-            result.add(createCodeAction(client, name, all ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, data(GeneratorUtils.GETTERS_ONLY, uri, offset, all, pair.first().stream().map(variableElement -> {
+            result.add(createCodeAction(client, name, all ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, null, "nbls.generate.code", GENERATE_GETTER_SETTER, data(GeneratorUtils.GETTERS_ONLY, uri, offset, all, pair.first().stream().map(variableElement -> {
                 QuickPickItem item = new QuickPickItem(createLabel(info, variableElement));
                 item.setUserData(new ElementData(variableElement));
                 return item;
-            }).collect(Collectors.toList())), all && pair.first().size() > 1 ? "workbench.action.focusActiveEditorGroup" : null));
+            }).collect(Collectors.toList()))));
         }
         if (missingSetters) {
             String name = pair.second().size() == 1 ? Bundle.DN_GenerateSetterFor(pair.second().iterator().next().getSimpleName().toString()) : Bundle.DN_GenerateSetters();
-            result.add(createCodeAction(client, name, all ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, data(GeneratorUtils.SETTERS_ONLY, uri, offset, all, pair.second().stream().map(variableElement -> {
+            result.add(createCodeAction(client, name, all ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, null, "nbls.generate.code", GENERATE_GETTER_SETTER, data(GeneratorUtils.SETTERS_ONLY, uri, offset, all, pair.second().stream().map(variableElement -> {
                 QuickPickItem item = new QuickPickItem(createLabel(info, variableElement));
                 item.setUserData(new ElementData(variableElement));
                 return item;
-            }).collect(Collectors.toList())), all && pair.first().size() > 1 ? "workbench.action.focusActiveEditorGroup" : null));
+            }).collect(Collectors.toList()))));
         }
         if (missingGetters && missingSetters) {
             pair.first().retainAll(pair.second());
             String name = pair.first().size() == 1 ? Bundle.DN_GenerateGetterSetterFor(pair.first().iterator().next().getSimpleName().toString()) : Bundle.DN_GenerateGettersSetters();
-            result.add(createCodeAction(client, name, all ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, data(0, uri, offset, all, pair.first().stream().map(variableElement -> {
+            result.add(createCodeAction(client, name, all ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, null, "nbls.generate.code", GENERATE_GETTER_SETTER, data(0, uri, offset, all, pair.first().stream().map(variableElement -> {
                 QuickPickItem item = new QuickPickItem(createLabel(info, variableElement));
                 item.setUserData(new ElementData(variableElement));
                 return item;
-            }).collect(Collectors.toList())), all && pair.first().size() > 1 ? "workbench.action.focusActiveEditorGroup" : null));
+            }).collect(Collectors.toList()))));
         }
         return result;
+    }
+
+    @Override
+    public Set<String> getCommands() {
+        return Collections.singleton(GENERATE_GETTER_SETTER);
     }
 
     @Override
@@ -134,14 +140,18 @@ public final class GetterSetterGenerator extends CodeActionsProvider {
         "DN_SelectSetters=Select fields to generate setters for",
         "DN_SelectGettersSetters=Select fields to generate getters and setters for",
     })
-    public CompletableFuture<CodeAction> resolve(NbCodeLanguageClient client, CodeAction codeAction, Object data) {
-        CompletableFuture<CodeAction> future = new CompletableFuture<>();
+    public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
+        if (arguments.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        JsonObject data = (JsonObject) arguments.get(0);
+        CompletableFuture<Object> future = new CompletableFuture<>();
         try {
-            int kind = ((JsonObject) data).getAsJsonPrimitive(KIND).getAsInt();
-            String uri = ((JsonObject) data).getAsJsonPrimitive(URI).getAsString();
-            int offset = ((JsonObject) data).getAsJsonPrimitive(OFFSET).getAsInt();
-            boolean all = ((JsonObject) data).getAsJsonPrimitive(ALL).getAsBoolean();
-            List<QuickPickItem> fields = Arrays.asList(gson.fromJson(((JsonObject) data).get(FIELDS), QuickPickItem[].class));
+            int kind = data.getAsJsonPrimitive(KIND).getAsInt();
+            String uri = data.getAsJsonPrimitive(URI).getAsString();
+            int offset = data.getAsJsonPrimitive(OFFSET).getAsInt();
+            boolean all = data.getAsJsonPrimitive(ALL).getAsBoolean();
+            List<QuickPickItem> fields = Arrays.asList(gson.fromJson(data.get(FIELDS), QuickPickItem[].class));
             String title;
             String text;
             switch (kind) {
@@ -152,23 +162,13 @@ public final class GetterSetterGenerator extends CodeActionsProvider {
             if (all && fields.size() > 1) {
                 client.showQuickPick(new ShowQuickPickParams(title, text, true, fields)).thenAccept(selected -> {
                     try {
-                        if (selected != null && !selected.isEmpty()) {
-                            WorkspaceEdit edit = generate(kind, uri, offset, selected);
-                            if (edit != null) {
-                                codeAction.setEdit(edit);
-                            }
-                        }
-                        future.complete(codeAction);
+                        future.complete(selected != null && !selected.isEmpty() ? generate(kind, uri, offset, selected) : null);
                     } catch (IOException | IllegalArgumentException ex) {
                         future.completeExceptionally(ex);
                     }
                 });
             } else {
-                WorkspaceEdit edit = generate(kind, uri, offset, fields);
-                if (edit != null) {
-                    codeAction.setEdit(edit);
-                }
-                future.complete(codeAction);
+                future.complete(generate(kind, uri, offset, fields));
             }
         } catch(JsonSyntaxException | IOException | IllegalArgumentException ex) {
             future.completeExceptionally(ex);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ImplementOverrideMethodGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ImplementOverrideMethodGenerator.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.lang.model.SourceVersion;
@@ -62,6 +63,7 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = CodeActionsProvider.class, position = 70)
 public final class ImplementOverrideMethodGenerator extends CodeActionsProvider {
 
+    private static final String GENERATE_IMPLEMENT_OVERRIDE = "nbls.java.generate.implement.override.method";
     private static final String URI =  "uri";
     private static final String OFFSET =  "offset";
     private static final String IS_IMPLEMET =  "isImplement";
@@ -107,7 +109,7 @@ public final class ImplementOverrideMethodGenerator extends CodeActionsProvider 
                 implementMethods.add(new QuickPickItem(createLabel(info, method), enclosingTypeName, null, mustImplement, new ElementData(method)));
             }
             if (!implementMethods.isEmpty()) {
-                result.add(createCodeAction(client, Bundle.DN_GenerateImplementMethod(), CODE_GENERATOR_KIND, data(uri, offset, true, implementMethods), "workbench.action.focusActiveEditorGroup"));
+                result.add(createCodeAction(client, Bundle.DN_GenerateImplementMethod(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_IMPLEMENT_OVERRIDE, data(uri, offset, true, implementMethods)));
             }
         }
         if (typeElement.getKind().isClass() || typeElement.getKind().isInterface()) {
@@ -123,10 +125,15 @@ public final class ImplementOverrideMethodGenerator extends CodeActionsProvider 
                 overrideMethods.add(item);
             }
             if (!overrideMethods.isEmpty()) {
-                result.add(createCodeAction(client, Bundle.DN_GenerateOverrideMethod(), CODE_GENERATOR_KIND, data (uri, offset, false, overrideMethods), "workbench.action.focusActiveEditorGroup"));
+                result.add(createCodeAction(client, Bundle.DN_GenerateOverrideMethod(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_IMPLEMENT_OVERRIDE, data(uri, offset, false, overrideMethods)));
             }
         }
         return result;
+    }
+
+    @Override
+    public Set<String> getCommands() {
+        return Collections.singleton(GENERATE_IMPLEMENT_OVERRIDE);
     }
 
     @Override
@@ -134,24 +141,22 @@ public final class ImplementOverrideMethodGenerator extends CodeActionsProvider 
         "DN_SelectImplementMethod=Select methods to implement",
         "DN_SelectOverrideMethod=Select methods to override",
     })
-    public CompletableFuture<CodeAction> resolve(NbCodeLanguageClient client, CodeAction codeAction, Object data) {
-        CompletableFuture<CodeAction> future = new CompletableFuture<>();
+    public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
+        if (arguments.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        JsonObject data = (JsonObject) arguments.get(0);
+        CompletableFuture<Object> future = new CompletableFuture<>();
         try {
-            String uri = ((JsonObject) data).getAsJsonPrimitive(URI).getAsString();
-            int offset = ((JsonObject) data).getAsJsonPrimitive(OFFSET).getAsInt();
-            boolean isImplement = ((JsonObject) data).getAsJsonPrimitive(IS_IMPLEMET).getAsBoolean();
-            List<QuickPickItem> methods = Arrays.asList(gson.fromJson(((JsonObject) data).get(METHODS), QuickPickItem[].class));
+            String uri = data.getAsJsonPrimitive(URI).getAsString();
+            int offset = data.getAsJsonPrimitive(OFFSET).getAsInt();
+            boolean isImplement = data.getAsJsonPrimitive(IS_IMPLEMET).getAsBoolean();
+            List<QuickPickItem> methods = Arrays.asList(gson.fromJson(data.get(METHODS), QuickPickItem[].class));
             String title = isImplement ? Bundle.DN_GenerateImplementMethod(): Bundle.DN_GenerateOverrideMethod();
             String text = isImplement ? Bundle.DN_SelectImplementMethod() : Bundle.DN_SelectOverrideMethod();
             client.showQuickPick(new ShowQuickPickParams(title, text, true, methods)).thenAccept(selected -> {
                 try {
-                    if (selected != null && !selected.isEmpty()) {
-                        WorkspaceEdit edit = generate(uri, offset, isImplement, selected);
-                        if (edit != null) {
-                            codeAction.setEdit(edit);
-                        }
-                    }
-                    future.complete(codeAction);
+                    future.complete(selected != null && !selected.isEmpty() ? generate(uri, offset, isImplement, selected) : null);
                 } catch (IOException | IllegalArgumentException ex) {
                     future.completeExceptionally(ex);
                 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LoggerGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LoggerGenerator.java
@@ -30,6 +30,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 import javax.lang.model.element.Modifier;
@@ -63,6 +64,7 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = CodeActionsProvider.class, position = 20)
 public final class LoggerGenerator extends CodeActionsProvider {
 
+    private static final String GENERATE_LOGGER = "nbls.java.generate.logger";
     private static final String URI =  "uri";
     private static final String OFFSET =  "offset";
 
@@ -106,18 +108,27 @@ public final class LoggerGenerator extends CodeActionsProvider {
         Map<String, Object> data = new HashMap<>();
         data.put(URI, uri);
         data.put(OFFSET, offset);
-        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateLogger(), CODE_GENERATOR_KIND, data, "workbench.action.focusActiveEditorGroup"));
+        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateLogger(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_LOGGER, data));
+    }
+
+    @Override
+    public Set<String> getCommands() {
+        return Collections.singleton(GENERATE_LOGGER);
     }
 
     @Override
     @NbBundle.Messages({
         "DN_SelectLoggerName=Logger field name",
     })
-    public CompletableFuture<CodeAction> resolve(NbCodeLanguageClient client, CodeAction codeAction, Object data) {
-        CompletableFuture<CodeAction> future = new CompletableFuture<>();
+    public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
+        if (arguments.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        JsonObject data = (JsonObject) arguments.get(0);
+        CompletableFuture<Object> future = new CompletableFuture<>();
         try {
-            String uri = ((JsonObject) data).getAsJsonPrimitive(URI).getAsString();
-            int offset = ((JsonObject) data).getAsJsonPrimitive(OFFSET).getAsInt();
+            String uri = data.getAsJsonPrimitive(URI).getAsString();
+            int offset = data.getAsJsonPrimitive(OFFSET).getAsInt();
             client.showInputBox(new ShowInputBoxParams(Bundle.DN_GenerateLogger(), Bundle.DN_SelectLoggerName(), "LOG", false)).thenAccept(value -> {
                 try {
                     if (value != null && BaseUtilities.isJavaIdentifier(value)) {
@@ -136,11 +147,10 @@ public final class LoggerGenerator extends CodeActionsProvider {
                                 wc.rewrite(cls, GeneratorUtilities.get(wc).insertClassMember(cls, field));
                             }
                         });
-                        if (!edits.isEmpty()) {
-                            codeAction.setEdit(new WorkspaceEdit(Collections.singletonMap(uri, edits)));
-                        }
+                        future.complete(edits.isEmpty() ? null : new WorkspaceEdit(Collections.singletonMap(uri, edits)));
+                    } else {
+                        future.complete(null);
                     }
-                    future.complete(codeAction);
                 } catch (IOException | IllegalArgumentException ex) {
                     future.completeExceptionally(ex);
                 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ToStringGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ToStringGenerator.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Element;
@@ -62,6 +63,7 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = CodeActionsProvider.class, position = 50)
 public final class ToStringGenerator extends CodeActionsProvider {
 
+    private static final String GENERATE_TO_STRING = "nbls.java.generate.toString";
     private static final String URI =  "uri";
     private static final String OFFSET =  "offset";
     private static final String FIELDS =  "fields";
@@ -114,35 +116,34 @@ public final class ToStringGenerator extends CodeActionsProvider {
         data.put(URI, uri);
         data.put(OFFSET, offset);
         data.put(FIELDS, fields);
-        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateToString(), CODE_GENERATOR_KIND, data, fields.isEmpty() ? null : "workbench.action.focusActiveEditorGroup"));
+        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateToString(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_TO_STRING, data));
+    }
+
+    @Override
+    public Set<String> getCommands() {
+        return Collections.singleton(GENERATE_TO_STRING);
     }
 
     @Override
     @NbBundle.Messages({
         "DN_SelectToString=Select fields to be included in toString()",
     })
-    public CompletableFuture<CodeAction> resolve(NbCodeLanguageClient client, CodeAction codeAction, Object data) {
-        CompletableFuture<CodeAction> future = new CompletableFuture<>();
+    public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
+        if (arguments.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        JsonObject data = (JsonObject) arguments.get(0);
+        CompletableFuture<Object> future = new CompletableFuture<>();
         try {
-            String uri = ((JsonObject) data).getAsJsonPrimitive(URI).getAsString();
-            int offset = ((JsonObject) data).getAsJsonPrimitive(OFFSET).getAsInt();
-            List<QuickPickItem> fields = Arrays.asList(gson.fromJson(((JsonObject) data).get(FIELDS), QuickPickItem[].class));
+            String uri = data.getAsJsonPrimitive(URI).getAsString();
+            int offset = data.getAsJsonPrimitive(OFFSET).getAsInt();
+            List<QuickPickItem> fields = Arrays.asList(gson.fromJson(data.get(FIELDS), QuickPickItem[].class));
             if (fields.isEmpty()) {
-                WorkspaceEdit edit = generate(uri, offset, fields);
-                if (edit != null) {
-                    codeAction.setEdit(edit);
-                }
-                future.complete(codeAction);
+                future.complete(generate(uri, offset, fields));
             } else {
                 client.showQuickPick(new ShowQuickPickParams(Bundle.DN_GenerateToString(), Bundle.DN_SelectToString(), true, fields)).thenAccept(selected -> {
                     try {
-                        if (selected != null) {
-                            WorkspaceEdit edit = generate(uri, offset, fields);
-                            if (edit != null) {
-                                codeAction.setEdit(edit);
-                            }
-                        }
-                        future.complete(codeAction);
+                        future.complete(selected != null ? generate(uri, offset, fields) : null);
                     } catch (IOException | IllegalArgumentException ex) {
                         future.completeExceptionally(ex);
                     }

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.java.lsp.server.protocol;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FileWriter;
@@ -3018,7 +3019,13 @@ public class ServerTest extends NbTestCase {
         assertTrue(generateGetterSetter.isPresent());
         CodeAction resolvedCodeAction = server.getTextDocumentService().resolveCodeAction(generateGetterSetter.get()).get();
         assertNotNull(resolvedCodeAction);
-        WorkspaceEdit edit = resolvedCodeAction.getEdit();
+        Command command = resolvedCodeAction.getCommand();
+        assertNotNull(command);
+        assertEquals("nbls.generate.code", command.getCommand());
+        List<Object> args = command.getArguments();
+        assertEquals(2, args.size());
+        Object ret = server.getWorkspaceService().executeCommand(new ExecuteCommandParams(((JsonPrimitive) args.get(0)).getAsString(), Collections.singletonList(args.get(1)))).get();
+        WorkspaceEdit edit = gson.fromJson(gson.toJsonTree(ret), WorkspaceEdit.class);
         assertNotNull(edit);
         assertEquals(1, edit.getChanges().size());
         List<TextEdit> fileChanges = edit.getChanges().get(uri);
@@ -3048,7 +3055,7 @@ public class ServerTest extends NbTestCase {
         try (Writer w = new FileWriter(src)) {
             w.write(code);
         }
-        AtomicReference<Object> data = new AtomicReference<>();
+        AtomicReference<JsonObject> data = new AtomicReference<>();
         Launcher<LanguageServer> serverLauncher = createClientLauncherWithLogging(new TestCodeLanguageClient() {
             @Override
             public CompletableFuture<ApplyWorkspaceEditResponse> applyEdit(ApplyWorkspaceEditParams params) {
@@ -3058,7 +3065,7 @@ public class ServerTest extends NbTestCase {
             @Override
             public CompletableFuture<Map<String, Either<List<QuickPickItem>, String>>> showMultiStepInput(ShowMutliStepInputParams params) {
                 Map<String, Either<List<QuickPickItem>, String>> map = new HashMap<>();
-                List<QuickPickItem> fields = Arrays.asList(gson.fromJson(((JsonObject)data.get()).getAsJsonObject("data").get("fields"), QuickPickItem[].class));
+                List<QuickPickItem> fields = Arrays.asList(gson.fromJson(data.get().get("fields"), QuickPickItem[].class));
                 map.put("fields", Either.forLeft(fields.stream().filter(item -> item.isPicked()).collect(Collectors.toList())));
                 return CompletableFuture.completedFuture(map);
             }
@@ -3077,10 +3084,16 @@ public class ServerTest extends NbTestCase {
                            .filter(a -> Bundle.DN_GenerateConstructor().equals(a.getTitle()))
                            .findAny();
         assertTrue(generateConstructor.isPresent());
-        data.set(generateConstructor.get().getData());
         CodeAction resolvedCodeAction = server.getTextDocumentService().resolveCodeAction(generateConstructor.get()).get();
         assertNotNull(resolvedCodeAction);
-        WorkspaceEdit edit = resolvedCodeAction.getEdit();
+        Command command = resolvedCodeAction.getCommand();
+        assertNotNull(command);
+        assertEquals("nbls.generate.code", command.getCommand());
+        List<Object> args = command.getArguments();
+        assertEquals(2, args.size());
+        data.set((JsonObject) args.get(1));
+        Object ret = server.getWorkspaceService().executeCommand(new ExecuteCommandParams(((JsonPrimitive) args.get(0)).getAsString(), Collections.singletonList(args.get(1)))).get();
+        WorkspaceEdit edit = gson.fromJson(gson.toJsonTree(ret), WorkspaceEdit.class);
         assertNotNull(edit);
         assertEquals(1, edit.getChanges().size());
         List<TextEdit> fileChanges = edit.getChanges().get(uri);
@@ -3151,7 +3164,13 @@ public class ServerTest extends NbTestCase {
         assertTrue(generateGetterSetter.isPresent());
         CodeAction resolvedCodeAction = server.getTextDocumentService().resolveCodeAction(generateGetterSetter.get()).get();
         assertNotNull(resolvedCodeAction);
-        WorkspaceEdit edit = resolvedCodeAction.getEdit();
+        Command command = resolvedCodeAction.getCommand();
+        assertNotNull(command);
+        assertEquals("nbls.generate.code", command.getCommand());
+        List<Object> args = command.getArguments();
+        assertEquals(2, args.size());
+        Object ret = server.getWorkspaceService().executeCommand(new ExecuteCommandParams(((JsonPrimitive) args.get(0)).getAsString(), Collections.singletonList(args.get(1)))).get();
+        WorkspaceEdit edit = gson.fromJson(gson.toJsonTree(ret), WorkspaceEdit.class);
         assertNotNull(edit);
         assertEquals(1, edit.getChanges().size());
         List<TextEdit> fileChanges = edit.getChanges().get(uri);
@@ -3180,7 +3199,13 @@ public class ServerTest extends NbTestCase {
         assertTrue(generateGetter.isPresent());
         resolvedCodeAction = server.getTextDocumentService().resolveCodeAction(generateGetter.get()).get();
         assertNotNull(resolvedCodeAction);
-        edit = resolvedCodeAction.getEdit();
+        command = resolvedCodeAction.getCommand();
+        assertNotNull(command);
+        assertEquals("nbls.generate.code", command.getCommand());
+        args = command.getArguments();
+        assertEquals(2, args.size());
+        ret = server.getWorkspaceService().executeCommand(new ExecuteCommandParams(((JsonPrimitive) args.get(0)).getAsString(), Collections.singletonList(args.get(1)))).get();
+        edit = gson.fromJson(gson.toJsonTree(ret), WorkspaceEdit.class);
         assertNotNull(edit);
         assertEquals(1, edit.getChanges().size());
         fileChanges = edit.getChanges().get(uri);
@@ -3206,7 +3231,7 @@ public class ServerTest extends NbTestCase {
         try (Writer w = new FileWriter(src)) {
             w.write(code);
         }
-        AtomicReference<Object> data = new AtomicReference<>();
+        AtomicReference<JsonObject> data = new AtomicReference<>();
         Launcher<LanguageServer> serverLauncher = createClientLauncherWithLogging(new TestCodeLanguageClient() {
             @Override
             public CompletableFuture<ApplyWorkspaceEditResponse> applyEdit(ApplyWorkspaceEditParams params) {
@@ -3216,9 +3241,9 @@ public class ServerTest extends NbTestCase {
             @Override
             public CompletableFuture<Map<String, Either<List<QuickPickItem>, String>>> showMultiStepInput(ShowMutliStepInputParams params) {
                 Map<String, Either<List<QuickPickItem>, String>> map = new HashMap<>();
-                List<QuickPickItem> constructors = Arrays.asList(gson.fromJson(((JsonObject)data.get()).getAsJsonObject("data").get("constructors"), QuickPickItem[].class));
+                List<QuickPickItem> constructors = Arrays.asList(gson.fromJson(data.get().get("constructors"), QuickPickItem[].class));
                 map.put("constructors", Either.forLeft(constructors.subList(0, 2)));
-                List<QuickPickItem> fields = Arrays.asList(gson.fromJson(((JsonObject)data.get()).getAsJsonObject("data").get("fields"), QuickPickItem[].class));
+                List<QuickPickItem> fields = Arrays.asList(gson.fromJson(data.get().get("fields"), QuickPickItem[].class));
                 map.put("fields", Either.forLeft(fields));
                 return CompletableFuture.completedFuture(map);
             }
@@ -3237,10 +3262,16 @@ public class ServerTest extends NbTestCase {
                            .filter(a -> Bundle.DN_GenerateConstructor().equals(a.getTitle()))
                            .findAny();
         assertTrue(generateConstructor.isPresent());
-        data.set(generateConstructor.get().getData());
         CodeAction resolvedCodeAction = server.getTextDocumentService().resolveCodeAction(generateConstructor.get()).get();
         assertNotNull(resolvedCodeAction);
-        WorkspaceEdit edit = resolvedCodeAction.getEdit();
+        Command command = resolvedCodeAction.getCommand();
+        assertNotNull(command);
+        assertEquals("nbls.generate.code", command.getCommand());
+        List<Object> args = command.getArguments();
+        assertEquals(2, args.size());
+        data.set((JsonObject) args.get(1));
+        Object ret = server.getWorkspaceService().executeCommand(new ExecuteCommandParams(((JsonPrimitive) args.get(0)).getAsString(), Collections.singletonList(args.get(1)))).get();
+        WorkspaceEdit edit = gson.fromJson(gson.toJsonTree(ret), WorkspaceEdit.class);
         assertNotNull(edit);
         assertEquals(1, edit.getChanges().size());
         List<TextEdit> fileChanges = edit.getChanges().get(uri);
@@ -3317,7 +3348,13 @@ public class ServerTest extends NbTestCase {
         assertTrue(generateEquals.isPresent());
         CodeAction resolvedCodeAction = server.getTextDocumentService().resolveCodeAction(generateEquals.get()).get();
         assertNotNull(resolvedCodeAction);
-        WorkspaceEdit edit = resolvedCodeAction.getEdit();
+        Command command = resolvedCodeAction.getCommand();
+        assertNotNull(command);
+        assertEquals("nbls.generate.code", command.getCommand());
+        List<Object> args = command.getArguments();
+        assertEquals(2, args.size());
+        Object ret = server.getWorkspaceService().executeCommand(new ExecuteCommandParams(((JsonPrimitive) args.get(0)).getAsString(), Collections.singletonList(args.get(1)))).get();
+        WorkspaceEdit edit = gson.fromJson(gson.toJsonTree(ret), WorkspaceEdit.class);
         assertNotNull(edit);
         assertEquals(1, edit.getChanges().size());
         List<TextEdit> fileChanges = edit.getChanges().get(uri);
@@ -3384,7 +3421,13 @@ public class ServerTest extends NbTestCase {
         assertTrue(generateToString.isPresent());
         CodeAction resolvedCodeAction = server.getTextDocumentService().resolveCodeAction(generateToString.get()).get();
         assertNotNull(resolvedCodeAction);
-        WorkspaceEdit edit = resolvedCodeAction.getEdit();
+        Command command = resolvedCodeAction.getCommand();
+        assertNotNull(command);
+        assertEquals("nbls.generate.code", command.getCommand());
+        List<Object> args = command.getArguments();
+        assertEquals(2, args.size());
+        Object ret = server.getWorkspaceService().executeCommand(new ExecuteCommandParams(((JsonPrimitive) args.get(0)).getAsString(), Collections.singletonList(args.get(1)))).get();
+        WorkspaceEdit edit = gson.fromJson(gson.toJsonTree(ret), WorkspaceEdit.class);
         assertNotNull(edit);
         assertEquals(1, edit.getChanges().size());
         List<TextEdit> fileChanges = edit.getChanges().get(uri);
@@ -3414,7 +3457,7 @@ public class ServerTest extends NbTestCase {
         try (Writer w = new FileWriter(src)) {
             w.write(code);
         }
-        AtomicReference<Object> data = new AtomicReference<>();
+        AtomicReference<JsonObject> data = new AtomicReference<>();
         Launcher<LanguageServer> serverLauncher = createClientLauncherWithLogging(new TestCodeLanguageClient() {
             @Override
             public CompletableFuture<ApplyWorkspaceEditResponse> applyEdit(ApplyWorkspaceEditParams params) {
@@ -3434,7 +3477,7 @@ public class ServerTest extends NbTestCase {
             @Override
             public CompletableFuture<Map<String, Either<List<QuickPickItem>, String>>> showMultiStepInput(ShowMutliStepInputParams params) {
                 Map<String, Either<List<QuickPickItem>, String>> map = new HashMap<>();
-                List<QuickPickItem> fields = Arrays.asList(gson.fromJson(((JsonObject)data.get()).getAsJsonObject("data").get("fields"), QuickPickItem[].class));
+                List<QuickPickItem> fields = Arrays.asList(gson.fromJson(data.get().get("fields"), QuickPickItem[].class));
                 map.put("methods", Either.forLeft(Arrays.asList(new QuickPickItem[] {
                     new QuickPickItem("s.chars(): IntStream", null, null, false, new CodeActionsProvider.ElementData(ElementHandleAccessor.getInstance().create(ElementKind.METHOD, new String[] {
                         "java.lang.CharSequence",
@@ -3464,10 +3507,16 @@ public class ServerTest extends NbTestCase {
                            .filter(a -> Bundle.DN_GenerateDelegateMethod().equals(a.getTitle()))
                            .findAny();
         assertTrue(generateDelegateMethod.isPresent());
-        data.set(generateDelegateMethod.get().getData());
         CodeAction resolvedCodeAction = server.getTextDocumentService().resolveCodeAction(generateDelegateMethod.get()).get();
         assertNotNull(resolvedCodeAction);
-        WorkspaceEdit edit = resolvedCodeAction.getEdit();
+        Command command = resolvedCodeAction.getCommand();
+        assertNotNull(command);
+        assertEquals("nbls.generate.code", command.getCommand());
+        List<Object> args = command.getArguments();
+        assertEquals(2, args.size());
+        data.set((JsonObject) args.get(1));
+        Object ret = server.getWorkspaceService().executeCommand(new ExecuteCommandParams(((JsonPrimitive) args.get(0)).getAsString(), Collections.singletonList(args.get(1)))).get();
+        WorkspaceEdit edit = gson.fromJson(gson.toJsonTree(ret), WorkspaceEdit.class);
         assertNotNull(edit);
         assertEquals(1, edit.getChanges().size());
         List<TextEdit> fileChanges = edit.getChanges().get(uri);
@@ -3529,7 +3578,13 @@ public class ServerTest extends NbTestCase {
         assertTrue(generateOverrideMethod.isPresent());
         CodeAction resolvedCodeAction = server.getTextDocumentService().resolveCodeAction(generateOverrideMethod.get()).get();
         assertNotNull(resolvedCodeAction);
-        WorkspaceEdit edit = resolvedCodeAction.getEdit();
+        Command command = resolvedCodeAction.getCommand();
+        assertNotNull(command);
+        assertEquals("nbls.generate.code", command.getCommand());
+        List<Object> args = command.getArguments();
+        assertEquals(2, args.size());
+        Object ret = server.getWorkspaceService().executeCommand(new ExecuteCommandParams(((JsonPrimitive) args.get(0)).getAsString(), Collections.singletonList(args.get(1)))).get();
+        WorkspaceEdit edit = gson.fromJson(gson.toJsonTree(ret), WorkspaceEdit.class);
         assertNotNull(edit);
         assertEquals(1, edit.getChanges().size());
         List<TextEdit> fileChanges = edit.getChanges().get(uri);
@@ -3593,7 +3648,13 @@ public class ServerTest extends NbTestCase {
         assertTrue(generateLogger.isPresent());
         CodeAction resolvedCodeAction = server.getTextDocumentService().resolveCodeAction(generateLogger.get()).get();
         assertNotNull(resolvedCodeAction);
-        WorkspaceEdit edit = resolvedCodeAction.getEdit();
+        Command command = resolvedCodeAction.getCommand();
+        assertNotNull(command);
+        assertEquals("nbls.generate.code", command.getCommand());
+        List<Object> args = command.getArguments();
+        assertEquals(2, args.size());
+        Object ret = server.getWorkspaceService().executeCommand(new ExecuteCommandParams(((JsonPrimitive) args.get(0)).getAsString(), Collections.singletonList(args.get(1)))).get();
+        WorkspaceEdit edit = gson.fromJson(gson.toJsonTree(ret), WorkspaceEdit.class);
         assertNotNull(edit);
         assertEquals(1, edit.getChanges().size());
         List<TextEdit> fileChanges = edit.getChanges().get(uri);


### PR DESCRIPTION
Modified to follow change in VSCode behavior when `codeAction/resolve` LSP call is invoked also on mouse hover and not only on source action selection (see https://github.com/microsoft/vscode/issues/175008). The source actions that require user interaction to compute their workspace edits should no more do it on `codeAction/resolve`.