### PR TITLE
Fix Url in modules description

### DIFF
--- a/enterprise/websvc.restkit/src/org/netbeans/modules/websvc/restkit/Bundle.properties
+++ b/enterprise/websvc.restkit/src/org/netbeans/modules/websvc/restkit/Bundle.properties
@@ -21,6 +21,6 @@ OpenIDE-Module-Display-Category=Java Web and EE
 OpenIDE-Module-Long-Description=\
 <p>Provides rapid application development environment based on Java API for RESTful Web Services (JSR-311).</p>\
 <p>This plugin include JSR-311 Reference Implementation Library (Jersey).  The version of Jersey Library that is included is reflected by the plugin version.  For details of changes see:</p>\
-<a href=\"https://jersey.dev.java.net/source/browse/jersey/trunk/jersey/changes.txt?view=markup\">https://jersey.dev.java.net/source/browse/jersey/trunk/jersey/changes.txt?view=markup</a>
+<a href=\"https://github.com/eclipse-ee4j/jersey">https://github.com/eclipse-ee4j/jersey</a>
 OpenIDE-Module-Name=RESTful Web Services
 OpenIDE-Module-Short-Description=RESTful Web Services Development Support

--- a/ide/hudson/src/org/netbeans/modules/hudson/Bundle.properties
+++ b/ide/hudson/src/org/netbeans/modules/hudson/Bundle.properties
@@ -17,6 +17,6 @@
 
 OpenIDE-Module-Display-Category=Base IDE
 OpenIDE-Module-Long-Description=\
-    Helps browse and manage installations of the Jenkins continuous integration server (https://www.jenkins.io/ ). 
+    Helps browse and manage installations of the Jenkins continuous integration server (<a href="https://www.jenkins.io/">https://www.jenkins.io/</a>).
 OpenIDE-Module-Name=Jenkins
 OpenIDE-Module-Short-Description=Support for the Jenkins continuous integration server.

--- a/java/maven.kit/src/org/netbeans/modules/maven/feature/Bundle.properties
+++ b/java/maven.kit/src/org/netbeans/modules/maven/feature/Bundle.properties
@@ -17,7 +17,7 @@
 
 OpenIDE-Module-Display-Category=Java SE
 OpenIDE-Module-Name=Maven
-OpenIDE-Module-Long-Description=NetBeans IDE support for <a href="http://maven.apache.org">Apache Maven</a>. <p> \
-  Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information. To learn more about Apache Maven, visit <a href="http://maven.apache.org/what-is-maven.html">What is Maven?</a> page. <p> \
+OpenIDE-Module-Long-Description=NetBeans IDE support for <a href="https://maven.apache.org">Apache Maven</a>. <p> \
+  Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information. To learn more about Apache Maven, visit <a href="https://maven.apache.org/what-is-maven.html">What is Maven?</a> page. <p> \
  The IDE support includes own project type entirely based on Maven's medatata, code completion for Maven's project files, integration with other tools in the IDE etc. 
 OpenIDE-Module-Short-Description=NetBeans Maven project system support

--- a/platform/core.kit/src/org/netbeans/modules/core/kit/Bundle.properties
+++ b/platform/core.kit/src/org/netbeans/modules/core/kit/Bundle.properties
@@ -20,4 +20,4 @@ OpenIDE-Module-Short-Description=NetBeans RCP Platform
 OpenIDE-Module-Long-Description=\
     The NetBeans RCP Platform is a generic framework for Swing applications. \
     It provides the services common to almost all large desktop applications: window management, menus, settings and storage, update management, file access, etc.\
-    <br><br>See more information at <a href="http://platform.netbeans.org">platform.netbeans.org</a>.
+    <br><br>See more information at <a href="https://platform.netbeans.org">Apache NetBeans Platform Learning Trail</a>.

--- a/webcommon/cordova/src/org/netbeans/modules/cordova/Bundle.properties
+++ b/webcommon/cordova/src/org/netbeans/modules/cordova/Bundle.properties
@@ -18,7 +18,7 @@ build-ios=Build iOS
 build-android=Build Android
 OpenIDE-Module-Long-Description=\
     Support for Cordova. \
-    See http://cordova.apache.org
+    See <a href="https://cordova.apache.org">Apache Cordova</a>
 OpenIDE-Module-Short-Description=Cordova Support
 sim-ios=Run iOS
 sim-android=Run Android

--- a/webcommon/javascript2.kit/src/org/netbeans/modules/javascript2/kit/Bundle.properties
+++ b/webcommon/javascript2.kit/src/org/netbeans/modules/javascript2/kit/Bundle.properties
@@ -20,4 +20,4 @@ OpenIDE-Module-Name=JavaScript2 Kit
 OpenIDE-Module-Short-Description=An umbrella module covering all modules required for JavaScript support.
 OpenIDE-Module-Long-Description=\
     JavaScript support: editing, refactoring, hints, etc.\n\n\
-    For more information, see\nhttp://wiki.netbeans.org/wiki/view/JavaScript
+    For more information, see <a href="https://netbeans.apache.org/wiki/main/wiki/JavaScript/">Apache NetBeans JavaScript</a>

--- a/webcommon/javascript2.prototypejs/src/org/netbeans/modules/javascript2/prototypejs/Bundle.properties
+++ b/webcommon/javascript2.prototypejs/src/org/netbeans/modules/javascript2/prototypejs/Bundle.properties
@@ -17,6 +17,6 @@
 OpenIDE-Module-Display-Category=JavaScript
 OpenIDE-Module-Long-Description=\
     Editor support for PrototypeJs framework. \
-    More about the framework you can read at http://prototypejs.org/ .
+    More about the framework you can read at <a href="http://prototypejs.org/">http://prototypejs.org/</a>.
 OpenIDE-Module-Name=JavaScript2 PrototypeJs
 OpenIDE-Module-Short-Description=PrototypeJs support


### PR DESCRIPTION
Try to make some url linkable in module long description, to have some interaction link we have for gradle / maven plugin. 
Fix old link.

Found a missing javascript wiki page ressurected in this PR
https://github.com/apache/netbeans-antora-wiki/pull/9

https://jersey.dev.java.net is https://github.com/eclipse-ee4j/jersey