### PR TITLE
Fix DB selection in JPA entity generation and improve derby integration

### DIFF
--- a/ide/db/src/org/netbeans/modules/db/explorer/dlg/AddDriverDialog.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/dlg/AddDriverDialog.java
@@ -570,30 +570,25 @@ public final class AddDriverDialog extends javax.swing.JPanel {
                 URLClassLoader jarloader = getJarClassLoader();
 
                 for (int i = 0; i < dlm.size(); i++) {
-                    try {
-                        String file  = dlm.get(i);
-                        JarFile jf = new JarFile(file);
-                        try {
-                            Enumeration<JarEntry> entries = jf.entries();
-                            while (entries.hasMoreElements()) {
-                                JarEntry entry = (JarEntry)entries.nextElement();
-                                String className = entry.getName();
-                                if (className.endsWith(".class")) { // NOI18N
-                                    className = className.replace('/', '.');
-                                    className = className.substring(0, className.length() - 6);
-                                    if ( isDriverClass(jarloader, className) ) {
-                                        if (progressHandle != null) {
-                                            addDriverClass(className);
-                                        } else {
-                                            // already stopped
-                                            updateState();
-                                            return;
-                                        }
+                    String file = dlm.get(i);
+                    try (JarFile jf = new JarFile(file)) {
+                        Enumeration<JarEntry> entries = jf.entries();
+                        while (entries.hasMoreElements()) {
+                            JarEntry entry = (JarEntry) entries.nextElement();
+                            String className = entry.getName();
+                            if (className.endsWith(".class")) { // NOI18N
+                                className = className.replace('/', '.');
+                                className = className.substring(0, className.length() - 6);
+                                if (isDriverClass(jarloader, className)) {
+                                    if (progressHandle != null) {
+                                        addDriverClass(className);
+                                    } else {
+                                        // already stopped
+                                        updateState();
+                                        return;
                                     }
                                 }
                             }
-                        } finally {
-                            jf.close();
                         }
                     } catch (IOException exc) {
                         //PENDING

--- a/ide/db/src/org/netbeans/modules/db/util/Bundle.properties
+++ b/ide/db/src/org/netbeans/modules/db/util/Bundle.properties
@@ -33,8 +33,10 @@ ERR_InvalidURL=Invalid URL, should be of the form \n{0}
 
 DRIVERNAME_MySQL=MySQL (Connector/J driver)
 DRIVERNAME_MariaDB=MariaDB (MySQL-compatible)
-DRIVERNAME_JavaDbEmbedded=Java DB (Embedded)
-DRIVERNAME_JavaDbNetwork=Java DB (Network)
+DRIVERNAME_JavaDbEmbedded=Java DB (Embedded, version <= 10.14)
+DRIVERNAME_JavaDbNetwork=Java DB (Network, version <= 10.14)
+DRIVERNAME_JavaDbEmbeddedModular=Java DB (Embedded, version >= 10.15)
+DRIVERNAME_JavaDbNetworkModular=Java DB (Network, version >= 10.15)
 DRIVERNAME_PostgreSQL=PostgreSQL
 DRIVERNAME_OracleThin=Oracle Thin
 DRIVERNAME_OracleOCI=Oracle OCI

--- a/ide/db/src/org/netbeans/modules/db/util/DriverListUtil.java
+++ b/ide/db/src/org/netbeans/modules/db/util/DriverListUtil.java
@@ -96,11 +96,19 @@ public class DriverListUtil {
         add("Cloudscape RMI",
         "RmiJdbc.RJDriver",
         "jdbc:rmi://<HOST>[:<PORT>]/jdbc:cloudscape:<DB>");
+
+        add(NbBundle.getMessage(DriverListUtil.class, "DRIVERNAME_JavaDbEmbeddedModular"),
+        "org.apache.derby.iapi.jdbc.AutoloadedDriver",
+        "jdbc:derby:<DB>[;<ADDITIONAL>]", true);
+
+        add(NbBundle.getMessage(DriverListUtil.class, "DRIVERNAME_JavaDbNetworkModular"),
+        "org.apache.derby.client.ClientAutoloadedDriver",
+        "jdbc:derby://<HOST>[:<PORT>]/<DB>[;<ADDITIONAL>]", true);
         
         add(NbBundle.getMessage(DriverListUtil.class, "DRIVERNAME_JavaDbEmbedded"),
         "org.apache.derby.jdbc.EmbeddedDriver",
         "jdbc:derby:<DB>[;<ADDITIONAL>]", true);
-        
+
         add(NbBundle.getMessage(DriverListUtil.class, "DRIVERNAME_JavaDbNetwork"),
         "org.apache.derby.jdbc.ClientDriver",
         "jdbc:derby://<HOST>[:<PORT>]/<DB>[;<ADDITIONAL>]", true);

--- a/ide/derby/src/org/netbeans/modules/derby/ConnectDatabaseAction.java
+++ b/ide/derby/src/org/netbeans/modules/derby/ConnectDatabaseAction.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.derby;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -34,6 +35,8 @@ import org.openide.nodes.Node;
 import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
 import org.openide.util.actions.NodeAction;
+
+import static java.util.Arrays.asList;
 
 /**
  * Connect to a database
@@ -77,12 +80,14 @@ public class ConnectDatabaseAction extends NodeAction {
         try {
             if ( conns.isEmpty() )
             {
-                JDBCDriver drivers[] = JDBCDriverManager.getDefault().getDrivers(DerbyOptions.DRIVER_CLASS_NET);
-                if (drivers.length == 0) {
+                List<JDBCDriver> drivers = new ArrayList<>();
+                drivers.addAll(asList(JDBCDriverManager.getDefault().getDrivers(DerbyOptions.DRIVER_CLASS_NET)));
+                drivers.addAll(asList(JDBCDriverManager.getDefault().getDrivers(DerbyOptions.DRIVER_CLASS_NET_MODULAR)));
+                if (drivers.isEmpty()) {
                     showDriverNotFoundDialog();
                     return;
                 }
-                final DatabaseConnection dbconn = DatabaseConnection.create(drivers[0], "jdbc:derby://localhost:" + // NOI18N
+                final DatabaseConnection dbconn = DatabaseConnection.create(drivers.get(0), "jdbc:derby://localhost:" + // NOI18N
                         RegisterDerby.getDefault().getPort() +
                         "/" + dbname, // NOI18N
                         DerbyDatabasesImpl.getDefault().getUser(dbname),

--- a/ide/derby/src/org/netbeans/modules/derby/DerbyDatabasesImpl.java
+++ b/ide/derby/src/org/netbeans/modules/derby/DerbyDatabasesImpl.java
@@ -52,6 +52,8 @@ import org.openide.modules.InstalledFileLocator;
 import org.openide.util.Exceptions;
 import org.openide.util.NbPreferences;
 
+import static java.util.Arrays.asList;
+
 /**
  *
  * @author Andrei Badea, Jiri Rechtacek
@@ -488,15 +490,17 @@ public final class DerbyDatabasesImpl {
      * on the local Derby server.
      */
     private  synchronized DatabaseConnection registerDatabase(String databaseName, String user, String schema, String password, boolean rememberPassword) throws DatabaseException {
-        JDBCDriver drivers[] = JDBCDriverManager.getDefault().getDrivers(DerbyOptions.DRIVER_CLASS_NET);
-        if (drivers.length == 0) {
+        List<JDBCDriver> drivers = new ArrayList<>();
+        drivers.addAll(asList(JDBCDriverManager.getDefault().getDrivers(DerbyOptions.DRIVER_CLASS_NET)));
+        drivers.addAll(asList(JDBCDriverManager.getDefault().getDrivers(DerbyOptions.DRIVER_CLASS_NET_MODULAR)));
+        if (drivers.isEmpty()) {
             throw new IllegalStateException("The " + DerbyOptions.DRIVER_DISP_NAME_NET + " driver was not found"); // NOI18N
         }
         Preferences pref = NbPreferences.root().node(PATH_TO_DATABASE_PREFERENCES + databaseName);
         pref.put(USER_KEY, user == null ? "" : user);
         pref.put(SCHEMA_KEY, schema == null ? "" : schema);
         pref.put(PASSWORD_KEY, password == null ? "" : password);
-        DatabaseConnection dbconn = DatabaseConnection.create(drivers[0], "jdbc:derby://localhost:" + RegisterDerby.getDefault().getPort() + "/" + databaseName, user, schema, password, rememberPassword); // NOI18N
+        DatabaseConnection dbconn = DatabaseConnection.create(drivers.get(0), "jdbc:derby://localhost:" + RegisterDerby.getDefault().getPort() + "/" + databaseName, user, schema, password, rememberPassword); // NOI18N
         if (ConnectionManager.getDefault().getConnection(dbconn.getName()) == null) {
             ConnectionManager.getDefault().addConnection(dbconn);
         }
@@ -551,8 +555,19 @@ public final class DerbyDatabasesImpl {
             }
             URL[] driverURLs = new URL[] { derbyClient.toURI().toURL() }; // NOI18N
             DbURLClassLoader l = new DbURLClassLoader(driverURLs);
-            Class<?> c = Class.forName(DerbyOptions.DRIVER_CLASS_NET, true, l);
-            return (Driver)c.getDeclaredConstructor().newInstance();
+            Class<?> driverClass = null;
+            for (String driverCandidate : new String[]{DerbyOptions.DRIVER_CLASS_NET, DerbyOptions.DRIVER_CLASS_NET_MODULAR}) {
+                try {
+                    driverClass = Class.forName(driverCandidate, true, l);
+                    break;
+                } catch (ClassNotFoundException ex) {
+                    exception = ex;
+                }
+            }
+            if(driverClass != null) {
+                exception = null;
+            }
+            return (Driver)driverClass.getDeclaredConstructor().newInstance();
         } catch (MalformedURLException | ReflectiveOperationException e) {
             exception = e;
         }
@@ -581,13 +596,14 @@ public final class DerbyDatabasesImpl {
 
     List<DatabaseConnection> findDatabaseConnections(String databaseName) {
         String url = "jdbc:derby://localhost:" + RegisterDerby.getDefault().getPort() + "/" + databaseName;
-        List<DatabaseConnection> result = new ArrayList<DatabaseConnection>();
+        List<DatabaseConnection> result = new ArrayList<>();
 
         DatabaseConnection[] connections = ConnectionManager.getDefault().getConnections();
 
         for (DatabaseConnection conn : connections) {
             // If there's already a connection registered, we're done
-            if (conn.getDriverClass().equals(DerbyOptions.DRIVER_CLASS_NET)
+            if ((conn.getDriverClass().equals(DerbyOptions.DRIVER_CLASS_NET)
+                    || conn.getDriverClass().equals(DerbyOptions.DRIVER_CLASS_NET_MODULAR))
                     && conn.getDatabaseURL().equals(url)) {
                 result.add(conn);
             }

--- a/ide/derby/src/org/netbeans/modules/derby/ExecSupport.java
+++ b/ide/derby/src/org/netbeans/modules/derby/ExecSupport.java
@@ -282,7 +282,7 @@ public class ExecSupport {
 
         @Override
         public void run() {
-            while (loop) {
+            while (loop && child.isAlive()) {
                 if (isStringFound()) {
                     status = true;
                     break;

--- a/ide/derby/src/org/netbeans/modules/derby/layer.xml
+++ b/ide/derby/src/org/netbeans/modules/derby/layer.xml
@@ -38,6 +38,10 @@
                 <attr name="instanceCreate" methodvalue="org.netbeans.modules.derby.RegisterDerby.getDefault"/>
                 <attr name="instanceOf" stringvalue="org.netbeans.spi.db.explorer.DatabaseRuntime"/>
             </file>
+            <file name="DerbyRuntimeModular.instance">
+                <attr name="instanceCreate" methodvalue="org.netbeans.modules.derby.RegisterDerby.getModular"/>
+                <attr name="instanceOf" stringvalue="org.netbeans.spi.db.explorer.DatabaseRuntime"/>
+            </file>
         </folder>
     </folder>
 </filesystem>

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DatabaseTablesPanel.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/DatabaseTablesPanel.java
@@ -349,7 +349,7 @@ public class DatabaseTablesPanel extends javax.swing.JPanel implements AncestorL
         String databaseUrl = datasource.getUrl();
         String user = datasource.getUsername();
         for (DatabaseConnection dbconn : ConnectionManager.getDefault().getConnections()) {
-            if (databaseUrl.equals(dbconn.getDatabaseURL())) {
+            if (Objects.equals(databaseUrl, dbconn.getDatabaseURL())) {
                 result.add(dbconn);
             }
         }


### PR DESCRIPTION
- JPA: Prevent NullPointerException when checking for DB connection for JakartaEE server
-  Enable starting older derby versions on new JVMs and support derby JDBC driver for derby >= 10.15
    - derby versions before 10.15 try to set the security manager for the JVM when they start the network server. On JDK > 17 this fails and the failure is silent (no message). NetBeans has already a work around when the start raises error messages, an autodetection for the problem was added and disables the use of the security manager on JVMs > 17
    - With version 10.15 derby was made compatible with the java module system (JPMS). The required package split lead to changes in the names for the JDBC drivers.

Closes: #7225
Closes: #7035