### PR TITLE
[NETBEANS-3725] Preventing a crash in Flow due to unattributed ASTs (cleared nerrors prevents post attr to run in some cases).

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/JavaSource.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/JavaSource.java
@@ -502,8 +502,6 @@ public final class JavaSource {
                 assert cc != null;
                 cc.setJavaSource(this.js);
                 task.run (cc);
-                final JavacTaskImpl jt = cc.impl.getJavacTask();
-                Log.instance(jt.getContext()).nerrors = 0;
             }
             else {
                 Parser.Result result = findEmbeddedJava (resultIterator);
@@ -515,8 +513,6 @@ public final class JavaSource {
                 assert cc != null;
                 cc.setJavaSource(this.js);
                 task.run (cc);
-                final JavacTaskImpl jt = cc.impl.getJavacTask();
-                Log.instance(jt.getContext()).nerrors = 0;
             }
         }
 
@@ -673,8 +669,6 @@ public final class JavaSource {
                     copy.toPhase(Phase.PARSED);
                 }
                 task.run(copy);
-                final JavacTaskImpl jt = copy.impl.getJavacTask();
-                Log.instance(jt.getContext()).nerrors = 0;
                 final List<ModificationResult.Difference> diffs = copy.getChanges(result.tag2Span);
                 if (diffs != null && diffs.size() > 0) {
                     final FileObject file = copy.getFileObject();

--- a/java/java.source.base/src/org/netbeans/api/java/source/ModificationResult.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ModificationResult.java
@@ -118,8 +118,6 @@ public final class ModificationResult {
                     } finally {
                         WorkingCopy.instance = null;
                     }
-                    final JavacTaskImpl jt = copy.impl.getJavacTask();
-                    Log.instance(jt.getContext()).nerrors = 0;
                     final List<ModificationResult.Difference> diffs = copy.getChanges(result.tag2Span);
                     if (diffs != null && diffs.size() > 0)
                         result.diffs.put(copy.getFileObject(), diffs);

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/JavaSourceTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/JavaSourceTest.java
@@ -165,6 +165,7 @@ public class JavaSourceTest extends NbTestCase {
         suite.addTest(new JavaSourceTest("testDocumentChanges"));
         suite.addTest(new JavaSourceTest("testMultipleFiles"));
         suite.addTest(new JavaSourceTest("testMultipleFilesSameJavac"));
+        suite.addTest(new JavaSourceTest("testMultipleFilesWithErrors"));
         /*
         suite.addTest(new JavaSourceTest("testParsingDelay"));
 //        suite.addTest(new JavaSourceTest("testJavaSourceIsReclaimable"));     fails in trunk
@@ -1988,6 +1989,33 @@ public class JavaSourceTest extends NbTestCase {
             },true);
     }
 
+    public void testMultipleFilesWithErrors() throws Exception {
+        final FileObject testFile1 = createTestFile("Test1",
+                                                    "public class Test1 extends Test2 {\n" +
+                                                    "     public int inv(Unknown u) {\n" +
+                                                    "         return this.doesNotExist(u);\n" +
+                                                    "     }\n" +
+                                                    "}\n");
+        final FileObject testFile2 = createTestFile("Test2",
+                                                    "public class Test2 {\n" +
+                                                    "     public int inv(Unknown u) {\n" +
+                                                    "         return this.doesNotExist(u);\n" +
+                                                    "     }\n" +
+                                                    "}\n");
+        final JavaSource js = JavaSource.create(ClasspathInfo.create(testFile1), testFile1, testFile2);
+        assertNotNull(js);
+        js.runUserActionTask(new Task<CompilationController>() {
+            public void run (final CompilationController c) throws IOException, BadLocationException {
+                c.toPhase(JavaSource.Phase.RESOLVED);
+            }
+        }, true);
+        js.runModificationTask(new Task<WorkingCopy>() {
+            public void run (final WorkingCopy c) throws IOException, BadLocationException {
+                c.toPhase(JavaSource.Phase.RESOLVED);
+            }
+        });
+    }
+
     private static class FindMethodRegionsVisitor extends SimpleTreeVisitor<Void,Void> {
 
         final Document doc;
@@ -2419,21 +2447,23 @@ public class JavaSourceTest extends NbTestCase {
 
     private FileObject createTestFile (String className) {
         try {
-            File workdir = this.getWorkDir();
-            File root = new File (workdir, "src");
-            root.mkdir();
-            File data = new File (root, className+".java");
-
-            PrintWriter out = new PrintWriter (new FileWriter (data));
-            try {
-                out.println(MessageFormat.format(TEST_FILE_CONTENT, new Object[] {className}));
-            } finally {
-                out.close ();
-            }
-            return FileUtil.toFileObject(data);
+            return createTestFile(className,
+                                  MessageFormat.format(TEST_FILE_CONTENT, new Object[] {className}) + System.getProperty("line.separator"));
         } catch (IOException ioe) {
             return null;
         }
+    }
+
+    private FileObject createTestFile (String className, String content) throws IOException {
+        File workdir = this.getWorkDir();
+        File root = new File (workdir, "src");
+        root.mkdir();
+        File data = new File (root, className+".java");
+
+        try (Writer w = new FileWriter (data)) {
+            w.write(content);
+        }
+        return FileUtil.toFileObject(data);
     }
 
     private ClassPath createBootPath () throws MalformedURLException {

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/BatchUtilities.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/BatchUtilities.java
@@ -146,8 +146,6 @@ public class BatchUtilities {
                     return false;
                 }
 
-                final JavacTaskImpl jt = JavaSourceAccessor.getINSTANCE().getJavacTask(copy);
-                Log.instance(jt.getContext()).nerrors = 0;
                 Method getChanges = WorkingCopy.class.getDeclaredMethod("getChanges", Map.class);
                 getChanges.setAccessible(true);
 
@@ -333,8 +331,6 @@ public class BatchUtilities {
         
                 JavaFixImpl.Accessor.INSTANCE.process(f, perFixCopy, false, perFixResourceContentChanges, new ArrayList<>());
                 
-                final JavacTaskImpl jt = JavaSourceAccessor.getINSTANCE().getJavacTask(perFixCopy);
-                Log.instance(jt.getContext()).nerrors = 0;
                 Method getChanges = WorkingCopy.class.getDeclaredMethod("getChanges", Map.class);
                 getChanges.setAccessible(true);
                 


### PR DESCRIPTION
javac processes code in several phases, and one of the phase is "analyze" which looks into method bodies, attaches attributes to the AST nodes and looks for various errors in the method bodies. It consists of two sub-phases, Attr and Flow.

It sometimes may happen that Attr leaves some fields in the AST unfilled when the code is erroneous. In the normal way javac works, this is not problematic, as if there's a compile-time error reported during Attr, Flow does not run. But, when running inside NetBeans, we push javac to Flow regardless of any errors anywhere in the compilation pipeline. To facilitate that, javac will fill various error-like types/symbols on the AST after Attr, if it continues with Flow, and if error was reported.

Up to this point, everything works reasonably.

But, the current code in NetBeans is clearing the number of reported errors, and then javac cannot detect that an error was reported, and fill not fill the AST with the error-like attributes. And this then may lead to a crash in Flow.

I believe the clearing of nerrors was needed to force javac to continue processing even after an error was detected, before the introduction of the current `-Dshould-stop.at=FLOW` approach. But, I don't think it is needed (on most places) currently, and is actually harmful, as described above.

So, this patch removes the `nerrors = 0` on all places I could find except in `VanillaCompileWorker`. The situation in the `VanillaCompileWorker` is different - we only clear `nerrors` after we fix (or at least try to) the AST to not contain errors.
