### PR TITLE
NB Build: Basic support for javac.release property.

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/NbModuleProject.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/NbModuleProject.java
@@ -689,9 +689,13 @@ public final class NbModuleProject implements Project {
     
     /** Get the Java source level used for this module. Default is 1.4. */
     public String getJavacSource() {
-        String javacSource = evaluator().getProperty(SingleModuleProperties.JAVAC_SOURCE);
-        assert javacSource != null;
-        return javacSource;
+        String sourceLevel = evaluator().getProperty(SingleModuleProperties.JAVAC_RELEASE);
+        if (sourceLevel != null && !sourceLevel.isEmpty()) {
+            return sourceLevel;
+        }
+        sourceLevel = evaluator().getProperty(SingleModuleProperties.JAVAC_SOURCE);
+        assert sourceLevel != null;
+        return sourceLevel;
     }
     
     private ClassPath[] boot, source, compile;

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerSources.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerSources.java
@@ -32,6 +32,9 @@ import org.openide.modules.SpecificationVersion;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 
+import static org.netbeans.modules.apisupport.project.ui.customizer.SingleModuleProperties.JAVAC_RELEASE;
+import static org.netbeans.modules.apisupport.project.ui.customizer.SingleModuleProperties.JAVAC_SOURCE;
+
 /**
  * Represents <em>Sources</em> panel in Netbeans Module customizer.
  *
@@ -51,7 +54,7 @@ final class CustomizerSources extends NbPropertyPanel.Single {
                 if (srcLevelValueBeingUpdated) {
                     return;
                 }
-                final String oldLevel = getProperty(SingleModuleProperties.JAVAC_SOURCE);
+                final String oldLevel = getProperty(getJavacLanguageLevelKey());
                 final String newLevel = (String) srcLevelValue.getSelectedItem();
                 SpecificationVersion jdk5 = new SpecificationVersion("1.5"); // NOI18N
                 if (new SpecificationVersion(oldLevel).compareTo(jdk5) < 0 && new SpecificationVersion(newLevel).compareTo(jdk5) >= 0) {
@@ -80,6 +83,7 @@ final class CustomizerSources extends NbPropertyPanel.Single {
         });
     }
     
+    @Override
     protected void refresh() {
         if (getProperties().getSuiteDirectoryPath() == null) {
             moduleSuite.setVisible(false);
@@ -95,16 +99,20 @@ final class CustomizerSources extends NbPropertyPanel.Single {
             for (String level : levels) {
                 srcLevelValue.addItem(level);
             }
-            srcLevelValue.setSelectedItem(getProperty(SingleModuleProperties.JAVAC_SOURCE));
+            srcLevelValue.setSelectedItem(getProperty(getJavacLanguageLevelKey()));
         } finally {
             srcLevelValueBeingUpdated = false;
         }
         ApisupportAntUIUtils.setText(prjFolderValue, getProperties().getProjectDirectory());
     }
     
+    @Override
     public void store() {
-        setProperty(SingleModuleProperties.JAVAC_SOURCE,
-                (String) srcLevelValue.getSelectedItem());
+        setProperty(getJavacLanguageLevelKey(), (String) srcLevelValue.getSelectedItem());
+    }
+
+    private String getJavacLanguageLevelKey() {
+        return containsProperty(JAVAC_RELEASE) ? JAVAC_RELEASE : JAVAC_SOURCE;
     }
     
     /** This method is called from within the constructor to

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/NbPropertyPanel.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/NbPropertyPanel.java
@@ -65,6 +65,11 @@ public abstract class NbPropertyPanel extends JPanel implements
         return props.getProperty(key);
     }
     
+    boolean containsProperty(String key) {
+        String prop = props.getProperty(key);
+        return prop != null && !prop.isEmpty();
+    }
+    
     void setProperty(String key, String property) {
         props.setProperty(key, property);
     }

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SingleModuleProperties.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SingleModuleProperties.java
@@ -110,6 +110,7 @@ public final class SingleModuleProperties extends ModuleProperties {
     public static final String IS_AUTOLOAD = "is.autoload"; // NOI18N
     public static final String IS_EAGER = "is.eager"; // NOI18N
     public static final String JAVAC_SOURCE = "javac.source"; // NOI18N
+    public static final String JAVAC_RELEASE = "javac.release"; // NOI18N
     public static final String JAVADOC_TITLE = "javadoc.title"; // NOI18N
     public static final String LICENSE_FILE = "license.file"; // NOI18N
     public static final String NBM_HOMEPAGE = "nbm.homepage"; // NOI18N

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
@@ -69,7 +69,11 @@ public class CustomJavac extends Javac {
     @Override
     public void execute() throws BuildException {
         String release = getRelease();
-        if (release == null || release.isEmpty()) {
+        if (release != null && release.isEmpty()) {
+            setRelease(null); // unset property
+            release = null;
+        }
+        if (release == null) {
             String tgr = getTarget();
             if (tgr.matches("\\d+")) {
                 tgr = "1." + tgr;

--- a/nbbuild/antsrc/org/netbeans/nbbuild/JarWithModuleAttributes.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/JarWithModuleAttributes.java
@@ -218,8 +218,12 @@ public class JarWithModuleAttributes extends Jar {
                     added.addConfiguredAttribute(new Manifest.Attribute("OpenIDE-Module-Module-Dependencies", moduleDeps));
                 }
             }
-            String javaDep = getProject().getProperty("javac.target");
+            String javaDep = getProject().getProperty("javac.release");
+            if (javaDep == null || javaDep.trim().isEmpty()) {
+                javaDep = getProject().getProperty("javac.target");
+            }
             if (javaDep != null && javaDep.matches("[0-9]+(\\.[0-9]+)*")) {
+                log("Setting requires JDK " + javaDep, Project.MSG_DEBUG); // NOI18N
                 if (isOSGiMode) {
                     if (javaDep.matches("1\\.[0-5]")) {
                         added.addConfiguredAttribute(new Manifest.Attribute("Bundle-RequiredExecutionEnvironment", "J2SE-" + javaDep));

--- a/nbbuild/templates/common.xml
+++ b/nbbuild/templates/common.xml
@@ -68,6 +68,7 @@
         <property name="javac.source" value="1.7"/>
         <property name="javac.default.target" value="${javac.source}"/>
         <property name="javac.target" value="${javac.default.target}"/>
+        <property name="javac.release" value=""/>
         <property name="javac.compilerargs" value=""/>
         <property name="module.auto.deps.xml" location="module-auto-deps.xml"/>
         <condition property="has.module.auto.deps">
@@ -202,7 +203,7 @@
         </depend>
         <property name="javac.fork" value="false"/>
         <nb-javac srcdir="${src.dir}" destdir="${build.classes.dir}" debug="${build.compiler.debug}" debuglevel="${build.compiler.debuglevel}" encoding="UTF-8"
-                  deprecation="${build.compiler.deprecation}" optimize="${build.compiler.optimize}" source="${javac.source}" target="${javac.target}" includeantruntime="false"
+                  deprecation="${build.compiler.deprecation}" optimize="${build.compiler.optimize}" source="${javac.source}" target="${javac.target}" release="${javac.release}" includeantruntime="false"
                   fork="${javac.fork}"
         >
             <classpath refid="cp"/>
@@ -236,7 +237,7 @@
         </delete>
         <nb-javac srcdir="${src.dir}" destdir="${build.classes.dir}"
                   debug="${build.compiler.debug}" deprecation="${build.compiler.deprecation}" encoding="UTF-8"
-                  source="${javac.source}" target="${javac.target}" includes="${javac.includes}" optimize="${build.compiler.optimize}" includeantruntime="false">
+                  source="${javac.source}" target="${javac.target}" release="${javac.release}" includes="${javac.includes}" optimize="${build.compiler.optimize}" includeantruntime="false">
             <classpath refid="cp"/>
             <compilerarg line="${javac.compilerargs}"/>
             <processorpath refid="processor.cp"/>
@@ -635,7 +636,7 @@
             <property name="test.javac.excludes" value=""/> <!-- # 113770 -->
             <nb-javac srcdir="${test.@{test.type}.src.dir}" destdir="${build.test.@{test.type}.classes.dir}" excludes="${test.javac.excludes}"
                       debug="true" deprecation="${build.compiler.deprecation}" encoding="UTF-8"
-                      source="${javac.source}" target="${javac.target}" optimize="${build.compiler.optimize}" includeantruntime="false">
+                      source="${javac.source}" target="${javac.target}" release="${javac.release}" optimize="${build.compiler.optimize}" includeantruntime="false">
                 <classpath refid="test.@{test.type}.cp"/>
                 <compilerarg line="${javac.compilerargs}"/>
                 <processorpath refid="test.@{test.type}.cp"/>
@@ -677,7 +678,7 @@
                 </depend>
                 <nb-javac srcdir="${test.@{test.type}.src.dir}" destdir="${build.test.@{test.type}.classes.dir}"
                           debug="true" deprecation="${build.compiler.deprecation}" encoding="UTF-8"
-                          source="${javac.source}" target="${javac.target}" includeantruntime="false" optimize="${build.compiler.optimize}" includes="${javac.includes}">
+                          source="${javac.source}" target="${javac.target}" release="${javac.release}" includeantruntime="false" optimize="${build.compiler.optimize}" includes="${javac.includes}">
                     <classpath refid="test.@{test.type}.cp"/>
                     <compilerarg line="${javac.compilerargs}"/>
                     <processorpath refid="test.@{test.type}.cp"/>

--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -747,7 +747,11 @@
         </condition>
         <property name="sigtest.mail" value="${commit.mail}"/>
 
-        <echo>sigtest check: ${module.name}; cnb: ${code.name.base.dashes}; email: ${sigtest.mail}; type: ${sigtest.check.type}</echo>
+        <condition property="sigtest.release" value="${javac.target}" else="${javac.release}">
+            <equals arg1="${javac.release}" arg2=""/>
+        </condition>
+
+        <echo>sigtest check: ${module.name}; cnb: ${code.name.base.dashes}; release: ${sigtest.release}; email: ${sigtest.mail}; type: ${sigtest.check.type}</echo>
     </target>
 
     <target name="gen-sigtest" depends="-sigtest-init" unless="${sigtest.skip.gen}">
@@ -758,7 +762,7 @@
                  classpath="${sigtest.class.path}"
                  version="${mf.OpenIDE-Module-Specification-Version}"
                  action="generate"
-                 release="${javac.target}"
+                 release="${sigtest.release}"
                  packages="${sigtest.public.packages}"
                  report="${sigtest.output.dir}/generate-${code.name.base.dashes}.xml"
                  failonerror="${sigtest.gen.fail.on.error}"
@@ -771,7 +775,7 @@
                  sigtestJar="${sigtest.jar}"
                  classpath="${sigtest.class.path}"
                  version="${mf.OpenIDE-Module-Specification-Version}"
-                 release="${javac.target}"
+                 release="${sigtest.release}"
                  action="${sigtest.check.type}"
                  packages="${sigtest.public.packages}"
                  report="${sigtest.output.dir}/${code.name.base.dashes}.xml"


### PR DESCRIPTION
 - custom javac and sigtest tasks needed updates
 - `JarWithModuleAttributes` too, which sets the `OpenIDE-Module-Java-Dependencies` manifest attribute based on the language level
 - ant nbm projects (`apisupport.ant`) needed to be made aware of the javac release property

`apisupport.ant` of NB 21 loads all projects which use `javac.release` as java 1.4 projects, if we get this into NB 22 and devs start using the new release, we can start swapping out `source/target` with `release` during the NB 23 dev cycle.