### PR TITLE
Changelog updates for upcoming VSNetBeans 21.9.9 release.

### DIFF
--- a/java/java.lsp.server/vscode/CHANGELOG.md
+++ b/java/java.lsp.server/vscode/CHANGELOG.md
@@ -20,6 +20,18 @@
     under the License.
 
 -->
+
+## Version 21.9.9
+* This is Early Access of 22.0.0 version (this version used due to VSCode versioning)
+* Simplified LSP server startup
+* Project and priming build fixes
+* LSP: Do not compute text edits in source actions on `resolve` call
+* Micronaut:
+   * Micronaut PUT/POST Data Endpoints method generation
+   * Code completion for Repository finder methods enhanced
+   * Code completion for Java static members
+   * Plain and Data Controllers have separate templates
+
 ## Version 21.0.0
 * Improved vulnerability audit results and display 
 * Number of fixes in Maven projects processing 

--- a/java/java.lsp.server/vscode/README.md
+++ b/java/java.lsp.server/vscode/README.md
@@ -25,6 +25,8 @@
 [![Build Status](https://ci-builds.apache.org/job/Netbeans/view/vscode/job/netbeans-vscode/badge/icon)](https://ci-builds.apache.org/job/Netbeans/view/vscode/job/netbeans-vscode/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/apache/netbeans/blob/master/LICENSE)
 
+**Version 21.9.9 is 22.0 Early Access version.**
+
 This is [Apache NetBeans](http://netbeans.org) Language Server extension for VS Code. Use it to get all the _goodies of NetBeans_ via the VS Code user interface! Runs on __JDK11__ and all newer versions.
 
 Apache NetBeans Language Server brings full featured Java development (edit-compile-debug & test cycle) for Maven and Gradle projects to VSCode. As well as other features.


### PR DESCRIPTION
Updated CHANGELOG and README.MD. 

- List of features and fixes related to VSNetBeans
- Mentioned 21.9.9 is de facto 22.0 Early Access, number selected due to VSCode versioning rules.