### PR TITLE
JS: Handle meta-properties new.target and import.meta and improve code completion with newlines and comments

### DIFF
--- a/webcommon/html.knockout/test/unit/data/completion/foreach/index.html.testForEach.completion
+++ b/webcommon/html.knockout/test/unit/data/completion/foreach/index.html.testForEach.completion
@@ -6,7 +6,9 @@ CONSTRUCTO Bulici                          [PUBLIC]   index.html
 CONSTRUCTO Clobrda                         [PUBLIC]   index.html
 CLASS      $context                        [PRIVATE]  <font color=#999999>index.html</font>
 CLASS      $parentContext                  [PRIVATE]  <font color=#999999>index.html</font>
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      ko                              [PUBLIC]   <font color=#999999>Knockout</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 METHOD     init(): undefined               [PUBLIC]   index.html
 FIELD      age: Number                     [PUBLIC]   index.html
 FIELD      jmeno                           [PUBLIC]   index.html

--- a/webcommon/html.knockout/test/unit/data/completion/foreachAlias/index.html.testForEachAlias.completion
+++ b/webcommon/html.knockout/test/unit/data/completion/foreachAlias/index.html.testForEachAlias.completion
@@ -4,7 +4,9 @@ Code completion result for source line:
 ------------------------------------
 CLASS      $context                        [PRIVATE]  <font color=#999999>index.html</font>
 CLASS      $parentContext                  [PRIVATE]  <font color=#999999>index.html</font>
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      ko                              [PUBLIC]   <font color=#999999>Knockout</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      viewModel                       [PUBLIC]   index.html
 VARIABLE   $data                           [PRIVATE]  <font color=#999999>index.html</font>
 VARIABLE   $element                        [PRIVATE]  <font color=#999999>index.html</font>

--- a/webcommon/html.knockout/test/unit/data/completion/issue231569/index.html.testIssue231569.completion
+++ b/webcommon/html.knockout/test/unit/data/completion/issue231569/index.html.testIssue231569.completion
@@ -5,7 +5,9 @@ Code completion result for source line:
 CONSTRUCTO TestModel                       [PUBLIC]   index.html
 CLASS      $context                        [PRIVATE]  <font color=#999999>index.html</font>
 CLASS      $parentContext                  [PRIVATE]  <font color=#999999>index.html</font>
+CLASS      import                          [PUBLIC]   metaproperties.js
 CLASS      ko                              [PUBLIC]   <font color=#999999>Knockout</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 FIELD      savedLists: ko.observableArray  [PUBLIC]   <font color=#999999>index.html</font>
 FIELD      userNameToAddIsValid            [PUBLIC]   <font color=#999999>index.html</font>
 VARIABLE   $data: ko.$bindings             [PRIVATE]  <font color=#999999>index.html</font>

--- a/webcommon/html.knockout/test/unit/data/completion/template/index.html.testTemplate.completion
+++ b/webcommon/html.knockout/test/unit/data/completion/template/index.html.testTemplate.completion
@@ -5,7 +5,9 @@ Code completion result for source line:
 CONSTRUCTO MyViewModel                     [PUBLIC]   index.html
 CLASS      $context                        [PRIVATE]  <font color=#999999>index.html</font>
 CLASS      $parentContext                  [PRIVATE]  <font color=#999999>index.html</font>
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      ko                              [PUBLIC]   <font color=#999999>Knockout</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 FIELD      credits: Number                 [PUBLIC]   index.html
 FIELD      name: String                    [PUBLIC]   index.html
 VARIABLE   $data                           [PRIVATE]  <font color=#999999>index.html</font>

--- a/webcommon/html.knockout/test/unit/data/completion/templateForEach/index.html.testTemplateForEach.completion
+++ b/webcommon/html.knockout/test/unit/data/completion/templateForEach/index.html.testTemplateForEach.completion
@@ -5,7 +5,9 @@ Code completion result for source line:
 CONSTRUCTO MyViewModel                     [PUBLIC]   index.html
 CLASS      $context                        [PRIVATE]  <font color=#999999>index.html</font>
 CLASS      $parentContext                  [PRIVATE]  <font color=#999999>index.html</font>
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      ko                              [PUBLIC]   <font color=#999999>Knockout</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 FIELD      credits: Number                 [PUBLIC]   index.html
 FIELD      name: String                    [PUBLIC]   index.html
 VARIABLE   $data                           [PRIVATE]  <font color=#999999>index.html</font>

--- a/webcommon/html.knockout/test/unit/data/completion/templateInner/index.html.testTemplateInner.completion
+++ b/webcommon/html.knockout/test/unit/data/completion/templateInner/index.html.testTemplateInner.completion
@@ -4,7 +4,9 @@ Code completion result for source line:
 ------------------------------------
 CLASS      $context                        [PRIVATE]  <font color=#999999>index.html</font>
 CLASS      $parentContext                  [PRIVATE]  <font color=#999999>index.html</font>
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      ko                              [PUBLIC]   <font color=#999999>Knockout</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      viewModel                       [PUBLIC]   index.html
 FIELD      months: Array                   [PUBLIC]   index.html
 FIELD      name: String                    [PUBLIC]   index.html

--- a/webcommon/html.knockout/test/unit/data/completion/with/index.html.testWith.completion
+++ b/webcommon/html.knockout/test/unit/data/completion/with/index.html.testWith.completion
@@ -6,7 +6,9 @@ CONSTRUCTO Bulici                          [PUBLIC]   index.html
 CONSTRUCTO Clobrda                         [PUBLIC]   index.html
 CLASS      $context                        [PRIVATE]  <font color=#999999>index.html</font>
 CLASS      $parentContext                  [PRIVATE]  <font color=#999999>index.html</font>
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      ko                              [PUBLIC]   <font color=#999999>Knockout</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 METHOD     init(): undefined               [PUBLIC]   index.html
 FIELD      age: Number                     [PUBLIC]   index.html
 FIELD      jmeno                           [PUBLIC]   index.html

--- a/webcommon/javascript2.editor/nbproject/project.properties
+++ b/webcommon/javascript2.editor/nbproject/project.properties
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.source=11
+javac.target=11
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 nbm.needs.restart=true

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/CompletionContextFinder.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/CompletionContextFinder.java
@@ -318,6 +318,12 @@ public class CompletionContextFinder {
         int orgTokenSequencePos = tokenSequence.offset();
         boolean accept = true;
         boolean moreTokens = movePrevious ? tokenSequence.movePrevious() : true;
+        while((tokenSequence.token().id() == JsTokenId.BLOCK_COMMENT || tokenSequence.token().id() == JsTokenId.LINE_COMMENT)) {
+            moreTokens = tokenSequence.movePrevious();
+            if(! moreTokens) {
+                break;
+            }
+        }
 
         for (int i = tokenIdChain.length - 1; i >= 0; i --){
             Object tokenID = tokenIdChain[i];
@@ -328,8 +334,14 @@ public class CompletionContextFinder {
             }
 
            if (tokenID instanceof JsTokenId) {
-                if (tokenSequence.token().id() == tokenID){
+                if (tokenSequence.token().id() == tokenID) {
                     moreTokens = tokenSequence.movePrevious();
+                    while ((tokenSequence.token().id() == JsTokenId.BLOCK_COMMENT || tokenSequence.token().id() == JsTokenId.LINE_COMMENT)) {
+                        moreTokens = tokenSequence.movePrevious();
+                        if (!moreTokens) {
+                            break;
+                        }
+                    }
                 } else {
                     // NO MATCH
                     accept = false;
@@ -342,7 +354,7 @@ public class CompletionContextFinder {
 
         tokenSequence.move(orgTokenSequencePos);
         tokenSequence.moveNext();
-       return accept;
+        return accept;
     }
 
     private static void balanceBracketBack(TokenSequence<JsTokenId> ts) {

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/classpath/MetaPropertiesModelContributor.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/classpath/MetaPropertiesModelContributor.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javascript2.editor.classpath;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.netbeans.modules.javascript2.editor.parser.JsParserResult;
+import org.netbeans.modules.javascript2.model.api.JsObject;
+import org.netbeans.modules.javascript2.model.api.Model;
+import org.netbeans.modules.javascript2.model.spi.ModelElementFactory;
+import org.netbeans.modules.javascript2.model.spi.ModelInterceptor;
+import org.netbeans.modules.javascript2.model.spi.ModelInterceptor.Registration;
+import org.netbeans.modules.parsing.api.ParserManager;
+import org.netbeans.modules.parsing.api.Source;
+import org.netbeans.modules.parsing.spi.ParseException;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.URLMapper;
+
+@Registration
+public class MetaPropertiesModelContributor implements ModelInterceptor {
+
+    private static final Logger LOG = Logger.getLogger(MetaPropertiesModelContributor.class.getName());
+
+    private static Model GLOBALS = null;
+
+    @Override
+    public Collection<JsObject> interceptGlobal(ModelElementFactory factory, FileObject fo) {
+        if(GLOBALS == null) {
+            try {
+                FileObject globalsJS = URLMapper.findFileObject(MetaPropertiesModelContributor.class.getResource("metaproperties.js")); //NOI18N
+                Source source = Source.create(globalsJS);
+                ParserManager.parse(Set.of(source), (resultIterator) -> {
+                    Model model = Model.getModel((JsParserResult) resultIterator.getParserResult(), true);
+                    JsObject globalsVariables = model.getGlobalObject().getProperty("metaproperties"); //NOI18N
+                    for(String propertyName: new ArrayList<>(globalsVariables.getProperties().keySet())) {
+                        globalsVariables.moveProperty(propertyName, model.getGlobalObject());
+                    }
+                    model.getGlobalObject().getProperties().remove("metaproperties"); //NOI18N
+                    GLOBALS = model;
+                });
+            } catch (ParseException ex) {
+                LOG.log(Level.WARNING, "Failed to initialize metaproperties.js to supply i.e. new.target and import.meta");
+            }
+        }
+        JsObject globals = GLOBALS.getGlobalObject();
+        return List.of(globals);
+    }
+
+}

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/classpath/metaproperties.js
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/classpath/metaproperties.js
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+var metaproperties = {};
+
+metaproperties.new = {};
+/**
+ * The <strong><code>new.target</code></strong> meta-property lets you detect
+ * whether a function or constructor was called using the <code>new</code>
+ * operator. In constructors and functions invoked using the <code>new</code>
+ * operator, <strong><code>new.target</code></strong> returns a reference to the
+ * constructor or function that new was called upon. In normal function calls,
+ * <strong><code>new.target</code></strong> is undefined.
+ */
+metaproperties.new.target = function(){};
+
+metaproperties.import = {};
+metaproperties.import.meta = {};
+/**
+ * The full URL to the module, includes query parameters and/or hash (following
+ * the ? or #).
+ *
+ * In browsers, this is either the URL from which the script was obtained (for
+ * external scripts), or the URL of the containing document (for inline
+ * scripts).
+ *
+ * In Node.js, this is the file path (including the file:// protocol).
+ *
+ * @type String|null
+ */
+metaproperties.import.meta.url = "";
+/**
+ * import.meta.resolve() is a built-in function defined on the import.meta
+ * object of a JavaScript module that resolves a module specifier to a URL using
+ * the current module's URL as base.
+ *
+ * @param {String} moduleName
+ * @returns {String}
+ */
+metaproperties.import.meta.resolve = function(moduleName) {};

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/callback/callback01.js.testOfferingCallbackFunction01.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/callback/callback01.js.testOfferingCallbackFunction01.completion
@@ -79,6 +79,8 @@ CONSTRUCTO Uint8ClampedArray               [PUBLIC]   JS Platform
 CONSTRUCTO WeakMap                         [PUBLIC]   JS Platform
 CONSTRUCTO WeakRef                         [PUBLIC]   JS Platform
 CONSTRUCTO WeakSet                         [PUBLIC]   JS Platform
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 METHOD     ImportAssertions                [PUBLIC]   JS Platform
 METHOD     Intl(): undefined               [PUBLIC]   JS Platform
 METHOD     Math                            [PUBLIC]   JS Platform

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/constructors.js.testConstructors_01.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/constructors.js.testConstructors_01.completion
@@ -4,6 +4,8 @@ var hisObject = new |MyObject();
 ------------------------------------
 CONSTRUCTO sheObject(): sheObject          [PRIVATE]  constructors.js
 CLASS      Context                         [PUBLIC]   constructors.js
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 METHOD     MyObject(): undefined           [PRIVATE]  constructors.js
 METHOD     test()                          [PUBLIC]   constructors.js
 METHOD     yourObject(): undefined         [PRIVATE]  constructors.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_0.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_0.js
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+impo

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_0.js.testGH5919_0_1.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_0.js.testGH5919_0_1.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+impo|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      import                          [PUBLIC]   metaproperties.js
+KEYWORD    import                                     ECMAScript 6 - 2015

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import.meta.url;
+function dummy() {
+    new.target;
+}

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js.testGH5919_1_1.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js.testGH5919_1_1.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+import.|meta.url;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      meta                            [PUBLIC]   metaproperties.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js.testGH5919_1_2.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js.testGH5919_1_2.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+import.me|ta.url;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      meta                            [PUBLIC]   metaproperties.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js.testGH5919_1_3.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js.testGH5919_1_3.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+import.meta.|url;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     resolve(moduleName: String): S  [PUBLIC]   <font color=#999999>metaproperties.js</font>
+FIELD      url: null|String                [PUBLIC]   <font color=#999999>metaproperties.js</font>

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js.testGH5919_1_4.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js.testGH5919_1_4.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+import.meta.ur|l;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+FIELD      url: null|String                [PUBLIC]   <font color=#999999>metaproperties.js</font>

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js.testGH5919_1_5.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js.testGH5919_1_5.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+ne|w.target;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      new                             [PUBLIC]   metaproperties.js
+KEYWORD    new                                        null

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js.testGH5919_1_6.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js.testGH5919_1_6.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+new.|target;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     target(): undefined             [PUBLIC]   metaproperties.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js.testGH5919_1_7.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_1.js.testGH5919_1_7.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+new.targ|et;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     target(): undefined             [PUBLIC]   metaproperties.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import/*dummy*/.meta.url;
+function dummy() {
+    new/*dummy*/.target;
+}

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js.testGH5919_2_1.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js.testGH5919_2_1.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+import/*dummy*/.|meta.url;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      meta                            [PUBLIC]   metaproperties.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js.testGH5919_2_2.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js.testGH5919_2_2.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+import/*dummy*/.me|ta.url;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      meta                            [PUBLIC]   metaproperties.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js.testGH5919_2_3.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js.testGH5919_2_3.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+import/*dummy*/.meta.|url;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     resolve(moduleName: String): S  [PUBLIC]   <font color=#999999>metaproperties.js</font>
+FIELD      url: null|String                [PUBLIC]   <font color=#999999>metaproperties.js</font>

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js.testGH5919_2_4.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js.testGH5919_2_4.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+import/*dummy*/.meta.ur|l;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+FIELD      url: null|String                [PUBLIC]   <font color=#999999>metaproperties.js</font>

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js.testGH5919_2_5.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js.testGH5919_2_5.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+ne|w/*dummy*/.target;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      new                             [PUBLIC]   metaproperties.js
+KEYWORD    new                                        null

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js.testGH5919_2_6.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js.testGH5919_2_6.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+new/*dummy*/.|target;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     target(): undefined             [PUBLIC]   metaproperties.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js.testGH5919_2_7.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_2.js.testGH5919_2_7.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+new/*dummy*/.targ|et;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     target(): undefined             [PUBLIC]   metaproperties.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import/*dummy*/./*dummy*/meta.url;
+function dummy() {
+    new/*dummy*/./*dummy*/target;
+}

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_1.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_1.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+import/*dummy*/.|/*dummy*/meta.url;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      meta                            [PUBLIC]   metaproperties.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_2.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_2.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+import/*dummy*/./*dummy*/|meta.url;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      meta                            [PUBLIC]   metaproperties.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_3.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_3.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+import/*dummy*/./*dummy*/me|ta.url;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      meta                            [PUBLIC]   metaproperties.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_4.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_4.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+import/*dummy*/./*dummy*/meta.|url;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     resolve(moduleName: String): S  [PUBLIC]   <font color=#999999>metaproperties.js</font>
+FIELD      url: null|String                [PUBLIC]   <font color=#999999>metaproperties.js</font>

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_5.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_5.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+import/*dummy*/./*dummy*/meta.ur|l;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+FIELD      url: null|String                [PUBLIC]   <font color=#999999>metaproperties.js</font>

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_6.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_6.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+ne|w/*dummy*/./*dummy*/target;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      new                             [PUBLIC]   metaproperties.js
+KEYWORD    new                                        null

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_7.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_7.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+new/*dummy*/.|/*dummy*/target;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     target(): undefined             [PUBLIC]   metaproperties.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_8.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_8.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+new/*dummy*/./*dummy*/|target;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     target(): undefined             [PUBLIC]   metaproperties.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_9.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/gh5919/gh5919_3.js.testGH5919_3_9.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+new/*dummy*/./*dummy*/targ|et;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     target(): undefined             [PUBLIC]   metaproperties.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/issue226650.html.testIssue226650.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/issue226650.html.testIssue226650.completion
@@ -2,6 +2,8 @@ Code completion result for source line:
 <script>|
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 KEYWORD    async                                      ECMAScript 7 - 2016 (Experimental)
 KEYWORD    await                                      ECMAScript 7 - 2016 (Experimental)
 KEYWORD    break                                      null

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/issue232178.js.testIssue232178_01.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/issue232178.js.testIssue232178_01.completion
@@ -4,6 +4,8 @@ Code completion result for source line:
 ------------------------------------
 CONSTRUCTO Test                            [PUBLIC]   issue232178.js
 CLASS      document                        [PUBLIC]   issue232178.js
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      synergy                         [PUBLIC]   issue232178.js
 CLASS      util                            [PUBLIC]   issue232178.js
 METHOD     Date                            [PUBLIC]   issue232178.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/issue240914.js.testIssue240914_01.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/issue240914.js.testIssue240914_01.completion
@@ -3,7 +3,9 @@ Code completion result for source line:
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
 CLASS      console                         [PUBLIC]   issue240914.js
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      issue290914                     [PUBLIC]   issue240914.js
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 FIELD      age: Number                     [PUBLIC]   issue240914.js
 FIELD      name: String                    [PUBLIC]   issue240914.js
 KEYWORD    async                                      ECMAScript 7 - 2016 (Experimental)

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/issue240914.js.testIssue240914_04.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/issue240914.js.testIssue240914_04.completion
@@ -3,7 +3,9 @@ Code completion result for source line:
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
 CLASS      console                         [PUBLIC]   issue240914.js
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      issue290914                     [PUBLIC]   issue240914.js
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      prop3                           [PUBLIC]   issue240914.js
 METHOD     create(): issue290914           [PUBLIC]   issue240914.js
 FIELD      prop1: Number                   [PUBLIC]   issue240914.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/issue254609/issue254609Test.js.testIssue254609_01.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/issue254609/issue254609Test.js.testIssue254609_01.completion
@@ -2,6 +2,7 @@ Code completion result for source line:
 n|;//test1
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
+CLASS      new                             [PUBLIC]   metaproperties.js
 FIELD      name: String                    [PUBLIC]   controllers.js
 KEYWORD    new                                        null
 KEYWORD    null                                       null

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/typeInferenceNew.js.testTypeInferenceNew01.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/typeInferenceNew.js.testTypeInferenceNew01.completion
@@ -6,6 +6,8 @@ CONSTRUCTO Address                         [PUBLIC]   typeInferenceNew.js
 CONSTRUCTO Car                             [PUBLIC]   typeInferenceNew.js
 CLASS      Context                         [PUBLIC]   typeInferenceNew.js
 CLASS      formatter                       [PUBLIC]   typeInferenceNew.js
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 VARIABLE   object: Address|Car             [PUBLIC]   typeInferenceNew.js
 KEYWORD    async                                      ECMAScript 7 - 2016 (Experimental)
 KEYWORD    await                                      ECMAScript 7 - 2016 (Experimental)

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/with/with1.js.testWith1.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/with/with1.js.testWith1.completion
@@ -79,6 +79,8 @@ CONSTRUCTO WeakMap                         [PUBLIC]   JS Platform
 CONSTRUCTO WeakRef                         [PUBLIC]   JS Platform
 CONSTRUCTO WeakSet                         [PUBLIC]   JS Platform
 CLASS      b                               [PUBLIC]   with1.js
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      prototype                       [PUBLIC]   JS Platform
 CLASS      z                               [PUBLIC]   with1.js
 METHOD     ImportAssertions                [PUBLIC]   JS Platform

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/with/with3.js.testWith3.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/with/with3.js.testWith3.completion
@@ -79,6 +79,8 @@ CONSTRUCTO WeakMap                         [PUBLIC]   JS Platform
 CONSTRUCTO WeakRef                         [PUBLIC]   JS Platform
 CONSTRUCTO WeakSet                         [PUBLIC]   JS Platform
 CLASS      b                               [PUBLIC]   with3.js
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      z                               [PUBLIC]   with3.js
 METHOD     ImportAssertions                [PUBLIC]   JS Platform
 METHOD     Intl(): undefined               [PUBLIC]   JS Platform

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/withAnonymous/with5.js.testWith5.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/withAnonymous/with5.js.testWith5.completion
@@ -78,7 +78,9 @@ CONSTRUCTO Uint8ClampedArray               [PUBLIC]   JS Platform
 CONSTRUCTO WeakMap                         [PUBLIC]   JS Platform
 CONSTRUCTO WeakRef                         [PUBLIC]   JS Platform
 CONSTRUCTO WeakSet                         [PUBLIC]   JS Platform
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      ko                              [PUBLIC]   with5.js
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      z                               [PUBLIC]   declaration.js
 METHOD     ImportAssertions                [PUBLIC]   JS Platform
 METHOD     Intl(): undefined               [PUBLIC]   JS Platform

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/withComplex/with4.js.testWith4a.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/withComplex/with4.js.testWith4a.completion
@@ -79,6 +79,8 @@ CONSTRUCTO WeakMap                         [PUBLIC]   JS Platform
 CONSTRUCTO WeakRef                         [PUBLIC]   JS Platform
 CONSTRUCTO WeakSet                         [PUBLIC]   JS Platform
 CLASS      b                               [PUBLIC]   with4.js
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      prototype                       [PUBLIC]   JS Platform
 CLASS      z                               [PUBLIC]   with4.js
 METHOD     ImportAssertions                [PUBLIC]   JS Platform

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/withComplex/with4.js.testWith4b.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/withComplex/with4.js.testWith4b.completion
@@ -79,6 +79,8 @@ CONSTRUCTO WeakMap                         [PUBLIC]   JS Platform
 CONSTRUCTO WeakRef                         [PUBLIC]   JS Platform
 CONSTRUCTO WeakSet                         [PUBLIC]   JS Platform
 CLASS      b                               [PUBLIC]   with4.js
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      prototype                       [PUBLIC]   JS Platform
 CLASS      z                               [PUBLIC]   with4.js
 METHOD     ImportAssertions                [PUBLIC]   JS Platform

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/completion/withComplex/with4.js.testWith4c.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/completion/withComplex/with4.js.testWith4c.completion
@@ -79,6 +79,8 @@ CONSTRUCTO WeakMap                         [PUBLIC]   JS Platform
 CONSTRUCTO WeakRef                         [PUBLIC]   JS Platform
 CONSTRUCTO WeakSet                         [PUBLIC]   JS Platform
 CLASS      b                               [PUBLIC]   with4.js
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      prototype                       [PUBLIC]   JS Platform
 CLASS      z                               [PUBLIC]   with4.js
 METHOD     ImportAssertions                [PUBLIC]   JS Platform

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/assign-new-target.js.ast.xml
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/assign-new-target.js.ast.xml
@@ -57,9 +57,12 @@
               <isInitializedHere/>
             </IdentNode>
             <!-- VarNode Init -->
-            <IdentNode start='27' end='37'>
-              <name>new.target</name>
-            </IdentNode>
+            <AccessNode property='target' start='27' end='37'>
+              <!-- AccessNode Base -->
+              <IdentNode start='27' end='30'>
+                <name>new</name>
+              </IdentNode>
+            </AccessNode>
           </VarNode>
         </Block>
       </FunctionNode>

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve-comment.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve-comment.js
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+console.log(import./*first comment*/meta. /*second comment*/ resolve("demo"));

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve-comment.js.ast.xml
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve-comment.js.ast.xml
@@ -19,42 +19,39 @@
 
 -->
 
-<FunctionNode name=':program' kind='SCRIPT' start='0' end='33'>
-  <hasDeclaredFunctions/>
+<FunctionNode name='import-meta-resolve-comment.js' kind='MODULE' start='0' end='888'>
   <isProgram/>
   <!-- FunctionNode Parameters -->
   <!-- FunctionNode Body -->
-  <Block start='0' end='32'>
+  <Block start='0' end='887'>
     <isFunctionBody/>
     <isSynthetic/>
     <!-- Block Statements -->
-    <VarNode name='f' start='0' end='32'>
-      <hasInit/>
-      <isAssignment/>
-      <isFunctionDeclaration/>
-      <!-- VarNode Assignment Dest -->
-      <IdentNode start='9' end='10'>
-        <name>f</name>
-        <isInitializedHere/>
-      </IdentNode>
-      <!-- VarNode Init -->
-      <FunctionNode name='f' kind='NORMAL' start='0' end='32'>
-        <isDeclared/>
-        <!-- FunctionNode Parameters -->
-        <!-- FunctionNode Body -->
-        <Block start='13' end='30'>
-          <isFunctionBody/>
-          <!-- Block Statements -->
-          <ExpressionStatement start='19' end='30'>
-            <AccessNode property='target' start='19' end='29'>
+    <ExpressionStatement start='809' end='887'>
+      <CallNode start='809' end='886'>
+        <!-- CallNode Arguments -->
+        <CallNode start='821' end='885'>
+          <!-- CallNode Arguments -->
+          <StringLiteralNode value='demo' start='879' end='883'/>
+          <!-- CallNode Function -->
+          <AccessNode property='resolve' start='821' end='877'>
+            <!-- AccessNode Base -->
+            <AccessNode property='meta' start='821' end='849'>
               <!-- AccessNode Base -->
-              <IdentNode start='19' end='22'>
-                <name>new</name>
+              <IdentNode start='821' end='827'>
+                <name>import</name>
               </IdentNode>
             </AccessNode>
-          </ExpressionStatement>
-        </Block>
-      </FunctionNode>
-    </VarNode>
+          </AccessNode>
+        </CallNode>
+        <!-- CallNode Function -->
+        <AccessNode property='log' start='809' end='820'>
+          <!-- AccessNode Base -->
+          <IdentNode start='809' end='816'>
+            <name>console</name>
+          </IdentNode>
+        </AccessNode>
+      </CallNode>
+    </ExpressionStatement>
   </Block>
 </FunctionNode>

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve-multiline.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve-multiline.js
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import(
+    import
+        .meta
+        .resolve("demo")
+);

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve-multiline.js.ast.xml
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve-multiline.js.ast.xml
@@ -1,0 +1,54 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<FunctionNode name='import-meta-resolve-multiline.js' kind='MODULE' start='0' end='870'>
+  <isProgram/>
+  <!-- FunctionNode Parameters -->
+  <!-- FunctionNode Body -->
+  <Block start='0' end='869'>
+    <isFunctionBody/>
+    <isSynthetic/>
+    <!-- Block Statements -->
+    <ExpressionStatement start='809' end='869'>
+      <CallNode start='809' end='868'>
+        <!-- CallNode Arguments -->
+        <CallNode start='821' end='866'>
+          <!-- CallNode Arguments -->
+          <StringLiteralNode value='demo' start='860' end='864'/>
+          <!-- CallNode Function -->
+          <AccessNode property='resolve' start='821' end='858'>
+            <!-- AccessNode Base -->
+            <AccessNode property='meta' start='821' end='841'>
+              <!-- AccessNode Base -->
+              <IdentNode start='821' end='827'>
+                <name>import</name>
+              </IdentNode>
+            </AccessNode>
+          </AccessNode>
+        </CallNode>
+        <!-- CallNode Function -->
+        <IdentNode start='815' end='815'>
+          <name>import</name>
+        </IdentNode>
+      </CallNode>
+    </ExpressionStatement>
+  </Block>
+</FunctionNode>

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve.js
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+console.log(import.meta.resolve("demo"));

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve.js.ast.xml
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve.js.ast.xml
@@ -19,42 +19,39 @@
 
 -->
 
-<FunctionNode name=':program' kind='SCRIPT' start='0' end='33'>
-  <hasDeclaredFunctions/>
+<FunctionNode name='import-meta-resolve.js' kind='MODULE' start='0' end='851'>
   <isProgram/>
   <!-- FunctionNode Parameters -->
   <!-- FunctionNode Body -->
-  <Block start='0' end='32'>
+  <Block start='0' end='850'>
     <isFunctionBody/>
     <isSynthetic/>
     <!-- Block Statements -->
-    <VarNode name='f' start='0' end='32'>
-      <hasInit/>
-      <isAssignment/>
-      <isFunctionDeclaration/>
-      <!-- VarNode Assignment Dest -->
-      <IdentNode start='9' end='10'>
-        <name>f</name>
-        <isInitializedHere/>
-      </IdentNode>
-      <!-- VarNode Init -->
-      <FunctionNode name='f' kind='NORMAL' start='0' end='32'>
-        <isDeclared/>
-        <!-- FunctionNode Parameters -->
-        <!-- FunctionNode Body -->
-        <Block start='13' end='30'>
-          <isFunctionBody/>
-          <!-- Block Statements -->
-          <ExpressionStatement start='19' end='30'>
-            <AccessNode property='target' start='19' end='29'>
+    <ExpressionStatement start='809' end='850'>
+      <CallNode start='809' end='849'>
+        <!-- CallNode Arguments -->
+        <CallNode start='821' end='848'>
+          <!-- CallNode Arguments -->
+          <StringLiteralNode value='demo' start='842' end='846'/>
+          <!-- CallNode Function -->
+          <AccessNode property='resolve' start='821' end='840'>
+            <!-- AccessNode Base -->
+            <AccessNode property='meta' start='821' end='832'>
               <!-- AccessNode Base -->
-              <IdentNode start='19' end='22'>
-                <name>new</name>
+              <IdentNode start='821' end='827'>
+                <name>import</name>
               </IdentNode>
             </AccessNode>
-          </ExpressionStatement>
-        </Block>
-      </FunctionNode>
-    </VarNode>
+          </AccessNode>
+        </CallNode>
+        <!-- CallNode Function -->
+        <AccessNode property='log' start='809' end='820'>
+          <!-- AccessNode Base -->
+          <IdentNode start='809' end='816'>
+            <name>console</name>
+          </IdentNode>
+        </AccessNode>
+      </CallNode>
+    </ExpressionStatement>
   </Block>
 </FunctionNode>

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-url.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-url.js
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+console.log(import.meta.url);

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-url.js.ast.xml
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/import-meta-url.js.ast.xml
@@ -1,0 +1,52 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<FunctionNode name='import-meta-url.js' kind='MODULE' start='0' end='839'>
+  <isProgram/>
+  <!-- FunctionNode Parameters -->
+  <!-- FunctionNode Body -->
+  <Block start='0' end='838'>
+    <isFunctionBody/>
+    <isSynthetic/>
+    <!-- Block Statements -->
+    <ExpressionStatement start='809' end='838'>
+      <CallNode start='809' end='837'>
+        <!-- CallNode Arguments -->
+        <AccessNode property='url' start='821' end='836'>
+          <!-- AccessNode Base -->
+          <AccessNode property='meta' start='821' end='832'>
+            <!-- AccessNode Base -->
+            <IdentNode start='821' end='827'>
+              <name>import</name>
+            </IdentNode>
+          </AccessNode>
+        </AccessNode>
+        <!-- CallNode Function -->
+        <AccessNode property='log' start='809' end='820'>
+          <!-- AccessNode Base -->
+          <IdentNode start='809' end='816'>
+            <name>console</name>
+          </IdentNode>
+        </AccessNode>
+      </CallNode>
+    </ExpressionStatement>
+  </Block>
+</FunctionNode>

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/new-new-target.js.ast.xml
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/new-new-target.js.ast.xml
@@ -52,9 +52,12 @@
                 <isNew/>
                 <!-- CallNode Arguments -->
                 <!-- CallNode Function -->
-                <IdentNode start='23' end='33'>
-                  <name>new.target</name>
-                </IdentNode>
+                <AccessNode property='target' start='23' end='33'>
+                  <!-- AccessNode Base -->
+                  <IdentNode start='23' end='26'>
+                    <name>new</name>
+                  </IdentNode>
+                </AccessNode>
               </CallNode>
             </UnaryNode>
           </ExpressionStatement>

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/new-target-expression.js.ast.xml
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/new-target-expression.js.ast.xml
@@ -45,9 +45,12 @@
           <isFunctionBody/>
           <!-- Block Statements -->
           <ExpressionStatement start='21' end='32'>
-            <IdentNode start='21' end='31'>
-              <name>new.target</name>
-            </IdentNode>
+            <AccessNode property='target' start='21' end='31'>
+              <!-- AccessNode Base -->
+              <IdentNode start='21' end='24'>
+                <name>new</name>
+              </IdentNode>
+            </AccessNode>
           </ExpressionStatement>
         </Block>
       </FunctionNode>

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/new-target-invoke.js.ast.xml
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/new-target-invoke.js.ast.xml
@@ -49,9 +49,12 @@
             <CallNode start='19' end='31'>
               <!-- CallNode Arguments -->
               <!-- CallNode Function -->
-              <IdentNode start='19' end='29'>
-                <name>new.target</name>
-              </IdentNode>
+              <AccessNode property='target' start='19' end='29'>
+                <!-- AccessNode Base -->
+                <IdentNode start='19' end='22'>
+                  <name>new</name>
+                </IdentNode>
+              </AccessNode>
             </CallNode>
           </ExpressionStatement>
         </Block>

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/new-target-precedence.js.ast.xml
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/ecmascript6/parser/ES6/meta-property/new-target-precedence.js.ast.xml
@@ -55,9 +55,12 @@
                   <isNew/>
                   <!-- CallNode Arguments -->
                   <!-- CallNode Function -->
-                  <IdentNode start='23' end='33'>
-                    <name>new.target</name>
-                  </IdentNode>
+                  <AccessNode property='target' start='23' end='33'>
+                    <!-- AccessNode Base -->
+                    <IdentNode start='23' end='26'>
+                      <name>new</name>
+                    </IdentNode>
+                  </AccessNode>
                 </CallNode>
               </UnaryNode>
             </CallNode>

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/issue232792.js.testCCinWith01.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/issue232792.js.testCCinWith01.completion
@@ -5,6 +5,8 @@ Code completion result for source line:
 CLASS      A                               [PUBLIC]   issue232792.js
 CLASS      B                               [PUBLIC]   issue232792.js
 CLASS      console                         [PUBLIC]   issue232792.js
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 METHOD     getGlobal(): undefined          [PUBLIC]   issue232792.js
 METHOD     getInfo(): undefined            [PUBLIC]   issue232792.js
 METHOD     getName(): undefined            [PUBLIC]   issue232792.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/with/issue234373.js.testIssue234373_02.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/with/issue234373.js.testIssue234373_02.completion
@@ -4,6 +4,8 @@ Code completion result for source line:
 ------------------------------------
 CONSTRUCTO Player234373                    [PUBLIC]   issue234373.js
 CLASS      console                         [PUBLIC]   issue234373.js
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      window                          [PUBLIC]   issue234373.js
 METHOD     play(): undefined               [PROTECTE  issue234373.js
 FIELD      brand: String                   [PUBLIC]   issue234373.js

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/with/issue234381.js.testIssue234381_03.completion
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/with/issue234381.js.testIssue234381_03.completion
@@ -3,6 +3,8 @@ var z = |test() * times;
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
 CLASS      MyObject234381                  [PUBLIC]   issue234381.js
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
+CLASS      new                             [PUBLIC]   <font color=#999999>metaproperties.js</font>
 METHOD     test(): Number                  [PROTECTE  issue234381.js
 FIELD      times: Number                   [PUBLIC]   issue234381.js
 VARIABLE   z: Number                       [PUBLIC]   issue234381.js

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsCodeCompletionIssueGH5919.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsCodeCompletionIssueGH5919.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javascript2.editor;
+
+public class JsCodeCompletionIssueGH5919 extends JsCodeCompletionBase {
+
+    public JsCodeCompletionIssueGH5919(String testName) {
+        super(testName);
+    }
+
+    public void testGH5919_0_1() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_0.js", "impo^", false);
+    }
+
+    public void testGH5919_1_1() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_1.js", "import.^", false);
+    }
+
+    public void testGH5919_1_2() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_1.js", "import.me^", false);
+    }
+
+    public void testGH5919_1_3() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_1.js", "import.meta.^", false);
+    }
+
+    public void testGH5919_1_4() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_1.js", "import.meta.ur^", false);
+    }
+
+    public void testGH5919_1_5() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_1.js", "    ne^w.target;", false);
+    }
+
+    public void testGH5919_1_6() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_1.js", "    new.^target;", false);
+    }
+
+    public void testGH5919_1_7() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_1.js", "    new.targ^et;", false);
+    }
+
+    public void testGH5919_2_1() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_2.js", "import/*dummy*/.^", false);
+    }
+
+    public void testGH5919_2_2() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_2.js", "import/*dummy*/.me^", false);
+    }
+
+    public void testGH5919_2_3() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_2.js", "import/*dummy*/.meta.^", false);
+    }
+
+    public void testGH5919_2_4() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_2.js", "import/*dummy*/.meta.ur^", false);
+    }
+
+    public void testGH5919_2_5() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_2.js", "    ne^w/*dummy*/.target;", false);
+    }
+
+    public void testGH5919_2_6() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_2.js", "    new/*dummy*/.^target;", false);
+    }
+
+    public void testGH5919_2_7() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_2.js", "    new/*dummy*/.targ^et;", false);
+    }
+
+    public void testGH5919_3_1() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_3.js", "import/*dummy*/.^/*dummy*/", false);
+    }
+
+    public void testGH5919_3_2() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_3.js", "import/*dummy*/./*dummy*/^", false);
+    }
+
+    public void testGH5919_3_3() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_3.js", "import/*dummy*/./*dummy*/me^", false);
+    }
+
+    public void testGH5919_3_4() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_3.js", "import/*dummy*/./*dummy*/meta.^", false);
+    }
+
+    public void testGH5919_3_5() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_3.js", "import/*dummy*/./*dummy*/meta.ur^", false);
+    }
+
+    public void testGH5919_3_6() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_3.js", "    ne^w/*dummy*/./*dummy*/target;", false);
+    }
+
+    public void testGH5919_3_7() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_3.js", "    new/*dummy*/.^/*dummy*/target;", false);
+    }
+
+    public void testGH5919_3_8() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_3.js", "    new/*dummy*/./*dummy*/^target;", false);
+    }
+
+    public void testGH5919_3_9() throws Exception {
+        checkCompletion("testfiles/completion/gh5919/gh5919_3.js", "    new/*dummy*/./*dummy*/targ^et;", false);
+    }
+}

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/parser/AstTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/parser/AstTest.java
@@ -3115,6 +3115,10 @@ public class AstTest extends CslTestBase {
         checkAstResult("testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve-comment.js");
     }
 
+    public void testImportMetaResolveMultiline() throws Exception {
+        checkAstResult("testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve-multiline.js");
+    }
+
     private void checkAstResult(String relFilePath) throws Exception {
         FileObject testFO = getTestFile(relFilePath);
         if (testFO == null) {

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/parser/AstTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/parser/AstTest.java
@@ -3102,7 +3102,19 @@ public class AstTest extends CslTestBase {
     public void testAwait() throws Exception {
         checkAstResult("testfiles/coloring/await.js");
     }
-    
+
+    public void testImportMetaUrl() throws Exception {
+        checkAstResult("testfiles/ecmascript6/parser/ES6/meta-property/import-meta-url.js");
+    }
+
+    public void testImportMetaResolve() throws Exception {
+        checkAstResult("testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve.js");
+    }
+
+    public void testImportMetaResolveComment() throws Exception {
+        checkAstResult("testfiles/ecmascript6/parser/ES6/meta-property/import-meta-resolve-comment.js");
+    }
+
     private void checkAstResult(String relFilePath) throws Exception {
         FileObject testFO = getTestFile(relFilePath);
         if (testFO == null) {

--- a/webcommon/javascript2.jquery/test/unit/data/testfiles/completion/jQueryFragment01.js.testProperty01.completion
+++ b/webcommon/javascript2.jquery/test/unit/data/testfiles/completion/jQueryFragment01.js.testProperty01.completion
@@ -3,7 +3,9 @@ Code completion result for source line:
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
 CLASS      formatter                       [PUBLIC]   jQueryFragment01.js
+CLASS      import                          [PUBLIC]   <font color=#999999>metaproperties.js</font>
 CLASS      jQuery                          [PRIVATE]  jQueryFragment01.js
+CLASS      new                             [PUBLIC]   metaproperties.js
 METHOD     $()                             [PUBLIC]   <font color=#999999>jquery-api.xml</font>
 METHOD     jQuery()                        [PUBLIC]   <font color=#999999>jquery-api.xml</font>
 VARIABLE   arguments: Arguments            [PRIVATE]  jQueryFragment01.js

--- a/webcommon/javascript2.lexer/test/unit/data/testfiles/metaproperties.js
+++ b/webcommon/javascript2.lexer/test/unit/data/testfiles/metaproperties.js
@@ -1,0 +1,10 @@
+function demo() {
+    if (new.target) {
+        console.log("Invoked with new");
+    } else {
+        console.log("Invoked without new");
+    }
+}
+
+console.log(import.meta.url);
+console.log(import.meta.resolve("dummy.js"));

--- a/webcommon/javascript2.lexer/test/unit/data/testfiles/metaproperties.js.tokens.txt
+++ b/webcommon/javascript2.lexer/test/unit/data/testfiles/metaproperties.js.tokens.txt
@@ -1,0 +1,85 @@
+<Unnamed test>
+KEYWORD_FUNCTION  "function", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+WHITESPACE      " ", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+IDENTIFIER      "demo", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_LEFT_PAREN  "(", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_RIGHT_PAREN  ")", st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+WHITESPACE      " ", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_LEFT_CURLY  "{", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+EOL             "\n", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+WHITESPACE      "    ", la=1, st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+KEYWORD_IF      "if", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+WHITESPACE      " ", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_LEFT_PAREN  "(", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+KEYWORD_NEW     "new", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+OPERATOR_DOT    ".", la=1, st=LexerState{canFollowLiteral=true, canFollowKeyword=false, braceBalances=[], jsxBalances=[]}
+IDENTIFIER      "target", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_RIGHT_PAREN  ")", st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+WHITESPACE      " ", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_LEFT_CURLY  "{", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+EOL             "\n", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+WHITESPACE      "        ", la=1, st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+IDENTIFIER      "console", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+OPERATOR_DOT    ".", la=1, st=LexerState{canFollowLiteral=true, canFollowKeyword=false, braceBalances=[], jsxBalances=[]}
+IDENTIFIER      "log", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_LEFT_PAREN  "(", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+STRING_BEGIN    """, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+STRING          "Invoked with new", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+STRING_END      """, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_RIGHT_PAREN  ")", st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+OPERATOR_SEMICOLON  ";", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+EOL             "\n", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+WHITESPACE      "    ", la=1, st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_RIGHT_CURLY  "}", st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+WHITESPACE      " ", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+KEYWORD_ELSE    "else", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+WHITESPACE      " ", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_LEFT_CURLY  "{", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+EOL             "\n", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+WHITESPACE      "        ", la=1, st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+IDENTIFIER      "console", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+OPERATOR_DOT    ".", la=1, st=LexerState{canFollowLiteral=true, canFollowKeyword=false, braceBalances=[], jsxBalances=[]}
+IDENTIFIER      "log", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_LEFT_PAREN  "(", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+STRING_BEGIN    """, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+STRING          "Invoked without new", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+STRING_END      """, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_RIGHT_PAREN  ")", st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+OPERATOR_SEMICOLON  ";", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+EOL             "\n", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+WHITESPACE      "    ", la=1, st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_RIGHT_CURLY  "}", st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+EOL             "\n", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_RIGHT_CURLY  "}", st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+EOL             "\n", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+EOL             "\n", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+IDENTIFIER      "console", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+OPERATOR_DOT    ".", la=1, st=LexerState{canFollowLiteral=true, canFollowKeyword=false, braceBalances=[], jsxBalances=[]}
+IDENTIFIER      "log", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_LEFT_PAREN  "(", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+KEYWORD_IMPORT  "import", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+OPERATOR_DOT    ".", la=1, st=LexerState{canFollowLiteral=true, canFollowKeyword=false, braceBalances=[], jsxBalances=[]}
+IDENTIFIER      "meta", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+OPERATOR_DOT    ".", la=1, st=LexerState{canFollowLiteral=true, canFollowKeyword=false, braceBalances=[], jsxBalances=[]}
+IDENTIFIER      "url", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_RIGHT_PAREN  ")", st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+OPERATOR_SEMICOLON  ";", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+EOL             "\n", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+IDENTIFIER      "console", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+OPERATOR_DOT    ".", la=1, st=LexerState{canFollowLiteral=true, canFollowKeyword=false, braceBalances=[], jsxBalances=[]}
+IDENTIFIER      "log", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_LEFT_PAREN  "(", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+KEYWORD_IMPORT  "import", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+OPERATOR_DOT    ".", la=1, st=LexerState{canFollowLiteral=true, canFollowKeyword=false, braceBalances=[], jsxBalances=[]}
+IDENTIFIER      "meta", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+OPERATOR_DOT    ".", la=1, st=LexerState{canFollowLiteral=true, canFollowKeyword=false, braceBalances=[], jsxBalances=[]}
+IDENTIFIER      "resolve", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_LEFT_PAREN  "(", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+STRING_BEGIN    """, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+STRING          "dummy.js", la=1, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+STRING_END      """, st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_RIGHT_PAREN  ")", st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+BRACKET_RIGHT_PAREN  ")", st=LexerState{canFollowLiteral=false, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+OPERATOR_SEMICOLON  ";", st=LexerState{canFollowLiteral=true, canFollowKeyword=true, braceBalances=[], jsxBalances=[]}
+----- EOF -----
+

--- a/webcommon/javascript2.lexer/test/unit/src/org/netbeans/modules/javascript2/lexer/JsTokenDumpTest.java
+++ b/webcommon/javascript2.lexer/test/unit/src/org/netbeans/modules/javascript2/lexer/JsTokenDumpTest.java
@@ -107,4 +107,10 @@ public class JsTokenDumpTest extends NbTestCase {
         LexerTestUtilities.checkTokenDump(this, "testfiles/numbers.js",
                 JsTokenId.javascriptLanguage());
     }
+
+    @SuppressWarnings("unchecked")
+    public void testMetaProperties() throws Exception {
+        LexerTestUtilities.checkTokenDump(this, "testfiles/metaproperties.js",
+                JsTokenId.javascriptLanguage());
+    }
 }

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/ModelUtils.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/ModelUtils.java
@@ -1769,8 +1769,6 @@ public class ModelUtils {
             while (token.id() != JsTokenId.OPERATOR_SEMICOLON
                     && token.id() != JsTokenId.BRACKET_RIGHT_CURLY && token.id() != JsTokenId.BRACKET_LEFT_CURLY
                     && token.id() != JsTokenId.BRACKET_LEFT_PAREN
-                    && token.id() != JsTokenId.BLOCK_COMMENT
-                    && token.id() != JsTokenId.LINE_COMMENT
                     && token.id() != JsTokenId.OPERATOR_ASSIGNMENT
                     && token.id() != JsTokenId.OPERATOR_PLUS) {
 
@@ -1791,7 +1789,7 @@ public class ModelUtils {
                         }
                     }
                 }
-                if (token.id() != JsTokenId.EOL) {
+                if (token.id() != JsTokenId.WHITESPACE && token.id() != JsTokenId.EOL && token.id() != JsTokenId.BLOCK_COMMENT && token.id() != JsTokenId.LINE_COMMENT) {
                     if (token.id() != JsTokenId.OPERATOR_DOT && token.id() != JsTokenId.OPERATOR_OPTIONAL_ACCESS) {
                         if (token.id() == JsTokenId.BRACKET_RIGHT_PAREN) {
                             parenBalancer++;
@@ -1847,7 +1845,7 @@ public class ModelUtils {
                         wasLastDot = true;
                     }
                 } else {
-                    if (!wasLastDot && ts.movePrevious()) {
+                    if (token.id() != JsTokenId.BLOCK_COMMENT && token.id() != JsTokenId.LINE_COMMENT && !wasLastDot && ts.movePrevious()) {
                         // check whether it's continuatino of previous line
                         token = LexUtilities.findPrevious(ts, Arrays.asList(JsTokenId.WHITESPACE, JsTokenId.BLOCK_COMMENT, JsTokenId.LINE_COMMENT));
                         if (token.id() != JsTokenId.OPERATOR_DOT && token.id() != JsTokenId.OPERATOR_OPTIONAL_ACCESS) {

--- a/webcommon/libs.nashorn/src/com/oracle/js/parser/Parser.java
+++ b/webcommon/libs.nashorn/src/com/oracle/js/parser/Parser.java
@@ -470,6 +470,7 @@ public class Parser extends AbstractParser {
 
         if (env.dumpOnError) {
             e.printStackTrace(env.getErr());
+            env.getErr().flush();
         }
     }
 
@@ -3629,13 +3630,15 @@ loop:
 
             lhs = new CallNode(callLine, callToken, finish, lhs, arguments, false);
         } else if (type == IMPORT && this.isAtLeastES11()) {
-            final String name2 = type.getName();
-            next();
-            IdentNode identNode = new IdentNode(token, finish, name2);
+            if (lookaheadFunctionCall()) {
+                final String name2 = type.getName();
+                next();
+                IdentNode identNode = new IdentNode(token, finish, name2);
 
-            final List<Expression> arguments = optimizeList(argumentList());
+                final List<Expression> arguments = optimizeList(argumentList());
 
-            lhs = new CallNode(callLine, callToken, finish, identNode, arguments, false);
+                lhs = new CallNode(callLine, callToken, finish, identNode, arguments, false);
+            }
         }
 
 loop:
@@ -3736,6 +3739,7 @@ loop:
         next();
 
         if (type == PERIOD && isAtLeastES6()) {
+            IdentNode newTokenIdentifier = new IdentNode(newToken, finish, "new");
             next();
             if (type == IDENT && "target".equals(getValue())) {
                 if (lc.getCurrentFunction().isProgram()) {
@@ -3743,7 +3747,7 @@ loop:
                 }
                 next();
                 markNewTarget(lc);
-                return new IdentNode(newToken, finish, "new.target");
+                return new AccessNode(newToken, finish, newTokenIdentifier, "target", false);
             } else {
                 throw error(AbstractParser.message("expected.target"), token);
             }
@@ -3781,6 +3785,47 @@ loop:
         final CallNode callNode = new CallNode(callLine, constructor.getToken(), finish, constructor, optimizeList(arguments), true);
 
         return new UnaryNode(newToken, callNode);
+    }
+
+    private Expression importMetaExpression() {
+        if(isAtLeastES11()) {
+            if(lookaheadMetaProperty()) {
+                final long importToken = token;
+                next(); // consume the import
+                IdentNode importNode = new IdentNode(importToken, finish, "import");
+                next(); // consume the period
+                next(); // consume the meta
+                return new AccessNode(importToken, finish, importNode, "meta", false);
+            }
+        }
+        return null;
+    }
+
+    private boolean lookaheadMetaProperty() {
+        int lookAheadPos = 1;
+        OUTER: for (;; lookAheadPos++) {
+            TokenType t = T(k + lookAheadPos);
+            switch (t) {
+            case COMMENT:
+                continue;
+            default:
+                if(t != PERIOD) {
+                    return false;
+                } else {
+                    break OUTER;
+                }
+            }
+        }
+        lookAheadPos++;
+        for (;; lookAheadPos++) {
+            TokenType t = T(k + lookAheadPos);
+            switch (t) {
+            case COMMENT:
+                continue;
+            default:
+                return t == IDENT && "meta".equals(getValue(getToken(k + lookAheadPos)));
+            }
+        }
     }
 
     /**
@@ -3862,6 +3907,10 @@ loop:
             } else {
                 // fall through
             }
+
+        case IMPORT:
+            lhs = importMetaExpression();
+            break;
 
         default:
             if (isAtLeastES7() && type == IDENT && ASYNC_IDENT.equals((String) getValue(token))
@@ -5439,28 +5488,22 @@ loop:
         // FIXME this decorator handling is not described in spec
         // yet certain frameworks uses it this way
         List<Expression> decorators = new ArrayList<>();
+
         loop: while (type != EOF) {
-            switch (type) {
-            case EOF:
+            if (type == EOF) {
                 break loop;
-            case IMPORT:
+            } else if (type == IMPORT && lookaheadNotFunctionCallNotPropertyAccess()) {
                 importDeclaration();
                 decorators.clear();
-                break;
-            case EXPORT:
+            } else if (type == EXPORT) {
                 exportDeclaration(decorators);
                 decorators.clear();
-                break;
-            case AT:
-                if (isAtLeastES7()) {
-                    decorators.addAll(decoratorList());
-                    break;
-                }
-            default:
+            } else if (type == AT && isAtLeastES7()) {
+                decorators.addAll(decoratorList());
+            } else {
                 // StatementListItem
                 statement(true, false, false, false, decorators);
                 decorators.clear();
-                break;
             }
         }
     }
@@ -5550,6 +5593,30 @@ loop:
             }
         }
         endOfLine();
+    }
+
+    private boolean lookaheadNotFunctionCallNotPropertyAccess() {
+        for (int i = 1;; i++) {
+            TokenType t = T(k + i);
+            switch (t) {
+            case COMMENT:
+                continue;
+            default:
+                return t != TokenType.LPAREN && t != TokenType.PERIOD;
+            }
+        }
+    }
+
+    private boolean lookaheadFunctionCall() {
+        for (int i = 1;; i++) {
+            TokenType t = T(k + i);
+            switch (t) {
+            case COMMENT:
+                continue;
+            default:
+                return t == TokenType.LPAREN;
+            }
+        }
     }
 
     /**

--- a/webcommon/libs.nashorn/src/com/oracle/js/parser/Parser.java
+++ b/webcommon/libs.nashorn/src/com/oracle/js/parser/Parser.java
@@ -3807,6 +3807,7 @@ loop:
             TokenType t = T(k + lookAheadPos);
             switch (t) {
             case COMMENT:
+            case EOL:
                 continue;
             default:
                 if(t != PERIOD) {
@@ -3821,6 +3822,7 @@ loop:
             TokenType t = T(k + lookAheadPos);
             switch (t) {
             case COMMENT:
+            case EOL:
                 continue;
             default:
                 return t == IDENT && "meta".equals(getValue(getToken(k + lookAheadPos)));

--- a/webcommon/libs.nashorn/src/com/oracle/js/parser/resources/Messages.properties
+++ b/webcommon/libs.nashorn/src/com/oracle/js/parser/resources/Messages.properties
@@ -92,6 +92,7 @@ parser.error.expected.binding=expected BindingIdentifier or BindingPattern
 parser.error.multiple.proto.key=property name __proto__ appears more than once in object literal
 parser.error.new.target.in.function=new.target expression is only allowed in functions
 parser.error.expected.target=expected 'target'
+parser.error.expected.meta=expected 'meta'
 parser.error.invalid.super=invalid use of keyword super
 parser.error.expected.arrow.parameter=expected arrow function parameter list
 parser.error.invalid.arrow.parameter=invalid arrow function parameter

--- a/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/DumpingVisitor.java
+++ b/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/DumpingVisitor.java
@@ -84,13 +84,26 @@ class DumpingVisitor extends NodeVisitor {
             System.out.println(indent() + node.getClass().getName() + " [" + ((BinaryNode) node).tokenType() + "]");
         } else if (node instanceof AccessNode) {
             AccessNode an = (AccessNode) node;
-            System.out.println(indent() + node.getClass().getName() + " [property=" + an.getProperty() + ", optional=" + an.isOptional() + "]");
+            System.out.printf("%s%s [property=%s, optional=%b]  [%d-%d]%n",
+                    indent(),
+                    node.getClass().getName(),
+                    an.getProperty(),
+                    an.isOptional(),
+                    an.getStart(),
+                    an.getFinish()
+            );
         } else if (node instanceof IndexNode) {
             IndexNode in = (IndexNode) node;
             System.out.println(indent() + node.getClass().getName() + " [" + in.isOptional() + "]");
         } else if (node instanceof CallNode) {
             CallNode cn = (CallNode) node;
-            System.out.println(indent() + node.getClass().getName() + " [" + cn.isOptional() + "]");
+            System.out.printf("%s%s [%b]  [%d-%d]%n",
+                    indent(),
+                    node.getClass().getName(),
+                    cn.isOptional(),
+                    cn.getStart(),
+                    cn.getFinish()
+            );
         } else if (node instanceof PropertyNode) {
             PropertyNode pn = (PropertyNode) node;
             System.out.printf("%s%s [%d-%d, static=%b]%n", indent(),

--- a/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/ManualTest.java
+++ b/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/ManualTest.java
@@ -22,6 +22,7 @@ package com.oracle.js.parser;
 import com.oracle.js.parser.ErrorManager.PrintWriterErrorManager;
 import com.oracle.js.parser.ir.FunctionNode;
 import com.oracle.js.parser.ir.LexicalContext;
+import java.io.PrintWriter;
 
 public class ManualTest {
 
@@ -38,13 +39,15 @@ public class ManualTest {
 //        Source source = Source.sourceFor("dummy.js", "var a = import('test');");
 //        Source source = Source.sourceFor("dummy.js", "try {} catch (e) {}");
 //        Source source = Source.sourceFor("dummy.js", "function a() {}; async function b() {}; class x { y(){} async z(){} }");
-        Source source = Source.sourceFor("dummy.js", "const a = <table>{/* Test */ /* Test */ /* Test */}{ a = 3 }</table>");
+//        Source source = Source.sourceFor("dummy.js", "const a = <table>{/* Test */ /* Test */ /* Test */}{ a = 3 }</table>");
+//        Source source = Source.sourceFor("dummy.js", "function dummy() {console.log(new.target);}");
+        Source source = Source.sourceFor("dummy.js", "console.log(import.meta.url);");
         ScriptEnvironment.Builder builder = ScriptEnvironment.builder();
         Parser parser = new Parser(
-                builder.emptyStatements(true).ecmacriptEdition(13).jsx(true).build(),
+                builder.emptyStatements(true).ecmacriptEdition(13).jsx(true).dumpOnError(new PrintWriter(System.err)).build(),
                 source,
                 new PrintWriterErrorManager());
-        FunctionNode fn = parser.parse();
+        FunctionNode fn = parser.parseModule("x");
         DumpingVisitor dv = new DumpingVisitor(new LexicalContext());
         fn.accept(dv);
     }

--- a/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/ManualTest.java
+++ b/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/ManualTest.java
@@ -41,7 +41,7 @@ public class ManualTest {
 //        Source source = Source.sourceFor("dummy.js", "function a() {}; async function b() {}; class x { y(){} async z(){} }");
 //        Source source = Source.sourceFor("dummy.js", "const a = <table>{/* Test */ /* Test */ /* Test */}{ a = 3 }</table>");
 //        Source source = Source.sourceFor("dummy.js", "function dummy() {console.log(new.target);}");
-        Source source = Source.sourceFor("dummy.js", "console.log(import.meta.url);");
+        Source source = Source.sourceFor("dummy.js", "function demo() {console.log(import\n\n.meta.url)}");
         ScriptEnvironment.Builder builder = ScriptEnvironment.builder();
         Parser parser = new Parser(
                 builder.emptyStatements(true).ecmacriptEdition(13).jsx(true).dumpOnError(new PrintWriter(System.err)).build(),


### PR DESCRIPTION
JS currently provides two meta-properties:

- `new.target`
- `import.meta` 

`new.target` was already partially supported and lexed as a single identifier. This makes it hard to support embedded comments or new lines. MDN describes both as properties as:

> The import.meta syntax consists of the keyword import, a dot, and the identifier meta. Because import is a reserved word not an identifier, this is not a property accessor but a special expression syntax.

The lexer lexes `import.meta` and `new.target` as three tokens:

- Keyword `new`  or `import`
- Operator `.`
- Identifier `target` or `meta`

The parser will handle it slightly different and create an `AccessNode` with the property name `target` or `import` on an IdentNode `new` or `import`.

In addition the handling of new lines and comments in expression chains (`obj.prop1.prop2`) was improved.

Closes: #5919 