### PR TITLE
Fix editor background shortcut colour for some non-default LAFs

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/view/EditorView.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/EditorView.java
@@ -487,6 +487,9 @@ public class EditorView extends ViewElement {
             Color shortcutColor = UIManager.getColor("EditorTab.underlineColor");
             if (shortcutColor != null) {
                 shortcut.setTitleColor(shortcutColor);
+            } else {
+                shortcutColor = new Color(0x164B7B);
+                shortcut.setTitleColor(shortcutColor);
             }
             Font font = getFont();
             if (font != null) {


### PR DESCRIPTION
As discussed in https://github.com/apache/netbeans/pull/7239, add hardcoded fallback for background actions shortcut colour for some non-default LAFs, resembling the approach taken in the aforementioned PR regarding link colour.

