### PR TITLE
Add null check on originalEncoding parameter of EncodingModel

### DIFF
--- a/ide/projectuiapi/src/org/netbeans/spi/project/ui/support/ProjectCustomizer.java
+++ b/ide/projectuiapi/src/org/netbeans/spi/project/ui/support/ProjectCustomizer.java
@@ -747,26 +747,29 @@ public final class ProjectCustomizer {
 
     private static final class EncodingModel extends DefaultComboBoxModel {
 
-        EncodingModel (String originalEncoding) {
+        EncodingModel(String originalEncoding) {
             Charset defEnc = null;
-            for (Charset c : Charset.availableCharsets().values()) {
-                if (c.name().equals(originalEncoding)) {
-                    defEnc = c;
-                } else if (c.aliases().contains(originalEncoding)) { //Mobility - can have hand-entered encoding
-                    defEnc = c;
+            if (originalEncoding != null) {
+                for (Charset c : Charset.availableCharsets().values()) {
+                    if (c.name().equals(originalEncoding)) {
+                        defEnc = c;
+                    } else if (c.aliases().contains(originalEncoding)) { //Mobility - can have hand-entered encoding
+                        defEnc = c;
+                    }
+                    addElement(c);
                 }
-                addElement(c);
-            }
-            if (originalEncoding != null && defEnc == null) {
-                //Create artificial Charset to keep the original value
-                //May happen when the project was set up on the platform
-                //which supports more encodings
-                try {
-                    defEnc = new UnknownCharset (originalEncoding);
-                    addElement(defEnc);
-                } catch (IllegalCharsetNameException e) {
-                    //The source.encoding property is completely broken
-                    LOG.log(Level.INFO, "IllegalCharsetName: {0}", originalEncoding);
+
+                if (defEnc == null) {
+                    //Create artificial Charset to keep the original value
+                    //May happen when the project was set up on the platform
+                    //which supports more encodings
+                    try {
+                        defEnc = new UnknownCharset(originalEncoding);
+                        addElement(defEnc);
+                    } catch (IllegalCharsetNameException e) {
+                        //The source.encoding property is completely broken
+                        LOG.log(Level.INFO, "IllegalCharsetName: {0}", originalEncoding);
+                    }
                 }
             }
             if (defEnc == null) {

--- a/ide/projectuiapi/test/unit/src/org/netbeans/spi/project/ui/support/ProjectCustomizerTest.java
+++ b/ide/projectuiapi/test/unit/src/org/netbeans/spi/project/ui/support/ProjectCustomizerTest.java
@@ -179,4 +179,13 @@ public class ProjectCustomizerTest extends NbTestCase {
         }
     }
     
+    public void testEncodingModel() {
+        // Issue 7507 - just test the CBM is created without throwing NPE.
+        javax.swing.ComboBoxModel model1 = ProjectCustomizer.encodingModel("UTF-8");
+        assertNotNull(model1);
+        javax.swing.ComboBoxModel model2 = ProjectCustomizer.encodingModel("non-existent");
+        assertNotNull(model2);
+        javax.swing.ComboBoxModel model3 = ProjectCustomizer.encodingModel(null);
+        assertNotNull(model3);
+    }
 }


### PR DESCRIPTION
`EncodingModel` is an internal class, implementing `ComboBoxModel`, which is used for a combo box intended to show all the encodings available to the current JVM. It is constructed with a parameter called `originalEncoding` which pre-selects the encoding to show in the combo. A value of null means to pick the default encoding. 
Due to implementation changes, passing in null causes a null pointer exception when `Set#contains()` is called.
This PR adds an extra check to skip straight to selecting the default encoding if `originalEncoding` is null.

Fixes #7057 



