### PR TITLE
PHP: Fixing a few bugs with phpDoc

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/api/Utils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/api/Utils.java
@@ -26,6 +26,7 @@ import org.netbeans.modules.csl.spi.ParserResult;
 import org.netbeans.modules.php.editor.CodeUtils;
 import org.netbeans.modules.php.editor.parser.PHPParseResult;
 import org.netbeans.modules.php.editor.parser.astnodes.ASTNode;
+import org.netbeans.modules.php.editor.parser.astnodes.Block;
 import org.netbeans.modules.php.editor.parser.astnodes.ClassDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.Comment;
 import org.netbeans.modules.php.editor.parser.astnodes.Expression;
@@ -78,16 +79,24 @@ public final class Utils {
                 int start = possible.getEndOffset() + 1;
                 int end = getNodeRangeLocatorEndOffset(node);
                 if (start <= end) {
+                    //Check that a possible comment and a node are in the same block
+                    ASTNode nodeAtStartOffset = getNodeAtOffset(root, start);
+                    if (nodeAtStartOffset instanceof Block) {
+                        if (node.getStartOffset() > nodeAtStartOffset.getEndOffset()) {
+                            return null;
+                        }
+                    }
+
                     List<ASTNode> nodes = (new NodeRangeLocator()).locate(root, new OffsetRange(start, end));
                     if (!nodes.isEmpty()) {
                         if (!isConstantDeclaration(nodes, node)
                                 && !isFieldDeclaration(nodes, node)) {
-                            possible = null;
+                            return null;
                         }
                     }
                 } else {
                     // e.g. public self|A /* comment */ |null $unionType; (start > end)
-                    possible = null;
+                   return null;
                 }
             }
         }

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/phpDocAndFunctionInDifferentBlocks.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/phpDocAndFunctionInDifferentBlocks.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class TestClass
+{
+
+    public function method1(): void {
+        /**
+         *
+         * @param string $param
+         * @return int
+         */
+    }
+
+    public function method2(int $param): string {
+
+        /**
+         *
+         * @param string $param
+         * @return int
+         */
+    }
+
+}
+
+
+function func1(int $param): string {
+/**
+ *
+ * @param string $param
+ * @return int
+ */
+}
+
+function func2(int $param): string {
+
+}
+
+
+$instance = new TestClass();
+$instance->method2(1);
+
+func1(1);
+func2(1);
+

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/phpDocAndFunctionInDifferentBlocks.php.testPhpDocAndFunctionInDifferentBlocks_01.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/phpDocAndFunctionInDifferentBlocks.php.testPhpDocAndFunctionInDifferentBlocks_01.html
@@ -1,0 +1,13 @@
+<html><body>
+<pre>Code completion result for source line:
+func1|(1);
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+METHOD     func1(int $param)               [PUBLIC]   phpDocAndFunctionInDifferentBlocks.php
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>func1</b><br/><br/><br />
+<h3>Parameters:</h3>
+<table cellspacing=0 style="border: 0px; width: 100%;">
+<tr><td>&nbsp;</td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr>int</nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr><b>$param</b></nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;width:80%;" >PHPDoc not found</td></tr>
+</table>
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>string</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/phpDocAndFunctionInDifferentBlocks.php.testPhpDocAndFunctionInDifferentBlocks_02.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/phpDocAndFunctionInDifferentBlocks.php.testPhpDocAndFunctionInDifferentBlocks_02.html
@@ -1,0 +1,13 @@
+<html><body>
+<pre>Code completion result for source line:
+func2|(1);
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+METHOD     func2(int $param)               [PUBLIC]   phpDocAndFunctionInDifferentBlocks.php
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>func2</b><br/><br/><br />
+<h3>Parameters:</h3>
+<table cellspacing=0 style="border: 0px; width: 100%;">
+<tr><td>&nbsp;</td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr>int</nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr><b>$param</b></nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;width:80%;" >PHPDoc not found</td></tr>
+</table>
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>string</td></tr></table></body></html>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/phpDocAndFunctionInDifferentBlocks.php.testPhpDocAndMethodInDifferentBlocks.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/phpDocAndFunctionInDifferentBlocks.php.testPhpDocAndMethodInDifferentBlocks.html
@@ -1,0 +1,13 @@
+<html><body>
+<pre>Code completion result for source line:
+$instance->method2|(1);
+(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+METHOD     method2(int $param)             [PUBLIC]   TestClass
+</pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>method2</b><br/><br/><br />
+<h3>Parameters:</h3>
+<table cellspacing=0 style="border: 0px; width: 100%;">
+<tr><td>&nbsp;</td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr>int</nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;" ><nobr><b>$param</b></nobr></td><td valign="top" style="text-aling:left; border-width: 0px;padding: 1px;padding:3px;width:80%;" >PHPDoc not found</td></tr>
+</table>
+<h3>Returns:</h3>
+<table>
+<tr><th align="left">Type:</th><td>string</td></tr></table></body></html>

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
@@ -642,6 +642,18 @@ public class PHPCCDocumentationTest extends PHPCodeCompletionTestBase {
         checkCompletionDocumentation("testfiles/completion/documentation/php81/enumCases.php", "BackeEnumCaseInt::CASE_C^;", false, "");
     }
 
+    public void testPhpDocAndMethodInDifferentBlocks() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/phpDocAndFunctionInDifferentBlocks.php", "$instance->method2^(1)", false, "");
+    }
+
+    public void testPhpDocAndFunctionInDifferentBlocks_01() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/phpDocAndFunctionInDifferentBlocks.php", "func1^(1)", false, "");
+    }
+
+    public void testPhpDocAndFunctionInDifferentBlocks_02() throws Exception {
+        checkCompletionDocumentation("testfiles/completion/documentation/phpDocAndFunctionInDifferentBlocks.php", "func2^(1)", false, "");
+    }
+
     @Override
     protected String alterDocumentationForTest(String documentation) {
         int start = documentation.indexOf("file:");

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/typinghooks/PhpCommentGeneratorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/typinghooks/PhpCommentGeneratorTest.java
@@ -912,6 +912,124 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                             "?>\n");
     }
 
+    public void testCommentAndFunctionInDifferentBlocks_01()  throws Exception {
+        insertBreak( "<?php\n" +
+                            "function bar() {\n" +
+                            "/**^\n" +
+                            "}\n" +
+                            "function foo() {\n" +
+                            "    if (true) {\n" +
+                            "       return 'str';\n" +
+                            "    }\n" +
+                            "    return [1, 2];\n" +
+                            "}\n" +
+                            "?>\n",
+                            "<?php\n" +
+                            "function bar() {\n" +
+                            "/**\n" +
+                            " * ^\n" +
+                            " */\n" +
+                            "}\n" +
+                            "function foo() {\n" +
+                            "    if (true) {\n" +
+                            "       return 'str';\n" +
+                            "    }\n" +
+                            "    return [1, 2];\n" +
+                            "}\n" +
+                            "?>\n");
+    }
+
+    public void testCommentAndFunctionInDifferentBlocks_02()  throws Exception {
+        insertBreak( "<?php\n" +
+                            "class TestClass {\n" +
+                            "/**^\n" +
+                            "}\n" +
+                            "function foo() {\n" +
+                            "    if (true) {\n" +
+                            "       return 'str';\n" +
+                            "    }\n" +
+                            "    return [1, 2];\n" +
+                            "}\n" +
+                            "?>\n",
+                            "<?php\n" +
+                            "class TestClass {\n" +
+                            "/**\n" +
+                            " * ^\n" +
+                            " */\n" +
+                            "}\n" +
+                            "function foo() {\n" +
+                            "    if (true) {\n" +
+                            "       return 'str';\n" +
+                            "    }\n" +
+                            "    return [1, 2];\n" +
+                            "}\n" +
+                            "?>\n");
+    }
+
+    public void testCommentAndFunctionInDifferentBlocks_03()  throws Exception {
+        insertBreak( "<?php\n" +
+                            "class TestClass {\n" +
+                            "    public function test() {\n" +
+                            "        /**^\n" +
+                            "    }\n" +
+                            "}\n" +
+                            "function foo() {\n" +
+                            "    if (true) {\n" +
+                            "       return 'str';\n" +
+                            "    }\n" +
+                            "    return [1, 2];\n" +
+                            "}\n" +
+                            "?>\n",
+                            "<?php\n" +
+                            "class TestClass {\n" +
+                            "    public function test() {\n" +
+                            "        /**\n" +
+                            "         * ^\n" +
+                            "         */\n" +
+                            "    }\n" +
+                            "}\n" +
+                            "function foo() {\n" +
+                            "    if (true) {\n" +
+                            "       return 'str';\n" +
+                            "    }\n" +
+                            "    return [1, 2];\n" +
+                            "}\n" +
+                            "?>\n");
+    }
+
+    public void testCommentAndMethodInDifferentBlocks_01()  throws Exception {
+        insertBreak( "<?php\n" +
+                            "class TestClass {\n" +
+                            "    public function test1() {\n" +
+                            "        /**^\n" +
+                            "    }\n" +
+                            "\n" +
+                            "    public function test2() {\n" +
+                            "       if (true) {\n" +
+                            "           return 'str';\n" +
+                            "       }\n" +
+                            "       return [1, 2];\n" +
+                            "    }\n" +
+                            "}\n" +
+                            "?>\n",
+                            "<?php\n" +
+                            "class TestClass {\n" +
+                            "    public function test1() {\n" +
+                            "        /**\n" +
+                            "         * ^\n" +
+                            "         */\n" +
+                            "    }\n" +
+                            "\n" +
+                            "    public function test2() {\n" +
+                            "       if (true) {\n" +
+                            "           return 'str';\n" +
+                            "       }\n" +
+                            "       return [1, 2];\n" +
+                            "    }\n" +
+                            "}\n" +
+                            "?>\n");
+    }
+
     @Override
     public void insertNewline(String source, String reformatted, IndentPrefs preferences) throws Exception {
         int sourcePos = source.indexOf('^');


### PR DESCRIPTION
- Fix bug where phpdoc for a function or method is generated in the wrong block.

Example:
```php
class ClassExample
{

    public function method1()
    {
        
    }

    private function method2($params)
    {
        return false;
    }
}
```

Before:

https://github.com/apache/netbeans/assets/9607501/f2f8b6f6-8d39-4174-83f4-4e8ffe3eb19b


After:

https://github.com/apache/netbeans/assets/9607501/6548b366-6ccc-406f-a01c-ec61219c7a99


- Fix bug where phpdoc from another block is used to display documentation for a function or method.
Example:
```php
class ClassExample
{

    public function method1()
    {
        /**
         *
         * @param string $params
         * @return int
         */
    }

    private function method2(int $params)
    {
        return 'string';
    }
}
```

Before:
![phpdoc_before](https://github.com/apache/netbeans/assets/9607501/a96c719e-ae2c-4430-aa72-c9a66df49aec)

After:
![phpdoc_after](https://github.com/apache/netbeans/assets/9607501/3ecaa515-b95e-4ceb-94be-cbf23509401d)

