### PR TITLE
Improve priming from LSP client

### DIFF
--- a/java/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/ExtensionModule.java
+++ b/java/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/ExtensionModule.java
@@ -20,8 +20,12 @@ package org.netbeans.modules.maven.embedder.impl;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import com.google.inject.Scopes;
 import org.apache.maven.model.building.ModelBuilder;
 import org.apache.maven.plugin.internal.PluginDependenciesResolver;
+import org.eclipse.aether.impl.ArtifactDescriptorReader;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.impl.VersionResolver;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.localrepo.LocalRepositoryManagerFactory;
@@ -48,6 +52,12 @@ public class ExtensionModule implements Module {
         //exxperimental only.
 //        binder.bind(InheritanceAssembler.class).to(NbInheritanceAssembler.class);
         binder.bind(ModelBuilder.class).to(NBModelBuilder.class);
+        
+        // This allows to capture origin for version and artifact queries, so that ArtifactFixer can determine
+        // if a pom was really requested, or some other artifact's classifier/type was
+        binder.bind(VersionResolver.class).to(NbVersionResolver2.class).in(Scopes.SINGLETON);
+        binder.bind(VersionRangeResolver.class).to(NbVersionResolver2.class).in(Scopes.SINGLETON);
+        binder.bind(ArtifactDescriptorReader.class).to(NbVersionResolver2.class).in(Scopes.SINGLETON);
     }
     
 }

--- a/java/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NbVersionResolver2.java
+++ b/java/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NbVersionResolver2.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.embedder.impl;
+
+import javax.inject.Inject;
+import org.apache.maven.repository.internal.DefaultArtifactDescriptorReader;
+import org.apache.maven.repository.internal.DefaultVersionRangeResolver;
+import org.apache.maven.repository.internal.DefaultVersionResolver;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.impl.ArtifactDescriptorReader;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.impl.VersionResolver;
+import org.eclipse.aether.resolution.ArtifactDescriptorException;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.resolution.VersionRequest;
+import org.eclipse.aether.resolution.VersionResolutionException;
+import org.eclipse.aether.resolution.VersionResult;
+
+/**
+ * This resolver intercepts requests to resolve artifact versions and artifact descriptor. The NbWorkspaceReader may 
+ * then discover which artifact is actually missing and pass that information to ArtifactFixer.
+ * <p>
+ * Maven attempts to resolve the artifact and its POM - as another artifact, but the knowledge that the POM is actually
+ * implied by the real artifact is lost in Maven's DependencyResolver. This interceptor saves the info so that
+ * the Fixer has some context to report missing project dependencies.
+ * 
+ * @author sdedic
+ */
+public final class NbVersionResolver2 implements VersionResolver, VersionRangeResolver, ArtifactDescriptorReader {
+    private static final ThreadLocal<Artifact> resolvingArtifact = new ThreadLocal<>();
+    private static final ThreadLocal<Artifact> resolvingPom = new ThreadLocal<>();
+    
+    private final DefaultVersionResolver resolverDelegate;
+    private final DefaultVersionRangeResolver rangeResolverDelegate;
+    private final DefaultArtifactDescriptorReader descriptorReader;
+    
+    @Inject
+    public NbVersionResolver2(DefaultVersionResolver r, DefaultVersionRangeResolver r2, DefaultArtifactDescriptorReader reader) {
+        this.resolverDelegate = r;
+        this.rangeResolverDelegate = r2;
+        this.descriptorReader = reader;
+        reader.setVersionResolver(this);
+        reader.setVersionRangeResolver(this);
+    }
+
+    @Override
+    public ArtifactDescriptorResult readArtifactDescriptor(RepositorySystemSession rss, ArtifactDescriptorRequest adr) throws ArtifactDescriptorException {
+        Artifact save = resolvingPom.get();
+        try {
+            resolvingPom.set(adr.getArtifact());
+            return descriptorReader.readArtifactDescriptor(rss, adr);
+        } finally {
+            resolvingPom.set(save);
+        }
+    }
+    
+    @Override
+    public VersionResult resolveVersion(RepositorySystemSession session, VersionRequest request) throws VersionResolutionException {
+        Artifact a = request.getArtifact();
+        Artifact rq = null;
+        // TODO: also can record the artifact SCOPE. It is not present directly, but
+        // one can traverse through request.getTrace(), seeking for e.g. CollectStep that contains Dependency, which have a scope. Leaving for
+        // future improvement.
+        if (request.getTrace().getData() instanceof ArtifactDescriptorRequest) {
+            rq = ((ArtifactDescriptorRequest)request.getTrace().getData()).getArtifact();
+            if (rq.getArtifactId().equals(a.getArtifactId()) && rq.getGroupId().equals(a.getGroupId()) && rq.getVersion().equals(a.getVersion())) {
+                // replace POM artifacts with their original ones
+                a = rq;
+            }
+        } else if ("pom".equals(a.getExtension()) && 
+            (request.getTrace().getData() instanceof ArtifactRequest) && request.getTrace().getParent() != null && 
+            (request.getTrace().getParent().getData() instanceof ArtifactDescriptorRequest)) {
+            rq = ((ArtifactDescriptorRequest)request.getTrace().getParent().getData()).getArtifact();
+        }
+        if (rq != null && 
+            rq.getArtifactId().equals(a.getArtifactId()) && rq.getGroupId().equals(a.getGroupId()) && rq.getVersion().equals(a.getVersion())) {
+            // replace POM artifacts with their original ones
+            a = rq;
+        }
+        Artifact save = resolvingArtifact.get();
+        resolvingArtifact.set(a);
+        try {
+            return resolverDelegate.resolveVersion(session, request);
+        } finally {
+            resolvingArtifact.set(save);
+        }
+    }
+
+    @Override
+    public VersionRangeResult resolveVersionRange(RepositorySystemSession rss, VersionRangeRequest vrr) throws VersionRangeResolutionException {
+        Artifact a = vrr.getArtifact();
+        if (vrr.getTrace().getData() instanceof ArtifactDescriptorRequest) {
+            Artifact rq = ((ArtifactDescriptorRequest)vrr.getTrace().getData()).getArtifact();
+            if (rq.getArtifactId().equals(a.getArtifactId()) && rq.getGroupId().equals(a.getGroupId()) && rq.getVersion().equals(a.getVersion())) {
+                // replace POM artifacts with their original ones
+                a = rq;
+            }
+        }
+        Artifact save = resolvingArtifact.get();
+        resolvingArtifact.set(a);
+        try {
+            return rangeResolverDelegate.resolveVersionRange(rss, vrr);
+        } finally {
+            resolvingArtifact.set(save);
+        }
+    }
+    
+    public Artifact getResolvingArtifact() {
+        Artifact pomOrigin = resolvingPom.get();
+        Artifact resolving = resolvingArtifact.get();
+        if (resolving == null) {
+            if (pomOrigin != null) {
+                resolving = pomOrigin;
+            }
+        } else if (pomOrigin != null) {
+            if (resolving.getGroupId().equals(pomOrigin.getGroupId()) && 
+                resolving.getArtifactId().equals(pomOrigin.getArtifactId()) &&
+                resolving.getVersion().equals(pomOrigin.getVersion())) {
+                resolving = pomOrigin;
+            }
+        }
+        return resolving;
+    }
+}

--- a/java/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NbWorkspaceReader.java
+++ b/java/maven.embedder/src/org/netbeans/modules/maven/embedder/impl/NbWorkspaceReader.java
@@ -21,7 +21,10 @@ package org.netbeans.modules.maven.embedder.impl;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import org.netbeans.modules.maven.embedder.ArtifactFixer;
 import org.openide.util.Lookup;
 import org.eclipse.aether.repository.WorkspaceReader;
@@ -33,12 +36,14 @@ import org.eclipse.aether.repository.WorkspaceRepository;
  */
 public class NbWorkspaceReader implements WorkspaceReader {
     private final WorkspaceRepository repo;
+    private final NbVersionResolver2 resolver;
     private final Collection<? extends ArtifactFixer> fixers;
     boolean silence = false;
     
-    public NbWorkspaceReader() {
+    public NbWorkspaceReader(NbVersionResolver2 resolver) {
         repo = new WorkspaceRepository("ide", getClass());
         fixers = Lookup.getDefault().lookupAll(ArtifactFixer.class);
+        this.resolver = resolver;
     }
 
     @Override
@@ -51,7 +56,26 @@ public class NbWorkspaceReader implements WorkspaceReader {
         if (silence) {
             return null;
         }
-        
+        if (resolver != null) {
+            org.eclipse.aether.artifact.Artifact a = resolver.getResolvingArtifact();
+            if (a != null &&
+                (!Objects.equals(a.getClassifier(), artifact.getClassifier()) ||
+                 !Objects.equals(a.getExtension(), artifact.getExtension()) ||
+                 !Objects.equals(a.getVersion(), artifact.getVersion()))) {
+                // POM is requested, but it is not required by the project itself, but implied
+                // as metadata of some really requested artifact. Add the classifier/extension
+                // of the true artifact as attributes, so that ArtifactFixer may read it.
+                
+                // TODO: improve interface to ArtifactFixer, so the info can be provided in a
+                // more sane way.
+                Map<String, String> m = new HashMap<>(artifact.getProperties());
+                m.put("nbResolvingArtifact.group", artifact.getGroupId());
+                m.put("nbResolvingArtifact.id", artifact.getArtifactId());
+                m.put("nbResolvingArtifact.classifier", a.getClassifier());
+                m.put("nbResolvingArtifact.extension", a.getExtension());
+                artifact = artifact.setProperties(m);
+            }
+        }
         for (ArtifactFixer fixer : fixers) {
             File f = fixer.resolve(artifact);
             if (f != null) {
@@ -67,6 +91,21 @@ public class NbWorkspaceReader implements WorkspaceReader {
             return Collections.emptyList();
         }
         //this is important for snapshots, without it the SNAPSHOT will be attempted to be resolved to time-based snapshot version
+        if (resolver != null) {
+            org.eclipse.aether.artifact.Artifact a = resolver.getResolvingArtifact();
+            if (a != null &&
+                (!Objects.equals(a.getClassifier(), artifact.getClassifier()) ||
+                 !Objects.equals(a.getExtension(), artifact.getExtension()) ||
+                 !Objects.equals(a.getVersion(), artifact.getVersion()))) {
+                // see note in findArtifact
+                Map<String, String> m = new HashMap<>(artifact.getProperties());
+                m.put("nbResolvingArtifact.group", artifact.getGroupId());
+                m.put("nbResolvingArtifact.id", artifact.getArtifactId());
+                m.put("nbResolvingArtifact.classifier", a.getClassifier());
+                m.put("nbResolvingArtifact.extension", a.getExtension());
+                artifact = artifact.setProperties(m);
+            }
+        }
         for (ArtifactFixer fixer : fixers) {
             File f = fixer.resolve(artifact);
             if (f != null) {

--- a/java/maven/src/org/netbeans/modules/maven/modelcache/MavenProjectCache.java
+++ b/java/maven/src/org/netbeans/modules/maven/modelcache/MavenProjectCache.java
@@ -287,6 +287,7 @@ public final class MavenProjectCache {
                     LOG.log(Level.FINE, "Maven reported:", t);
                 }
             }
+            LOG.log(Level.FINE, "Loaded project flags - incomplete {0}, fake count {1}", new Object[] { isIncompleteProject(newproject), fakes.size() });
             if (!fakes.isEmpty() && !isIncompleteProject(newproject)) {
                 LOG.log(Level.FINE, "Incomplete artifact encountered during loading the project: {0}", fakes);
                 newproject.setContextValue(CONTEXT_PARTIAL_PROJECT, Boolean.TRUE);

--- a/java/maven/src/org/netbeans/modules/maven/modelcache/MavenProjectCache.java
+++ b/java/maven/src/org/netbeans/modules/maven/modelcache/MavenProjectCache.java
@@ -208,7 +208,7 @@ public final class MavenProjectCache {
             res = NbArtifactFixer.collectFallbackArtifacts(() -> projectEmbedder.readProjectWithDependencies(req, true), (c) -> 
                 c.forEach(a -> {
                     // artifact fixer only fakes POMs.
-                    fakes.add(projectEmbedder.createArtifactWithClassifier(a.getGroupId(), a.getArtifactId(), a.getVersion(), "pom", a.getClassifier())); // NOI18N
+                    fakes.add(projectEmbedder.createArtifactWithClassifier(a.getGroupId(), a.getArtifactId(), a.getVersion(), a.getExtension(), a.getClassifier())); // NOI18N
                 }
             ));
             newproject = res.getProject();

--- a/java/maven/src/org/netbeans/modules/maven/problems/MavenModelProblemsProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/problems/MavenModelProblemsProvider.java
@@ -29,6 +29,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -235,6 +236,7 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
                 List<ProjectProblem> toRet = null;
                 while (round <= 1) {
                     try {
+                        LOG.log(Level.FINER, "Analysing project {0}@{1}, round {2}", new Object[] { prj, System.identityHashCode(prj), round });
                         boolean ok = false;
                         synchronized (MavenModelProblemsProvider.this) {
                             try {
@@ -243,7 +245,9 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
                                 toRet = new ArrayList<>();
                                 MavenExecutionResult res = MavenProjectCache.getExecutionResult(prj);
                                 if (res != null && res.hasExceptions()) {
-                                    toRet.addAll(reportExceptions(res));
+                                    Collection<ProjectProblem> exceptions = reportExceptions(res);
+                                    LOG.log(Level.FINE, "Project has loaded with exceptions: {0}", exceptions);
+                                    toRet.addAll(exceptions);
                                 }
                                 //#217286 doArtifactChecks can call FileOwnerQuery and attempt to aquire the project mutex.
                                 toRet.addAll(doArtifactChecks(prj));
@@ -253,6 +257,9 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
                                 break;
                             } finally {
                                 if (ok || round > 0) {
+                                    LOG.log(Level.FINER, "Project {0} problems: {1}, sanity {2}, ok {3}, round {4}", new Object[] {
+                                        prj, sanityBuildStatus, ok, round
+                                    });
                                     //mark the project model as checked once and cached
                                     prj.setContextValue(MavenModelProblemsProvider.class.getName(), new Object());
                                     // change globals before exiting synchronized section
@@ -330,6 +337,7 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
     })
     public Collection<ProjectProblem> doArtifactChecks(@NonNull MavenProject project) {
         List<ProjectProblem> toRet = new ArrayList<ProjectProblem>();
+        LOG.log(Level.FINE, "Performing artifact checks for {0}", project);
         
         if (MavenProjectCache.unknownBuildParticipantObserved(project)) {
             StringBuilder sb = new StringBuilder();
@@ -342,9 +350,32 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
         
         boolean missingNonSibling = false;
         List<Artifact> missingJars = new ArrayList<Artifact>();
-        for (Artifact art : project.getArtifacts()) {
+        List<Artifact> artifactsToCheck = new ArrayList<>(project.getArtifacts());
+        MavenProject partial = MavenProjectCache.getPartialProject(project);
+        Collection<Artifact> fakes = (Collection<Artifact>)project.getContextValue("NB_FakedArtifacts");
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.log(Level.FINER, "Checking artifacts: {0}", artifactsToCheck);
+            if (partial != null && partial != project) {
+                Collection<Artifact> partialFakes = (Collection<Artifact>)partial.getContextValue("NB_FakedArtifacts");
+                LOG.log(Level.FINER, "Partial project for {0}@{1} is: {2}@{3}, fake artifacts: {4}", new Object[] { 
+                    project, System.identityHashCode(project), partial, System.identityHashCode(partial), partialFakes
+                });
+            }
+            LOG.log(Level.FINER, "Fake artifacts for {0}@{1}: {2}", new Object[] { 
+                project, System.identityHashCode(project), fakes
+            });
+        }
+        
+        Collection<Artifact> toCheck = new HashSet<>(project.getArtifacts());
+        if (fakes != null) {
+            toCheck.addAll(fakes);
+        }
+        
+        for (Artifact art : toCheck) {
             File file = art.getFile();
+            LOG.log(Level.FINEST, "Checking {0}", art);
             if (file == null || !file.exists()) {                
+                LOG.log(Level.FINEST, "File does not exist for {0}", art);
                 if(Artifact.SCOPE_SYSTEM.equals(art.getScope())){
                     //TODO create a correction action for this.
                     toRet.add(ProjectProblem.createWarning(ERR_SystemScope(), MSG_SystemScope(), new ProblemReporterImpl.MavenProblemResolver(OpenPOMAction.instance().createContextAwareInstance(Lookups.fixed(project)), "SCOPE_DEPENDENCY")));
@@ -354,6 +385,7 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
                         missingNonSibling = true;
                     } else {
                         final URL archiveUrl = FileUtil.urlForArchiveOrDir(file);
+                        LOG.log(Level.FINEST, "File for {0} is {1}, archive URL {2}", new Object[] { art, file, archiveUrl });
                         if (archiveUrl != null) { //#236050 null check
                             //a.getFile should be already normalized
                             SourceForBinaryQuery.Result2 result = SourceForBinaryQuery.findSourceRoots2(archiveUrl);
@@ -366,6 +398,7 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
                     missingJars.add(art);
                 }
             } else if (NbArtifactFixer.isFallbackFile(file)) {
+                LOG.log(Level.FINEST, "Artifact is a fallback {0} with file {1}", new Object[] { art, file });
                 addMissingArtifact(art);
                 missingJars.add(art);
                 missingNonSibling = true;
@@ -376,6 +409,7 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
             for (Artifact art : missingJars) {
                 mess.append(art.getId()).append('\n');
             }
+            LOG.log(Level.FINER, "Project is missing artifacts: {0}, nonlocal = {1}", new Object[] { missingJars, missingNonSibling });
             if (missingNonSibling) {
                 toRet.add(ProjectProblem.createWarning(ERR_NonLocal(), MSG_NonLocal(mess), createSanityBuildAction()));
             } else {
@@ -421,6 +455,7 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
         synchronized (this) {
             SanityBuildAction a = cachedSanityBuild.get();
             sanityBuildStatus = true;
+            LOG.log(Level.FINE, "Creating sanity build action for {0}", project.getProjectDirectory());
             if (a != null) {
                 Future<ProjectProblemsProvider.Result> r = a.getPendingResult();
                 if (r != null) {

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/problems/PrimingActionTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/problems/PrimingActionTest.java
@@ -249,7 +249,8 @@ public class PrimingActionTest extends NbTestCase {
         setupBrokenProject();
         Project p = ProjectManager.getDefault().findProject(FileUtil.toFileObject(getWorkDir()));
         Collection<? extends ProjectProblemsProvider.ProjectProblem> probs = collectProblems(p);
-        assertEquals(1, probs.size());
+        // #1 - parent POM is missing, #2 - dependencies are missing.
+        assertEquals(2, probs.size());
         ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
         boolean enabled = ap.isActionEnabled(ActionProvider.COMMAND_PRIME, Lookups.fixed(r));
         assertTrue(enabled);


### PR DESCRIPTION
In Oracle Luna Labs environment, where Apache NBLS runs alongside Microsoft Java support, we've encountered an interesting situation: 
- the client starts from a pristine VM. No Gradle or Maven artifact caches, or locally downloaded artifacts.
- when LSP client asks NBLS to open a project, NBLS checks if a priming build should run
- Maven enables priming build if and only if project loading fails, or a (1) direct dependency is missing
- at the time, NBLS Maven attempts to load the root project, the direct dependencies are already fetched by Microsoft Java initializing Maven in parallel to NBLS
- NBLS *is now able* to load the project; however certain dependencies from the deep of the dependency tree are still being loaded to the computer. (2) But the priming build on the root project is now disabled - no need to prime.
- NBLS skips prime, searches for subprojects and opens them (3) without priming 
- Subprojects contain *direct dependencies* on artifacts that the root project did not reference (althoug they may have been in the closure)
- As subprojects open, they are analyzed. POM load fails and (4) a notification dialog will pop up (missing dependencies, missing properties)

So this fix contains two changes. Changes project analysis (1) in that not only direct dependencies, but indirect ones, too, will cause the project to be marked as "broken", suggesting to run a priming build (to download dependencies). This might be useful, since in NB21, when the user adds a dependency to `pom.xml`, it is not really visible in completion unless the dependency *happens* to be in the local repository - until the next build. This fixes (2).

And the second fix modifies (3) in that each newly discovered subproject is checked for priming action and potentially primed. The subproject check is then done again ... and again until the closure is searched fully.
Note that the parent primes first (if possible), so chances are all children will be primed during this process. And children  are always processed only after the parent primes. 

The 2nd+ child level processing will happen if the local repository is partially populated in a way that satisfies the parent (parent load does not notice any issues), but NOT the subprojects - this may be the case even after (1) is improved by this PR. This fixes (4).

