### PR TITLE
Update the mx suite parsing to work with sources of GraalVM version 23.1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -907,9 +907,7 @@ jobs:
           java-version: 17
           distribution: ${{ env.default_java_distribution }}
 
-      # TODO fix JDK 21 incompatibilites
       - name: java/java.mx.project
-        continue-on-error: ${{ github.event_name != 'pull_request' }}
         run: .github/retry.sh ant $OPTS -f java/java.mx.project test
 
       - name: java/gradle.java

--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/suitepy/Parse.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/suitepy/Parse.java
@@ -63,13 +63,15 @@ final class Parse {
                 if (line == null) {
                     break;
                 }
-                sb.append(jsonify(line)).append("\n");
+                line = line.replaceAll("(\\s*)#.*", "$1");
+                sb.append(line).append("\n");
             }
         }
+        String text = jsonify(sb.toString());
         Object value;
         try {
             final JSONParser p = new JSONParser();
-            value = p.parse(sb.toString());
+            value = p.parse(text);
         } catch (ParseException ex) {
             throw new IOException("Cannot parse " + u, ex);
         }
@@ -78,9 +80,8 @@ final class Parse {
     }
 
     private static String jsonify(String content) {
-        String text = content.replaceFirst("^suite *= *\\{", "{");
+        String text = content.replaceFirst("\\s*suite *= *\\{", "{");
         text = text.replace("True", "true").replace("False", "false");
-        text = text.replaceAll("(\\s*)#.*", "$1");
         text = text.replaceAll(",\\s*(\\]|\\})", "$1");
         text = replaceQuotes("\"\"\"", text);
         text = replaceQuotes("'''", text);

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/CoreSuiteTest.java
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/CoreSuiteTest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.java.mx.project;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,7 +40,7 @@ public final class CoreSuiteTest {
 
     public static void main(String... args) throws Exception {
         // mx version "5.279.0"
-        URL u = new URL("https://raw.githubusercontent.com/graalvm/mx/dcfad27487a5d13d406febc92976cf3c026e50dd/mx.mx/suite.py");
+        URL u = new URI("https://raw.githubusercontent.com/graalvm/mx/dcfad27487a5d13d406febc92976cf3c026e50dd/mx.mx/suite.py").toURL();
         assert u != null : "mx suite found";
         MxSuite mxSuite = MxSuite.parse(u);
 


### PR DESCRIPTION
The mx project of recent versions of GraalVM can not be successfully parsed. There is an issue in graal/sdk suite.
This change adapts to the mx suite form and a test is updated to work with the new unchained project structure.