### PR TITLE
Replace usage of package `org.codehaus.plexus.util.IOUtil` with Java native methods.

### DIFF
--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/AccessQueryImpl.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/AccessQueryImpl.java
@@ -30,7 +30,6 @@ import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 import org.netbeans.api.annotations.common.SuppressWarnings;
 import org.netbeans.modules.maven.api.NbMavenProject;
-import org.codehaus.plexus.util.IOUtil;
 import org.netbeans.api.project.Project;
 import org.netbeans.spi.java.queries.AccessibilityQueryImplementation;
 import org.netbeans.spi.project.ProjectServiceProvider;
@@ -166,17 +165,13 @@ public class AccessQueryImpl implements AccessibilityQueryImplementation {
         } else {
             FileObject obj = project.getProjectDirectory().getFileObject(MANIFEST_PATH);
             if (obj != null) {
-                InputStream in = null;
-                try {
-                    in = obj.getInputStream();
+                try (InputStream in = obj.getInputStream()) {
                     Manifest man = new Manifest();
                     man.read(in);
                     String value = man.getMainAttributes().getValue(ATTR_PUBLIC_PACKAGE);
                     toRet = prepareManifestPublicPackagesPatterns(value);
                 } catch (Exception ex) {
                     Exceptions.printStackTrace(ex);
-                } finally {
-                    IOUtil.close(in);
                 }
             }
         }

--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenWhiteListQueryImpl.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenWhiteListQueryImpl.java
@@ -44,7 +44,6 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.netbeans.api.annotations.common.NonNull;
@@ -367,18 +366,14 @@ public class MavenWhiteListQueryImpl implements WhiteListQueryImplementation {
     private Manifest getManifest(FileObject root) {
         FileObject manifestFo = root.getFileObject("META-INF/MANIFEST.MF");
         if (manifestFo != null) {
-            InputStream is = null;
-            try {
-                is = manifestFo.getInputStream();
-                return new Manifest(is);
+            try (InputStream is = manifestFo.getInputStream()) {
+                Manifest manifest = new Manifest(is);
+                return manifest;
             } catch (IOException ex) {
                 //Exceptions.printStackTrace(ex);
-            } finally {
-                IOUtil.close(is);
             }
         }
         return null;
-
     }
     
     private static class MavenWhiteListImplementation implements WhiteListImplementation {

--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NBMNativeMWI.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NBMNativeMWI.java
@@ -24,6 +24,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -32,7 +34,6 @@ import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.PluginManagement;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.netbeans.modules.apisupport.project.api.EditableManifest;
@@ -103,14 +104,10 @@ final class NBMNativeMWI {
             if (packageName != null) {
                 String path = packageName.replace(".", "/") + "/Bundle.properties";
                 mf.setAttribute("OpenIDE-Module-Localizing-Bundle", path, null);
-                BufferedOutputStream bos = null;
-                try {
-                    bos = new BufferedOutputStream(new FileOutputStream(new File(src, "manifest.mf")));
-                    mf.write(bos);
+                try (OutputStream os = new BufferedOutputStream(new FileOutputStream(new File(src, "manifest.mf")))) {
+                    mf.write(os);
                 } catch (IOException ex) {
                     Exceptions.printStackTrace(ex);
-                } finally {
-                    IOUtil.close(bos);
                 }
                 
             }
@@ -121,20 +118,13 @@ final class NBMNativeMWI {
                 String path = packageName.replace(".", File.separator);
                 File res = new File(src, path);
                 res.mkdirs();
-                OutputStream bos = null;
-                try {
-                    bos = new BufferedOutputStream(new FileOutputStream(new File(res, "Bundle.properties")));
+                try (OutputStream os = new BufferedOutputStream(new FileOutputStream(new File(res, "Bundle.properties")))) {
                     Properties p = new Properties();
-                    p.store(bos, EMPTY_BUNDLE_FILE);
-                    
+                    p.store(os, EMPTY_BUNDLE_FILE);
                 } catch (IOException ex) {
                     Exceptions.printStackTrace(ex);
-                } finally {
-                    IOUtil.close(bos);
                 }
-                
             }
-            
         }
     }
 

--- a/java/maven.checkstyle/nbproject/project.properties
+++ b/java/maven.checkstyle/nbproject/project.properties
@@ -14,5 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.source=11
+javac.target=11
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/java/maven.checkstyle/src/org/netbeans/modules/maven/checkstyle/Bundle.properties
+++ b/java/maven.checkstyle/src/org/netbeans/modules/maven/checkstyle/Bundle.properties
@@ -1,3 +1,4 @@
+OpenIDE-Module-Display-Category=Maven
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/java/maven.checkstyle/src/org/netbeans/modules/maven/format/checkstyle/AuxPropsImpl.java
+++ b/java/maven.checkstyle/src/org/netbeans/modules/maven/format/checkstyle/AuxPropsImpl.java
@@ -41,7 +41,6 @@ import org.apache.maven.model.ReportPlugin;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
-import org.codehaus.plexus.util.IOUtil;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.modules.maven.api.Constants;
@@ -93,14 +92,8 @@ public class AuxPropsImpl implements AuxiliaryProperties, PropertyChangeListener
         if (file == null) {
             file = cacheDir.createData("checkstyle-checker", "xml");
         }
-        InputStream inst = in;
-        OutputStream outst = null;
-        try {
-            outst = file.getOutputStream();
+        try (in; OutputStream outst = file.getOutputStream()) {
             FileUtil.copy(in, outst);
-        } finally {
-            IOUtil.close(inst);
-            IOUtil.close(outst);
         }
         return file;
     }
@@ -159,10 +152,8 @@ public class AuxPropsImpl implements AuxiliaryProperties, PropertyChangeListener
                                     RP.post(new Runnable() {
                                         @Override
                                         public void run() {
-                                            InputStream urlis = null;
-                                            try {
-                                                urlis = url.openStream();
-                                                byte[] arr = IOUtil.toByteArray(urlis);
+                                            try (InputStream urlis = url.openStream()) {
+                                                byte[] arr = urlis.readAllBytes();
                                                 synchronized (AuxPropsImpl.this) {
                                                     //#174401
                                                     ByteArrayInputStream bais = new ByteArrayInputStream(arr);
@@ -171,8 +162,6 @@ public class AuxPropsImpl implements AuxiliaryProperties, PropertyChangeListener
                                                 }
                                             } catch (IOException ex) {
                                                 ex.printStackTrace();
-                                            } finally {
-                                                IOUtil.close(urlis);
                                             }
                                         }
                                     });

--- a/java/maven.checkstyle/src/org/netbeans/modules/maven/format/checkstyle/ModuleConvertor.java
+++ b/java/maven.checkstyle/src/org/netbeans/modules/maven/format/checkstyle/ModuleConvertor.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.maven.format.checkstyle;
 
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
 import java.io.IOException;
 import java.io.InputStream;
@@ -103,7 +102,7 @@ private static String PROP_NEWLINE_WHILE = "org-netbeans-modules-editor-indent.t
                return is;
             }
         });
-        try {
+        try (checkstyleStream) {
             Document doc = bldr.build(checkstyleStream);
             Element root = doc.getRootElement();
             processModule(root, "", props);
@@ -114,8 +113,6 @@ private static String PROP_NEWLINE_WHILE = "org-netbeans-modules-editor-indent.t
             Exceptions.printStackTrace(ex);
         } catch (IOException ex) {
             Exceptions.printStackTrace(ex);
-        } finally {
-            IOUtil.close(checkstyleStream);
         }
         return props;
 

--- a/java/maven/src/org/netbeans/modules/maven/customizer/CustomizerProviderImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/CustomizerProviderImpl.java
@@ -34,7 +34,6 @@ import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.jdom2.DefaultJDOMFactory;
 import org.jdom2.Document;
@@ -415,10 +414,6 @@ public class CustomizerProviderImpl implements CustomizerProvider2 {
             @Override
             public void run() throws IOException {
                 JDOMFactory factory = new DefaultJDOMFactory();
-                
-                InputStream inStr = null;
-                FileLock lock = null;
-                OutputStreamWriter outStr = null;
                 try {
                     Document doc;
                     if (mapping.getActions().isEmpty()) { //#224450 don't write empty nbactions.xml files
@@ -434,19 +429,19 @@ public class CustomizerProviderImpl implements CustomizerProvider2 {
                         doc = factory.document(factory.element("actions")); //NOI18N
                     } else {
                         //TODO..
-                        inStr = fo.getInputStream();
-                        SAXBuilder builder = new SAXBuilder();
-                        doc = builder.build(inStr);
-                        inStr.close();
-                        inStr = null;
+                        try (InputStream inStr = fo.getInputStream()) {
+                            SAXBuilder builder = new SAXBuilder();
+                            doc = builder.build(inStr);
+                        }
                     }
-                    lock = fo.lock();
-                    NetbeansBuildActionJDOMWriter writer = new NetbeansBuildActionJDOMWriter();
                     String encoding = mapping.getModelEncoding() != null ? mapping.getModelEncoding() : "UTF-8"; //NOI18N
-                    outStr = new OutputStreamWriter(fo.getOutputStream(lock), encoding);
-                    Format form = Format.getRawFormat().setEncoding(encoding);
-                    form = form.setLineSeparator(System.getProperty("line.separator")); //NOI18N
-                    writer.write(mapping, doc, outStr, form);
+                    try (FileLock lock = fo.lock();
+                            OutputStreamWriter outStr = new OutputStreamWriter(fo.getOutputStream(lock), encoding);) {
+                        NetbeansBuildActionJDOMWriter writer = new NetbeansBuildActionJDOMWriter();
+                        Format form = Format.getRawFormat().setEncoding(encoding);
+                        form = form.setLineSeparator(System.getProperty("line.separator")); //NOI18N
+                        writer.write(mapping, doc, outStr, form);
+                    }
                 } catch (JDOMException exc){
                     //throw (IOException) new IOException("Cannot parse the nbactions.xml by JDOM.").initCause(exc); //NOI18N
                     //TODO this would need it's own problem provider, but how to access it in project lookup if all are merged into one?
@@ -461,13 +456,6 @@ public class CustomizerProviderImpl implements CustomizerProvider2 {
                         impl.addReport(rep);
                     }
                     Logger.getLogger(CustomizerProviderImpl.class.getName()).log(Level.INFO, exc.getMessage(), exc);
-                } finally {
-                    IOUtil.close(inStr);
-                    IOUtil.close(outStr);
-                    if (lock != null) {
-                        lock.releaseLock();
-                    }
-                    
                 }
             }
         });


### PR DESCRIPTION
- Use `try-with-resources` instead of `IOUtil.close()` method
- Use `readAllBytes()` instead of `IOUtil.toByteArray()`
- Bump `javac.source` and `javac.target` to version 11 in module `maven.checkstyle`. Needed for method `readAllBytes()` and to use a variable inside `try-with-resources`
- Add `Maven` as a display category to the module `maven.checkstyle`

NetBeans Testing:

- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Verify Sigtests
- Verify successful execution of unit tests for modules `maven.apisupport`, `maven.checkstyle`, and `maven`
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS