### PR TITLE
Jakarta 11 license fixes

### DIFF
--- a/enterprise/jakartaee11.platform/external/generated-jakarta.jakartaee-api-11.0.0-javadoc-license.txt
+++ b/enterprise/jakartaee11.platform/external/generated-jakarta.jakartaee-api-11.0.0-javadoc-license.txt
@@ -2,8 +2,8 @@ Name: JakartaEE API 11.0.0 Documentation
 Version: 11.0.0
 License: EPL-v20
 Description: JakartaEE API 11.0.0 Documentation
-Origin: Eclipse Foundation (https://mvnrepository.com/artifact/jakarta.platform/jakarta.jakartaee-api/11.0.0-M1)
-Files: jakarta.jakartaee-api-11.0.0-M1-javadoc.jar
+Origin: Generated from jakarta.jakartaee-api-11.0.0-M1-javadoc.jar
+Type: generated
 
 Eclipse Public License - v 2.0
 THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (“AGREEMENT”). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.


### PR DESCRIPTION
A follow up to #6988 to fix license issue we have on jenkins build. I suppose the verify license is done pristine and no generated lib are present but the check wants it.

Done the same way it was for jakarta 10
