### PR TITLE
Update versions after incompatible changes in versioning.util and mercurial

### DIFF
--- a/ide/bugtracking.bridge/manifest.mf
+++ b/ide/bugtracking.bridge/manifest.mf
@@ -3,4 +3,4 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.bugtracking.bridge
 OpenIDE-Module-Layer: org/netbeans/modules/bugtracking/bridge/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/bugtracking/bridge/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.69
+OpenIDE-Module-Specification-Version: 1.70

--- a/ide/bugtracking.bridge/nbproject/project.xml
+++ b/ide/bugtracking.bridge/nbproject/project.xml
@@ -100,7 +100,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.40</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/git/nbproject/project.properties
+++ b/ide/git/nbproject/project.properties
@@ -23,7 +23,7 @@ nbm.needs.restart=true
 
 # #178009
 # disable.qa-functional.tests=false
-spec.version.base=1.46.0
+spec.version.base=1.47.0
 
 test.config.stable.includes=**/*Test.class
 

--- a/ide/git/nbproject/project.xml
+++ b/ide/git/nbproject/project.xml
@@ -212,7 +212,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.68.0.3</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/localhistory/manifest.mf
+++ b/ide/localhistory/manifest.mf
@@ -2,4 +2,4 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.localhistory
 OpenIDE-Module-Install: org/netbeans/modules/localhistory/ModuleLifecycleManager.class
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/localhistory/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.58
+OpenIDE-Module-Specification-Version: 1.59

--- a/ide/localhistory/nbproject/project.xml
+++ b/ide/localhistory/nbproject/project.xml
@@ -102,7 +102,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.45</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/mercurial/manifest.mf
+++ b/ide/mercurial/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-OpenIDE-Module: org.netbeans.modules.mercurial
+OpenIDE-Module: org.netbeans.modules.mercurial/2
 OpenIDE-Module-Layer: org/netbeans/modules/mercurial/resources/hg-layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/mercurial/Bundle.properties
 OpenIDE-Module-Requires: org.netbeans.api.javahelp.Help

--- a/ide/mercurial/nbproject/project.properties
+++ b/ide/mercurial/nbproject/project.properties
@@ -19,7 +19,7 @@ javac.source=1.8
 nbm.homepage=http://wiki.netbeans.org/wiki/view/MercurialVersionControl
 nbm.module.author=John Rice and Padraig O'Briain
 nbm.needs.restart=true
-spec.version.base=2.0.0
+spec.version.base=2.0.1
 
 #qa-functional
 test.qa-functional.cp.extra=${openide.nodes.dir}/modules/org-openide-nodes.jar:\${openide.util.dir}/lib/org-openide-util.jar:${openide.util.ui.dir}/lib/org-openide-util-ui.jar

--- a/ide/mercurial/nbproject/project.xml
+++ b/ide/mercurial/nbproject/project.xml
@@ -195,7 +195,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.68.0.3</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/subversion/nbproject/project.properties
+++ b/ide/subversion/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-spec.version.base=1.65.0
+spec.version.base=1.66.0
 
 javac.compilerargs=-Xlint:unchecked
 javac.source=1.8

--- a/ide/subversion/nbproject/project.xml
+++ b/ide/subversion/nbproject/project.xml
@@ -214,7 +214,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.68.0.3</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/team.ide/manifest.mf
+++ b/ide/team.ide/manifest.mf
@@ -2,4 +2,4 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.team.ide
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/team/ide/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.37
+OpenIDE-Module-Specification-Version: 1.38

--- a/ide/team.ide/nbproject/project.xml
+++ b/ide/team.ide/nbproject/project.xml
@@ -126,7 +126,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.40</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/versioning.indexingbridge/manifest.mf
+++ b/ide/versioning.indexingbridge/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.versioning.indexingbridge/0
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/versioning/indexingbridge/Bundle.properties
 OpenIDE-Module-Provides: org.netbeans.modules.versioning.indexingbridge
-OpenIDE-Module-Specification-Version: 1.49
+OpenIDE-Module-Specification-Version: 1.50
 

--- a/ide/versioning.indexingbridge/nbproject/project.xml
+++ b/ide/versioning.indexingbridge/nbproject/project.xml
@@ -47,7 +47,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.7</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/versioning.ui/nbproject/project.properties
+++ b/ide/versioning.ui/nbproject/project.properties
@@ -19,4 +19,4 @@ is.eager=true
 javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 
-spec.version.base=1.46.0
+spec.version.base=1.47.0

--- a/ide/versioning.ui/nbproject/project.xml
+++ b/ide/versioning.ui/nbproject/project.xml
@@ -170,7 +170,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.68.0.2</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/versioning.util/manifest.mf
+++ b/ide/versioning.util/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-OpenIDE-Module: org.netbeans.modules.versioning.util
+OpenIDE-Module: org.netbeans.modules.versioning.util/2
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/versioning/util/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/versioning/util/resources/layer.xml
 OpenIDE-Module-Recommends: org.netbeans.modules.versioning.indexingbridge

--- a/ide/versioning.util/nbproject/project.properties
+++ b/ide/versioning.util/nbproject/project.properties
@@ -20,7 +20,7 @@ javac.source=11
 javac.target=11
 
 javadoc.name=Versioning Support Utilities
-spec.version.base=2.0.0
+spec.version.base=2.0.1
 is.autoload=true
 
 # Fatal error: Fatal error: class javax.net.SocketFactory not found


### PR DESCRIPTION
- Incompatible changes in the API of a module should not only bump the major part of the specification version, but also the release version of the module, which is reflected in the manifest as MODULENAME/RELEASEVERSION
- All modules depending on a module that is incompatibly changed need to be updated and their specification version needs to be updated so that they are covered by autoupdate.
