### PR TITLE
Entities from databases: Bugfix entity generation in plain java (non webapp) projects 

### DIFF
--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DatabaseTablesPanel.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DatabaseTablesPanel.java
@@ -69,6 +69,7 @@ import org.netbeans.spi.project.ui.templates.support.Templates;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.WizardDescriptor;
+import org.openide.awt.Mnemonics;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.ChangeSupport;
@@ -150,6 +151,7 @@ public class DatabaseTablesPanel extends javax.swing.JPanel implements AncestorL
                 // (server change was not propagated there yet). In worst case combo model will be set twice:
                 datasourceServerComboBox.setModel(new DefaultComboBoxModel());
                 initializeWithDatasources();
+                Mnemonics.setLocalizedText(datasourceLabel, org.openide.util.NbBundle.getMessage(DatabaseTablesPanel.class, "LBL_Datasource"));
             }
         };
 
@@ -161,14 +163,11 @@ public class DatabaseTablesPanel extends javax.swing.JPanel implements AncestorL
             }
         }
 
-
-        boolean serverIsSelected = ProviderUtil.isValidServerInstanceOrNone(project);
-        boolean canServerBeSelected = ProviderUtil.canServerBeSelected(project);
-
         {
             boolean hasJPADataSourcePopulator = project.getLookup().lookup(JPADataSourcePopulator.class) != null;
             initializeWithDatasources();
             initializeWithDbConnections();
+            Mnemonics.setLocalizedText(datasourceLabel, org.openide.util.NbBundle.getMessage(DatabaseTablesPanel.class, "LBL_Datasource"));
 
             DBSchemaUISupport.connect(dbschemaComboBox, dbschemaFileList);
             boolean hasDBSchemas = (dbschemaComboBox.getItemCount() > 0 && dbschemaComboBox.getItemAt(0) instanceof FileObject);

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DatabaseTablesPanel.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DatabaseTablesPanel.java
@@ -179,7 +179,9 @@ public class DatabaseTablesPanel extends javax.swing.JPanel implements AncestorL
             datasourceLocalRadioButton.setVisible(hasDBSchemas || hasJPADataSourcePopulator);
             datasourceServerRadioButton.setVisible(hasJPADataSourcePopulator);
             datasourceServerRadioButton.setEnabled(hasJPADataSourcePopulator);
-            
+            datasourceServerComboBox.setEnabled(hasJPADataSourcePopulator);
+            datasourceServerComboBox.setVisible(hasJPADataSourcePopulator);
+
             selectDefaultTableSource(tableSource, hasJPADataSourcePopulator, project, targetFolder);
         } 
 
@@ -203,7 +205,11 @@ public class DatabaseTablesPanel extends javax.swing.JPanel implements AncestorL
 
     private void initializeWithDatasources() {
         JPADataSourcePopulator dsPopulator = project.getLookup().lookup(JPADataSourcePopulator.class);
-        dsPopulator.connect(datasourceServerComboBox);
+        if(dsPopulator != null) {
+            dsPopulator.connect(datasourceServerComboBox);
+        } else {
+            datasourceServerComboBox.removeAllItems();
+        }
     }
 
     private void initializeWithDbConnections() {
@@ -315,7 +321,11 @@ public class DatabaseTablesPanel extends javax.swing.JPanel implements AncestorL
         // nothing got selected so far, so select the data source / connection
         // radio button, but don't select an actual data source or connection
         // (since this would cause the connect dialog to be displayed)
-        datasourceServerRadioButton.setSelected(true);
+        if(datasourceServerComboBox.isVisible()) {
+            datasourceServerRadioButton.setSelected(true);
+        } else {
+            datasourceLocalRadioButton.setSelected(true);
+        }
     }
 
     /**


### PR DESCRIPTION
For plain java projects there is no JPADataSourcePopulator available,
so it must not be called to populate the schema list. The schema
combobox for this case should then not be shown.

For the case when no JPADataSourcePopulator and no schema file is
present, the default selected datasource selector should not be
server datasources, but local data sources.

Closes: #7144