### PR TITLE
JSF: Support composite components in resource folder defined by jakarta.faces.WEBAPP_RESOURCES_DIRECTORY

### DIFF
--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/index/CompositeComponentModel.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/index/CompositeComponentModel.java
@@ -64,6 +64,7 @@ public class CompositeComponentModel extends JsfPageModel {
     static final String HAS_IMPLEMENTATION_KEY = "has_implementation"; //NOI18N
     //other
     private static final String WEBAPP_RESOURCES_DIRECTORY = "javax.faces.WEBAPP_RESOURCES_DIRECTORY";
+    private static final String WEBAPP_RESOURCES_DIRECTORY_JAKARTA = "jakarta.faces.WEBAPP_RESOURCES_DIRECTORY";
     private static final String RESOURCES_FOLDER_NAME = "resources"; //NOI18N
     private static final char VALUES_SEPARATOR = ','; //NOI18N
     private static final char ATTRIBUTES_SEPARATOR = ';'; //NOI18N
@@ -231,7 +232,8 @@ public class CompositeComponentModel extends JsfPageModel {
                         if (ddRoot != null) {
                             InitParam[] parameters = ddRoot.getContextParam();
                             for (InitParam param: parameters) {
-                                if (param.getParamName().contains(WEBAPP_RESOURCES_DIRECTORY)) {
+                                if (param.getParamName().contains(WEBAPP_RESOURCES_DIRECTORY)
+                                        || param.getParamName().contains(WEBAPP_RESOURCES_DIRECTORY_JAKARTA)) {
                                     relPath = param.getParamValue().trim();
                                 }
                             }


### PR DESCRIPTION
Together with the packages and namespaces the JavaEE -> JakartaEE transition also invalidated/renewed the names of context parameters.

This also affects the resources folder which is defined by the context parameter javax.faces.WEBAPP_RESOURCES_DIRECTORY or jakarta.faces.WEBAPP_RESOURCES_DIRECTORY.

Both parameters need to be checked if they are present and are now considered to search for composite components (the last defined definitions wins).

Closes: #7226
