### PR TITLE
Update guava from 32.1.2-jre to 33.0.0-jre

### DIFF
--- a/ide/c.google.guava.failureaccess/external/binaries-list
+++ b/ide/c.google.guava.failureaccess/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-1DCF1DE382A0BF95A3D8B0849546C88BAC1292C9 com.google.guava:failureaccess:1.0.1
+C4A06A64E650562F30B7BF9AAEC1BFED43ACA12B com.google.guava:failureaccess:1.0.2

--- a/ide/c.google.guava.failureaccess/external/failureaccess-1.0.2-license.txt
+++ b/ide/c.google.guava.failureaccess/external/failureaccess-1.0.2-license.txt
@@ -1,8 +1,8 @@
-Name: Guava
-Version: 32.1.2
+Name: Guava - Failure Access Library
+Version: 1.0.2
 License: Apache-2.0
 Origin: https://github.com/google/guava
-Description: Guava is a set of core libraries that includes new collection types (such as multimap and multiset), immutable collections, a graph library, and utilities for concurrency, I/O, hashing, primitives, strings, and more.
+Description: A Guava subproject
 
 
                                  Apache License

--- a/ide/c.google.guava.failureaccess/nbproject/project.properties
+++ b/ide/c.google.guava.failureaccess/nbproject/project.properties
@@ -17,6 +17,6 @@
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 spec.version.base=1.2.0
-release.external/failureaccess-1.0.1.jar=modules/com-google-guava-failureaccess.jar
+release.external/failureaccess-1.0.2.jar=modules/com-google-guava-failureaccess.jar
 is.autoload=true
 nbm.module.author=Tomas Stupka

--- a/ide/c.google.guava.failureaccess/nbproject/project.xml
+++ b/ide/c.google.guava.failureaccess/nbproject/project.xml
@@ -28,7 +28,7 @@
            <public-packages/>
            <class-path-extension>
                <runtime-relative-path>com-google-guava-failureaccess.jar</runtime-relative-path>
-               <binary-origin>external/failureaccess-1.0.1.jar</binary-origin>
+               <binary-origin>external/failureaccess-1.0.2.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/c.google.guava/external/binaries-list
+++ b/ide/c.google.guava/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-5E64EC7E056456BEF3A4BC4C6FDAEF71E8AB6318 com.google.guava:guava:32.1.2-jre
+161BA27964A62F241533807A46B8711B13C1D94B com.google.guava:guava:33.0.0-jre

--- a/ide/c.google.guava/external/guava-33.0.0-jre-license.txt
+++ b/ide/c.google.guava/external/guava-33.0.0-jre-license.txt
@@ -1,8 +1,8 @@
-Name: Guava - Failure Access Library
-Version: 1.0.1
+Name: Guava
+Version: 33.0.0
 License: Apache-2.0
 Origin: https://github.com/google/guava
-Description: A Guava subproject
+Description: Guava is a set of core libraries that includes new collection types (such as multimap and multiset), immutable collections, a graph library, and utilities for concurrency, I/O, hashing, primitives, strings, and more.
 
 
                                  Apache License

--- a/ide/c.google.guava/nbproject/project.properties
+++ b/ide/c.google.guava/nbproject/project.properties
@@ -17,6 +17,6 @@
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 spec.version.base=27.17.0
-release.external/guava-32.1.2-jre.jar=modules/com-google-guava.jar
+release.external/guava-33.0.0-jre.jar=modules/com-google-guava.jar
 is.autoload=true
 nbm.module.author=Tomas Stupka

--- a/ide/c.google.guava/nbproject/project.xml
+++ b/ide/c.google.guava/nbproject/project.xml
@@ -28,7 +28,7 @@
            <public-packages/>
            <class-path-extension>
                <runtime-relative-path>com-google-guava.jar</runtime-relative-path>
-               <binary-origin>external/guava-32.1.2-jre.jar</binary-origin>
+               <binary-origin>external/guava-33.0.0-jre.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -26,7 +26,7 @@ ide/db.sql.visualeditor/external/javacc-7.0.10.jar java/performance/external/jav
 java/maven.embedder/external/apache-maven-3.9.6-bin.zip ide/slf4j.api/external/slf4j-api-1.7.36.jar
 java/maven.embedder/external/apache-maven-3.9.6-bin.zip platform/o.apache.commons.lang3/external/commons-lang3-3.12.0.jar
 java/maven.embedder/external/apache-maven-3.9.6-bin.zip platform/o.apache.commons.codec/external/commons-codec-1.16.0.jar
-java/maven.embedder/external/apache-maven-3.9.6-bin.zip ide/c.google.guava.failureaccess/external/failureaccess-1.0.1.jar
+java/maven.embedder/external/apache-maven-3.9.6-bin.zip ide/c.google.guava.failureaccess/external/failureaccess-1.0.2.jar
 
 # Used to parse data during build, but need to as a lib for ide cluster
 nbbuild/external/json-simple-1.1.1.jar ide/libs.json_simple/external/json-simple-1.1.1.jar
@@ -57,7 +57,7 @@ enterprise/web.core.syntax/external/struts-tiles-1.3.10.jar enterprise/web.strut
 
 # gradle is used at build-time, so we can ignore the duplicates
 extide/gradle/external/gradle-7.4-bin.zip enterprise/libs.amazon/external/ion-java-1.0.2.jar
-extide/gradle/external/gradle-7.4-bin.zip ide/c.google.guava.failureaccess/external/failureaccess-1.0.1.jar
+extide/gradle/external/gradle-7.4-bin.zip ide/c.google.guava.failureaccess/external/failureaccess-1.0.2.jar
 extide/gradle/external/gradle-7.4-bin.zip ide/c.jcraft.jzlib/external/jzlib-1.1.3.jar
 extide/gradle/external/gradle-7.4-bin.zip ide/libs.commons_compress/external/commons-compress-1.24.0.jar
 extide/gradle/external/gradle-7.4-bin.zip ide/o.apache.commons.lang/external/commons-lang-2.6.jar


### PR DESCRIPTION
 - update guava from 32.1.2-jre to [33.0.0-jre](https://github.com/google/guava/releases/tag/v33.0.0)
 - and also guava's failureaccess lib from 1.0.1 to 1.0.2

the lsp modules are the only guava users atm ([search](https://github.com/search?q=repo%3Aapache%2Fnetbeans+%3Ccode-name-base%3Ecom.google.guava%3C%2Fcode-name-base%3E&type=code))

Maven/gradle bundles have their own versions in the zip.