### PR TITLE
Set up locator services to fix NPE during Maven priming

### DIFF
--- a/enterprise/micronaut/test/unit/src/org/netbeans/modules/micronaut/NbSuiteTestBase.java
+++ b/enterprise/micronaut/test/unit/src/org/netbeans/modules/micronaut/NbSuiteTestBase.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.micronaut;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+import javax.swing.text.Document;
+import static junit.framework.TestCase.assertNotNull;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.parsing.impl.indexing.implspi.ActiveDocumentProvider;
+import org.openide.modules.DummyInstalledFileLocator;
+import org.openide.util.lookup.ServiceProvider;
+import org.openide.windows.IOProvider;
+
+/**
+ *
+ * @author sdedic
+ */
+public class NbSuiteTestBase extends NbTestCase {
+
+    public NbSuiteTestBase(String name) {
+        super(name);
+    }
+    
+    @org.openide.util.lookup.ServiceProvider(service=org.openide.modules.InstalledFileLocator.class, position = 1000)
+        public static class InstalledFileLocator extends DummyInstalledFileLocator {
+    }
+
+    // must register ADP: otherwise maven fails at the start and will not even run 
+    // Prime command.
+    @ServiceProvider(service = ActiveDocumentProvider.class)
+    public static class ActiveDocumentProviderImpl implements ActiveDocumentProvider {
+
+        @Override
+        public Document getActiveDocument() {
+            return null;
+        }
+
+        @Override
+        public Set<? extends Document> getActiveDocuments() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public void addActiveDocumentListener(ActiveDocumentProvider.ActiveDocumentListener listener) {
+        }
+
+        @Override
+        public void removeActiveDocumentListener(ActiveDocumentProvider.ActiveDocumentListener listener) {
+        }
+        
+    }
+
+    private static File getTestNBDestDir() throws Exception {
+        String destDir = System.getProperty("test.netbeans.dest.dir");
+        // set in project.properties as test-unit-sys-prop.test.netbeans.dest.dir
+        assertNotNull("test.netbeans.dest.dir property has to be set when running within binary distribution", destDir);
+        return new File(destDir);
+    }
+    
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        // This is needed, otherwose the core window's startup code will redirect
+        // System.out/err to the IOProvider, and its Trivial implementation will redirect
+        // it back to System.err - loop is formed. Initialize IOProvider first, it gets
+        // the real System.err/out references.
+        IOProvider p = IOProvider.getDefault();
+
+        System.setProperty("test.reload.sync", "true");
+        // Configure the DummyFilesLocator with NB harness dir
+        File destDirF = getTestNBDestDir();
+        DummyInstalledFileLocator.registerDestDir(destDirF);
+    }
+    
+}

--- a/enterprise/micronaut/test/unit/src/org/netbeans/modules/micronaut/completion/MicronautExpressionLanguageCompletionTestBase.java
+++ b/enterprise/micronaut/test/unit/src/org/netbeans/modules/micronaut/completion/MicronautExpressionLanguageCompletionTestBase.java
@@ -30,7 +30,7 @@ import org.netbeans.api.lsp.Completion;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ui.OpenProjects;
-import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.micronaut.NbSuiteTestBase;
 import org.netbeans.spi.project.ActionProgress;
 import org.netbeans.spi.project.ActionProvider;
 import org.openide.cookies.EditorCookie;
@@ -43,7 +43,7 @@ import org.openide.util.lookup.Lookups;
  *
  * @author Dusan Balek
  */
-public class MicronautExpressionLanguageCompletionTestBase extends NbTestCase {
+public class MicronautExpressionLanguageCompletionTestBase extends NbSuiteTestBase {
 
     private Project project;
 
@@ -52,8 +52,8 @@ public class MicronautExpressionLanguageCompletionTestBase extends NbTestCase {
     }
 
     protected @Override void setUp() throws Exception {
+        super.setUp();
         clearWorkDir();
-        System.setProperty("test.reload.sync", "true");
         FileObject dataFO = FileUtil.toFileObject(getDataDir());
         FileObject testApp = dataFO.getFileObject("maven/micronaut4/simple");
         FileObject prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "mn4-cc");

--- a/enterprise/micronaut/test/unit/src/org/netbeans/modules/micronaut/maven/MicronautPackagingArtifactImplTest.java
+++ b/enterprise/micronaut/test/unit/src/org/netbeans/modules/micronaut/maven/MicronautPackagingArtifactImplTest.java
@@ -21,66 +21,34 @@ package org.netbeans.modules.micronaut.maven;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
-import javax.swing.text.Document;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectActionContext;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ui.OpenProjects;
-import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.maven.api.MavenConfiguration;
-import org.netbeans.modules.parsing.impl.indexing.implspi.ActiveDocumentProvider;
+import org.netbeans.modules.micronaut.NbSuiteTestBase;
 import org.netbeans.modules.project.dependency.ArtifactSpec;
 import org.netbeans.modules.project.dependency.ProjectArtifactsQuery;
 import org.netbeans.spi.project.ActionProgress;
 import org.netbeans.spi.project.ActionProvider;
-import org.netbeans.spi.project.ProjectConfiguration;
 import org.netbeans.spi.project.ProjectConfigurationProvider;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.modules.DummyInstalledFileLocator;
 import org.openide.util.lookup.Lookups;
-import org.openide.util.lookup.ServiceProvider;
 import org.openide.windows.IOProvider;
 
 /**
  *
  * @author sdedic
  */
-public class MicronautPackagingArtifactImplTest extends NbTestCase {
-    
-    // must register ADP: otherwise maven fails at the start and will not even run 
-    // Prime command.
-    @ServiceProvider(service = ActiveDocumentProvider.class)
-    public static class ActiveDocumentProviderImpl implements ActiveDocumentProvider {
-
-        @Override
-        public Document getActiveDocument() {
-            return null;
-        }
-
-        @Override
-        public Set<? extends Document> getActiveDocuments() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public void addActiveDocumentListener(ActiveDocumentListener listener) {
-        }
-
-        @Override
-        public void removeActiveDocumentListener(ActiveDocumentListener listener) {
-        }
-        
-    }
-
+public class MicronautPackagingArtifactImplTest extends NbSuiteTestBase {
     public MicronautPackagingArtifactImplTest(String name) {
         super(name);
     }


### PR DESCRIPTION
Maven module attempts to find the included Maven libraries using `InstalledFilesLocator` which wasn't found, so maven home == null causing NPEs and broken classpath.

The testsuite might work occasionally, as if the Artifact tests, which contain this setup already, or other test that downloads Micronaut libraries to local repository runs BEFORE the completion tests, Maven priming is skipped as all necessary poms are available and the project loads smoothly. If the tests are ordered "incorrectly", maven priming fails and fail the completion tests.

I have moved the setup to a common test base.

@mbien this is the cause of failing tests i https://github.com/apache/netbeans/actions/runs/8444656505/job/23130853755#step:6:1262
