### PR TITLE
Fixed concurrency issues in GradleDaemonExecutor

### DIFF
--- a/platform/core.execution/src/org/netbeans/core/execution/ExecutionEngine.java
+++ b/platform/core.execution/src/org/netbeans/core/execution/ExecutionEngine.java
@@ -70,13 +70,13 @@ public final class
     private static final IOTable taskIOs = new IOTable(base, systemIO);
 
     /* table of window:threadgrp */
-    private static WindowTable wtable = new WindowTable();
+    private static final WindowTable wtable = new WindowTable();
 
     /** list of ExecutionListeners */
-    private HashSet<ExecutionListener> executionListeners = new HashSet<ExecutionListener>();
+    private final HashSet<ExecutionListener> executionListeners = new HashSet<>();
 
     /** List of running executions */
-    private List<ExecutorTask> runningTasks = Collections.synchronizedList(new ArrayList<ExecutorTask>( 5 ));
+    private final List<ExecutorTask> runningTasks = Collections.synchronizedList(new ArrayList<>(5));
 
     static {
         systemIO.out = new OutputStreamWriter(System.out);
@@ -131,13 +131,14 @@ public final class
     * @param executor to start
     * @param info about class to start
     */
+    @Override
     public ExecutorTask execute(String name, Runnable run, final InputOutput inout) {
         TaskThreadGroup g = new TaskThreadGroup(base, "exec_" + name + "_" + number); // NOI18N
         g.setDaemon(true);
         ExecutorTaskImpl task = new ExecutorTaskImpl();
         synchronized (task.lock) {
             try {
-                new RunClassThread(g, name, number++, inout, this, task, Lookup.getDefault(), run);
+                new RunClassThread(g, name, number++, inout, this, task, Lookup.getDefault(), run).start();
                 task.lock.wait();
             } catch (InterruptedException e) { // #171795
                 inout.closeInputOutput();
@@ -157,6 +158,7 @@ public final class
     *
     * @return class path to libraries
     */
+    @Override
     protected NbClassPath createLibraryPath() {
         List<File> l = Main.getModuleSystem().getModuleJars();
         return new NbClassPath (l.toArray (new File[0]));
@@ -181,6 +183,7 @@ public final class
      * @param io an InputOutput
      * @return PermissionCollection for given CodeSource and InputOutput
      */
+    @Override
     protected final PermissionCollection createPermissions(CodeSource cs, InputOutput io) {
         PermissionCollection pc = Policy.getPolicy().getPermissions(cs);
         ThreadGroup grp = Thread.currentThread().getThreadGroup();
@@ -252,6 +255,7 @@ public final class
             this.std = std;
         }
 
+        @Override
         public void write(int b) throws IOException {
             if (std) {
                 getTaskIOs().getOut().write(b);

--- a/platform/core.execution/src/org/netbeans/core/execution/RunClassThread.java
+++ b/platform/core.execution/src/org/netbeans/core/execution/RunClassThread.java
@@ -71,7 +71,6 @@ final class RunClassThread extends Thread implements IOThreadIfc {
         this.originalLookup = originalLookup;
         // #33789 - this thread must not be daemon otherwise it is immediately destroyed
         setDaemon(false);
-        this.start();
     }
 
     /** runs the thread
@@ -166,6 +165,7 @@ final class RunClassThread extends Thread implements IOThreadIfc {
         }
     } // run method
 
+    @Override
     public InputOutput getInputOutput() {
         return io;
     }


### PR DESCRIPTION
the internal `GradleTask` appears to cover s similar usecase as the
`CompletableFuture` class. The implementation however caused a three
state race condition:

 - executor calls `finish(int)` before someone calls `result()`: this
   seems to be the intended usecase to create a fast-path which
   finishes the task early
 - result() is called before `finish(int)`: this will block on the
   wrapped task and finish has no effect. This behavior can be
   reproduced by attempting to delete a gradle project, the delete
   project dialog will stay open for almost a minute.
 - third state is when `createTask()` is called too late: this will cause
   a NPE since the task is already started via `setTask()`, the
   executor would try to call finish on a task wrapper which is null.
   Can be easily reproduced by setting a breakpoint in the codepath
   which calls `createTask()` or the method itself
   example:
   ```
   java.lang.NullPointerException: Cannot invoke "org.netbeans.modules.gradle.execute.GradleDaemonExecutor$GradleTask.finish(int)" because "this.gradleTask" is null
   	at org.netbeans.modules.gradle.execute.GradleDaemonExecutor.run(GradleDaemonExecutor.java:263)
   	at org.netbeans.core.execution.RunClassThread.doRun(RunClassThread.java:132)
   	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
   	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
   [catch] at org.netbeans.core.execution.RunClassThread.run(RunClassThread.java:81)
   ```

fixes:

 - block on `CountDownLatch` instead of delegate
 - create wrapper right when the task starts
 - the other commit fixes an issue where a `start()` is called from within the thread's constructor
 
 this has also positive performance side effects: e.g project creation is also faster now