### PR TITLE
Fix how to define fallback values for a jdk installation in some xml files

### DIFF
--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/jdkselection/jdk.xml
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/jdkselection/jdk.xml
@@ -162,6 +162,9 @@
             <available file="${java.home.parent}/lib/tools.jar" type="file"/>
         </condition>
         <condition property="nbjdk.home" value="${java.home}">
+            <available file="${java.home}/jmods/java.base.jmod" type="file"/>
+        </condition>
+        <condition property="nbjdk.home" value="${java.home}">
             <available file="${java.home}/lib/tools.jar" type="file"/>
         </condition>
         <!-- Mac OS X -->

--- a/nbbuild/jdk.xml
+++ b/nbbuild/jdk.xml
@@ -210,10 +210,10 @@
         <!-- Define fallback values of some things. -->
         <property name="java.home.parent" location="${java.home}/.."/>
         <condition property="nbjdk.home" value="${java.home.parent}">
-            <available file="${java.home.parent}/lib/tools.jar" type="file"/>
+            <available file="${java.home.parent}/jmods/java.base.jmod" type="file"/>
         </condition>
         <condition property="nbjdk.home" value="${java.home}">
-            <available file="${java.home}/lib/tools.jar" type="file"/>
+            <available file="${java.home}/jmods/java.base.jmod" type="file"/>
         </condition>
 
         <!-- Mac OS X -->

--- a/nbbuild/nbproject/jdk.xml
+++ b/nbbuild/nbproject/jdk.xml
@@ -159,10 +159,10 @@
         
         <property name="java.home.parent" location="${java.home}/.."/>
         <condition property="nbjdk.home" value="${java.home.parent}">
-            <available file="${java.home.parent}/lib/tools.jar" type="file"/>
+            <available file="${java.home.parent}/jmods/java.base.jmod" type="file"/>
         </condition>
         <condition property="nbjdk.home" value="${java.home}">
-            <available file="${java.home}/lib/tools.jar" type="file"/>
+            <available file="${java.home}/jmods/java.base.jmod" type="file"/>
         </condition>
         
         <condition property="nbjdk.home" value="/Library/Java/Home">


### PR DESCRIPTION
The file `tools.jar` is no more on JDK since version 9, a file that differentiate between a JDK or JRE install would be `java.base.jmod`.


NetBeans Testing:
- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Verify Sigtests
- Verify successful assignment of the fallback value with `<echo message=...`
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS