### PR TITLE
PHP: Implemented display of exception message when exception breakpoints are hit

### DIFF
--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/breakpoints/ExceptionBreakpoint.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/breakpoints/ExceptionBreakpoint.java
@@ -18,6 +18,9 @@
  */
 package org.netbeans.modules.php.dbgp.breakpoints;
 
+import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.api.annotations.common.NullAllowed;
+import org.netbeans.modules.php.api.util.StringUtils;
 import org.netbeans.modules.php.dbgp.DebugSession;
 
 /**
@@ -26,7 +29,13 @@ import org.netbeans.modules.php.dbgp.DebugSession;
  *
  */
 public class ExceptionBreakpoint extends AbstractBreakpoint {
+    private static final String FONT_GRAY_COLOR = "<font color=\"#999999\">"; //NOI18N
+    private static final String CLOSE_FONT = "</font>"; //NOI18N
     private final String exceptionName;
+    @NullAllowed
+    private volatile String message;
+    @NullAllowed
+    private volatile String code;
 
     public ExceptionBreakpoint(String exceptionName) {
         this.exceptionName = exceptionName;
@@ -34,6 +43,37 @@ public class ExceptionBreakpoint extends AbstractBreakpoint {
 
     public String getException() {
         return exceptionName;
+    }
+
+    public void setExceptionMessage(String message) {
+        this.message = message;
+    }
+
+    @CheckForNull
+    public String getExceptionMessage() {
+        return buildText(message);
+    }
+
+    public void setExceptionCode(String code) {
+        this.code = code;
+    }
+
+    @CheckForNull
+    public String getExceptionCode() {
+        return buildText(code);
+    }
+
+    @CheckForNull
+    private String buildText(String text) {
+        if (!StringUtils.isEmpty(text)) {
+            StringBuilder builder = new StringBuilder()
+                .append(FONT_GRAY_COLOR)
+                .append(text)
+                .append(CLOSE_FONT);
+            return builder.toString();
+        }
+
+        return null;
     }
 
     @Override


### PR DESCRIPTION
The implementation is made for xdebug since version `3.1.6`. 
Tested on versions of xdebug: `3.1.6`, `3.2.0`, `3.3.0`.

Code example:
```php
<?php

class MyException extends Exception
{}

function throwException()
{
    throw new MyException("Test exception breakpoint", 42);
}

echo 'Test exception breakpoint';

$foo = $bar['foo'];

try {
    throwException();
} catch (Exception $e) {}
```

before:

https://github.com/apache/netbeans/assets/9607501/fc8914b6-1de2-482e-a5b0-c4c3dd348d7c


after:

https://github.com/apache/netbeans/assets/9607501/bdf4fb55-e0ef-45e6-a5aa-a615a88ae15c



for `throw new MyException("Test exception breakpoint")` it looks like this:
![without_code](https://github.com/apache/netbeans/assets/9607501/23d9fb32-b951-4c13-9b8c-4a2122f5a994)

for `throw new MyException("", 42)` it looks like this:
![with_code_without_message](https://github.com/apache/netbeans/assets/9607501/142ea073-10a2-4779-b40f-ea0e90a27ef5)

for `throw new MyException("")` and `throw new MyException()` it looks like this:
![with_empty_message](https://github.com/apache/netbeans/assets/9607501/c74c8518-2e5d-4199-9a55-c1177082359d)

How it looks in a dark theme:
![exception_message_dark_theme](https://github.com/apache/netbeans/assets/9607501/0caf11b1-19e0-4a0d-bdc7-f492f9c5e4e2)




