### PR TITLE
Very simple support for native-image build for Helidon projects.

### DIFF
--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/helidon-actions-maven.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/helidon-actions-maven.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<actions>
+    <action>
+        <actionName>native-build</actionName>
+        <packagings>
+            <packaging>*</packaging>
+        </packagings>
+        <goals>
+            <goal>compile</goal>
+        </goals>
+        <activatedProfiles>
+            <activatedProfile>native-image</activatedProfile>
+            <goal>native:compile</goal>
+        </activatedProfiles>
+    </action>
+</actions>

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
@@ -119,6 +119,21 @@
                     </file>
                 </folder>
             </folder>
+            <folder name="configuredPlugins">
+                <folder name="io.helidon.build-tools:helidon-maven-plugin">
+                    <folder name="Lookup">
+                        <file name="maven-project-actions.instance">
+                            <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>
+                            <attr name="instanceCreate" methodvalue="org.netbeans.api.maven.MavenActions.forProjectLayer"/>
+                            <attr name="resource" stringvalue="nbres:/org/netbeans/modules/micronaut/resources/helidon-actions-maven.xml"/>
+                        </file>
+                        <file name="native-image-artifacts.instance">
+                            <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>
+                            <attr name="instanceCreate" methodvalue="org.netbeans.modules.micronaut.maven.MicronautPackagingArtifactsImpl.projectLookup"/>
+                        </file>
+                    </folder>
+                </folder>
+            </folder>
             <folder name="LifecycleParticipants">
                 <folder name="org.graalvm.buildtools.maven.NativeExtension">
                     <attr name="ignoreOnModelLoad" boolvalue="true"/>

--- a/java/maven/src/org/netbeans/modules/maven/layer.xml
+++ b/java/maven/src/org/netbeans/modules/maven/layer.xml
@@ -190,6 +190,9 @@
                     <attr name="goals" stringvalue="exec"/>
                 </file>
             </folder>
+            <folder name="configuredPlugins">
+                <!-- Placeholder -->
+            </folder>
         </folder>
     </folder>
     <folder name="OptionsExport">


### PR DESCRIPTION
There are two key components. The "trigger" `io.helidon.build-tools:helidon-maven-plugin` is not by default part of the project's build lifecycle, but is pre-configured in the `dependencyManagement` part of the parent POM. I did not want to merge registrations for 'potential' plugins (project technologies not activated) with the regular plugin lookups, so I've invented the `configuredPlugins` subfolder. A module developer can choose if he really needs "eager" registration of whatever services his module wants to contribute to Maven projects.

The second part is the actual trigger, that adds "Native Compilation" action to maven project's context menu, which activates `native-image` profile (provided by helidon's application parent pom).

The rest of the processing is handled by Micronaut (actual graalvm native-image) support in Micronaut module.