### PR TITLE
gracefully handle case, when encSimpleName is equal to simpleName

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/usages/BinaryAnalyser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/usages/BinaryAnalyser.java
@@ -737,6 +737,9 @@ public class BinaryAnalyser {
                         final String encSimpleName = getInternalSimpleName(enclosingMethod.getClassName());
                         if (simpleName.startsWith(encSimpleName)) {
                             len -= encSimpleName.length() + 1;
+                            if (len < 0) {
+                                len = simpleName.length();
+                            }
                             found = true;
                         }
                     }


### PR DESCRIPTION
This fixes assert (see below) when parsing non-compilant class file generated by kotlin.


```
WARNING [org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater]: AssertionError while indexing: jar:file:/Users/thurka/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2023.3.4/135ab387b2066e14bd52d6ee5c827a7fbebe7078/ideaIC-2023.3.4/lib/testFramework.jar!/
java.lang.AssertionError: com.intellij.platform.uast.testFramework.common.NestedMapsKt$transformMap2$$inlined$transform$1$lambda$1c
	at org.netbeans.modules.java.source.usages.BinaryName.<init>(BinaryName.java:42)
	at org.netbeans.modules.java.source.usages.BinaryName.create(BinaryName.java:150)
	at org.netbeans.modules.java.source.usages.BinaryAnalyser.analyse(BinaryAnalyser.java:678)
	at org.netbeans.modules.java.source.usages.BinaryAnalyser.access$800(BinaryAnalyser.java:119)
	at org.netbeans.modules.java.source.usages.BinaryAnalyser$ArchiveProcessor.executeImpl(BinaryAnalyser.java:1297)
	at org.netbeans.modules.java.source.usages.BinaryAnalyser$RootProcessor.execute(BinaryAnalyser.java:1187)
	at org.netbeans.modules.java.source.usages.BinaryAnalyser.analyse(BinaryAnalyser.java:376)
	at org.netbeans.modules.java.source.usages.BinaryAnalyser.analyse(BinaryAnalyser.java:360)
	at org.netbeans.modules.java.source.indexing.JavaBinaryIndexer.doIndex(JavaBinaryIndexer.java:101)
	at org.netbeans.modules.java.source.indexing.JavaBinaryIndexer.index(JavaBinaryIndexer.java:86)
	at org.netbeans.modules.parsing.spi.indexing.Indexable$MyAccessor$1.run(Indexable.java:126)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater.runIndexer(RepositoryUpdater.java:274)
	at org.netbeans.modules.parsing.spi.indexing.Indexable$MyAccessor.index(Indexable.java:124)
[catch] at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Work.indexBinary(RepositoryUpdater.java:3099)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$AbstractRootsWork.lambda$scanBinary$2(RepositoryUpdater.java:5363)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater.lambda$runInContext$4(RepositoryUpdater.java:2119)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:288)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater.runInContext(RepositoryUpdater.java:2117)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater.runInContext(RepositoryUpdater.java:2106)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater.access$1900(RepositoryUpdater.java:135)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$AbstractRootsWork.scanBinary(RepositoryUpdater.java:5391)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$AbstractRootsWork.lambda$scanBinaries$0(RepositoryUpdater.java:5308)
	at org.netbeans.modules.parsing.impl.indexing.IndexBinaryWorkPool$Task.call(IndexBinaryWorkPool.java:181)
	at org.netbeans.modules.parsing.impl.indexing.IndexBinaryWorkPool$Task.call(IndexBinaryWorkPool.java:162)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1420)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2035)
```
