### PR TITLE
Micronaut: code completion for update methods fixed.

### DIFF
--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautDataCompletionTask.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautDataCompletionTask.java
@@ -317,7 +317,7 @@ public class MicronautDataCompletionTask {
                 for (String propName : prop2Types.keySet()) {
                     String name = pattern + BY + propName;
                     if (prefix.length() >= name.length() && prefix.startsWith(name)) {
-                        addPropertyCriterionCompletions(prop2Types, name, prefix, full ? pattern.startsWith(COUNT) ? "int" : pattern.startsWith(EXISTS) ? "boolean" : "void"
+                        addCriterionCompletions(prop2Types, name, prefix, full ? pattern.startsWith(COUNT) ? "int" : pattern.startsWith(EXISTS) ? "boolean" : "void"
                                 : null, factory, consumer);
                     } else if (Utils.startsWith(name, prefix)) {
                         consumer.accept(full ? factory.createFinderMethodItem(name, name.startsWith(COUNT) ? "int" : name.startsWith(EXISTS) ? "boolean" : "void", anchorOffset)
@@ -336,14 +336,17 @@ public class MicronautDataCompletionTask {
 
     private <T> void addPropertyCriterionCompletions(Map<String, String> prop2Types, String namePrefix, String prefix, String returnType, ItemFactory<T> factory, Consumer<T> consumer) {
         for (String propName : prop2Types.keySet()) {
-            for (String criterion : CRITERION_EXPRESSIONS) {
-                String name = propName + criterion;
-                if (prefix.length() >= namePrefix.length() + name.length() && prefix.startsWith(namePrefix + name)) {
-                    addComposeAndOrderCompletions(prop2Types, namePrefix + name, prefix, returnType, factory, consumer);
-                } else if (Utils.startsWith(namePrefix + name, prefix)) {
-                    consumer.accept(returnType != null ? factory.createFinderMethodItem(namePrefix + name, returnType, anchorOffset)
-                            : factory.createFinderMethodNameItem(namePrefix, name, anchorOffset));
-                }
+            addCriterionCompletions(prop2Types, namePrefix + propName, prefix, returnType, factory, consumer);
+        }
+    }
+
+    private <T> void addCriterionCompletions(Map<String, String> prop2Types, String namePrefix, String prefix, String returnType, ItemFactory<T> factory, Consumer<T> consumer) {
+        for (String criterion : CRITERION_EXPRESSIONS) {
+            if (prefix.length() >= namePrefix.length() + criterion.length() && prefix.startsWith(namePrefix + criterion)) {
+                addComposeAndOrderCompletions(prop2Types, namePrefix + criterion, prefix, returnType, factory, consumer);
+            } else if (Utils.startsWith(namePrefix + criterion, prefix)) {
+                consumer.accept(returnType != null ? factory.createFinderMethodItem(namePrefix + criterion, returnType, anchorOffset)
+                        : factory.createFinderMethodNameItem(namePrefix, criterion, anchorOffset));
             }
         }
     }


### PR DESCRIPTION
Invoking code completion inside Micronaut repository interface with `updateByPropertyName` prefix, code completion should not offer ProperyNames again (similary to the case with `findByPropertyName` prefix).