### PR TITLE
Fix empty Test Results with maven surefire plugin.

### DIFF
--- a/java/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputListenerProvider.java
+++ b/java/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputListenerProvider.java
@@ -103,7 +103,7 @@ public class JUnitOutputListenerProvider implements OutputProcessor {
     private static final String GROUP_FILE_NAME = "dir";
     
     public JUnitOutputListenerProvider(RunConfig config) {
-        runningPattern = Pattern.compile("(?:\\[surefire\\] )?Running (.*)", Pattern.DOTALL); //NOI18N        
+        runningPattern = Pattern.compile("(?:\\[(?:INFO|surefire)\\] )?Running (.*)", Pattern.DOTALL); //NOI18N
         outDirPattern = Pattern.compile ("(?:\\[INFO\\] )?Surefire report directory\\: (?<" + GROUP_FILE_NAME + ">.*)", Pattern.DOTALL); //NOI18N
         outDirPattern2 = Pattern.compile("(?:\\[INFO\\] )?Setting reports dir\\: (?<" + GROUP_FILE_NAME + ">.*)", Pattern.DOTALL); //NOI18N
         this.config = config;


### PR DESCRIPTION
When running junit tests with maven and the surefire plugin 3.0.0+, the log level can be included in the output for the plugin.  This output is used to detect which class is being tested for display in the Test Results tab. Updated the class matching regex to ignore the log level if present.

This change should fix:
- #4734
- #6181

Tested with combinations of maven-surefire-plugin 2.12.4 and 3.2.5, bundled and local maven, and Options - Java - Maven - "Print Maven output logging level" setting.
