### PR TITLE
Revert "Allow user to manipulate Truffle breakpoints"

### DIFF
--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/RemoteServices.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/RemoteServices.java
@@ -83,7 +83,6 @@ import org.netbeans.modules.debugger.jpda.jdi.UnsupportedOperationExceptionWrapp
 import org.netbeans.modules.debugger.jpda.jdi.VMDisconnectedExceptionWrapper;
 import org.netbeans.modules.debugger.jpda.jdi.VirtualMachineWrapper;
 import org.netbeans.modules.debugger.jpda.models.JPDAThreadImpl;
-import static org.netbeans.modules.debugger.jpda.truffle.TruffleDebugManager.configureTruffleBreakpoint;
 
 import org.openide.util.Exceptions;
 import org.openide.util.RequestProcessor;
@@ -331,7 +330,7 @@ public final class RemoteServices {
         
         mb.setBreakpointType(MethodBreakpoint.TYPE_METHOD_ENTRY);
         mb.setSuspend(MethodBreakpoint.SUSPEND_EVENT_THREAD);
-        configureTruffleBreakpoint(mb);
+        mb.setHidden(true);
         mb.setThreadFilters(dbg, new JPDAThread[] { awtThread });
         mb.addJPDABreakpointListener(new JPDABreakpointListener() {
             @Override

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/TruffleDebugManager.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/TruffleDebugManager.java
@@ -53,7 +53,6 @@ import org.netbeans.modules.debugger.jpda.truffle.actions.PauseInGraalScriptActi
 import org.netbeans.modules.javascript2.debug.breakpoints.JSLineBreakpoint;
 import org.netbeans.spi.debugger.ActionsProvider;
 import org.netbeans.spi.debugger.DebuggerServiceRegistration;
-import org.openide.util.NbBundle;
 
 /**
  * Initiates guest language debugging, detects Engine in the JVM.
@@ -95,7 +94,7 @@ public class TruffleDebugManager extends DebuggerManagerAdapter {
         */
         debugManagerLoadBP = MethodBreakpoint.create(ENGINE_BUILDER_CLASS, "build");
         ((MethodBreakpoint) debugManagerLoadBP).setBreakpointType(MethodBreakpoint.TYPE_METHOD_ENTRY);
-        configureTruffleBreakpoint(debugManagerLoadBP);
+        debugManagerLoadBP.setHidden(true);
         
         LOG.log(Level.FINE, "TruffleDebugManager.initBreakpoints(): submitted BP {0}", debugManagerLoadBP);
         TruffleAccess.init();
@@ -156,7 +155,7 @@ public class TruffleDebugManager extends DebuggerManagerAdapter {
     private JPDABreakpoint addRemoteServiceInitBP(final JPDADebugger debugger) {
         MethodBreakpoint bp = MethodBreakpoint.create(REMOTE_SERVICES_TRIGGER_CLASS, REMOTE_SERVICES_TRIGGER_METHOD);
         bp.setBreakpointType(MethodBreakpoint.TYPE_METHOD_ENTRY);
-        configureTruffleBreakpoint(bp);
+        bp.setHidden(true);
         bp.setSession(debugger);
 
         JPDABreakpointListener bpl = new JPDABreakpointListener() {
@@ -228,11 +227,11 @@ public class TruffleDebugManager extends DebuggerManagerAdapter {
      */
     private void handleEngineBuilder(final JPDADebugger debugger, JPDABreakpointEvent entryEvent) {
         MethodBreakpoint builderExitBreakpoint = MethodBreakpoint.create(ENGINE_BUILDER_CLASS, "build");
-        builderExitBreakpoint.setBreakpointType(MethodBreakpoint.TYPE_METHOD_ENTRY);
+        builderExitBreakpoint.setBreakpointType(MethodBreakpoint.TYPE_METHOD_EXIT);
         builderExitBreakpoint.setThreadFilters(debugger, new JPDAThread[]{entryEvent.getThread()});
         builderExitBreakpoint.setSuspend(JPDABreakpoint.SUSPEND_EVENT_THREAD);
         builderExitBreakpoint.setSession(debugger);
-        configureTruffleBreakpoint(builderExitBreakpoint);
+        builderExitBreakpoint.setHidden(true);
         builderExitBreakpoint.addJPDABreakpointListener(exitEvent -> {
             try {
                 builderExitBreakpoint.disable();
@@ -253,7 +252,7 @@ public class TruffleDebugManager extends DebuggerManagerAdapter {
             haveExistingEnginesTrigger.put(debugger, Boolean.TRUE);
         }
         MethodBreakpoint execTrigger = MethodBreakpoint.create(EXISTING_ENGINES_TRIGGER, "*");
-        configureTruffleBreakpoint(execTrigger);
+        execTrigger.setHidden(true);
         execTrigger.setSession(debugger);
         execTrigger.addJPDABreakpointListener((event) -> {
             DebuggerManager.getDebuggerManager().removeBreakpoint(execTrigger);
@@ -350,10 +349,4 @@ public class TruffleDebugManager extends DebuggerManagerAdapter {
         }
     }
 
-    @NbBundle.Messages({
-        "CTL_BreakpointGroup=Truffle"
-    })
-    public static void configureTruffleBreakpoint(JPDABreakpoint b) {
-        b.setGroupName(Bundle.CTL_BreakpointGroup());
-    }
 }

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/access/TruffleAccess.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/access/TruffleAccess.java
@@ -87,7 +87,6 @@ import org.netbeans.modules.debugger.jpda.models.JPDAThreadImpl;
 import org.netbeans.modules.debugger.jpda.truffle.LanguageName;
 import org.netbeans.modules.debugger.jpda.truffle.RemoteServices;
 import org.netbeans.modules.debugger.jpda.truffle.TruffleDebugManager;
-import static org.netbeans.modules.debugger.jpda.truffle.TruffleDebugManager.configureTruffleBreakpoint;
 import org.netbeans.modules.debugger.jpda.truffle.Utils;
 import org.netbeans.modules.debugger.jpda.truffle.actions.StepActionProvider;
 import org.netbeans.modules.debugger.jpda.truffle.ast.TruffleNode;
@@ -176,7 +175,7 @@ public class TruffleAccess implements JPDABreakpointListener {
     private JPDABreakpoint createBP(String className, String methodName, JPDADebugger debugger) {
         final MethodBreakpoint mb = MethodBreakpoint.create(className, methodName);
         mb.setBreakpointType(MethodBreakpoint.TYPE_METHOD_ENTRY);
-        configureTruffleBreakpoint(mb);
+        mb.setHidden(true);
         mb.setSession(debugger);
         mb.addJPDABreakpointListener(this);
         DebuggerManager.getDebuggerManager().addBreakpoint(mb);
@@ -311,7 +310,7 @@ public class TruffleAccess implements JPDABreakpointListener {
         MethodBreakpoint clearLeakingReferencesBreakpoint = MethodBreakpoint.create(CLEAR_REFERENCES_CLASS, CLEAR_REFERENCES_METHOD);
         clearLeakingReferencesBreakpoint.setBreakpointType(MethodBreakpoint.TYPE_METHOD_ENTRY);
         clearLeakingReferencesBreakpoint.setThreadFilters(debugger, new JPDAThread[] { thread });
-        configureTruffleBreakpoint(clearLeakingReferencesBreakpoint);
+        clearLeakingReferencesBreakpoint.setHidden(true);
         Function<EventSet, Boolean> breakpointEventInterceptor = eventSet -> {
             try {
                 ThreadReference etr = null;

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/actions/StepActionProvider.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/actions/StepActionProvider.java
@@ -51,7 +51,6 @@ import org.netbeans.modules.debugger.jpda.jdi.VMDisconnectedExceptionWrapper;
 import org.netbeans.modules.debugger.jpda.jdi.request.EventRequestManagerWrapper;
 import org.netbeans.modules.debugger.jpda.models.AbstractVariable;
 import org.netbeans.modules.debugger.jpda.models.JPDAThreadImpl;
-import static org.netbeans.modules.debugger.jpda.truffle.TruffleDebugManager.configureTruffleBreakpoint;
 import org.netbeans.modules.debugger.jpda.truffle.access.CurrentPCInfo;
 import org.netbeans.modules.debugger.jpda.truffle.access.TruffleAccess;
 import org.netbeans.modules.debugger.jpda.truffle.access.TruffleStrataProvider;
@@ -179,7 +178,7 @@ public class StepActionProvider extends JPDADebuggerActionProvider {
         MethodBreakpoint stepIntoJavaBreakpoint = MethodBreakpoint.create(STEP2JAVA_CLASS, STEP2JAVA_METHOD);
         stepIntoJavaBreakpoint.setBreakpointType(MethodBreakpoint.TYPE_METHOD_ENTRY);
         stepIntoJavaBreakpoint.setThreadFilters(debugger, new JPDAThread[]{currentThread});
-        configureTruffleBreakpoint(stepIntoJavaBreakpoint);
+        stepIntoJavaBreakpoint.setHidden(true);
         stepIntoJavaBreakpoint.addJPDABreakpointListener(new JPDABreakpointListener() {
             @Override
             public void breakpointReached(JPDABreakpointEvent event) {

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/breakpoints/impl/TruffleBreakpointsHandler.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/breakpoints/impl/TruffleBreakpointsHandler.java
@@ -69,7 +69,6 @@ import org.netbeans.modules.debugger.jpda.jdi.UnsupportedOperationExceptionWrapp
 import org.netbeans.modules.debugger.jpda.jdi.VMDisconnectedExceptionWrapper;
 import org.netbeans.modules.debugger.jpda.models.JPDAThreadImpl;
 import org.netbeans.modules.debugger.jpda.truffle.PersistentValues;
-import static org.netbeans.modules.debugger.jpda.truffle.TruffleDebugManager.configureTruffleBreakpoint;
 import org.netbeans.modules.debugger.jpda.truffle.access.TruffleAccess;
 import org.netbeans.modules.debugger.jpda.truffle.source.Source;
 import org.netbeans.modules.debugger.jpda.truffle.source.SourceBinaryTranslator;
@@ -125,7 +124,7 @@ public class TruffleBreakpointsHandler {
             if (this.breakpointResolvedHandler == null) {
                 MethodBreakpoint methodBreakpoint = MethodBreakpoint.create(accessorClass.name(), ACCESSOR_LINE_BREAKPOINT_RESOLVED);
                 methodBreakpoint.setSession(debugger);
-                configureTruffleBreakpoint(methodBreakpoint);
+                methodBreakpoint.setHidden(true);
                 methodBreakpoint.setSuspend(JPDABreakpoint.SUSPEND_EVENT_THREAD);
                 methodBreakpoint.addJPDABreakpointListener(new JPDABreakpointListener() {
                     @Override


### PR DESCRIPTION
Reverts apache/netbeans#6866

master is broken, see https://github.com/apache/netbeans/pull/6866#issuecomment-2050404788

I enabled only graal tests here since its only the graal job which failed, e.g https://github.com/apache/netbeans/actions/runs/8649738844

cc @matthiasblaesing @sdedic 