### PR TITLE
Fixes all deprecated API usage in libs.jgit and update gitignore IO code

### DIFF
--- a/ide/libs.git/nbproject/project.properties
+++ b/ide/libs.git/nbproject/project.properties
@@ -17,7 +17,8 @@
 
 is.autoload=true
 
-javac.source=1.8
+javac.source=11
+javac.target=11
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/libs.git/src/org/netbeans/libs/git/GitBranch.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/GitBranch.java
@@ -91,4 +91,16 @@ public final class GitBranch {
     void setTrackedBranch (GitBranch trackedBranch) {
         this.trackedBranch = trackedBranch;
     }
+
+    @Override
+    public String toString() {
+        return "GitBranch{"
+                + "name=" + name
+                + ", id=" + getId()
+                + ", remote=" + remote
+                + ", active=" + active
+                + ", trackedBranch=" + trackedBranch
+                + '}';
+    }
+
 }

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/IgnoreRule.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/IgnoreRule.java
@@ -29,10 +29,10 @@ public class IgnoreRule extends org.eclipse.jgit.ignore.FastIgnoreRule {
     private final String noNegationPattern;
     
     public IgnoreRule (String pattern) {
-        super(pattern.trim());
+        super(pattern.strip());
         this.pattern = pattern;
-        pattern = pattern.trim();
-        this.noNegationPattern = pattern.startsWith("!") ? pattern.substring(1) : null;
+        String neg = pattern.strip();
+        this.noNegationPattern = neg.startsWith("!") ? neg.substring(1) : null;
     }
 
     public String getPattern (boolean preprocess) {
@@ -50,7 +50,7 @@ public class IgnoreRule extends org.eclipse.jgit.ignore.FastIgnoreRule {
 
     @Override
     public boolean isMatch(String target, boolean isDirectory) {
-        String trimmed = pattern.trim();
+        String trimmed = pattern.strip();
         if (trimmed.isEmpty() || trimmed.startsWith("#")) {
             // this is a comment or an empty line
             return false;

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/Utils.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/Utils.java
@@ -442,7 +442,7 @@ public final class Utils {
         }
     }
 
-    public static Map getAllBranches (Repository repository, GitClassFactory fac, ProgressMonitor monitor) throws GitException {
+    public static Map<String, GitBranch> getAllBranches(Repository repository, GitClassFactory fac, ProgressMonitor monitor) throws GitException {
         ListBranchCommand cmd = new ListBranchCommand(repository, fac, true, monitor);
         cmd.execute();
         return cmd.getBranches();

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/AddCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/AddCommand.java
@@ -110,7 +110,7 @@ public class AddCommand extends GitCommand {
                         if (f != null) { // the file exists
                             File file = new File(repository.getWorkTree().getAbsolutePath() + File.separator + path);
                             DirCacheEntry entry = new DirCacheEntry(path);
-                            entry.setLastModified(f.getEntryLastModified());
+                            entry.setLastModified(f.getEntryLastModifiedInstant());
                             int fm = f.getEntryFileMode().getBits();
                             long sz = f.getEntryLength();
                             Path p = null;
@@ -129,7 +129,7 @@ public class AddCommand extends GitCommand {
                                 entry.setLength(0);
                                 BasicFileAttributes attrs = Files.readAttributes(p, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
                                 if (attrs != null) {
-                                    entry.setLastModified(attrs.lastModifiedTime().toMillis());
+                                    entry.setLastModified(attrs.lastModifiedTime().toInstant());
                                 }
                                 entry.setObjectId(inserter.insert(Constants.OBJ_BLOB, Constants.encode(link.toString())));
                             } else if ((f.getEntryFileMode().getBits() & FileMode.TYPE_TREE) == FileMode.TYPE_TREE) {
@@ -153,7 +153,7 @@ public class AddCommand extends GitCommand {
                                 }
                             }
                             ObjectId oldId = treeWalk.getObjectId(0);
-                            if (ObjectId.equals(oldId, ObjectId.zeroId()) || !ObjectId.equals(oldId, entry.getObjectId())) {
+                            if (ObjectId.isEqual(oldId, ObjectId.zeroId()) || !ObjectId.isEqual(oldId, entry.getObjectId())) {
                                 listener.notifyFile(file, path);
                             }
                             builder.add(entry);

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/CheckoutRevisionCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/CheckoutRevisionCommand.java
@@ -71,6 +71,8 @@ import org.netbeans.libs.git.jgit.Utils;
 import org.netbeans.libs.git.progress.FileListener;
 import org.netbeans.libs.git.progress.ProgressMonitor;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  *
  * @author ondra
@@ -325,7 +327,7 @@ public class CheckoutRevisionCommand extends GitCommand {
                     DirCacheEntry e = new DirCacheEntry(path);
                     e.setCreationTime(theirs.getCreationTime());
                     e.setFileMode(theirs.getFileMode());
-                    e.setLastModified(theirs.getLastModified());
+                    e.setLastModified(theirs.getLastModifiedInstant());
                     e.setLength(theirs.getLength());
                     e.setObjectId(theirs.getObjectId());
                     builder.add(e);
@@ -360,8 +362,7 @@ public class CheckoutRevisionCommand extends GitCommand {
         try (OutputStream fos = opt.getAutoCRLF() != CoreConfig.AutoCRLF.FALSE
                 ? new AutoCRLFOutputStream(new FileOutputStream(file))
                 : new FileOutputStream(file)) {
-            format.formatMerge(fos, merge, Arrays.asList(new String[] { "BASE", "OURS", "THEIRS" }), //NOI18N
-                    Constants.CHARACTER_ENCODING);
+            format.formatMerge(fos, merge, Arrays.asList(new String[] { "BASE", "OURS", "THEIRS" }), UTF_8); //NOI18N
         }
     }
 }

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/ConflictCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/ConflictCommand.java
@@ -46,13 +46,11 @@ import org.netbeans.libs.git.progress.StatusListener;
 public class ConflictCommand extends StatusCommand {
 
     private final ProgressMonitor monitor;
-    private final StatusListener listener;
     private final File[] roots;
 
     public ConflictCommand (Repository repository, GitClassFactory gitFactory, File[] roots, ProgressMonitor monitor, StatusListener listener) {
         super(repository, Constants.HEAD, roots, gitFactory, monitor, listener);
         this.monitor = monitor;
-        this.listener = listener;
         this.roots = roots;
     }
 
@@ -93,7 +91,7 @@ public class ConflictCommand extends StatusCommand {
                     DirCacheIterator indexIterator = treeWalk.getTree(0, DirCacheIterator.class);
                     DirCacheEntry indexEntry = indexIterator != null ? indexIterator.getDirCacheEntry() : null;
                     int stage = indexEntry == null ? 0 : indexEntry.getStage();
-                    long indexTS = indexEntry == null ? -1 : indexEntry.getLastModified();
+                    long indexTS = indexEntry == null ? -1 : indexEntry.getLastModifiedInstant().toEpochMilli();
 
                     if (stage != 0) {
                         GitStatus status = getClassFactory().createStatus(true, path, workTreePath, file,

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/DeleteTagCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/DeleteTagCommand.java
@@ -19,6 +19,7 @@
 package org.netbeans.libs.git.jgit.commands;
 
 import java.io.IOException;
+import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.RefUpdate;
 import org.eclipse.jgit.lib.RefUpdate.Result;
@@ -35,23 +36,21 @@ import org.netbeans.libs.git.progress.ProgressMonitor;
  */
 public class DeleteTagCommand extends GitCommand {
     private final String tagName;
-    private GitRefUpdateResult result;
 
-    public DeleteTagCommand (Repository repository, GitClassFactory gitFactory, String tagName, ProgressMonitor monitor) {
+    public DeleteTagCommand(Repository repository, GitClassFactory gitFactory, String tagName, ProgressMonitor monitor) {
         super(repository, gitFactory, monitor);
         this.tagName = tagName;
     }
 
     @Override
-    protected void run () throws GitException {
+    protected void run() throws GitException {
         Repository repository = getRepository();
-        Ref currentRef = repository.getTags().get(tagName);
-        if (currentRef == null) {
-            throw new GitException.MissingObjectException(tagName, GitObjectType.TAG);
-        }
-        String fullName = currentRef.getName();
         try {
-            RefUpdate update = repository.updateRef(fullName);
+            Ref currentRef = repository.exactRef(Constants.R_TAGS + tagName);
+            if (currentRef == null) {
+                throw new GitException.MissingObjectException(tagName, GitObjectType.TAG);
+            }
+            RefUpdate update = repository.updateRef(currentRef.getName());
             update.setRefLogMessage("tag deleted", false);
             update.setForceUpdate(true);
             Result deleteResult = update.delete();
@@ -69,7 +68,7 @@ public class DeleteTagCommand extends GitCommand {
     }
 
     @Override
-    protected String getCommandDescription () {
+    protected String getCommandDescription() {
         return "git tag -d " + tagName;
     }
 }

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/IgnoreUnignoreCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/IgnoreUnignoreCommand.java
@@ -27,6 +27,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -64,7 +65,7 @@ public abstract class IgnoreUnignoreCommand extends GitCommand {
         super(repository, gitFactory, monitor);
         this.files = files;
         this.monitor = monitor;
-        this.ignoreFiles = new LinkedHashSet<File>();
+        this.ignoreFiles = new LinkedHashSet<>();
         this.listener = listener;
     }
 
@@ -133,7 +134,7 @@ public abstract class IgnoreUnignoreCommand extends GitCommand {
         BufferedWriter bw = null;
         File tmpFile = Files.createTempFile(gitIgnore.getParentFile().toPath(), Constants.DOT_GIT_IGNORE, "tmp").toFile(); //NOI18N
         try {
-            bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(tmpFile), Constants.CHARSET));
+            bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(tmpFile), StandardCharsets.UTF_8));
             for (ListIterator<IgnoreRule> it = ignoreRules.listIterator(); it.hasNext(); ) {
                 String s = it.next().getPattern(false);
                 bw.write(s, 0, s.length());
@@ -169,11 +170,11 @@ public abstract class IgnoreUnignoreCommand extends GitCommand {
     }
 
     private List<IgnoreRule> parse (File gitIgnore) throws IOException {
-        List<IgnoreRule> rules = new LinkedList<IgnoreRule>();
+        List<IgnoreRule> rules = new LinkedList<>();
         if (gitIgnore.exists()) {
             BufferedReader br = null;
             try {
-                br = new BufferedReader(new InputStreamReader(new FileInputStream(gitIgnore), Constants.CHARSET));
+                br = new BufferedReader(new InputStreamReader(new FileInputStream(gitIgnore), StandardCharsets.UTF_8));
                 String txt;
                 while ((txt = br.readLine()) != null) {
                     rules.add(new IgnoreRule(txt));

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/IgnoreUnignoreCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/IgnoreUnignoreCommand.java
@@ -22,21 +22,19 @@ package org.netbeans.libs.git.jgit.commands;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.eclipse.jgit.ignore.IgnoreNode.MatchResult;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.CoreConfig;
@@ -105,7 +103,7 @@ public abstract class IgnoreUnignoreCommand extends GitCommand {
     private void changeIgnoreStatus (File f) throws IOException {
         File parent = f;
         boolean isDirectory = f.isDirectory() && (! Files.isSymbolicLink(f.toPath()));
-        StringBuilder sb = new StringBuilder('/');
+        StringBuilder sb = new StringBuilder();
         if (isDirectory) {
             sb.append('/');
         }
@@ -130,68 +128,56 @@ public abstract class IgnoreUnignoreCommand extends GitCommand {
         return addStatement(ignoreRules, gitIgnore, path, isDirectory, forceWrite, true) == MatchResult.CHECK_PARENT;
     }
 
-    protected final void save (File gitIgnore, List<IgnoreRule> ignoreRules) throws IOException {
-        BufferedWriter bw = null;
-        File tmpFile = Files.createTempFile(gitIgnore.getParentFile().toPath(), Constants.DOT_GIT_IGNORE, "tmp").toFile(); //NOI18N
+    protected final void save(File gitIgnore, List<IgnoreRule> ignoreRules) throws IOException {
         try {
-            bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(tmpFile), StandardCharsets.UTF_8));
-            for (ListIterator<IgnoreRule> it = ignoreRules.listIterator(); it.hasNext(); ) {
-                String s = it.next().getPattern(false);
-                bw.write(s, 0, s.length());
-                bw.newLine();
-            }
-        } finally {
-            if (bw != null) {
-                try {
-                    bw.close();
-                } catch (IOException ex) { }
-            }
-            if (!tmpFile.renameTo(gitIgnore)) {
-                // cannot rename directly, try backup and delete te original .gitignore
-                File tmpCopy = generateTempFile(Constants.DOT_GIT_IGNORE, gitIgnore.getParentFile()); //NOI18N
-                boolean success = false;
-                if (gitIgnore.renameTo(tmpCopy)) {
-                    // and try to rename again
-                    success = tmpFile.renameTo(gitIgnore);
-                    if (!success) {
-                        // restore te original .gitignore file
-                        tmpCopy.renameTo(gitIgnore);
+            Path tmpFile = Files.createTempFile(gitIgnore.getParentFile().toPath(), Constants.DOT_GIT_IGNORE, "tmp"); //NOI18N
+            try {
+                String lineSeparator = probeLineSeparator(gitIgnore.toPath());
+                try (BufferedWriter writer = Files.newBufferedWriter(tmpFile)) {
+                    for (IgnoreRule rule : ignoreRules) {
+                        writer.write(rule.getPattern(false));
+                        writer.write(lineSeparator);
                     }
-                    tmpCopy.delete();
                 }
-                if (!success) {
-                    tmpFile.delete();
-                    throw new IOException("Cannot write to " + gitIgnore.getAbsolutePath());
-                }
+                Files.move(tmpFile, gitIgnore.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            } finally {
+                Files.deleteIfExists(tmpFile);
             }
-
+        } catch (IOException ex) {
+            throw new IOException("Cannot update .gitignore at " + gitIgnore.getAbsolutePath(), ex);
         }
         ignoreFiles.add(gitIgnore);
     }
 
-    private List<IgnoreRule> parse (File gitIgnore) throws IOException {
-        List<IgnoreRule> rules = new LinkedList<>();
+    private List<IgnoreRule> parse(File gitIgnore) throws IOException {
         if (gitIgnore.exists()) {
-            BufferedReader br = null;
-            try {
-                br = new BufferedReader(new InputStreamReader(new FileInputStream(gitIgnore), StandardCharsets.UTF_8));
-                String txt;
-                while ((txt = br.readLine()) != null) {
-                    rules.add(new IgnoreRule(txt));
-                }
-            } finally {
-                if (br != null) {
-                    try {
-                        br.close();
-                    } catch (IOException ex) { }
+            try (Stream<String> lines = Files.lines(gitIgnore.toPath())) {
+                return lines.map(IgnoreRule::new)
+                            .collect(Collectors.toCollection(LinkedList::new));
+            }
+        }
+        return new LinkedList<>();
+    }
+
+    @SuppressWarnings("NestedAssignment")
+    private static String probeLineSeparator(Path file) throws IOException {
+        if (Files.exists(file)) {
+            try (BufferedReader br = Files.newBufferedReader(file)) {
+                int current;
+                int last = -1;
+                while ((current = br.read()) != -1) {
+                    if (current == '\n') {
+                        return last == '\r' ? "\r\n" : "\n";
+                    }
+                    last = current;
                 }
             }
         }
-        return rules;
+        return System.lineSeparator();
     }
 
     public File[] getModifiedIgnoreFiles () {
-        return ignoreFiles.toArray(new File[0]);
+        return ignoreFiles.toArray(File[]::new);
     }
 
     protected abstract MatchResult addStatement (List<IgnoreRule> ignoreRules, File gitIgnore, String path, boolean isDirectory, boolean forceWrite, boolean writable) throws IOException;
@@ -213,14 +199,6 @@ public abstract class IgnoreUnignoreCommand extends GitCommand {
             return addStatement(ignoreRules, excludeFile, path, directory, false, false);
         }
         return MatchResult.NOT_IGNORED;
-    }
-
-    private File generateTempFile (String basename, File parent) {
-        File tempFile = new File(parent, basename);
-        while (tempFile.exists()) {
-            tempFile = new File(parent, basename + Long.toString(System.currentTimeMillis()));
-        }
-        return tempFile;
     }
 
     private File getGlobalExcludeFile () {

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/LogCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/LogCommand.java
@@ -165,7 +165,7 @@ public class LogCommand extends GitCommand {
                         fullWalk.parseCommit(commit), branches, repository)
                     );
                     if (commit.getParentCount() == 0) {
-                        Ref replace = repository.getAllRefs().get("refs/replace/" + commit.getId().getName());
+                        Ref replace = repository.exactRef("refs/replace/" + commit.getId().getName());
                         if (replace != null) {
                             final RevCommit newCommit = Utils.findCommit(repository, replace.getTarget().getName());
                             if (newCommit != null) {

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/ResetCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/ResetCommand.java
@@ -22,6 +22,7 @@ package org.netbeans.libs.git.jgit.commands;
 import java.io.File;
 import java.io.IOException;
 import java.text.MessageFormat;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -32,7 +33,6 @@ import org.eclipse.jgit.dircache.DirCache;
 import org.eclipse.jgit.dircache.DirCacheBuildIterator;
 import org.eclipse.jgit.dircache.DirCacheBuilder;
 import org.eclipse.jgit.dircache.DirCacheEntry;
-import org.eclipse.jgit.errors.CorruptObjectException;
 import org.eclipse.jgit.errors.NoWorkTreeException;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.FileMode;
@@ -128,7 +128,7 @@ public class ResetCommand extends GitCommand {
                             treeWalk.reset();
                             treeWalk.addTree(new DirCacheBuildIterator(builder));
                             treeWalk.addTree(commit.getTree());
-                            List<File> toDelete = new LinkedList<File>();
+                            List<File> toDelete = new LinkedList<>();
                             String lastAddedPath = null;
                             while (treeWalk.next() && !monitor.isCanceled()) {
                                 File path = new File(repository.getWorkTree(), treeWalk.getPathString());
@@ -159,7 +159,7 @@ public class ResetCommand extends GitCommand {
                                         DirCacheEntry e = new DirCacheEntry(treeWalk.getPathString());
                                         AbstractTreeIterator it = treeWalk.getTree(1, AbstractTreeIterator.class);
                                         e.setFileMode(it.getEntryFileMode());
-                                        e.setLastModified(System.currentTimeMillis());
+                                        e.setLastModified(Instant.now());
                                         e.setObjectId(it.getEntryObjectId());
                                         e.smudgeRacilyClean();
                                         builder.add(e);
@@ -216,17 +216,13 @@ public class ResetCommand extends GitCommand {
                     }
                 }
             }
-        } catch (NoWorkTreeException ex) {
-            throw new GitException(ex);
-        } catch (CorruptObjectException ex) {
-            throw new GitException(ex);
-        } catch (IOException ex) {
+        } catch (NoWorkTreeException | IOException ex) {
             throw new GitException(ex);
         }
     }
 
     private void deleteFile (File file, File[] roots) {
-        Set<File> rootFiles = new HashSet<File>(Arrays.asList(roots));
+        Set<File> rootFiles = new HashSet<>(Arrays.asList(roots));
         File[] children;
         while (file != null && !rootFiles.contains(file) && ((children = file.listFiles()) == null || children.length == 0)) {
             // file is an empty folder

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/RevertCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/RevertCommand.java
@@ -104,7 +104,7 @@ public class RevertCommand extends GitCommand {
                     ? "Revert \"" + revertedCommit.getShortMessage() + "\"" + "\n\n" + "This reverts commit " + revertedCommit.getId().getName() + "." //NOI18N
                     : message;
             if (merger.merge(headCommit, srcParent)) {
-                if (AnyObjectId.equals(headCommit.getTree().getId(), merger.getResultTreeId())) {
+                if (AnyObjectId.isEqual(headCommit.getTree().getId(), merger.getResultTreeId())) {
                     result = NO_CHANGE_INSTANCE;
                 } else {
                     DirCacheCheckout dco = new DirCacheCheckout(repository, headCommit.getTree(), dc = repository.lockDirCache(), merger.getResultTreeId());
@@ -123,7 +123,7 @@ public class RevertCommand extends GitCommand {
                             merger.getMergeResults() == null ? null : getFiles(repository.getWorkTree(), merger.getMergeResults().keySet()),
                             getFiles(repository.getWorkTree(), merger.getFailingPaths().keySet()));
                 } else {
-                    String mergeMessageWithConflicts = new MergeMessageFormatter().formatWithConflicts(commitMessage, merger.getUnmergedPaths());
+                    String mergeMessageWithConflicts = new MergeMessageFormatter().formatWithConflicts(commitMessage, merger.getUnmergedPaths(), '#');
                     repository.writeMergeCommitMsg(mergeMessageWithConflicts);
                     result = getClassFactory().createRevertResult(GitRevertResult.Status.CONFLICTING, null, 
                             merger.getMergeResults() == null ? null : getFiles(repository.getWorkTree(), merger.getMergeResults().keySet()),

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/StatusCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/StatusCommand.java
@@ -246,7 +246,7 @@ public class StatusCommand extends GitCommand {
                     }
 
                     int stage = indexEntry == null ? 0 : indexEntry.getStage();
-                    long indexTimestamp = indexEntry == null ? -1 : indexEntry.getLastModified();
+                    long indexTimestamp = indexEntry == null ? -1 : indexEntry.getLastModifiedInstant().toEpochMilli();
 
                     GitStatus status = getClassFactory().createStatus(tracked, path, workTreePath, file,
                             statusHeadIndex, statusIndexWC, statusHeadWC,

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/UpdateRefCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/UpdateRefCommand.java
@@ -46,7 +46,7 @@ public class UpdateRefCommand extends GitCommand {
     }
 
     @Override
-    protected void run () throws GitException {
+    protected void run() throws GitException {
         Repository repository = getRepository();
         try {
             
@@ -68,7 +68,7 @@ public class UpdateRefCommand extends GitCommand {
             }
             
             RefUpdate u = repository.updateRef(ref.getName());
-            newRef = repository.peel(newRef);
+            newRef = repository.getRefDatabase().peel(newRef);
             ObjectId srcObjectId = newRef.getPeeledObjectId();
             if (srcObjectId == null) {
                 srcObjectId = newRef.getObjectId();
@@ -85,11 +85,11 @@ public class UpdateRefCommand extends GitCommand {
     }
 
     @Override
-    protected String getCommandDescription () {
-        return new StringBuilder("git update-ref ").append(refName).append(" ").append(revision).toString(); //NOI18N
+    protected String getCommandDescription() {
+        return "git update-ref "+ refName + " " + revision; //NOI18N
     }
 
-    public GitRefUpdateResult getResult () {
+    public GitRefUpdateResult getResult() {
         return result;
     }
     

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/utils/CheckoutIndex.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/utils/CheckoutIndex.java
@@ -23,9 +23,8 @@ import java.io.File;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Collection;
-import java.util.logging.Logger;
+import org.eclipse.jgit.dircache.Checkout;
 import org.eclipse.jgit.dircache.DirCache;
-import org.eclipse.jgit.dircache.DirCacheCheckout;
 import org.eclipse.jgit.dircache.DirCacheEntry;
 import org.eclipse.jgit.dircache.DirCacheIterator;
 import org.eclipse.jgit.lib.FileMode;
@@ -52,7 +51,6 @@ public class CheckoutIndex {
     private final ProgressMonitor monitor;
     private final boolean checkContent;
     private final boolean recursively;
-    private static final Logger LOG = Logger.getLogger(CheckoutIndex.class.getName());
 
     public CheckoutIndex (Repository repository, DirCache cache, File[] roots, boolean recursively, FileListener listener, ProgressMonitor monitor, boolean checkContent) {
         this.repository = repository;
@@ -118,7 +116,9 @@ public class CheckoutIndex {
             }
             file.createNewFile();
             if (file.isFile()) {
-                DirCacheCheckout.checkoutEntry(repository, e, od);
+                new Checkout(repository)
+                        .setRecursiveDeletion(false)
+                        .checkout(e, null, od, null);
             } else {
                 monitor.notifyError(MessageFormat.format(Utils.getBundle(CheckoutIndex.class).getString("MSG_Warning_CannotCreateFile"), file.getAbsolutePath())); //NOI18N
             }
@@ -152,7 +152,4 @@ public class CheckoutIndex {
         return false;
     }
 
-    private static boolean isWindows () {
-        return System.getProperty("os.name", "").toLowerCase().contains("windows"); //NOI18N
-    }
 }

--- a/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/AbstractGitTestCase.java
+++ b/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/AbstractGitTestCase.java
@@ -219,8 +219,8 @@ public class AbstractGitTestCase extends NbTestCase {
             DirCacheEntry e = cache.getEntry(relativePath);
             assertNotNull(e);
             assertEquals(relativePath, e.getPathString());
-            if (f.lastModified() != e.getLastModified()) {
-                assertEquals((f.lastModified() / 1000) * 1000, (e.getLastModified() / 1000) * 1000);
+            if (f.lastModified() != e.getLastModifiedInstant().toEpochMilli()) {
+                assertEquals((f.lastModified() / 1000) * 1000, (e.getLastModifiedInstant().toEpochMilli() / 1000) * 1000);
             }
             try (InputStream in = new FileInputStream(f)) {
                 assertEquals(e.getObjectId(), repository.newObjectInserter().idFor(Constants.OBJ_BLOB, f.length(), in));

--- a/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/AddTest.java
+++ b/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/AddTest.java
@@ -525,7 +525,7 @@ public class AddTest extends AbstractGitTestCase {
         DirCacheEntry e = repository.readDirCache().getEntry(link.getName());
         assertEquals(FileMode.SYMLINK, e.getFileMode());
         ObjectId id = e.getObjectId();
-        assertTrue((ts - 1000) < e.getLastModified() && (ts + 1000) > e.getLastModified());
+        assertTrue((ts - 1000) < e.getLastModifiedInstant().toEpochMilli() && (ts + 1000) > e.getLastModifiedInstant().toEpochMilli());
         try(ObjectReader reader = repository.getObjectDatabase().newReader()) {
             assertTrue(reader.has(e.getObjectId()));
             byte[] bytes = reader.open(e.getObjectId()).getBytes();
@@ -541,7 +541,7 @@ public class AddTest extends AbstractGitTestCase {
             assertEquals(FileMode.SYMLINK, e2.getFileMode());
             assertEquals(id, e2.getObjectId());
             assertEquals(0, e2.getLength());
-            assertTrue((ts - 1000) < e2.getLastModified() && (ts + 1000) > e2.getLastModified());
+            assertTrue((ts - 1000) < e.getLastModifiedInstant().toEpochMilli() && (ts + 1000) > e.getLastModifiedInstant().toEpochMilli());
             assertTrue(reader.has(e2.getObjectId()));
             bytes = reader.open(e2.getObjectId()).getBytes();
             assertEquals(path, RawParseUtils.decode(bytes));

--- a/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CheckoutTest.java
+++ b/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CheckoutTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.dircache.Checkout;
 import org.eclipse.jgit.dircache.DirCache;
 import org.eclipse.jgit.dircache.DirCacheCheckout;
 import org.eclipse.jgit.dircache.DirCacheEntry;
@@ -357,7 +358,9 @@ public class CheckoutTest extends AbstractGitTestCase {
         WindowCacheConfig cfg = new WindowCacheConfig();
         cfg.setStreamFileThreshold((int) large.length() - 1);
         cfg.install();
-        DirCacheCheckout.checkoutEntry(repository, e, repository.newObjectReader());
+        new Checkout(repository)
+                .setRecursiveDeletion(false)
+                .checkout(e, null, repository.newObjectReader(), null);
     }
     
     public void testCheckoutBranch () throws Exception {

--- a/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CommitTest.java
+++ b/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CommitTest.java
@@ -21,6 +21,7 @@ package org.netbeans.libs.git.jgit.commands;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -492,7 +493,7 @@ public class CommitTest extends AbstractGitTestCase {
             DirCacheBuilder builder = cache.builder();
             DirCacheEntry e = new DirCacheEntry(f.getName(), 1);
             e.setLength(0);
-            e.setLastModified(0);
+            e.setLastModified(Instant.ofEpochMilli(0));
             e.setFileMode(FileMode.REGULAR_FILE);
             builder.add(e);
             builder.finish();

--- a/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/FetchTest.java
+++ b/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/FetchTest.java
@@ -234,8 +234,8 @@ public class FetchTest extends AbstractGitTestCase {
         RevTag tag = new RevWalk(repo).parseTag(ref.getObjectId());
         
         Map<String, GitTransportUpdate> updates = client.fetch("origin", NULL_PROGRESS_MONITOR);
-        Map<String, Ref> tags = repository.getTags();
-        assertEquals(tag.getId(), tags.get(tag.getTagName()).getTarget().getObjectId());
+        Ref tagRef = repository.getRefDatabase().findRef(tag.getTagName());
+        assertEquals(tag.getId(), tagRef.getTarget().getObjectId());
         assertEquals(1, updates.size());
         assertUpdate(updates.get(tag.getTagName()), tag.getTagName(), tag.getTagName(), tag.getId().getName(), null, new URIish(otherWT.toURI().toURL()).toString(), Type.TAG, GitRefUpdateResult.NEW);
     }

--- a/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/IgnoreTest.java
+++ b/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/IgnoreTest.java
@@ -21,6 +21,8 @@ package org.netbeans.libs.git.jgit.commands;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Map;
 import org.eclipse.jgit.lib.ConfigConstants;
@@ -597,5 +599,27 @@ public class IgnoreTest extends AbstractGitTestCase {
         File[] ignores = getClient(workDir).ignore(new File[] { f }, NULL_PROGRESS_MONITOR);
         assertTrue(gitIgnore.exists());
         assertTrue("The .gitignore file should ends with an empty new line.",containsCRorLF(gitIgnore));
+    }
+
+    public void testUpdateRetainsFileSpecificLineSeparators1() throws Exception {
+        checkLineSeparatorRetention("\r\n");
+    }
+
+    public void testUpdateRetainsFileSpecificLineSeparators2() throws Exception {
+        checkLineSeparatorRetention("\n");
+    }
+
+    private void checkLineSeparatorRetention(String lineSeparator) throws Exception {
+        Path gitignore = workDir.toPath().resolve(Constants.DOT_GIT_IGNORE);
+        Path toIgnore = workDir.toPath().resolve("file");
+        String firstLine = "#comment" + lineSeparator;
+        String secondLine = "/file" + lineSeparator;
+        Files.writeString(gitignore, firstLine);
+        Files.writeString(toIgnore, "ignore");
+        getClient(workDir).ignore(new File[] { toIgnore.toFile() }, NULL_PROGRESS_MONITOR);
+
+        String postUpdate = Files.readString(gitignore);
+        assertEquals(firstLine, postUpdate.substring(0, firstLine.length()));
+        assertEquals(secondLine, postUpdate.substring(firstLine.length(), firstLine.length() + secondLine.length()));
     }
 }

--- a/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/LogTest.java
+++ b/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/LogTest.java
@@ -22,7 +22,6 @@ package org.netbeans.libs.git.jgit.commands;
 import java.io.File;
 import java.io.IOException;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.Map;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.PersonIdent;
@@ -764,6 +763,11 @@ public class LogTest extends AbstractGitTestCase {
         
         client.checkoutRevision("newbranch", true, NULL_PROGRESS_MONITOR);
         write(f, "modification on branch");
+        // git commit timestamp resolution is one second.
+        // commits with the same time stamp don't seem to influence log order unless branches
+        // change between commits. In that case the branch name is also affecting the order.
+        // (renaming "newbranch" to "aaa" would fix this too but obfuscate the problem)
+        Thread.sleep(1100);
         add(files);
         commit(files);
         

--- a/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/ResetTest.java
+++ b/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/ResetTest.java
@@ -487,7 +487,7 @@ public class ResetTest extends AbstractGitTestCase {
         DirCacheEntry e1 = new DirCacheEntry(file.getName(), 1);
         e1.setCreationTime(e.getCreationTime());
         e1.setFileMode(e.getFileMode());
-        e1.setLastModified(e.getLastModified());
+        e1.setLastModified(e.getLastModifiedInstant());
         e1.setLength(e.getLength());
         e1.setObjectId(e.getObjectId());
         builder.add(e1);


### PR DESCRIPTION
first commit:
 - remove deprecated jgit api usage
 - fixed all other compiler warnings too (edit: only in `libs.jgit` :))

second commit:
 - renovate the git ignore/unignore IO code
 - make sure the file specific line separators are retained during file updates

I tested (stepped through it) some of it manually: list/switch branches, list/add/remove tags

lets see what tests say