### PR TITLE
ci dep checker: filter pre-releases and sort by version

### DIFF
--- a/.github/workflows/dependency-checks.yml
+++ b/.github/workflows/dependency-checks.yml
@@ -54,10 +54,10 @@ jobs:
 
       - name: Check Dependencies
         run: |
-          mvn -q dependency:get  -Dartifact=org.apache.maven.indexer:search-backend-smo:7.1.1
           mvn -q dependency:copy -Dartifact=org.apache.maven.indexer:search-backend-smo:7.1.1 -DoutputDirectory=./lib
           mvn -q dependency:copy -Dartifact=org.apache.maven.indexer:search-api:7.1.1         -DoutputDirectory=./lib
           mvn -q dependency:copy -Dartifact=com.google.code.gson:gson:2.10.1                  -DoutputDirectory=./lib
+          mvn -q dependency:copy -Dartifact=org.apache.maven:maven-artifact:3.9.6             -DoutputDirectory=./lib
           echo "<pre>" >> $GITHUB_STEP_SUMMARY
           java --enable-preview --source 22 -cp "lib/*" .github/scripts/BinariesListUpdates.java ./ | tee -a $GITHUB_STEP_SUMMARY
           echo "</pre>" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
don't suggest beta versions and sort results properly, since a more recent release does not have to mean that the version is greater.

this will also print some stats after the checks