### PR TITLE
Integrate NB Favorites with the FileChooser shortcuts panel

### DIFF
--- a/ide/o.n.swing.dirchooser/nbproject/project.properties
+++ b/ide/o.n.swing.dirchooser/nbproject/project.properties
@@ -14,5 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.source=11
+javac.target=11
 javadoc.arch=${basedir}/arch.xml

--- a/ide/o.n.swing.dirchooser/nbproject/project.xml
+++ b/ide/o.n.swing.dirchooser/nbproject/project.xml
@@ -35,6 +35,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.swing.plaf</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.66</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.openide.awt</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryCellEditor.java
+++ b/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryCellEditor.java
@@ -53,10 +53,12 @@ class DirectoryCellEditor extends DefaultCellEditor {
         this.fileChooser = fileChooser;
     }
     
+    @Override
     public boolean isCellEditable(EventObject event) {
-        return ((event instanceof MouseEvent) ? false : true);
+        return !(event instanceof MouseEvent);
     }
     
+    @Override
     public Component getTreeCellEditorComponent(JTree tree, Object value, boolean isSelected, boolean expanded, boolean leaf, int row) {
         Component c = super.getTreeCellEditorComponent(tree, value, isSelected, expanded, leaf, row);
         DirectoryNode node = (DirectoryNode)value;

--- a/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryChooserUI.java
+++ b/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryChooserUI.java
@@ -46,13 +46,27 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.AccessControlException;
 import java.text.MessageFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+import java.util.Set;
+import java.util.Vector;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.CellEditorListener;
 import javax.swing.event.ChangeEvent;
@@ -242,10 +256,9 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         // Decide whether to use the ShellFolder class to populate shortcut
         // panel and combobox.
         
-        Boolean prop =
-                (Boolean)fileChooser.getClientProperty(DelegatingChooserUI.USE_SHELL_FOLDER);
+        Boolean prop = (Boolean)fileChooser.getClientProperty(DelegatingChooserUI.USE_SHELL_FOLDER);
         if (prop != null) {
-            useShellFolder = prop.booleanValue();
+            useShellFolder = prop;
         } else {
             // See if FileSystemView.getRoots() returns the desktop folder,
             // i.e. the normal Windows hierarchy.
@@ -410,7 +423,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         
         // disable TAB focus transfer, we need it for completion
         Set<AWTKeyStroke> tKeys = filenameTextField.getFocusTraversalKeys(java.awt.KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS);
-        Set<AWTKeyStroke> newTKeys = new HashSet<AWTKeyStroke>(tKeys);
+        Set<AWTKeyStroke> newTKeys = new HashSet<>(tKeys);
         newTKeys.remove(AWTKeyStroke.getAWTKeyStroke(KeyEvent.VK_TAB, 0));
         // #107305: enable at least Ctrl+TAB if we have TAB for completion
         newTKeys.add(AWTKeyStroke.getAWTKeyStroke(KeyEvent.VK_TAB, KeyEvent.CTRL_DOWN_MASK));
@@ -604,7 +617,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         }
         // on Mac all icons from UIManager are the same, some default, so load our own.
         // it's also fallback if icon from UIManager not found, may happen
-        if (isMac || upOneLevelIcon == null || jdkBug6840086Workaround() ) {
+        if (isMac || upOneLevelIcon == null) {
             if (isMac) {
                 upOneLevelIcon = ImageUtilities.loadImageIcon("org/netbeans/swing/dirchooser/resources/upFolderIcon_mac.png", false);
             } else {
@@ -664,7 +677,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         }
         // on Mac all icons from UIManager are the same, some default, so load our own.
         // it's also fallback if icon from UIManager not found, may happen
-        if (isMac || newFoldIcon == null || jdkBug6840086Workaround()) {
+        if (isMac || newFoldIcon == null) {
             if (isMac) {
                 newFoldIcon = ImageUtilities.loadImageIcon("org/netbeans/swing/dirchooser/resources/newFolderIcon_mac.png", false);
             } else {
@@ -770,13 +783,6 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         return scrollBar;
     }
 
-    private boolean jdkBug6840086Workaround() {
-        //see issue #167080
-        return Utilities.isWindows()
-                && "Windows 7".equals(System.getProperty("os.name"))
-                && "1.6.0_16".compareTo(System.getProperty("java.version")) >=0;
-    }
-
     /** 
      * Handles alt-up key 
      */
@@ -789,7 +795,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         
         @Override
         public void keyPressed(KeyEvent evt) {
-            if(evt.getKeyCode() == KeyEvent.VK_UP && (evt.getModifiers() & KeyEvent.ALT_MASK) == KeyEvent.ALT_MASK) {
+            if(evt.getKeyCode() == KeyEvent.VK_UP && evt.isAltDown()) {
                 Action action = getChangeToParentDirectoryAction();
                 action.actionPerformed(new ActionEvent(evt.getSource(), 0, ""));
                 component.requestFocus();
@@ -804,12 +810,9 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         
         StringBuffer searchBuf = new StringBuffer();
         
-        java.util.List<TreePath> paths;
-        private final Timer resetBufferTimer = new Timer(2000, new ActionListener() {
-            @Override
-            public void actionPerformed (ActionEvent e) {
-                resetBuffer();
-            }
+        List<TreePath> paths;
+        private final Timer resetBufferTimer = new Timer(2000, (ActionEvent e) -> {
+            resetBuffer();
         });
                 
         @Override
@@ -895,7 +898,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
                 return false;
             }
             // #110975: refuse modifiers
-            if (evt.getModifiers() != 0) {
+            if (evt.getModifiersEx() != 0) {
                 return false;
             }
             return (Character.isJavaIdentifierPart(ch) && !Character.isIdentifierIgnorable(ch)) 
@@ -909,10 +912,9 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         
     }
     
-    private java.util.List<TreePath> getVisiblePaths () {
+    private List<TreePath> getVisiblePaths () {
         int rowCount = tree.getRowCount();
-        DirectoryNode node = null;
-        java.util.List<TreePath> result = new ArrayList<TreePath>(rowCount);
+        List<TreePath> result = new ArrayList<>(rowCount);
         for (int i = 0; i < rowCount; i++) {
             result.add(tree.getPathForRow(i));
         }
@@ -925,20 +927,14 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         item1.addActionListener(newFolderAction);
         
         JMenuItem item2 = new JMenuItem(getBundle().getString("LBL_Rename"));
-        item2.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                DirectoryNode node = (DirectoryNode)tree.getLastSelectedPathComponent();
-                applyEdit(node);
-            }
+        item2.addActionListener((ActionEvent e) -> {
+            DirectoryNode node = (DirectoryNode)tree.getLastSelectedPathComponent();
+            applyEdit(node);
         });
         
         JMenuItem item3 = new JMenuItem(getBundle().getString("LBL_Delete"));
-        item3.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                deleteAction();
-            }
+        item3.addActionListener((ActionEvent e) -> {
+            deleteAction();
         });
         
         popupMenu.add(item1);
@@ -974,9 +970,9 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             
             RequestProcessor.getDefault().post(new Runnable() {
                 DirectoryNode node;
-                ArrayList<File> list = new ArrayList<File>();
+                ArrayList<File> list = new ArrayList<>();
                 int cannotDelete;
-                ArrayList<DirectoryNode> nodes2Remove = new ArrayList<DirectoryNode>(nodePath.length);
+                ArrayList<DirectoryNode> nodes2Remove = new ArrayList<>(nodePath.length);
 
                 @Override
                 public void run() {
@@ -1015,7 +1011,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
                                 message = cannotDelete + " " + getBundle().getString("MSG_Plur_Delete");
                             }
                             
-                            setSelected((File[])list.toArray(new File[0]));
+                            setSelected((File[])list.toArray(File[]::new));
                             
                             JOptionPane.showConfirmDialog(fileChooser, message , getBundle().getString("MSG_Confirm"), JOptionPane.OK_OPTION);
                         } else {
@@ -1057,7 +1053,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
                 synchronized (listFilesWorker) {
                     if (!dir.equals(lastDir)) {
                         if (completionPopup != null) {
-                            completionPopup.setDataList(new Vector<File>(0));
+                            completionPopup.setDataList(new Vector<>(0));
                             completionPopup.detach();
                             completionPopup = null;
                         }
@@ -1095,7 +1091,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             synchronized (this) {
                 dir = d;
             }
-            List<File> files = new LinkedList<File>();
+            List<File> files = new LinkedList<>();
             File[] children = dir.listFiles();
             if (children != null) {
                 for (File f : children) {
@@ -1116,21 +1112,16 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             }
             synchronized (this) {
                 lastDir = dir;
-                lastChildren = files.toArray(new File[0]);
+                lastChildren = files.toArray(File[]::new);
             }
             if (lastChildren.length > 0) {
-                EventQueue.invokeLater(new Runnable() {
-                    @Override
-                    public void run() {
-                        updateCompletions();
-                    }
-                });
+                EventQueue.invokeLater(() -> updateCompletions());
             }
         }
     }
     
     public Vector<File> buildList(String text, File[] children, int max) {
-        Vector<File> files = new Vector<File>(children.length);
+        Vector<File> files = new Vector<>(children.length);
         Arrays.sort(children, DirectoryNode.FILE_NAME_COMPARATOR);
         
         for (File completion : children) {
@@ -1204,7 +1195,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
     }
     
     private void markStartTime () {
-        fileChooser.putClientProperty(DelegatingChooserUI.START_TIME, Long.valueOf(System.currentTimeMillis()));
+        fileChooser.putClientProperty(DelegatingChooserUI.START_TIME, System.currentTimeMillis());
     }
 
     private void checkUpdate() {
@@ -1216,7 +1207,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             // clean for future marking
             fileChooser.putClientProperty(DelegatingChooserUI.START_TIME, null);
 
-            long elapsed = System.currentTimeMillis() - startTime.longValue();
+            long elapsed = System.currentTimeMillis() - startTime;
             long timeOut = NbPreferences.forModule(DirectoryChooserUI.class).
                     getLong(TIMEOUT_KEY, 10000);
             if (timeOut > 0 && elapsed > timeOut && slownessPanel == null) {
@@ -1226,13 +1217,10 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
                 slownessPanel = new JPanel();
                 JButton notShow = new JButton(
                         NbBundle.getMessage(DirectoryChooserUI.class, "BTN_NotShow"));
-                notShow.addActionListener(new ActionListener() {
-                    @Override
-                    public void actionPerformed(ActionEvent e) {
-                        NbPreferences.forModule(DirectoryChooserUI.class).putLong(TIMEOUT_KEY, 0);
-                        centerPanel.remove(slownessPanel);
-                        centerPanel.revalidate();
-                    }
+                notShow.addActionListener((ActionEvent e) -> {
+                    NbPreferences.forModule(DirectoryChooserUI.class).putLong(TIMEOUT_KEY, 0);
+                    centerPanel.remove(slownessPanel);
+                    centerPanel.revalidate();
                 });
                 JPanel notShowP = new JPanel();
                 notShowP.add(notShow);
@@ -1251,7 +1239,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         Boolean themeActive = (Boolean)toolkit.getDesktopProperty("win.xpstyle.themeActive");
         if(themeActive == null)
             themeActive = Boolean.FALSE;
-        if (themeActive.booleanValue() && System.getProperty("swing.noxp") == null) {
+        if (themeActive && System.getProperty("swing.noxp") == null) {
             themeActive = Boolean.TRUE;
         }
         return themeActive;
@@ -1682,33 +1670,22 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
     }
     
     private void addNewDirectory(final TreePath path) {
-        RequestProcessor.getDefault().post(new Runnable() {
-            @Override
-            public void run() {
-                EventQueue.invokeLater(new Runnable() {
-                    @Override
-                    public void run() {
-                        DirectoryNode selectedNode = (DirectoryNode)path.getLastPathComponent();
-                        
-                        if(selectedNode == null || !canWrite(selectedNode.getFile())) {
-                            return;
-                        }
-                        
-                        try {
-                            newFolderNode = new DirectoryNode(fileChooser.getFileSystemView().createNewFolder(selectedNode.getFile()));
-                            model.insertNodeInto(newFolderNode, selectedNode, selectedNode.getChildCount());
-                            EventQueue.invokeLater(new Runnable() {
-                                @Override
-                                public void run () {
-                                    applyEdit(newFolderNode);
-                                }
-                            });
-                        } catch (IOException ex) {
-                            Exceptions.printStackTrace(ex);
-                        }
-                    }
-                });
-            }
+        RequestProcessor.getDefault().post(() -> {
+            EventQueue.invokeLater(() -> {
+                DirectoryNode selectedNode = (DirectoryNode)path.getLastPathComponent();
+                if(selectedNode == null || !canWrite(selectedNode.getFile())) {
+                    return;
+                }
+                try {
+                    newFolderNode = new DirectoryNode(fileChooser.getFileSystemView().createNewFolder(selectedNode.getFile()));
+                    model.insertNodeInto(newFolderNode, selectedNode, selectedNode.getChildCount());
+                    EventQueue.invokeLater(() -> {
+                        applyEdit(newFolderNode);
+                    });
+                } catch (IOException ex) {
+                    Exceptions.printStackTrace(ex);
+                }
+            });
         });
     }
     
@@ -1778,11 +1755,8 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
     
     private void setCursor (final JComponent comp, final int type) {
         if (!EventQueue.isDispatchThread()) {
-            EventQueue.invokeLater(new Runnable () {
-                @Override
-                public void run () {
-                    setCursor(comp, type);
-                }
+            EventQueue.invokeLater(() -> {
+                setCursor(comp, type);
             });
         } else {
             Window window = SwingUtilities.getWindowAncestor(comp);
@@ -1882,7 +1856,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
      * Data model for a type-face selection combo-box.
      */
     private class DirectoryComboBoxModel extends AbstractListModel implements ComboBoxModel {
-        Vector<File> directories = new Vector<File>();
+        Vector<File> directories = new Vector<>();
         int[] depths = null;
         File selectedDirectory = null;
         JFileChooser chooser = getFileChooser();
@@ -1920,7 +1894,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             // Get the canonical (full) path. This has the side
             // benefit of removing extraneous chars from the path,
             // for example /foo/bar/ becomes /foo/bar
-            File canonical = null;
+            File canonical;
             try {
                 canonical = directory.getCanonicalFile();
             } catch (IOException e) {
@@ -1931,7 +1905,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             // create File instances of each directory leading up to the top
             File sf = useShellFolder? getShellFolderForFile(canonical) : canonical;
             File f = sf;
-            Vector<File> path = new Vector<File>(10);
+            Vector<File> path = new Vector<>(10);
 
             
             /*
@@ -2220,7 +2194,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             JTree tree = (JTree) e.getSource();
             TreePath path = tree.getSelectionPath();
             TreePath curSel = e.getNewLeadSelectionPath();
-            curSelPath = (curSel != null) ? new WeakReference<TreePath>(curSel) : null;
+            curSelPath = (curSel != null) ? new WeakReference<>(curSel) : null;
             
             if(path != null) {
                 
@@ -2240,7 +2214,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         }
         
         private File[] getSelectedNodes(TreePath[] paths) {
-            List<File> files = new LinkedList<File>();
+            List<File> files = new LinkedList<>();
             for(int i = 0; i < paths.length; i++) {
                 File file = ((DirectoryNode)paths[i].getLastPathComponent()).getFile();
                 if(file.isDirectory()
@@ -2250,7 +2224,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
                 }
                 files.add(file);
             }
-            return files.toArray(new File[0]);
+            return files.toArray(File[]::new);
         }
         
         /********* impl of MouseListener ***********/
@@ -2258,7 +2232,6 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
         @Override
         public void mouseClicked(MouseEvent e) {
             final JTree tree = (JTree) e.getSource();
-            Point p = e.getPoint();
             final int x = e.getX();
             final int y = e.getY();
             int row = tree.getRowForLocation(x, y);
@@ -2510,7 +2483,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             public void run() {
                 if (!EventQueue.isDispatchThread()) {
                     // first phase
-                    realDirs = new HashSet<String>();
+                    realDirs = new HashSet<>();
                     File[] files = folder.listFiles();
                     files = files == null ? new File[0] : files;
                     for (File file : files) {
@@ -2525,7 +2498,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
                     // second phase, in EQ thread, invoked from first phase
                     int count = node.getChildCount();
                     Map<String,DirectoryNode> currentFiles =
-                        new HashMap<String,DirectoryNode>( );
+                        new HashMap<>( );
                     for( int i=0; i< count ; i++ ){
                         TreeNode child = node.getChildAt(i);
                         if ( child instanceof DirectoryNode ){
@@ -2534,7 +2507,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
                         }
                     }
 
-                    Set<String> realCloned = new HashSet<String>( realDirs );
+                    Set<String> realCloned = new HashSet<>( realDirs );
                     if ( realCloned.removeAll( currentFiles.keySet()) ){
                         // Handle added folders
                         for ( String name : realCloned ){
@@ -2542,7 +2515,7 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
                             model.insertNodeInto( added, node, node.getChildCount());
                         }
                     }
-                    Set<String> currentNames = new HashSet<String>( currentFiles.keySet());
+                    Set<String> currentNames = new HashSet<>( currentFiles.keySet());
                     if ( currentNames.removeAll( realDirs )){
                         // Handle deleted folders
                         for ( String name : currentNames ){
@@ -2593,12 +2566,9 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             public void run () {
                 final File f = file;
                 if (canWrite(f)) {
-                    EventQueue.invokeLater(new Runnable() {
-                        @Override
-                        public void run () {
-                            if (f == file) {
-                                setEnabled(true);
-                            }
+                    EventQueue.invokeLater(() -> {
+                        if (f == file) {
+                            setEnabled(true);
                         }
                     });
                 }
@@ -2720,15 +2690,12 @@ public class DirectoryChooserUI extends BasicFileChooserUI {
             node.loadChildren(fileChooser, true);
 
             // update UI in EQ thread
-            SwingUtilities.invokeLater(new Runnable() {
-                @Override
-                public void run() {
-                    ui.model = new DirectoryTreeModel(node);
-                    tree.setModel(ui.model);
-                    tree.repaint();
-                    ui.checkUpdate();
-                    restoreCursor();
-                }
+            SwingUtilities.invokeLater(() -> {
+                ui.model = new DirectoryTreeModel(node);
+                tree.setModel(ui.model);
+                tree.repaint();
+                ui.checkUpdate();
+                restoreCursor();
             });
         }
 

--- a/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryNode.java
+++ b/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/DirectoryNode.java
@@ -24,6 +24,7 @@ package org.netbeans.swing.dirchooser;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.Icon;
@@ -110,15 +111,13 @@ public class DirectoryNode extends DefaultMutableTreeNode {
         //fixed bug #97124
         if (loaded == false) {
             
-            ArrayList files = getFiles(chooser);
+            List<File> files = getFiles(chooser);
             
             if(files.isEmpty()) {
                 return false;
             }
             
-            for(int i = 0; i < files.size(); i++) {
-                File child = (File) files.get(i);
-                
+            for (File child : files) {
                 if(chooser.accept(child)) {
                     try {
                         DirectoryNode node = new DirectoryNode(child);
@@ -132,7 +131,7 @@ public class DirectoryNode extends DefaultMutableTreeNode {
                 }
             }
             
-            if (descend == true ||  (getChildCount() > 0)) {
+            if (descend == true || getChildCount() > 0) {
                 loaded = true;
             }
         }
@@ -140,9 +139,9 @@ public class DirectoryNode extends DefaultMutableTreeNode {
         return loaded;
     }
 
-    private ArrayList getFiles(JFileChooser chooser) {
+    private List<File> getFiles(JFileChooser chooser) {
         //fixed bug #97124
-        ArrayList list = new ArrayList();
+        List<File> list = new ArrayList<>();
         
         // Fix for IZ#116859 [60cat] Node update bug in the "open project" panel while deleting directories
         if ( directory == null || !directory.exists() ){
@@ -151,7 +150,7 @@ public class DirectoryNode extends DefaultMutableTreeNode {
 
         File[] files = chooser.getFileSystemView().getFiles(directory, chooser.isFileHidingEnabled());
         int mode = chooser.getFileSelectionMode();
-        if(mode == JFileChooser.DIRECTORIES_ONLY) {
+        if (mode == JFileChooser.DIRECTORIES_ONLY) {
             for(int i = 0; i < files.length; i++) {
                 File child = files[i];
                 if (child.isDirectory()) {
@@ -159,9 +158,9 @@ public class DirectoryNode extends DefaultMutableTreeNode {
                 }
             }
             list.sort(FILE_NAME_COMPARATOR);
-        } else if(mode == JFileChooser.FILES_AND_DIRECTORIES || mode == JFileChooser.FILES_ONLY) {
-            ArrayList dirList = new ArrayList();
-            ArrayList fileList = new ArrayList();
+        } else if (mode == JFileChooser.FILES_AND_DIRECTORIES || mode == JFileChooser.FILES_ONLY) {
+            List<File> dirList = new ArrayList<>();
+            List<File> fileList = new ArrayList<>();
             for(int i = 0; i < files.length; i++) {
                 File child = files[i];
                 if (child.isDirectory()) {
@@ -205,7 +204,7 @@ public class DirectoryNode extends DefaultMutableTreeNode {
     private static FileObject convertToValidDir(File f) {
         FileObject fo;
         File testFile = new File(f.getPath());
-        if (testFile == null || testFile.getParent() == null) {
+        if (testFile.getParent() == null) {
             // BTW this means that roots of file systems can't be project
             // directories.
             return null;

--- a/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/FileCompletionPopup.java
+++ b/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/FileCompletionPopup.java
@@ -111,8 +111,8 @@ public class FileCompletionPopup extends JPopupMenu implements KeyListener {
         if(list.getModel().getSize() == 0) {
             return;
         }
-        setPreferredSize(new Dimension(source.getWidth(), source.getHeight() * 4));
-        show(source,  x, y);
+        setPreferredSize(new Dimension(source.getWidth(), source.getHeight() * 6));
+        show(source, x, y);
         ensureSelection();
     }
     

--- a/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/FileCompletionPopup.java
+++ b/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/FileCompletionPopup.java
@@ -55,12 +55,12 @@ import javax.swing.text.JTextComponent;
  */
 public class FileCompletionPopup extends JPopupMenu implements KeyListener {
     
-    private JList list;
-    private JTextField textField;
-    private JFileChooser chooser;
+    private final JList<File> list;
+    private final JTextField textField;
+    private final JFileChooser chooser;
     
     public FileCompletionPopup(JFileChooser chooser, JTextField textField, Vector<File> files) {
-        this.list = new JList(files);
+        this.list = new JList<>(files);
         this.textField = textField;
         this.chooser = chooser;
         list.setVisibleRowCount(4);
@@ -80,7 +80,7 @@ public class FileCompletionPopup extends JPopupMenu implements KeyListener {
         textField.addKeyListener(this);
     }
      
-    public void setDataList(Vector files) {
+    public void setDataList(Vector<File> files) {
         list.setListData(files);
         ensureSelection();
     }
@@ -134,6 +134,7 @@ public class FileCompletionPopup extends JPopupMenu implements KeyListener {
     }
     
     private class MouseHandler extends MouseAdapter implements MouseMotionListener{
+        @Override
         public void mouseMoved(MouseEvent e) {
             if (e.getSource() == list) {
                 Point location = e.getPoint();
@@ -146,6 +147,7 @@ public class FileCompletionPopup extends JPopupMenu implements KeyListener {
             }
         }
         
+        @Override
         public void mouseDragged(MouseEvent e) {
             if (e.getSource() == list) {
                 return;
@@ -168,7 +170,7 @@ public class FileCompletionPopup extends JPopupMenu implements KeyListener {
             int index = list.locationToIndex(p);
             list.setSelectedIndex(index);
             setVisible(false);
-            File file = (File)list.getSelectedValue();
+            File file = list.getSelectedValue();
             if (file == null) {
                 return;
             }
@@ -186,7 +188,7 @@ public class FileCompletionPopup extends JPopupMenu implements KeyListener {
             MouseEvent newEvent = new MouseEvent( (Component)e.getSource(),
                     e.getID(),
                     e.getWhen(),
-                    e.getModifiers(),
+                    e.getModifiersEx(),
                     convertedPoint.x,
                     convertedPoint.y,
                     e.getClickCount(),
@@ -197,6 +199,7 @@ public class FileCompletionPopup extends JPopupMenu implements KeyListener {
 
     /****** implementation of KeyListener of fileNameTextField ******/
     
+    @Override
     public void keyPressed(KeyEvent e) {
         if (!isVisible()) {
             return;
@@ -220,7 +223,7 @@ public class FileCompletionPopup extends JPopupMenu implements KeyListener {
         }
         
         if (isCompletionKey(code, textField) && !e.isConsumed()) {
-            File file = (File)list.getSelectedValue();
+            File file = list.getSelectedValue();
             if(file != null) { 
                 if(file.equals(chooser.getCurrentDirectory())) {
                     chooser.firePropertyChange(JFileChooser.DIRECTORY_CHANGED_PROPERTY, false, true);
@@ -244,10 +247,12 @@ public class FileCompletionPopup extends JPopupMenu implements KeyListener {
         }
     }
 
+    @Override
     public void keyReleased(KeyEvent e) {
         // no operation
     }
     
+    @Override
     public void keyTyped(KeyEvent e) {
         // no operation
     }

--- a/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/InputBlocker.java
+++ b/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/InputBlocker.java
@@ -76,25 +76,15 @@ public class InputBlocker extends JComponent implements MouseInputListener {
         glassPane.setVisible(false);
     }
 
+    @Override
     public void mouseClicked(MouseEvent e) {
         Toolkit.getDefaultToolkit().beep();
     }
 
-    public void mousePressed(MouseEvent e) {
-    }
-
-    public void mouseReleased(MouseEvent e) {
-    }
-
-    public void mouseEntered(MouseEvent e) {
-    }
-
-    public void mouseExited(MouseEvent e) {
-    }
-
-    public void mouseDragged(MouseEvent e) {
-    }
-
-    public void mouseMoved(MouseEvent e) {
-    }
+    @Override public void mousePressed(MouseEvent e) {}
+    @Override public void mouseReleased(MouseEvent e) {}
+    @Override public void mouseEntered(MouseEvent e) {}
+    @Override public void mouseExited(MouseEvent e) {}
+    @Override public void mouseDragged(MouseEvent e) {}
+    @Override public void mouseMoved(MouseEvent e) {}
 }

--- a/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/Module.java
+++ b/ide/o.n.swing.dirchooser/src/org/netbeans/swing/dirchooser/Module.java
@@ -23,7 +23,6 @@
 package org.netbeans.swing.dirchooser;
 
 import java.awt.EventQueue;
-import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import javax.swing.UIDefaults;
 import javax.swing.UIManager;
@@ -57,11 +56,7 @@ public class Module extends ModuleInstall {
             @Override
             public void afterLoad (WindowSystemEvent event) {
                 WindowManager.getDefault().removeWindowSystemListener(this);
-                EventQueue.invokeLater(new Runnable() {
-                    public @Override void run() {
-                        install();
-                    }
-                });
+                EventQueue.invokeLater(Module::install);
             }
             @Override
             public void beforeSave (WindowSystemEvent event) {
@@ -73,11 +68,7 @@ public class Module extends ModuleInstall {
     }
 
     @Override public void uninstalled() {
-        EventQueue.invokeLater(new Runnable() {
-            public @Override void run() {
-                uninstall();
-            }
-        });
+        EventQueue.invokeLater(Module::uninstall);
     }
         
     private static void install() {
@@ -96,15 +87,12 @@ public class Module extends ModuleInstall {
             uid.put(val, impl);
         }
         // #61147: prevent NB from switching to a different UI later (under GTK):
-        uid.addPropertyChangeListener(pcl = new PropertyChangeListener() {
-            public @Override void propertyChange(PropertyChangeEvent evt) {
-                String name = evt.getPropertyName();
-                Object className = uid.get(KEY);
-                if ((name.equals(KEY) || name.equals("UIDefaults")) && !val.equals(className)
-                        && !isQuickFileChooser(className)) {
-                    originalImpl = (Class<?>) uid.getUIClass(KEY);
-                    uid.put(KEY, val);
-                }
+        uid.addPropertyChangeListener(pcl = (evt) -> {
+            String name = evt.getPropertyName();
+            Object className = uid.get(KEY);
+            if ((name.equals(KEY) || name.equals("UIDefaults")) && !val.equals(className) && !isQuickFileChooser(className)) {
+                originalImpl = (Class<?>) uid.getUIClass(KEY);
+                uid.put(KEY, val);
             }
         });
     }

--- a/platform/favorites/nbproject/project.properties
+++ b/platform/favorites/nbproject/project.properties
@@ -16,9 +16,3 @@
 # under the License.
 javac.compilerargs=-Xlint:all -Xlint:-serial -Xlint:-options -Werror
 javac.source=1.8
-test.config.stable.includes=\
-    gui/core/favorites/BasicsTest.class 
-
-test.config.stableBTD.includes=**/*Test.class
-test.config.stableBTD.excludes=\
-    gui/**/*

--- a/platform/favorites/nbproject/project.xml
+++ b/platform/favorites/nbproject/project.xml
@@ -35,6 +35,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.swing.plaf</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.66</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.openide.actions</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/platform/favorites/src/org/netbeans/modules/favorites/Module.java
+++ b/platform/favorites/src/org/netbeans/modules/favorites/Module.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.favorites;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import javax.swing.UIManager;
+import org.netbeans.modules.favorites.api.Favorites;
+import org.netbeans.swing.plaf.LFCustoms;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.windows.OnShowing;
+
+/**
+ * For lifecycle tasks.
+ * @author mbien
+ */
+public final class Module {
+
+    private Module() {}
+
+    @OnShowing
+    public final static class EDTInit implements Runnable {
+        @Override
+        public void run() {
+            Function<File[], File[]> favAppender = (files) -> {
+                if (!UIManager.getBoolean(LFCustoms.FILECHOOSER_FAVORITES_ENABLED)) {
+                    return files;
+                }
+                List<File> shortcuts = new ArrayList<>(Arrays.asList(files));
+                for (FileObject favorite : Favorites.getDefault().getFavoriteRoots()) {
+                    File file = FileUtil.toFile(favorite);
+                    if (file.isDirectory()) {
+                        shortcuts.add(file);
+                    }
+                }
+                return shortcuts.toArray(new File[0]);
+            };
+            UIManager.put(LFCustoms.FILECHOOSER_SHORTCUTS_FILESFUNCTION, favAppender);
+        }
+    }
+    
+}

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -32,6 +32,9 @@ spec.version.base.fatal.warning=false
 # So when FlatLaf is updated, the OpenIDE-Module-Implementation-Version entry
 # in manifest.mf needs to be updated to match the new FlatLaf version.
 release.external/flatlaf-3.3.jar=modules/ext/flatlaf-3.3.jar
+# com.formdev.flatlaf.ui intentionally ommitted.
+# rest is equivalent to the "public" packages for friend dependencies as declared in project.xml
+sigtest.public.packages=com.formdev.flatlaf,com.formdev.flatlaf.themes,com.formdev.flatlaf.util
 
 release.external/flatlaf-3.3.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
 release.external/flatlaf-3.3.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -45,6 +45,7 @@
             <public-packages>
                 <package>com.formdev.flatlaf</package>
                 <package>com.formdev.flatlaf.themes</package>
+                <package>com.formdev.flatlaf.ui</package>
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Bundle.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Bundle.properties
@@ -34,6 +34,7 @@ FlatLafOptionsPanel.unifiedTitleBarCheckBox.text=&Unified window title bar
 FlatLafOptionsPanel.menuBarEmbeddedCheckBox.text=&Embedded menu bar
 FlatLafOptionsPanel.underlineMenuSelectionCheckBox.text=Use underline menu &selection
 FlatLafOptionsPanel.alwaysShowMnemonicsCheckBox.text=Always show &mnemonics
+FlatLafOptionsPanel.showFileChooserFavoritesCheckBox.text=Show favorites in file chooser (experimental)
 
 LookAndFeel.Config.displayName=Look and Feel
 FlatLafOptionsPanel.Advanced.title=Advanced

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.swing.laf.flatlaf;
 
+import com.formdev.flatlaf.ui.FlatFileChooserUI;
 import com.formdev.flatlaf.util.SystemInfo;
 import com.formdev.flatlaf.util.UIScale;
 import java.awt.Color;
@@ -27,10 +28,11 @@ import java.awt.Insets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.Callable;
+import java.util.function.Function;
 import javax.swing.BorderFactory;
 import javax.swing.InputMap;
-import javax.swing.JFrame;
+import javax.swing.JComponent;
+import javax.swing.JFileChooser;
 import javax.swing.KeyStroke;
 import javax.swing.UIDefaults;
 import javax.swing.UIDefaults.LazyValue;
@@ -131,6 +133,12 @@ public class FlatLFCustoms extends LFCustoms {
             "Table.ancestorInputMap", new LazyModifyInputMap( "Table.ancestorInputMap", removeCtrlPageUpDownKeyBindings ), // NOI18N
             "Table.ancestorInputMap.RightToLeft", new LazyModifyInputMap( "Table.ancestorInputMap.RightToLeft", removeCtrlPageUpDownKeyBindings ), // NOI18N
             "Tree.focusInputMap", new LazyModifyInputMap( "Tree.focusInputMap", removeCtrlPageUpDownKeyBindings ), // NOI18N
+            FILECHOOSER_FAVORITES_ENABLED, FlatLafPrefs.isShowFileChooserFavorites(),
+            FILECHOOSER_SHORTCUTS_PANEL_FACTORY, new Function<JFileChooser, JComponent> () {
+                @Override public JComponent apply(JFileChooser t) {
+                    return new FlatFileChooserUI.FlatShortcutsPanel(t);
+                }
+            }
         };
         List<Object> result = new ArrayList<>();
         result.addAll(Arrays.asList(constants));

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.form
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.form
@@ -53,13 +53,13 @@
                   <Component id="underlineMenuSelectionCheckBox" min="-2" max="-2" attributes="0"/>
                   <Component id="alwaysShowMnemonicsCheckBox" min="-2" max="-2" attributes="0"/>
                   <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
                       <Component id="accentColorLabel" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="accentColorField" min="-2" pref="130" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="needsRestartLabel" min="-2" max="-2" attributes="0"/>
                   </Group>
+                  <Component id="showFileChooserFavoritesCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="32767" attributes="0"/>
           </Group>
@@ -73,7 +73,7 @@
                   <Component id="needsRestartLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="accentColorLabel" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Component id="useWindowDecorationsCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="unifiedTitleBarCheckBox" min="-2" max="-2" attributes="0"/>
@@ -83,9 +83,11 @@
               <Component id="underlineMenuSelectionCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="alwaysShowMnemonicsCheckBox" min="-2" max="-2" attributes="0"/>
-              <EmptySpace type="separate" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="showFileChooserFavoritesCheckBox" min="-2" max="-2" attributes="0"/>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Component id="advPanel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="69" max="32767" attributes="0"/>
+              <EmptySpace pref="42" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -219,5 +221,15 @@
         </Component>
       </SubComponents>
     </Container>
+    <Component class="javax.swing.JCheckBox" name="showFileChooserFavoritesCheckBox">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/swing/laf/flatlaf/Bundle.properties" key="FlatLafOptionsPanel.showFileChooserFavoritesCheckBox.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="showFileChooserFavoritesCheckBoxActionPerformed"/>
+      </Events>
+    </Component>
   </SubComponents>
 </Form>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.java
@@ -139,6 +139,7 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
         advPanel = new javax.swing.JPanel();
         customPropertiesLabel = new javax.swing.JLabel();
         customPropertiesButton = new javax.swing.JButton();
+        showFileChooserFavoritesCheckBox = new javax.swing.JCheckBox();
 
         setBorder(javax.swing.BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
@@ -205,7 +206,7 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
             .addGroup(advPanelLayout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(advPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(customPropertiesLabel, javax.swing.GroupLayout.DEFAULT_SIZE, 368, Short.MAX_VALUE)
+                    .addComponent(customPropertiesLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 368, Short.MAX_VALUE)
                     .addGroup(advPanelLayout.createSequentialGroup()
                         .addComponent(customPropertiesButton)
                         .addGap(0, 0, Short.MAX_VALUE)))
@@ -221,6 +222,13 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
+        org.openide.awt.Mnemonics.setLocalizedText(showFileChooserFavoritesCheckBox, org.openide.util.NbBundle.getMessage(FlatLafOptionsPanel.class, "FlatLafOptionsPanel.showFileChooserFavoritesCheckBox.text")); // NOI18N
+        showFileChooserFavoritesCheckBox.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                showFileChooserFavoritesCheckBoxActionPerformed(evt);
+            }
+        });
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
@@ -234,12 +242,12 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
                     .addComponent(underlineMenuSelectionCheckBox)
                     .addComponent(alwaysShowMnemonicsCheckBox)
                     .addGroup(layout.createSequentialGroup()
-                        .addGap(0, 0, 0)
                         .addComponent(accentColorLabel)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(accentColorField, javax.swing.GroupLayout.PREFERRED_SIZE, 130, javax.swing.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(needsRestartLabel)))
+                        .addComponent(needsRestartLabel))
+                    .addComponent(showFileChooserFavoritesCheckBox))
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         layout.setVerticalGroup(
@@ -249,7 +257,7 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
                     .addComponent(accentColorField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(needsRestartLabel)
                     .addComponent(accentColorLabel))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(useWindowDecorationsCheckBox)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(unifiedTitleBarCheckBox)
@@ -259,9 +267,11 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
                 .addComponent(underlineMenuSelectionCheckBox)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(alwaysShowMnemonicsCheckBox)
-                .addGap(18, 18, 18)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(showFileChooserFavoritesCheckBox)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(advPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(69, Short.MAX_VALUE))
+                .addContainerGap(42, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -317,6 +327,10 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
         fireChanged();
     }//GEN-LAST:event_accentColorFieldActionPerformed
 
+    private void showFileChooserFavoritesCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_showFileChooserFavoritesCheckBoxActionPerformed
+        fireChanged();
+    }//GEN-LAST:event_showFileChooserFavoritesCheckBoxActionPerformed
+
     private void fireChanged() {
         boolean isChanged = false;
         if(!Objects.equals(accentColorField.getSelectedColor(), getPrefsAccentColorOrDefault())
@@ -324,7 +338,8 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
                 || unifiedTitleBarCheckBox.isSelected() != FlatLafPrefs.isUnifiedTitleBar()
                 || menuBarEmbeddedCheckBox.isSelected() != FlatLafPrefs.isMenuBarEmbedded()
                 || underlineMenuSelectionCheckBox.isSelected() != FlatLafPrefs.isUnderlineMenuSelection()
-                || alwaysShowMnemonicsCheckBox.isSelected() != FlatLafPrefs.isAlwaysShowMnemonics()) {
+                || alwaysShowMnemonicsCheckBox.isSelected() != FlatLafPrefs.isAlwaysShowMnemonics()
+                || showFileChooserFavoritesCheckBox.isSelected() != FlatLafPrefs.isShowFileChooserFavorites()) {
             isChanged = true;
         }
         controller.changed(isChanged);
@@ -337,6 +352,7 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
         menuBarEmbeddedCheckBox.setSelected(FlatLafPrefs.isMenuBarEmbedded());
         underlineMenuSelectionCheckBox.setSelected(FlatLafPrefs.isUnderlineMenuSelection());
         alwaysShowMnemonicsCheckBox.setSelected(FlatLafPrefs.isAlwaysShowMnemonics());
+        showFileChooserFavoritesCheckBox.setSelected(FlatLafPrefs.isShowFileChooserFavorites());
 
         updateEnabled();
     }
@@ -349,6 +365,7 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
         FlatLafPrefs.setMenuBarEmbedded(menuBarEmbeddedCheckBox.isSelected());
         FlatLafPrefs.setUnderlineMenuSelection(underlineMenuSelectionCheckBox.isSelected());
         FlatLafPrefs.setAlwaysShowMnemonics(alwaysShowMnemonicsCheckBox.isSelected());
+        FlatLafPrefs.setShowFileChooserFavorites(showFileChooserFavoritesCheckBox.isSelected());
 
         if (!Objects.equals(accentColor, currentAccentColor)
                 || SystemInfo.isLinux && useWindowDecorationsCheckBox.isSelected() != currentUseWindowDecorations) {
@@ -397,6 +414,7 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
     private javax.swing.JLabel customPropertiesLabel;
     private javax.swing.JCheckBox menuBarEmbeddedCheckBox;
     private javax.swing.JLabel needsRestartLabel;
+    private javax.swing.JCheckBox showFileChooserFavoritesCheckBox;
     private javax.swing.JCheckBox underlineMenuSelectionCheckBox;
     private javax.swing.JCheckBox unifiedTitleBarCheckBox;
     private javax.swing.JCheckBox useWindowDecorationsCheckBox;

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanelController.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanelController.java
@@ -19,7 +19,6 @@
 package org.netbeans.swing.laf.flatlaf;
 
 import com.formdev.flatlaf.FlatLaf;
-import java.awt.Window;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import javax.swing.JComponent;
@@ -72,6 +71,7 @@ public class FlatLafOptionsPanelController extends OptionsPanelController {
             defaults.put("TitlePane.menuBarEmbedded", FlatLafPrefs.isMenuBarEmbedded());
             defaults.put("MenuItem.selectionType", FlatLafPrefs.isUnderlineMenuSelection() ? "underline" : null);
             defaults.put("Component.hideMnemonics", !FlatLafPrefs.isAlwaysShowMnemonics());
+            defaults.put(FlatLFCustoms.FILECHOOSER_FAVORITES_ENABLED, FlatLafPrefs.isShowFileChooserFavorites());
 
             FlatLFCustoms.updateUnifiedBackground();
 

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafPrefs.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafPrefs.java
@@ -35,6 +35,7 @@ class FlatLafPrefs {
     private static final String MENU_BAR_EMBEDDED = "menuBarEmbedded";
     private static final String UNDERLINE_MENU_SELECTION = "underlineMenuSelection";
     private static final String ALWAYS_SHOW_MNEMONICS = "alwaysShowMnemonics";
+    private static final String SHOW_FILECHOOSER_FAVORITES = "showFileChooserFavorites";
 
     private static final Preferences prefs = NbPreferences.forModule(FlatLafPrefs.class);
 
@@ -100,6 +101,14 @@ class FlatLafPrefs {
 
     static void setAlwaysShowMnemonics(boolean value) {
         putBoolean(ALWAYS_SHOW_MNEMONICS, value, false);
+    }
+
+    static boolean isShowFileChooserFavorites() {
+        return prefs.getBoolean(SHOW_FILECHOOSER_FAVORITES, false);
+    }
+
+    static void setShowFileChooserFavorites(boolean value) {
+        putBoolean(SHOW_FILECHOOSER_FAVORITES, value, false);
     }
 
     private static void putBoolean(String key, boolean value, boolean def) {

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/LFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/LFCustoms.java
@@ -436,4 +436,11 @@ public abstract class LFCustoms {
     public static final String OPTIONS_USE_UI_DEFAULT_COLORS = "nb.options.useUIDefaultsColors";
     public static final String OPTIONS_CATEGORIES_SEPARATOR_COLOR = "nb.options.categories.separatorColor";
     public static final String OPTIONS_CATEGORIES_BUTTON_USE_NIMBUS = "nb.options.categories.button.useNimbusCategoryButton";
+
+    /**
+     * FileChooser
+     */
+    public static final String FILECHOOSER_SHORTCUTS_FILESFUNCTION = "FileChooser.shortcuts.filesFunction";
+    public static final String FILECHOOSER_SHORTCUTS_PANEL_FACTORY = "FileChooser.shortcuts.panel.factory";
+    public static final String FILECHOOSER_FAVORITES_ENABLED = "FileChooser.favorites.enabled";
 }


### PR DESCRIPTION
Link the Favorites view with FlatLaf's `FileChooser` shortcuts panel. 

 - the first commit is code cleanup
 - second commit contains minor updates to the path completion functionality (who knew that the NB directory chooser had auto completion?)
 - third commit is the main change which provides the favorites shortcuts list

screenshots:
JDK's `FileChooser` with favorites:
![favs-in-file-chooser](https://github.com/apache/netbeans/assets/114367/e992f733-12a7-40e4-a5bd-558a6f3a967c)

NB's custom `DirectoryChooser` displaying lots of favorites in a `JScrollPane`.
![favs-in-file-chooser_scroll](https://github.com/apache/netbeans/assets/114367/99bbc245-a834-418f-98cd-b7a59531a8d2)

can be enabled via FlatLaf options (last checkbox):
![image](https://github.com/apache/netbeans/assets/114367/eb5f5263-2894-4891-bedc-7e569e005597)
