### PR TITLE
`NbLaunchDelegate` fix and test multi line texts in suite.py

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
@@ -550,7 +550,7 @@ public abstract class NbLaunchDelegate {
         ActionProvider provider = null;
         String command = null;
         Collection<ActionProvider> actionProviders = findActionProviders(prj);
-        Lookup testLookup = preferProjActions && prj != null ? Lookups.singleton(prj) : (singleMethod != null) ? Lookups.fixed(toRun, singleMethod) : Lookups.singleton(toRun);
+        Lookup testLookup = createTargetLookup(preferProjActions ? prj : null, singleMethod, toRun);
         String[] actions;
         if (!mainSource && singleMethod != null) {
             actions = debug ? new String[] {SingleMethod.COMMAND_DEBUG_SINGLE_METHOD}
@@ -564,7 +564,7 @@ public abstract class NbLaunchDelegate {
                 if (debug && !mainSource) {
                     // We are calling COMMAND_DEBUG_TEST_SINGLE instead of a missing COMMAND_DEBUG_TEST
                     // This is why we need to add the file to the lookup
-                    testLookup = (singleMethod != null) ? Lookups.fixed(toRun, singleMethod) : Lookups.singleton(toRun);
+                    testLookup = createTargetLookup(null, singleMethod, toRun);
                 }
             } else {
                 actions = debug ? mainSource ? new String[] {ActionProvider.COMMAND_DEBUG_SINGLE}
@@ -623,6 +623,18 @@ public abstract class NbLaunchDelegate {
             return null;
         }
         return Pair.of(provider, command);
+    }
+
+    static Lookup createTargetLookup(Project prj, SingleMethod singleMethod, FileObject toRun) {
+        if (prj != null) {
+            return prj.getLookup();
+        }
+        if (singleMethod != null) {
+            Lookup methodLookup = Lookups.singleton(singleMethod);
+            return new ProxyLookup(toRun.getLookup(), methodLookup);
+        } else {
+            return toRun.getLookup();
+        }
     }
 
     private static Collection<ActionProvider> findActionProviders(Project prj) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -61,7 +60,6 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Lookup;
 import org.openide.util.Utilities;
-import org.openide.util.lookup.Lookups;
 
 /**
  *

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegateTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegateTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.debugging.launch;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.modules.java.lsp.server.debugging.DebugAdapterContext;
+import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.ProjectFactory;
+import org.netbeans.spi.project.ProjectState;
+import org.netbeans.spi.project.SingleMethod;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.loaders.DataObject;
+import org.openide.util.Lookup;
+import org.openide.util.Pair;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.lookup.ServiceProvider;
+
+public class NbLaunchDelegateTest {
+
+    public NbLaunchDelegateTest() {
+    }
+
+    @Test
+    public void testFileObjectsLookup() throws Exception {
+        FileObject fo = FileUtil.createMemoryFileSystem().getRoot().createData("test.txt");
+        Lookup lkp = NbLaunchDelegate.createTargetLookup(null, null, fo);
+        assertEquals(fo, lkp.lookup(FileObject.class));
+
+        DataObject obj = lkp.lookup(DataObject.class);
+        assertNotNull("DataObject also found", obj);
+
+        assertEquals("It's FileObject's data object", obj, DataObject.find(fo));
+        assertNull("No single method", lkp.lookup(SingleMethod.class));
+    }
+
+    @Test
+    public void testFileObjectsLookupWithSingleMethod() throws Exception {
+        FileObject fo = FileUtil.createMemoryFileSystem().getRoot().createData("test-with-method.txt");
+        SingleMethod m = new SingleMethod(fo, "main");
+        Lookup lkp = NbLaunchDelegate.createTargetLookup(null, m, fo);
+        assertEquals(fo, lkp.lookup(FileObject.class));
+
+        DataObject obj = lkp.lookup(DataObject.class);
+        assertNotNull("DataObject also found", obj);
+
+        assertEquals("It's FileObject's data object", obj, DataObject.find(fo));
+
+        assertEquals("Found single method", m, lkp.lookup(SingleMethod.class));
+    }
+
+    @Test
+    public void testFindsMavenProject() throws Exception {
+        FileObject dir = FileUtil.createMemoryFileSystem().getRoot().createFolder("testprj");
+        FileObject xml = dir.createData("build.xml");
+        Project prj = ProjectManager.getDefault().findProject(dir);
+        assertNotNull("Project dir recognized", prj);
+
+        SingleMethod m = new SingleMethod(xml, "main");
+        Lookup lkp = NbLaunchDelegate.createTargetLookup(prj, m, xml);
+        assertNull("No file object", lkp.lookup(FileObject.class));
+        DataObject obj = lkp.lookup(DataObject.class);
+        assertNull("No DataObject ", obj);
+        assertNull("No single method", lkp.lookup(SingleMethod.class));
+        assertEquals(prj, lkp.lookup(Project.class));
+    }
+
+    @ServiceProvider(service = ProjectFactory.class)
+    public static final class MockProjectFactory implements ProjectFactory {
+
+        @Override
+        public boolean isProject(FileObject projectDirectory) {
+            return projectDirectory.getNameExt().equals("testprj");
+        }
+
+        @Override
+        public Project loadProject(FileObject projectDirectory, ProjectState state) throws IOException {
+            return new MockProject(projectDirectory);
+        }
+
+        @Override
+        public void saveProject(Project project) throws IOException, ClassCastException {
+        }
+
+        private static final class MockProject implements Project {
+            private final FileObject dir;
+
+            MockProject(FileObject dir) {
+                this.dir = dir;
+            }
+
+            @Override
+            public FileObject getProjectDirectory() {
+                return dir;
+            }
+
+            @Override
+            public Lookup getLookup() {
+                return Lookups.fixed(this);
+            }
+
+        }
+    }
+}

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/ParseSuitesTest.java
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/ParseSuitesTest.java
@@ -20,14 +20,17 @@ package org.netbeans.modules.java.mx.project;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.URL;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.java.mx.project.suitepy.MxDistribution;
 import org.netbeans.modules.java.mx.project.suitepy.MxSuite;
 
 public final class ParseSuitesTest extends NbTestCase {
@@ -38,6 +41,15 @@ public final class ParseSuitesTest extends NbTestCase {
 
     public void testParseThemAll() throws IOException {
         assertSuitePys(getDataDir(), 15);
+    }
+    
+    public void testParseMultiLineSuite() throws IOException {
+        URL url = getClass().getResource("multilinetexts.py");
+        MxSuite suite = MxSuite.parse(url);
+        assertNotNull("suite parsed", suite);
+        MxDistribution tool = suite.distributions().get("TOOLCHAIN");
+        assertNotNull("toolchain found", tool);
+        assertEquals("No deps", 0, tool.dependencies().size());
     }
 
     public static void main(String... args) throws IOException {

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/multilinetexts.py
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/multilinetexts.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+suite = {
+  "mxversion": "7.5.0",
+  "name" : "multilinetexts",
+  "version" : "1.0.0",
+  "repositories" : {
+  },
+  "libraries" : {
+  },
+  "licenses" : {
+},
+  "distributions" : {
+    "TOOLCHAIN": {
+      "native": True,
+      "platformDependent": True,
+      "os": {
+        "linux": {
+          "layout": {
+            "toolchain.multi": {
+              "source_type": "string",
+              "value": '''
+line1
+line2
+line3
+line5
+'''
+            },
+          },
+          "dependencies": [
+          ],
+        },
+      },
+      "maven" : False,
+    },
+  },
+}


### PR DESCRIPTION
I cannot open [graal/sdk](https://github.com/oracle/graal/tree/2ae0f674a8294da90eb1c2398aa70c8c1c986c74/sdk) project anymore. Turns out that now its [suite.py is using multiline texts](https://github.com/oracle/graal/blame/2ae0f674a8294da90eb1c2398aa70c8c1c986c74/sdk/mx.sdk/suite.py#L1139) and the conversion of `suite.py` to JSON fails to convert that properly. This PR provides a test and a fix to handle such conversion properly. With the fix I am able to open `sdk` as well as `truffle` project without errors.

This fix affects NetBeans IDE, **VSCode extension** and **IGV**. CCing @rschatz, @gilles-duboscq

