### PR TITLE
Remove pre-apache NetBeans 8.2 plugin portal from settings.

### DIFF
--- a/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
+++ b/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
@@ -25,14 +25,11 @@ OpenIDE-Module-Short-Description=Declares NetBeans autoupdate centers.
 
 Services/AutoupdateType/distribution-update-provider.instance=NetBeans Distribution
 Services/AutoupdateType/pluginportal-update-provider.instance=NetBeans Plugin Portal
-Services/AutoupdateType/82pluginportal-update-provider.instance=NetBeans 8.2 Plugin Portal
 
 #NOI18N
 URL_Distribution=@@metabuild.DistributionURL@@
 #NOI18N
 URL_PluginPortal=@@metabuild.PluginPortalURL@@
-#NOI18N
-URL_82PluginPortal=http://updates.netbeans.org/netbeans/updates/8.2/uc/final/distribution/catalog.xml.gz
 
 3rdparty=Third Party Libraries
 #NOI18N

--- a/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/NetBeansKeyStoreProvider.java
+++ b/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/NetBeansKeyStoreProvider.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.updatecenters.resources;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyStore;
 import java.util.logging.Level;
@@ -39,6 +38,7 @@ public final class NetBeansKeyStoreProvider implements KeyStoreProvider {
     public static final String KS_FILE_PATH = "core/ide.ks";
     private static final String KS_DEFAULT_PASSWORD = "open4all";
     
+    @Override
     public KeyStore getKeyStore() {
         return getKeyStore (getKeyStoreFile (), getPassword ());
     }
@@ -54,28 +54,17 @@ public final class NetBeansKeyStoreProvider implements KeyStoreProvider {
     * @param password
     */
     private static KeyStore getKeyStore(File file, String password) {
-        if (file == null) return null;
-        KeyStore keyStore = null;
-        InputStream is = null;
-        
-        try {
-
-            is = new FileInputStream (file);
-
-            keyStore = KeyStore.getInstance (KeyStore.getDefaultType ());
-            keyStore.load (is, password.toCharArray ());
-            
+        if (file == null) {
+            return null;
+        }
+        try (InputStream is = new FileInputStream(file)) {
+            KeyStore keyStore = KeyStore.getInstance (KeyStore.getDefaultType());
+            keyStore.load (is, password.toCharArray());
+            return keyStore;
         } catch (Exception ex) {
             Logger.getLogger ("global").log (Level.INFO, ex.getMessage (), ex);
-        } finally {
-            try {
-                if (is != null) is.close ();
-            } catch (IOException ex) {
-                assert false : ex;
-            }
         }
-
-        return keyStore;
+        return null;
     }
     
     private static String getPassword () {

--- a/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/mf-layer.xml
+++ b/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/mf-layer.xml
@@ -45,16 +45,6 @@
          <attr name="instanceOf" stringvalue="org.netbeans.spi.autoupdate.UpdateProvider"/>
          <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
       </file>
-      
-      <file name="82pluginportal-update-provider.instance">
-          <attr name="displayName" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#Services/AutoupdateType/82pluginportal-update-provider.instance"/>
-          <attr name="iconBase" stringvalue="org/netbeans/modules/updatecenters/resources/updateAction.gif"/>
-          <attr name="url" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#URL_82PluginPortal"/>
-          <attr name="category" stringvalue="STANDARD"/>
-          <attr name="enabled" boolvalue="false"/>
-          <attr name="instanceOf" stringvalue="org.netbeans.spi.autoupdate.UpdateProvider"/>
-          <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
-      </file>
 
       <file name="3rdparty.instance">
           <attr name="displayName" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#3rdparty"/>


### PR DESCRIPTION
 - the plugins haven't been updated for a long time and are of limited use, some require pack200, others broke for other reasons -> lets remove the plugin portal from the settings
 - commit contains a small language level cleanup, mostly try-with-resource blocks

there are currently 10 plugins on the old plugin portal:
![image](https://github.com/apache/netbeans/assets/114367/5bc95515-7b6e-41ce-b6ce-b7a5f75d35e4)

there are currently some efforts to re-integrate [CND](https://github.com/apache/netbeans/tree/cnd) back into NB, but this is without ETA.

closes #6810, [NETBEANS-4096](https://issues.apache.org/jira/browse/NETBEANS-4096), [NETBEANS-2719](https://issues.apache.org/jira/browse/NETBEANS-2719), [NETBEANS-2599](https://issues.apache.org/jira/browse/NETBEANS-2599) (as won't-fix essentially)
related #6969, #6979, #6987