### PR TITLE
Import Payara Server configurations after a NetBeans upgrade

### DIFF
--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/layer.xml
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/layer.xml
@@ -136,7 +136,7 @@
     <folder name="OptionsExport">
         <folder name="Advanced">
             <file name="J2EE">
-                <attr name="include" stringvalue="config/(J2EE|GlassFish|GlassFishEE6|GlassFishEE6WC||GlassFishEE7|GlassFishEE8|GlassFishJakartaEE8|GlassFishJakartaEE9|GlassFishJakartaEE91|GlassFishJakartaEE10)/.*"/>
+                <attr name="include" stringvalue="config/(J2EE|GlassFish|GlassFishEE6|GlassFishEE6WC|PayaraEE6|GlassFishEE7|GlassFishEE8|GlassFishJakartaEE8|GlassFishJakartaEE9|GlassFishJakartaEE91|GlassFishJakartaEE10)/.*"/>
                 <attr name="displayName" bundlevalue="org.netbeans.modules.j2ee.deployment.impl.Bundle#J2EE.Options.Export.displayName"/>
             </file>
         </folder>


### PR DESCRIPTION
Import Payara Server configurations when importing settings from a previous version of the IDE, similar to what happens with GlassFish.
