### PR TITLE
Gradle Project shall use the Java from the tooling not runtime.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
@@ -45,7 +45,7 @@ import org.netbeans.modules.gradle.spi.GradleFiles;
 public final class ProjectInfoDiskCache extends AbstractDiskCache<GradleFiles, QualifiedProjectInfo> {
 
     // Increase this number if new info is gathered from the projects.
-    private static final int COMPATIBLE_CACHE_VERSION = 24;
+    private static final int COMPATIBLE_CACHE_VERSION = 25;
     private static final String INFO_CACHE_FILE_NAME = "project-info.ser"; //NOI18N
     private static final Map<GradleFiles, ProjectInfoDiskCache> DISK_CACHES = Collections.synchronizedMap(new WeakHashMap<>());
 

--- a/java/gradle.java/apichanges.xml
+++ b/java/gradle.java/apichanges.xml
@@ -83,6 +83,28 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="sourceset-compiler-javahome">
+            <api name="gradle.java.api"/>
+            <summary>Support for per-language output directories</summary>
+            <version major="1" minor="26"/>
+            <date day="4" month="1" year="2024"/>
+            <author login="lkishalmi"/>
+            <compatibility semantic="compatible" addition="yes" deprecation="no"/>
+            <description>
+                <p>
+                    Gradle 6.7 introduced Java Toolchains to separate Gradle Java Runtime
+                    and the Java used for compilation (and other Java execution).
+                    <code><a href="@TOP@/org/netbeans/modules/gradle/java/api/GradleJavaSourceSet.html#getCompilerJavaHome-org.netbeans.modules.gradle.java.api.GradleJavaSourceSet.SourceType-">GradleJavaSourceSet.getCompilerJavaHome</a></code> has been added to
+                    return the Java Home of the JDK in use for compilation.
+                </p>
+                <p>
+                    In addition <code><a href="@TOP@/org/netbeans/modules/gradle/java/spi/support/JavaToolchainSupport.html">JavaToolchainSsupport</a></code>
+                    is provided in order to be easily work with the JDK home directories.
+                </p>
+            </description>
+            <class package="org.netbeans.modules.gradle.java.api" name="GradleJavaSourceSet"/>
+            <class package="org.netbeans.modules.gradle.java.spi.support" name="JavaToolchainSupport"/>
+        </change>
         <change id="sourceset-lang-output">
             <api name="gradle.java.api"/>
             <summary>Support for per-language output directories</summary>

--- a/java/gradle.java/manifest.mf
+++ b/java/gradle.java/manifest.mf
@@ -3,4 +3,5 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.gradle.java
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/java/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/java/Bundle.properties
+OpenIDE-Module-Java-Dependencies: Java > 17
 OpenIDE-Module-Implementation-Version: 1

--- a/java/gradle.java/nbproject/project.properties
+++ b/java/gradle.java/nbproject/project.properties
@@ -16,7 +16,8 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
+javac.source=17
+javac.target=17
 javac.compilerargs=-Xlint -Xlint:-serial
 nbm.module.author=Laszlo Kishalmi
 javadoc.arch=${basedir}/arch.xml

--- a/java/gradle.java/nbproject/project.xml
+++ b/java/gradle.java/nbproject/project.xml
@@ -389,6 +389,7 @@
                 <package>org.netbeans.modules.gradle.java.api</package>
                 <package>org.netbeans.modules.gradle.java.api.output</package>
                 <package>org.netbeans.modules.gradle.java.spi.debug</package>
+                <package>org.netbeans.modules.gradle.java.spi.support</package>
             </public-packages>
         </data>
     </configuration>

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaProjectBuilder.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaProjectBuilder.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.lookup.ServiceProvider;
 import static org.netbeans.modules.gradle.java.api.GradleJavaSourceSet.SourceType;
@@ -47,7 +48,7 @@ final class GradleJavaProjectBuilder implements ProjectInfoExtractor.Result {
     final GradleJavaProject prj = new GradleJavaProject();
 
     GradleJavaProjectBuilder(Map<String, Object> info) {
-        this.info = info;
+        this.info = new TreeMap<>(info);
     }
 
     GradleJavaProjectBuilder build() {
@@ -85,6 +86,7 @@ final class GradleJavaProjectBuilder implements ProjectInfoExtractor.Result {
 
                 Map<SourceType, String> sourceComp = new EnumMap<>(SourceType.class);
                 Map<SourceType, String> targetComp = new EnumMap<>(SourceType.class);
+                Map<SourceType, File> javaHomes = new EnumMap<>(SourceType.class);
                 Map<SourceType, List<String>> compilerArgs = new EnumMap<>(SourceType.class);
                 for (SourceType lang : Arrays.asList(JAVA, GROOVY, SCALA, KOTLIN)) {
                     String sc = (String) info.get("sourceset_" + name + "_" + lang.name() + "_source_compatibility");
@@ -94,6 +96,10 @@ final class GradleJavaProjectBuilder implements ProjectInfoExtractor.Result {
                     }
                     if (tc != null) {
                         targetComp.put(lang, tc);
+                    }
+                    File javaHome = (File) info.get("sourceset_" + name + "_" + lang.name() + "_compiler_java_home");
+                    if (javaHome != null) {
+                        javaHomes.put(lang, javaHome);
                     }
                     List<String> compArgs = (List<String>) info.get("sourceset_" + name + "_" + lang.name() + "_compiler_args");
                     if (compArgs != null) {
@@ -107,6 +113,7 @@ final class GradleJavaProjectBuilder implements ProjectInfoExtractor.Result {
                 }
                 sourceSet.sourcesCompatibility = Collections.unmodifiableMap(sourceComp);
                 sourceSet.targetCompatibility = Collections.unmodifiableMap(targetComp);
+                sourceSet.compilerJavaHomes = Collections.unmodifiableMap(javaHomes);
                 sourceSet.compilerArgs = Collections.unmodifiableMap(compilerArgs);
                 
                 for (File out : sourceSet.getOutputClassDirs()) {

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaSourceSet.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaSourceSet.java
@@ -89,6 +89,7 @@ public final class GradleJavaSourceSet implements Serializable {
 
     Map<SourceType, String> sourcesCompatibility = Collections.emptyMap();
     Map<SourceType, String> targetCompatibility = Collections.emptyMap();
+    Map<SourceType, File> compilerJavaHomes = Collections.emptyMap();
     Map<SourceType, List<String>> compilerArgs = Collections.emptyMap();
     boolean testSourceSet;
     Set<File> outputClassDirs;
@@ -600,6 +601,22 @@ public final class GradleJavaSourceSet implements Serializable {
         return null;
     }
 
+    /**
+     * Returns the JDK Home directory of the JVM what would be used during the
+     * compilation. Currently the {@linkplain SourceType#JAVA JAVA}, {@linkplain SourceType#GROOVY GROOVY}, and {@linkplain SourceType#SCALA SCALA}
+     * are expected to return a non {@code null} value. The home directory
+     * is determined by using the sourceSet default compile task. In Gradle 
+     * it is possible to define additional compile tasks with different Java Toolchain.
+     * NetBeans would ignore those.
+     * 
+     * @param type The source type of the compiler.
+     * @return The home directory of the JDK used for the default compile task.
+     * @since 1.26
+     */
+    public File getCompilerJavaHome(SourceType type) {
+        return compilerJavaHomes.get(type);
+    }
+    
     /**
      * Returns the compiler arguments for this source set defined for the given
      * language.

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/AbstractGradleClassPathImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/AbstractGradleClassPathImpl.java
@@ -25,12 +25,12 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.project.Project;
@@ -105,10 +105,7 @@ abstract class AbstractGradleClassPathImpl implements FlaggedClassPathImplementa
     @Override
     public final synchronized List<? extends PathResourceImplementation> getResources() {
         if (resources == null) {
-            resources = new ArrayList<>();
-            for (URL url : createPath()) {
-                resources.add(ClassPathSupport.createResource(url));
-            }
+            resources = createPath().stream().map(ClassPathSupport::createResource).toList();
         }
         return resources;
     }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
@@ -311,7 +311,7 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
 
         private synchronized ClassPath getBootClassPath() {
             if (boot == null) {
-                boot = ClassPathFactory.createClassPath(new BootClassPathImpl(project, false));
+                boot = ClassPathFactory.createClassPath(new BootClassPathImpl(project, group, false));
             }
             return boot;
         }
@@ -339,7 +339,7 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
 
         private synchronized ClassPath getPlatformModulesPath() {
             if (platformModules == null) {
-                platformModules = ClassPathFactory.createClassPath(new BootClassPathImpl(project, true));
+                platformModules = ClassPathFactory.createClassPath(new BootClassPathImpl(project, group, true));
             }
             return platformModules;
         }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GlobalClassPathProviderImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GlobalClassPathProviderImpl.java
@@ -66,20 +66,13 @@ public class GlobalClassPathProviderImpl extends ProjectOpenedHook implements Pr
         if (index < 0) return null;
         ClassPath cp = cache[index];
         if (cp == null) {
-            switch (type) {
-                case ClassPath.BOOT:
-                    cp = createClassPath(new BootClassPathImpl(project));
-                    break;
-                case ClassPath.SOURCE:
-                    cp = createClassPath(new GradleGlobalClassPathImpl.ProjectSourceClassPathImpl(project, excludeTests));
-                    break;
-                case ClassPath.COMPILE:
-                    cp = createClassPath(new GradleGlobalClassPathImpl.ProjectCompileClassPathImpl(project, excludeTests));
-                    break;
-                case ClassPath.EXECUTE:
-                    cp = createClassPath(new GradleGlobalClassPathImpl.ProjectRuntimeClassPathImpl(project, excludeTests));
-                    break;
-            }
+            cp = switch (type) {
+                case ClassPath.BOOT -> createClassPath(new BootClassPathImpl(project, null));
+                case ClassPath.SOURCE -> createClassPath(new GradleGlobalClassPathImpl.ProjectSourceClassPathImpl(project, excludeTests));
+                case ClassPath.COMPILE -> createClassPath(new GradleGlobalClassPathImpl.ProjectCompileClassPathImpl(project, excludeTests));
+                case ClassPath.EXECUTE -> createClassPath(new GradleGlobalClassPathImpl.ProjectRuntimeClassPathImpl(project, excludeTests));
+                default -> null;
+            };
             cache[index] = cp;
         }
         return cp;
@@ -87,22 +80,13 @@ public class GlobalClassPathProviderImpl extends ProjectOpenedHook implements Pr
 
     private static int type2Index(String type, boolean excludeTests) {
         int index;
-        switch (type) {
-            case ClassPath.BOOT:
-                index = BOOT;
-                break;
-            case ClassPath.SOURCE:
-                index = SOURCE;
-                break;
-            case ClassPath.COMPILE:
-                index = COMPILE;
-                break;
-            case ClassPath.EXECUTE:
-                index = RUNTIME;
-                break;
-            default:
-                index = -1;
-        }
+        index = switch (type) {
+            case ClassPath.BOOT -> BOOT;
+            case ClassPath.SOURCE -> SOURCE;
+            case ClassPath.COMPILE -> COMPILE;
+            case ClassPath.EXECUTE -> RUNTIME;
+            default -> -1;
+        };
 
         return (index >= 0) && excludeTests ? index + 1 : index;
     }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/customizer/Bundle.properties
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/customizer/Bundle.properties
@@ -18,3 +18,4 @@
 SourceSetPanel.jLabel1.text=Output Classes:
 SourceSetPanel.jLabel2.text=Output Resources:
 SourceSetPanel.jLabel3.text=Source/Binary Format:
+SourceSetPanel.lbPlatform.text=Java Platform:

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/customizer/SourceSetPanel.form
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/customizer/SourceSetPanel.form
@@ -37,15 +37,10 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="0" attributes="0">
+          <Group type="102" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="tpDetails" max="32767" attributes="0"/>
-                  <Group type="102" attributes="0">
-                      <Component id="jLabel3" min="-2" pref="169" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Component id="tfSourceLevel" pref="402" max="32767" attributes="0"/>
-                  </Group>
+                  <Component id="tpDetails" pref="580" max="32767" attributes="0"/>
                   <Group type="102" alignment="0" attributes="0">
                       <Group type="103" groupAlignment="1" max="-2" attributes="0">
                           <Component id="jLabel1" max="32767" attributes="0"/>
@@ -55,6 +50,20 @@
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Component id="tfOutputResources" alignment="0" max="32767" attributes="0"/>
                           <Component id="tfOutputClasses" max="32767" attributes="0"/>
+                      </Group>
+                  </Group>
+                  <Group type="102" alignment="0" attributes="0">
+                      <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                          <Component id="jLabel3" pref="157" max="32767" attributes="0"/>
+                          <Component id="lbPlatform" max="32767" attributes="0"/>
+                      </Group>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Group type="102" attributes="0">
+                              <Component id="tfSourceLevel" min="-2" pref="39" max="-2" attributes="0"/>
+                              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                          </Group>
+                          <Component id="jtPlatform" max="32767" attributes="0"/>
                       </Group>
                   </Group>
               </Group>
@@ -67,11 +76,16 @@
           <Group type="102" alignment="1" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="lbPlatform" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="jtPlatform" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="jLabel3" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="tfSourceLevel" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="tpDetails" pref="232" max="32767" attributes="0"/>
+              <Component id="tpDetails" pref="202" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
@@ -253,6 +267,21 @@
       </Properties>
     </Component>
     <Component class="javax.swing.JTextField" name="tfOutputClasses">
+      <Properties>
+        <Property name="editable" type="boolean" value="false"/>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JLabel" name="lbPlatform">
+      <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="jtPlatform"/>
+        </Property>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/gradle/java/customizer/Bundle.properties" key="SourceSetPanel.lbPlatform.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JTextField" name="jtPlatform">
       <Properties>
         <Property name="editable" type="boolean" value="false"/>
       </Properties>

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/customizer/SourceSetPanel.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/customizer/SourceSetPanel.java
@@ -36,6 +36,9 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
+import org.netbeans.api.java.platform.JavaPlatform;
+import org.netbeans.modules.gradle.java.spi.support.JavaToolchainSupport;
+import org.openide.filesystems.FileObject;
 import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
 import org.openide.util.NbBundle.Messages;
@@ -83,6 +86,19 @@ public class SourceSetPanel extends javax.swing.JPanel {
         this.sourceSet = sourceSet;
         relativeRoot = relativeTo.toPath();
         initComponents();
+        
+        File javaHome = sourceSet.getCompilerJavaHome(GradleJavaSourceSet.SourceType.JAVA);
+        JavaPlatform platform =JavaPlatform.getDefault();
+        if (javaHome != null) {
+            platform = JavaToolchainSupport.getDefault().platformByHome(javaHome);
+        }
+        jtPlatform.setText(platform.getDisplayName());
+        
+        if (platform.isValid()) {
+            FileObject home = platform.getInstallFolders().iterator().next();
+            jtPlatform.setToolTipText(home.getPath());
+        }
+        
         if (sourceSet.getSourcesCompatibility().equals(sourceSet.getTargetCompatibility())) {
             tfSourceLevel.setText(sourceSet.getSourcesCompatibility());
         } else {
@@ -178,6 +194,8 @@ public class SourceSetPanel extends javax.swing.JPanel {
         tfSourceLevel = new javax.swing.JTextField();
         tfOutputResources = new javax.swing.JTextField();
         tfOutputClasses = new javax.swing.JTextField();
+        lbPlatform = new javax.swing.JLabel();
+        jtPlatform = new javax.swing.JTextField();
 
         org.openide.awt.Mnemonics.setLocalizedText(jLabel1, org.openide.util.NbBundle.getMessage(SourceSetPanel.class, "SourceSetPanel.jLabel1.text")); // NOI18N
 
@@ -218,6 +236,11 @@ public class SourceSetPanel extends javax.swing.JPanel {
 
         tfOutputClasses.setEditable(false);
 
+        lbPlatform.setLabelFor(jtPlatform);
+        org.openide.awt.Mnemonics.setLocalizedText(lbPlatform, org.openide.util.NbBundle.getMessage(SourceSetPanel.class, "SourceSetPanel.lbPlatform.text")); // NOI18N
+
+        jtPlatform.setEditable(false);
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
@@ -225,11 +248,7 @@ public class SourceSetPanel extends javax.swing.JPanel {
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(tpDetails, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(jLabel3, javax.swing.GroupLayout.PREFERRED_SIZE, 169, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(tfSourceLevel, javax.swing.GroupLayout.DEFAULT_SIZE, 402, Short.MAX_VALUE))
+                    .addComponent(tpDetails, javax.swing.GroupLayout.DEFAULT_SIZE, 580, Short.MAX_VALUE)
                     .addGroup(layout.createSequentialGroup()
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
                             .addComponent(jLabel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
@@ -237,7 +256,17 @@ public class SourceSetPanel extends javax.swing.JPanel {
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(tfOutputResources)
-                            .addComponent(tfOutputClasses))))
+                            .addComponent(tfOutputClasses)))
+                    .addGroup(layout.createSequentialGroup()
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                            .addComponent(jLabel3, javax.swing.GroupLayout.DEFAULT_SIZE, 157, Short.MAX_VALUE)
+                            .addComponent(lbPlatform, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addGroup(layout.createSequentialGroup()
+                                .addComponent(tfSourceLevel, javax.swing.GroupLayout.PREFERRED_SIZE, 39, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addGap(0, 0, Short.MAX_VALUE))
+                            .addComponent(jtPlatform))))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -245,10 +274,14 @@ public class SourceSetPanel extends javax.swing.JPanel {
             .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(lbPlatform)
+                    .addComponent(jtPlatform, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jLabel3)
                     .addComponent(tfSourceLevel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(tpDetails, javax.swing.GroupLayout.DEFAULT_SIZE, 232, Short.MAX_VALUE)
+                .addComponent(tpDetails, javax.swing.GroupLayout.DEFAULT_SIZE, 202, Short.MAX_VALUE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(jLabel1)
@@ -318,6 +351,8 @@ public class SourceSetPanel extends javax.swing.JPanel {
     private javax.swing.JScrollPane jScrollPane3;
     private javax.swing.JScrollPane jScrollPane4;
     private javax.swing.JScrollPane jScrollPane6;
+    private javax.swing.JTextField jtPlatform;
+    private javax.swing.JLabel lbPlatform;
     private javax.swing.JList<File> lsAnnotationProcessors;
     private javax.swing.JList<File> lsCompile;
     private javax.swing.JList<File> lsRuntime;

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/spi/support/JavaToolchainSupport.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/spi/support/JavaToolchainSupport.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.spi.support;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.netbeans.api.java.platform.JavaPlatform;
+import org.netbeans.api.java.platform.JavaPlatformManager;
+import org.netbeans.modules.gradle.spi.Utils;
+import org.netbeans.modules.java.api.common.util.CommonProjectUtils;
+import org.netbeans.spi.java.platform.JavaPlatformFactory;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.Lookup;
+import org.openide.util.NbBundle;
+
+/**
+ * Support for creating retrieving JavaPlatforms from their install location 
+ * (home directory).
+ * 
+ * @since 1.26
+ * @author Laszlo Kishalmi
+ */
+public final class JavaToolchainSupport {
+
+    private final Map<File, JavaPlatform> platformCache;
+
+    private static JavaToolchainSupport instance;
+    
+    private JavaToolchainSupport() {
+        platformCache = new HashMap<>();
+    }
+    
+    public static JavaToolchainSupport getDefault() {
+        if (instance == null) {
+            instance = new JavaToolchainSupport();
+        }
+        return instance;
+    }
+    
+    /**
+     * Tries to locate a registered {@linkplain JavaPlatform} from its install
+     * location. If it is not registered among the NetBeans usual Java Platforms
+     * then a new non-registered one will be created.
+     * 
+     * @param home The home directory of a Java installation
+     * @return the {@linkplain JavaPlatform} representing the given directory.
+     */
+    public JavaPlatform platformByHome(File home) {
+        return platformCache.computeIfAbsent(home, this::detectPlatform);
+    }
+    
+    private JavaPlatform detectPlatform(File home) {
+        FileObject h = FileUtil.toFileObject(home);
+        for (JavaPlatform platform : JavaPlatformManager.getDefault().getInstalledPlatforms()) {
+            if (platform.isValid()) {
+                FileObject ph = platform.getInstallFolders().iterator().next();
+                if (ph.equals(h)) {
+                    return platform;
+                }
+            }
+        }
+        for (JavaPlatformFactory.Provider pvd : Lookup.getDefault().lookupAll(JavaPlatformFactory.Provider.class)) {
+            JavaPlatformFactory factory = pvd.forType(CommonProjectUtils.J2SE_PLATFORM_TYPE);
+            if (factory != null) {
+                try {
+                    JavaPlatform ret = factory.create(h, toolchainName(home), false);
+                    return ret;
+                } catch (IOException ex) {
+                    
+                }
+            }
+        }
+        return null;
+    }
+    
+    private static final Pattern GRADLE_JDK_DIST = Pattern.compile("(\\w+)-(\\d+)-(\\w+)-(\\w+)");
+    @NbBundle.Messages({
+        "# {0} - JDK Vendor",
+        "# {1} - Java Feature Version",
+        "# {2} - JDK Architecture",
+        "# {3} - JDK OS",
+        "GRADLE_INSTALLED_JDK_NAME=Java {1} {0} (from Java Toolchain)",
+        "# {0} - JDK Install folder name",
+        "# {1} - JDK Install folder path",
+        "OTHER_JDK_NAME=JDK {0} from {1}"
+    })
+    private static String toolchainName(File home) {
+        File distDir = home.getParentFile();
+        if (distDir != null) {
+            Matcher m = GRADLE_JDK_DIST.matcher(distDir.getName());
+            if (m.matches()) {
+                String vendor = Utils.capitalize(m.group(1).replace('_', ' '));
+                String version = m.group(2);
+                String arch = m.group(3);
+                String os = m.group(4);
+                return Bundle.GRADLE_INSTALLED_JDK_NAME(vendor, version, arch, os);
+            }
+        }
+        return Bundle.OTHER_JDK_NAME(home.getName(), home.getAbsolutePath());
+    }
+}


### PR DESCRIPTION
Gradle Java tooling is the recommended way to set the Java version for source sets since provably version 7.x. Java Tooling has been introduced in Gradle 6.7. In order to be able to split the Java compilation form the java runtime.

NetBeans haven't respected the tooling version from Gradle so far, rlied on that people would use the same tooling as runtime. This really needed to be fixed.