### PR TITLE
Refactoring pom.xml as well when renaming class inside editor

### DIFF
--- a/java/maven.model/nbproject/project.xml
+++ b/java/maven.model/nbproject/project.xml
@@ -225,6 +225,7 @@
                 <friend>org.netbeans.modules.maven.jaxws</friend>
                 <friend>org.netbeans.modules.maven.osgi</friend>
                 <friend>org.netbeans.modules.maven.persistence</friend>
+                <friend>org.netbeans.modules.maven.refactoring</friend>
                 <friend>org.netbeans.modules.maven.repository</friend>
                 <friend>org.netbeans.modules.maven.refactoring</friend>
                 <friend>org.netbeans.modules.selenium.maven</friend>

--- a/java/maven.refactoring/nbproject/project.xml
+++ b/java/maven.refactoring/nbproject/project.xml
@@ -100,7 +100,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.26</specification-version>
+                        <specification-version>1.68</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
When we currently rename any class inside the vscode editor, it refactors the file name, class name and other places where the class name is used, but it doesn't update the pom.xml in a maven project. So, this PR tries to address that issue.

For more info : https://github.com/oracle/javavscode/issues/30
