### PR TITLE
Debugging fixes

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/build.gradle
+++ b/extide/gradle/netbeans-gradle-tooling/build.gradle
@@ -23,6 +23,7 @@ mainClassName = 'org.netbeans.modules.gradle.DebugTooling'
 
 sourceCompatibility = '1.8'
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+[compileJava, compileTestJava]*.options*.debug = true
 
 repositories {
     mavenCentral()

--- a/extide/gradle/netbeans-gradle-tooling/build.xml
+++ b/extide/gradle/netbeans-gradle-tooling/build.xml
@@ -42,7 +42,7 @@
     </target>
     <target name="compile" depends="prepare-libs">
         <mkdir dir="build/classes/java/main"/>
-        <javac srcdir="src/main/java" destdir="build/classes/java/main" classpathref="compile.classpath" release="8" includeantruntime="false"/>
+        <javac srcdir="src/main/java" destdir="build/classes/java/main" classpathref="compile.classpath" release="8" includeantruntime="false" debug="true"/>
     </target>
 
     <target name="jar" depends="compile">

--- a/java/java.lsp.server/vscode/src/nbcode.ts
+++ b/java/java.lsp.server/vscode/src/nbcode.ts
@@ -70,8 +70,8 @@ export function launch(
         ideArgs.push('-J-Dnetbeans.logger.console=true');
     }
     ideArgs.push(`-J-Dnetbeans.extra.dirs=${clusterPath}`)
-    if (env['netbeans.extra.options']) {
-        ideArgs.push(...env['netbeans.extra.options'].split(' '));
+    if (env['netbeans_extra_options']) {
+        ideArgs.push(...env['netbeans_extra_options'].split(' '));
     }
     ideArgs.push(...extraArgs);
     if (env['netbeans_debug'] && extraArgs && extraArgs.find(s => s.includes("--list"))) {

--- a/java/java.lsp.server/vscode/src/test/runTest.ts
+++ b/java/java.lsp.server/vscode/src/test/runTest.ts
@@ -52,7 +52,7 @@ async function main() {
             extensionTestsPath,
             extensionTestsEnv: {
                 'ENABLE_CONSOLE_LOG' : 'true',
-                "netbeans.extra.options" : `-J-Dproject.limitScanRoot=${outRoot} -J-Dnetbeans.logger.console=true`
+                "netbeans_extra_options" : `-J-Dproject.limitScanRoot=${outRoot} -J-Dnetbeans.logger.console=true`
             },
             launchArgs: [
                 '--disable-extensions',


### PR DESCRIPTION
Late as always, but this time at least not affecting the IDE operation ....

During debugging of #7037, I've realized that `debug` flag was dropped during December from gradle tooling classes injected into gradle daemon. Debug info is needed for debugging and is very useful in stacktraces of user reports; I believe this change should go to the NB21 to provide better diagnostics.

The second fix is the name of the evn variable that NBLS launcher reads to inject extra options to the NBLS server. We used dotted name for historical reasons, but it seems it should be changed so that it is easier to set it up from the shell launcher. Dotted env var name requires use of `env` to launch the process, which is not always possible, i.e. in vscode remote development scenario that does a ssh login.

None of the changes affect normal IDE or NBLS operation. Please consider to include it into RC3, if not being already built.