### PR TITLE
Ensure Gradle new project wizard picks up latest Gradle version

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
@@ -57,6 +57,7 @@ import org.netbeans.modules.gradle.GradleProjectLoader;
 import org.netbeans.modules.gradle.ProjectTrust;
 import org.netbeans.modules.gradle.api.GradleProjects;
 import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
+import org.netbeans.modules.gradle.spi.GradleSettings;
 import org.openide.loaders.DataFolder;
 import org.openide.loaders.DataObject;
 import org.openide.util.Exceptions;
@@ -314,7 +315,11 @@ public final class TemplateOperation implements Runnable {
                     args.add(projectName);
                 }
 
-                pconn.newBuild().withArguments("--offline").forTasks(args.toArray(new String[0])).run(); //NOI18N
+                if (GradleSettings.getDefault().isOffline()) {
+                    pconn.newBuild().withArguments("--offline").forTasks(args.toArray(new String[0])).run(); //NOI18N
+                } else {
+                    pconn.newBuild().forTasks(args.toArray(new String[0])).run();
+                }
             } catch (GradleConnectionException | IllegalStateException ex) {
                 Exceptions.printStackTrace(ex);
             }
@@ -488,7 +493,11 @@ public final class TemplateOperation implements Runnable {
                     args.add("--gradle-version"); //NOI18N
                     args.add(version);
                 }
-                pconn.newBuild().withArguments("--offline").forTasks(args.toArray(new String[0])).run(); //NOI18N
+                if (GradleSettings.getDefault().isOffline()) {
+                    pconn.newBuild().withArguments("--offline").forTasks(args.toArray(new String[0])).run(); //NOI18N
+                } else {
+                    pconn.newBuild().forTasks(args.toArray(new String[0])).run();
+                }
             } catch (GradleConnectionException | IllegalStateException ex) {
                 // Well for some reason we were  not able to load Gradle.
                 // Ignoring that for now

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/newproject/SimpleApplicationProjectWizard.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/newproject/SimpleApplicationProjectWizard.java
@@ -66,8 +66,6 @@ public class SimpleApplicationProjectWizard extends BaseGradleWizardIterator {
         final File root = new File(loc, name);
 
         ops.createGradleInit(root, type).basePackage(packageBase).projectName(name).dsl("groovy").add(); // NOI18N
-        ops.addProjectPreload(root);
-        ops.addProjectPreload(new File(root, subFolder));
 
         Boolean initWrapper = (Boolean) params.get(PROP_INIT_WRAPPER);
         if (initWrapper == null || initWrapper) {
@@ -76,6 +74,10 @@ public class SimpleApplicationProjectWizard extends BaseGradleWizardIterator {
         } else {
             // @TODO delete wrapper added by init?
         }
+
+        ops.addProjectPreload(root);
+        ops.addProjectPreload(new File(root, subFolder));
+
     }
 
 }


### PR DESCRIPTION
Ensure Gradle new project wizard picks up latest Gradle version for wrapper where intended.

This moves the triggering of project load until after the wrapper is configured.  It also removes the `--offline` flag from wrapper initialization, which doesn't make a lot of sense, and might be why people were still seeing 8.4 rather than 8.5 or 8.6.

With this change, a new application or library project should be configured (at present) to use Gradle 8.6 and not show any JDK 21 warnings when created, even while using Gradle Tooling API 8.4.

This fix or similar should go in to NB21 whether or not the Tooling API is upgraded to 8.6 #6926  Triggering a dev build so the behaviour can be verified to work correctly before Tooling API upgrade.