### PR TITLE
Fix filtering of delete action on Favorites root nodes.

### DIFF
--- a/platform/favorites/src/org/netbeans/modules/favorites/FavoritesNode.java
+++ b/platform/favorites/src/org/netbeans/modules/favorites/FavoritesNode.java
@@ -598,9 +598,11 @@ public final class FavoritesNode extends FilterNode implements Index {
                     newArr.add(null);
                 }
                 //Do not add Delete action
-                if (!(arr1 instanceof DeleteAction)) {
-                    newArr.add(arr1);
+                if (arr1 instanceof DeleteAction ||
+                        (arr1 != null && "delete".equals(arr1.getValue("key")))) {
+                    continue;
                 }
+                newArr.add(arr1);
             }
             if (!added) {
                 added = true;
@@ -623,9 +625,11 @@ public final class FavoritesNode extends FilterNode implements Index {
                     newArr.add(null);
                 }
                 //Do not add Delete action
-                if (!(arr1 instanceof DeleteAction)) {
-                    newArr.add(arr1);
+                if (arr1 instanceof DeleteAction ||
+                        (arr1 != null && "delete".equals(arr1.getValue("key")))) {
+                    continue;
                 }
+                newArr.add(arr1);
             }
             if (!added) {
                 added = true;


### PR DESCRIPTION
Fixes filtering out of the delete action on Favorite root nodes.

A discussion with @mbien elsewhere mentioned it would be good if the delete action wasn't available in the popup menu. Turns out that filtering used to be in there but no longer works.  The type of the action is now `GeneralAction$DelegateAction` but we can also check if the `key` is `"delete"`.  Kept old check in case it's used anywhere.  The placement of the `Remove from Favorites` action is also in the "wrong" place for the same reason, but I think it's better at the bottom anyway.