### PR TITLE
Integrate hints preferences option in the vscode extension

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -2093,7 +2093,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
             String path = pathPrimitive.getAsString();
             Path p = Paths.get(path);
             FileObject preferencesFile = FileUtil.toFileObject(p);
-            if (preferencesFile != null && preferencesFile.isValid() && preferencesFile.canRead() && preferencesFile.getName().endsWith(".xml")) {
+            if (preferencesFile != null && preferencesFile.isValid() && preferencesFile.canRead() && preferencesFile.getExt().equals("xml")) {
                 this.hintsPrefsFile = preferencesFile;
             }
             else {

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -183,6 +183,11 @@
 					"description": "Path to the file containing exported formatter settings",
 					"default": null
 				},
+				"netbeans.hints.preferences": {
+					"type": "string",
+					"description": "Path to the file containing exported hints preferences",
+					"default": null
+				},
 				"netbeans.java.onSave.organizeImports": {
 					"type": "boolean",
 					"default": true,

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -1000,6 +1000,7 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
         documentSelector: documentSelectors,
         synchronize: {
             configurationSection: [
+                'netbeans.hints',
                 'netbeans.format',
                 'netbeans.java.imports',
                 'java+.runConfig.vmOptions'


### PR DESCRIPTION
I had earlier raised a PR for Computing hints based on custom preferences https://github.com/apache/netbeans/pull/6760, but forgot to push the changes to integrate it with vscode extension. 
So, here is the patch for that.
