### PR TITLE
ActionProvider and its Lookup in NbLaunchDelegate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2542,7 +2542,7 @@ jobs:
         run: tar --zstd -xf build.tar.zst
 
       - name: java/java.lsp.server
-        run: .github/retry.sh ant $OPTS -f java/java.lsp.server test
+        run: .github/retry.sh ant $OPTS -f java/java.lsp.server clean test
 
       - name: Create Test Summary
         uses: test-summary/action@v2

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
@@ -114,7 +114,7 @@ public abstract class NbLaunchDelegate {
     public abstract void preLaunch(Map<String, Object> launchArguments, DebugAdapterContext context);
 
     public abstract void postLaunch(Map<String, Object> launchArguments, DebugAdapterContext context);
-    
+
     protected void notifyFinished(DebugAdapterContext ctx, boolean success) {
         // Remove a possibly staled debugger listener
         DebuggerManagerListener listener = debuggerListeners.remove(ctx);
@@ -167,7 +167,7 @@ public abstract class NbLaunchDelegate {
 
                 @Override
                 public void flush() throws IOException {
-                    // nop 
+                    // nop
                 }
 
                 @Override
@@ -199,10 +199,10 @@ public abstract class NbLaunchDelegate {
                         testProgressHandler != null ? Lookups.fixed(contextObject, ioContext, progress, testProgressHandler) : Lookups.fixed(contextObject, ioContext, progress),
                         Lookup.getDefault()
                 );
-                
+
                 ProjectConfiguration selectConfiguration = null;
                 ProjectConfigurationProvider<ProjectConfiguration> pcp = null;
-                
+
                 Object o = launchArguments.get("launchConfiguration");
                 if (o instanceof String) {
                     if (prj != null) {
@@ -218,23 +218,21 @@ public abstract class NbLaunchDelegate {
                 runContext.add(params);
                 runContext.add(ioContext);
                 runContext.add(progress);
-                
-                Lookup lookup;
-                if (singleMethod != null) {
-                    runContext.add(singleMethod);
-                }
                 if (selectConfiguration != null) {
                     runContext.add(selectConfiguration);
                 }
-                
-                lookup = Lookups.fixed(runContext.toArray(new Object[runContext.size()]));
+
+                Lookup lookup = new ProxyLookup(
+                    createTargetLookup(prj, singleMethod, toRun),
+                    Lookups.fixed(runContext.toArray(new Object[runContext.size()]))
+                );
                 // the execution Lookup is fully populated now. If the Project supports Configurations,
-                // check if the action is actually enabled in the prescribed configuration. If it is not, 
+                // check if the action is actually enabled in the prescribed configuration. If it is not,
                 if (pcp != null) {
                     final ActionProvider ap = providerAndCommand.first();
                     final String cmd = providerAndCommand.second();
                     if (!ap.isActionEnabled(cmd, lookup)) {
-                        
+
                         // attempt to locate a different configuration that enables the action:
                         ProjectConfiguration supportive = null;
                         int confIndex = runContext.indexOf(selectConfiguration);
@@ -255,10 +253,10 @@ public abstract class NbLaunchDelegate {
                         String msg;
                         String recommended = defConfig ? Bundle.ERR_LaunchDefaultConfiguration(): Bundle.ERR_LaunchSupportiveConfigName(supportive.getDisplayName());
                         if (debug) {
-                            msg = supportive == null ? 
+                            msg = supportive == null ?
                                  Bundle.ERR_UnsupportedLaunchDebug() : Bundle.ERR_UnsupportedLaunchDebugConfig(selectConfiguration.getDisplayName(),  recommended);
                         } else {
-                            msg = supportive == null ? 
+                            msg = supportive == null ?
                                  Bundle.ERR_UnsupportedLaunch() : Bundle.ERR_UnsupportedLaunchConfig(selectConfiguration.getDisplayName(), recommended);
                         }
                         LanguageClient client = context.getLspSession().getLookup().lookup(LanguageClient.class);
@@ -487,7 +485,7 @@ public abstract class NbLaunchDelegate {
             throw new IllegalArgumentException("Expected String or String list");
         }
     }
-    
+
     private static CompletableFuture<Pair<ActionProvider, String>> findTargetWithPossibleRebuild(Project proj, boolean preferProjActions, FileObject toRun, SingleMethod singleMethod, boolean debug, boolean testRun, NbProcessConsole ioContext) throws IllegalArgumentException {
         Pair<ActionProvider, String> providerAndCommand = findTarget(proj, preferProjActions, toRun, singleMethod, debug, testRun);
         if (providerAndCommand != null) {
@@ -550,7 +548,7 @@ public abstract class NbLaunchDelegate {
         ActionProvider provider = null;
         String command = null;
         Collection<ActionProvider> actionProviders = findActionProviders(prj);
-        Lookup testLookup = preferProjActions && prj != null ? Lookups.singleton(prj) : (singleMethod != null) ? Lookups.fixed(toRun, singleMethod) : Lookups.singleton(toRun);
+        Lookup testLookup = createTargetLookup(preferProjActions ? prj : null, singleMethod, toRun);
         String[] actions;
         if (!mainSource && singleMethod != null) {
             actions = debug ? new String[] {SingleMethod.COMMAND_DEBUG_SINGLE_METHOD}
@@ -564,7 +562,7 @@ public abstract class NbLaunchDelegate {
                 if (debug && !mainSource) {
                     // We are calling COMMAND_DEBUG_TEST_SINGLE instead of a missing COMMAND_DEBUG_TEST
                     // This is why we need to add the file to the lookup
-                    testLookup = (singleMethod != null) ? Lookups.fixed(toRun, singleMethod) : Lookups.singleton(toRun);
+                    testLookup = createTargetLookup(null, singleMethod, toRun);
                 }
             } else {
                 actions = debug ? mainSource ? new String[] {ActionProvider.COMMAND_DEBUG_SINGLE}

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/TestCodeLanguageClient.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/TestCodeLanguageClient.java
@@ -138,7 +138,7 @@ public abstract class TestCodeLanguageClient implements NbCodeLanguageClient {
 
     @Override
     public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams params) {
-        throw new UnsupportedOperationException();
+        return CompletableFuture.completedFuture(new MessageActionItem(params.getActions().get(0).getTitle()));
     }
 
     @Override

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegateTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegateTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.debugging.launch;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.modules.java.lsp.server.debugging.DebugAdapterContext;
+import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.ProjectFactory;
+import org.netbeans.spi.project.ProjectState;
+import org.netbeans.spi.project.SingleMethod;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.loaders.DataObject;
+import org.openide.util.Lookup;
+import org.openide.util.Pair;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.lookup.ServiceProvider;
+
+public class NbLaunchDelegateTest {
+
+    public NbLaunchDelegateTest() {
+    }
+
+    @Test
+    public void testFileObjectsLookup() throws Exception {
+        FileObject fo = FileUtil.createMemoryFileSystem().getRoot().createData("test.txt");
+        Lookup lkp = NbLaunchDelegate.createTargetLookup(null, null, fo);
+        assertEquals(fo, lkp.lookup(FileObject.class));
+
+        DataObject obj = lkp.lookup(DataObject.class);
+        assertNotNull("DataObject also found", obj);
+
+        assertEquals("It's FileObject's data object", obj, DataObject.find(fo));
+        assertNull("No single method", lkp.lookup(SingleMethod.class));
+    }
+
+    @Test
+    public void testFileObjectsLookupWithSingleMethod() throws Exception {
+        FileObject fo = FileUtil.createMemoryFileSystem().getRoot().createData("test-with-method.txt");
+        SingleMethod m = new SingleMethod(fo, "main");
+        Lookup lkp = NbLaunchDelegate.createTargetLookup(null, m, fo);
+        assertEquals(fo, lkp.lookup(FileObject.class));
+
+        DataObject obj = lkp.lookup(DataObject.class);
+        assertNotNull("DataObject also found", obj);
+
+        assertEquals("It's FileObject's data object", obj, DataObject.find(fo));
+
+        assertEquals("Found single method", m, lkp.lookup(SingleMethod.class));
+    }
+
+    @Test
+    public void testFindsMavenProject() throws Exception {
+        FileObject dir = FileUtil.createMemoryFileSystem().getRoot().createFolder("testprj");
+        FileObject xml = dir.createData("build.xml");
+        Project prj = ProjectManager.getDefault().findProject(dir);
+        assertNotNull("Project dir recognized", prj);
+
+        SingleMethod m = new SingleMethod(xml, "main");
+        Lookup lkp = NbLaunchDelegate.createTargetLookup(prj, null, null);
+        assertNull("No file object", lkp.lookup(FileObject.class));
+        DataObject obj = lkp.lookup(DataObject.class);
+        assertNull("No DataObject ", obj);
+        assertNull("No single method", lkp.lookup(SingleMethod.class));
+        assertEquals(prj, lkp.lookup(Project.class));
+    }
+
+    @Test
+    public void testFindsWithFileObjectAndDataObject() throws Exception {
+        FileObject dir = FileUtil.createMemoryFileSystem().getRoot().createFolder("testprj");
+        FileObject xml = dir.createData("build.xml");
+        Project prj = ProjectManager.getDefault().findProject(dir);
+        assertNotNull("Project dir recognized", prj);
+
+        SingleMethod m = new SingleMethod(xml, "main");
+        Lookup lkp = NbLaunchDelegate.createTargetLookup(prj, m, xml);
+        assertEquals("File object is available", xml, lkp.lookup(FileObject.class));
+        DataObject obj = lkp.lookup(DataObject.class);
+        assertNotNull("DataObject is available", obj);
+        assertEquals("DataObject's FileObject is correct", xml, obj.getPrimaryFile());
+        assertEquals("Single method is also present", m, lkp.lookup(SingleMethod.class));
+        assertEquals(prj, lkp.lookup(Project.class));
+    }
+
+    @Test
+    public void testAvoidNPEWithoutActionsProviderInLookup() throws Exception {
+        MockProjectFactory.MockProject prj = new MockProjectFactory.MockProject(FileUtil.getConfigRoot());
+        Collection<ActionProvider> all = NbLaunchDelegate.findActionProviders(prj);
+        assertFalse("There shall be no null in " + all, all.contains(null));
+    }
+
+    @ServiceProvider(service = ProjectFactory.class)
+    public static final class MockProjectFactory implements ProjectFactory {
+
+        @Override
+        public boolean isProject(FileObject projectDirectory) {
+            return projectDirectory.getNameExt().equals("testprj");
+        }
+
+        @Override
+        public Project loadProject(FileObject projectDirectory, ProjectState state) throws IOException {
+            return new MockProject(projectDirectory);
+        }
+
+        @Override
+        public void saveProject(Project project) throws IOException, ClassCastException {
+        }
+
+        private static final class MockProject implements Project {
+            private final FileObject dir;
+
+            MockProject(FileObject dir) {
+                this.dir = dir;
+            }
+
+            @Override
+            public FileObject getProjectDirectory() {
+                return dir;
+            }
+
+            @Override
+            public Lookup getLookup() {
+                return Lookups.fixed(this);
+            }
+
+        }
+    }
+}

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegateTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegateTest.java
@@ -18,21 +18,12 @@
  */
 package org.netbeans.modules.java.lsp.server.debugging.launch;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
-import org.netbeans.modules.java.lsp.server.debugging.DebugAdapterContext;
 import org.netbeans.spi.project.ActionProvider;
 import org.netbeans.spi.project.ProjectFactory;
 import org.netbeans.spi.project.ProjectState;
@@ -41,7 +32,6 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
 import org.openide.util.Lookup;
-import org.openide.util.Pair;
 import org.openide.util.lookup.Lookups;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -128,7 +118,11 @@ public class NbLaunchDelegateTest {
 
         @Override
         public Project loadProject(FileObject projectDirectory, ProjectState state) throws IOException {
-            return new MockProject(projectDirectory);
+            if (isProject(projectDirectory)) {
+                return new MockProject(projectDirectory);
+            } else {
+                return null;
+            }
         }
 
         @Override

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
@@ -317,7 +317,10 @@ public class ServerTest extends NbTestCase {
     protected void tearDown() throws Exception {
         super.tearDown();
         TextDocumentServiceImpl.HOOK_NOTIFICATION = null;
-        serverThread.stop();
+        try {
+            serverThread.stop();
+        } catch (UnsupportedOperationException ex) {
+        }
         OpenProjects.getDefault().close(OpenProjects.getDefault().getOpenProjects());
     }
     
@@ -370,7 +373,7 @@ public class ServerTest extends NbTestCase {
 
         @Override
         public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-            throw new UnsupportedOperationException("Not supported yet.");
+            return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
         }
 
         @Override
@@ -710,7 +713,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -815,7 +818,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -962,7 +965,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -1045,7 +1048,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -1109,7 +1112,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams params) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(params.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -1167,7 +1170,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams params) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(params.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -1280,7 +1283,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -1335,7 +1338,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -1384,7 +1387,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -1442,7 +1445,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -1510,7 +1513,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -1648,7 +1651,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -1805,7 +1808,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -1910,7 +1913,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -1980,7 +1983,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -2119,7 +2122,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -2208,7 +2211,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -2298,7 +2301,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -2391,7 +2394,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -2481,7 +2484,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -2572,7 +2575,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -2680,7 +2683,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -2783,7 +2786,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -2886,7 +2889,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -2988,7 +2991,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -3121,7 +3124,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -3640,7 +3643,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -3782,7 +3785,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -4665,7 +4668,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -4744,7 +4747,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -4827,7 +4830,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -4906,7 +4909,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -4969,7 +4972,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -5103,7 +5106,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override
@@ -5165,7 +5168,7 @@ public class ServerTest extends NbTestCase {
 
             @Override
             public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams arg0) {
-                throw new UnsupportedOperationException("Not supported yet.");
+                return CompletableFuture.completedFuture(new MessageActionItem(arg0.getActions().get(0).getTitle()));
             }
 
             @Override

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/ParseSuitesTest.java
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/ParseSuitesTest.java
@@ -20,14 +20,17 @@ package org.netbeans.modules.java.mx.project;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.URL;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.java.mx.project.suitepy.MxDistribution;
 import org.netbeans.modules.java.mx.project.suitepy.MxSuite;
 
 public final class ParseSuitesTest extends NbTestCase {
@@ -38,6 +41,15 @@ public final class ParseSuitesTest extends NbTestCase {
 
     public void testParseThemAll() throws IOException {
         assertSuitePys(getDataDir(), 15);
+    }
+    
+    public void testParseMultiLineSuite() throws IOException {
+        URL url = getClass().getResource("multilinetexts.py");
+        MxSuite suite = MxSuite.parse(url);
+        assertNotNull("suite parsed", suite);
+        MxDistribution tool = suite.distributions().get("TOOLCHAIN");
+        assertNotNull("toolchain found", tool);
+        assertEquals("No deps", 0, tool.dependencies().size());
     }
 
     public static void main(String... args) throws IOException {

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/multilinetexts.py
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/multilinetexts.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+suite = {
+  "mxversion": "7.5.0",
+  "name" : "multilinetexts",
+  "version" : "1.0.0",
+  "repositories" : {
+  },
+  "libraries" : {
+  },
+  "licenses" : {
+},
+  "distributions" : {
+    "TOOLCHAIN": {
+      "native": True,
+      "platformDependent": True,
+      "os": {
+        "linux": {
+          "layout": {
+            "toolchain.multi": {
+              "source_type": "string",
+              "value": '''
+line1
+line2
+line3
+line5
+'''
+            },
+          },
+          "dependencies": [
+          ],
+        },
+      },
+      "maven" : False,
+    },
+  },
+}


### PR DESCRIPTION
Second attempt to integrate #7011. Makes sure the `FileObject` (and its `getLookup()`) are sent even in case of `COMMAND_RUN` and `COMMAND_DEBUG`. As a result even _"project oriented actions"_ can find out what's the currently selected file and operate on it.

My [Enso projects](https://github.com/enso-org/enso/blob/d87ba6e3cf7804e72909db1a984e1b53c4b0c004/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoRootProject.java#L42) don't have `ActionProvider` in their lookup. That misleads `NbLaunchDelegate.java` to create a `Collection` with `null` element that yields `NullPointerException` as soon as one tries to iterate over the collection and invoke a method on individual `ActionProvider`.