### PR TITLE
#7018: Avoid NPE on null properties (compatibility)

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
@@ -313,10 +313,11 @@ public final class NbMavenProjectImpl implements Project {
     public @NonNull MavenProject loadMavenProject(MavenEmbedder embedder, List<String> activeProfiles, Properties properties) {
         ProjectActionContext.Builder b = ProjectActionContext.newBuilder(this).
                 withProfiles(activeProfiles);
-        for (String pn : properties.stringPropertyNames()) {
-            b.withProperty(pn, properties.getProperty(pn));
+        if (properties != null) {
+            for (String pn : properties.stringPropertyNames()) {
+                b.withProperty(pn, properties.getProperty(pn));
+            }
         }
-        
         return MavenProjectCache.loadMavenProject(projectFile, 
                 b.context(), null);
         /*


### PR DESCRIPTION
See #7018 for description. The refactored code incorrectly did not accept `null`, which was permitted in the past.