### PR TITLE
Prevent `ParseException` when CC is run on the EOF

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/CompletionContextFinder.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/CompletionContextFinder.java
@@ -1662,6 +1662,7 @@ final class CompletionContextFinder {
     }
 
     static boolean isInAttribute(final int caretOffset, final TokenSequence ts, boolean allowInArgs) {
+        final int originalOffset = ts.offset();
         // e.g. #[MyAttr^ibute] ("^": caret)
         boolean result = false;
         int bracketBalance = 0;
@@ -1693,7 +1694,7 @@ final class CompletionContextFinder {
                 break;
             }
         }
-        ts.move(caretOffset);
+        ts.move(originalOffset);
         ts.moveNext();
         return result;
     }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
@@ -1671,6 +1671,9 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
         if (tokenSequence == null) {
             return;
         }
+        if (!tokenSequence.moveNext()) {
+            return;
+        }
         if (CompletionContextFinder.isInAttribute(request.anchor, tokenSequence, true)) {
             autoCompleteAttributeExpression(completionResult, request);
         } else {

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testParseException/testParseException.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testParseException/testParseException.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace TestA;
+
+function myFunction(): void {
+}
+
+namespace TestB;
+
+use function TestA\myFunction

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testParseException/testParseException.php.testParseException.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php80/testParseException/testParseException.php.testParseException.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+use function TestA\myFunction|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     myFunction()                    [PUBLIC]   TestA

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHP80CodeCompletionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHP80CodeCompletionTest.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.php.editor.completion;
 
 import java.io.File;
+import org.netbeans.modules.parsing.spi.ParseException;
 import org.netbeans.modules.php.api.PhpVersion;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -1672,4 +1673,11 @@ public class PHP80CodeCompletionTest extends PHPCodeCompletionTestBase {
         checkCompletion(getTestPath(), "    #[^]", false);
     }
 
+    public void testParseException() throws Exception {
+        try {
+            checkCompletion(getTestPath(), "use function TestA\\myFunction^", false);
+        } catch (ParseException e) {
+            fail("Must not throw ParseException.");
+        }
+    }
 }


### PR DESCRIPTION
- Set not a caret offset but an original offset to the token sequence
- Add a unit test

Example:
```php
<?php
namespace TestA;

function myFunction(): void {
}

namespace TestB;

use function TestA\myFunction^ // CC here 
```