### PR TITLE
Exclude JDK 17+ HCL module from graalvm tests

### DIFF
--- a/java/debugger.jpda.truffle/test/unit/src/org/netbeans/modules/debugger/jpda/truffle/JPDATestCase.java
+++ b/java/debugger.jpda.truffle/test/unit/src/org/netbeans/modules/debugger/jpda/truffle/JPDATestCase.java
@@ -47,7 +47,9 @@ public abstract class JPDATestCase extends NbTestCase {
                 failOnException(Level.INFO).
                 enableClasspathModules(false). 
                 clusters(".*").
-                enableModules("org.netbeans.libs.nbjavacapi").
+                // TODO remove once polyglot tests can run on JDK 17+ and uncomment the other line again
+                enableModules("(?!org.netbeans.modules.languages.hcl|org.netbeans.lib.nbjshell9|org.netbeans.lib.nbjshell|org.netbeans.libs.graalsdk.system).*").hideExtraModules(true).
+//                enableModules("org.netbeans.libs.nbjavacapi").
                 suite();
     }
 


### PR DESCRIPTION
 - graal tests still run on JDK 11
 - temporarily excluding a few nb modules allows to let them run a little while longer before they have to be upgraded or disabled

workaround for test failures caused due to https://github.com/apache/netbeans/pull/7097

graal tests are stuck on EOL GraalVM 11 due to https://github.com/apache/netbeans/issues/6925