### PR TITLE
Skip unreadable multiproperties.

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -661,6 +661,9 @@ class NbProjectInfoBuilder {
                 // MultipleSetter is probably for an overloaded setter
                 if (mp instanceof MultipleSetterProperty) {
                     MultipleSetterProperty msp = (MultipleSetterProperty)mp;
+                    if (msp.getGetter() == null) {
+                        continue;
+                    }
                     t = msp.getGetter().getReturnType();
                 }
             }
@@ -687,6 +690,7 @@ class NbProjectInfoBuilder {
                         // just ignore - the value cannot be obtained
                         continue;
                     }
+                    
                     if (!isMutableType(potentialValue)) {
                         continue;
                     }


### PR DESCRIPTION
Gradle projects for intellij plugins cannot be loaded - an exception is thrown:
```
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.inspectObjectAndValues0(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.inspectObjectAndValues(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.dumpValue(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.inspectObjectAndValues0(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.inspectObjectAndValues(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.inspectObjectAndValues(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.inspectObjectAndValues0(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.inspectObjectAndValues(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.inspectObjectAndValues(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.inspectObjectAndValues0(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.inspectObjectAndValues(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.startInspectObjectAndValues(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.detectTaskProperties(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.lambda$runAndRegisterPerf$7(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.runAndRegisterPerf(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.runAndRegisterPerf(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.lambda$buildAll$3(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.sinceGradle(Unknown Source)
org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.buildAll(Unknown Source)
org.netbeans.modules.gradle.tooling.NetBeansToolingPlugin$NetBeansToolingModelBuilder.buildAll(Unknown Source)
org.gradle.tooling.provider.model.internal.DefaultToolingModelBuilderRegistry$BuilderWithNoParameter.build(DefaultToolingModelBuilderRegistry.java:264)
```

The error is caused by an unreadable (without getter) multi-property - so this PR just checks if the getter exists. The check is already in place for metabean properties. Without a getter, `metaClazz.getProperty()` would throw an Exception anyway.