### PR TITLE
Update libs.graaljs, libs.graalsdk and libs.truffleapi to 24.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,16 +249,7 @@ jobs:
       - name: Commit Validation tests
         run: .github/retry.sh ant $OPTS -Dcluster.config=$CLUSTER_CONFIG commit-validation
 
-      - name: Set up JDK 11 for core.network
-        uses: actions/setup-java@v4
-        if: matrix.java == 17 && success()
-        with:
-          java-version: 11
-          distribution: ${{ env.default_java_distribution }}
-
-      # TODO fails on 17+
       - name: platform/core.network
-        if: matrix.java == 17 && success()
         run: ant $OPTS -f platform/core.network test
 
       - name: Create Test Summary
@@ -2632,9 +2623,9 @@ jobs:
 
       - name: Setup GraalVM {{ matrix.graal }}
         run: |
-          URL=https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${{ matrix.graal }}/graalvm-ce-java11-linux-amd64-${{ matrix.graal }}.tar.gz
+          URL=https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${{ matrix.graal }}/graalvm-ce-java17-linux-amd64-${{ matrix.graal }}.tar.gz
           curl -L $URL | tar -xz
-          GRAALVM=`pwd`/graalvm-ce-java11-${{ matrix.graal }}
+          GRAALVM=`pwd`/graalvm-ce-java17-${{ matrix.graal }}
           echo "JAVA_HOME=$GRAALVM" >> $GITHUB_ENV
 
       - name: Setup GraalVM Languages

--- a/ide/libs.graalsdk.system/external/binaries-list
+++ b/ide/libs.graalsdk.system/external/binaries-list
@@ -14,5 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-8E62643FD621053E00EE52D797C7FBD08D7FDEDC org.graalvm.sdk:graal-sdk:20.3.0
-8968BDBE4058F4E6610AF0DC184BD885B236A2B1 org.graalvm.sdk:launcher-common:20.3.0
+06055903437576484DCC6545AF995FF67E0A3B55 org.graalvm.sdk:launcher-common:24.0.0
+335646EC205A3BCE0D518748D08A5C45900A9869 org.graalvm.shadowed:jline:24.0.0
+26F391313D8B7A4376B0778EA32A075422FB70DD org.graalvm.polyglot:polyglot:24.0.0
+E7FBA15F217232D59E2C7EBA0EE7480F8DBF32B7 org.graalvm.sdk:collections:24.0.0
+B6BD5F7B8A375832A64E7BEA9F2AEED08E7AA9D1 org.graalvm.sdk:nativeimage:24.0.0
+DEA1FD82AECD2B7776FDA84FE944C605B0A44339 org.graalvm.sdk:word:24.0.0
+206525F96C8D47633769F7DD96ADE4C9253E1FD7 org.graalvm.sdk:jniutils:24.0.0

--- a/ide/libs.graalsdk.system/external/graal-sdk-24.0.0-license.txt
+++ b/ide/libs.graalsdk.system/external/graal-sdk-24.0.0-license.txt
@@ -1,9 +1,9 @@
-Name: Graal SDK and Truffle API
-Description: Graal SDK and Truffle API
+Name: Graal SDK and Truffle Runtime
+Description: Graal SDK and Truffle Runtime
 License: UPL
 Origin: https://github.com/oracle/graal
-Version: 20.3.0
-Files: truffle-api-20.3.0.jar
+Version: 24.0.0
+Files: launcher-common-24.0.0.jar collections-24.0.0.jar jniutils-24.0.0.jar nativeimage-24.0.0.jar polyglot-24.0.0.jar word-24.0.0.jar
 
 Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
 

--- a/ide/libs.graalsdk.system/external/jline-24.0.0-license.txt
+++ b/ide/libs.graalsdk.system/external/jline-24.0.0-license.txt
@@ -1,0 +1,40 @@
+Name: JLine3 shaded for Graal
+Description: JLine3 shaded for Graal
+License: BSD-jline3
+Origin: https://github.com/jline/jline3/tree/master
+Version: 24.0.0
+
+Copyright (c) 2002-2023, the original author or authors.
+All rights reserved.
+
+https://opensource.org/licenses/BSD-3-Clause
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the following
+conditions are met:
+
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with
+the distribution.
+
+Neither the name of JLine nor the names of its contributors
+may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ide/libs.graalsdk.system/manifest.mf
+++ b/ide/libs.graalsdk.system/manifest.mf
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.libs.graalsdk.system
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/graalsdk/system/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.23
+OpenIDE-Module-Specification-Version: 1.24
 OpenIDE-Module-Provides: org.netbeans.spi.scripting.EngineProvider
 OpenIDE-Module-Package-Dependencies: org.graalvm.polyglot[Engine]
+OpenIDE-Module-Java-Dependencies: Java > 17

--- a/ide/libs.graalsdk.system/nbproject/project.xml
+++ b/ide/libs.graalsdk.system/nbproject/project.xml
@@ -83,11 +83,35 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path></runtime-relative-path>
-                <binary-origin>external/graal-sdk-20.3.0.jar</binary-origin>
+                <binary-origin>external/launcher-common-24.0.0.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path></runtime-relative-path>
-                <binary-origin>external/launcher-common-20.3.0.jar</binary-origin>
+                <binary-origin>external/jline-24.0.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path></runtime-relative-path>
+                <binary-origin>external/collections-24.0.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path></runtime-relative-path>
+                <binary-origin>external/jniutils-24.0.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path></runtime-relative-path>
+                <binary-origin>external/launcher-common-24.0.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path></runtime-relative-path>
+                <binary-origin>external/nativeimage-24.0.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path></runtime-relative-path>
+                <binary-origin>external/polyglot-24.0.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path></runtime-relative-path>
+                <binary-origin>external/word-24.0.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/libs.graalsdk/external/binaries-list
+++ b/ide/libs.graalsdk/external/binaries-list
@@ -14,5 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-8E62643FD621053E00EE52D797C7FBD08D7FDEDC org.graalvm.sdk:graal-sdk:20.3.0
-8968BDBE4058F4E6610AF0DC184BD885B236A2B1 org.graalvm.sdk:launcher-common:20.3.0
+06055903437576484DCC6545AF995FF67E0A3B55 org.graalvm.sdk:launcher-common:24.0.0
+335646EC205A3BCE0D518748D08A5C45900A9869 org.graalvm.shadowed:jline:24.0.0
+26F391313D8B7A4376B0778EA32A075422FB70DD org.graalvm.polyglot:polyglot:24.0.0
+E7FBA15F217232D59E2C7EBA0EE7480F8DBF32B7 org.graalvm.sdk:collections:24.0.0
+B6BD5F7B8A375832A64E7BEA9F2AEED08E7AA9D1 org.graalvm.sdk:nativeimage:24.0.0
+DEA1FD82AECD2B7776FDA84FE944C605B0A44339 org.graalvm.sdk:word:24.0.0
+206525F96C8D47633769F7DD96ADE4C9253E1FD7 org.graalvm.sdk:jniutils:24.0.0

--- a/ide/libs.graalsdk/external/graal-sdk-24.0.0-license.txt
+++ b/ide/libs.graalsdk/external/graal-sdk-24.0.0-license.txt
@@ -1,9 +1,9 @@
-Name: Graal SDK and Truffle API
-Description: Graal SDK and Truffle API
+Name: Graal SDK and Truffle Runtime
+Description: Graal SDK and Truffle Runtime
 License: UPL
 Origin: https://github.com/oracle/graal
-Version: 20.3.0
-Files: graal-sdk-20.3.0.jar launcher-common-20.3.0.jar
+Version: 24.0.0
+Files: launcher-common-24.0.0.jar collections-24.0.0.jar jniutils-24.0.0.jar nativeimage-24.0.0.jar polyglot-24.0.0.jar word-24.0.0.jar
 
 Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
 

--- a/ide/libs.graalsdk/external/jline-24.0.0-license.txt
+++ b/ide/libs.graalsdk/external/jline-24.0.0-license.txt
@@ -1,0 +1,40 @@
+Name: JLine3 shaded for Graal
+Description: JLine3 shaded for Graal
+License: BSD-jline3
+Origin: https://github.com/jline/jline3/tree/master
+Version: 24.0.0
+
+Copyright (c) 2002-2023, the original author or authors.
+All rights reserved.
+
+https://opensource.org/licenses/BSD-3-Clause
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the following
+conditions are met:
+
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with
+the distribution.
+
+Neither the name of JLine nor the names of its contributors
+may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ide/libs.graalsdk/manifest.mf
+++ b/ide/libs.graalsdk/manifest.mf
@@ -2,8 +2,10 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.libs.graalsdk
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/graalsdk/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.24
+OpenIDE-Module-Specification-Version: 1.25
 OpenIDE-Module-Provides: org.netbeans.spi.scripting.EngineProvider
 OpenIDE-Module-Recommends: com.oracle.truffle.polyglot.PolyglotImpl
+OpenIDE-Module-Install: org/netbeans/libs/graalsdk/impl/Installer.class
+OpenIDE-Module-Java-Dependencies: Java > 17
 OpenIDE-Module-Hide-Classpath-Packages: org.graalvm.collections.**, org.graalvm.home.**, org.graalvm.nativeimage.**,
-    org.graalvm.options.**, org.graalvm.polyglot.**, org.graalvm.word.**
+    org.graalvm.options.**, org.graalvm.polyglot.**, org.graalvm.word.** jdk.vm.ci.services.**

--- a/ide/libs.graalsdk/nbproject/org-netbeans-libs-graalsdk.sig
+++ b/ide/libs.graalsdk/nbproject/org-netbeans-libs-graalsdk.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.23
+#Version 1.24
 
 CLSS public abstract interface java.io.Serializable
 
@@ -25,6 +25,14 @@ meth public java.lang.String toString()
 meth public static <%0 extends java.lang.Enum<{%%0}>> {%%0} valueOf(java.lang.Class<{%%0}>,java.lang.String)
 supr java.lang.Object
 
+CLSS public java.lang.Error
+cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.Throwable
+
 CLSS public java.lang.Exception
 cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
 cons public init()
@@ -43,6 +51,17 @@ CLSS public abstract interface java.lang.Iterable<%0 extends java.lang.Object>
 meth public abstract java.util.Iterator<{java.lang.Iterable%0}> iterator()
 meth public java.util.Spliterator<{java.lang.Iterable%0}> spliterator()
 meth public void forEach(java.util.function.Consumer<? super {java.lang.Iterable%0}>)
+
+CLSS public abstract java.lang.Number
+cons public init()
+intf java.io.Serializable
+meth public abstract double doubleValue()
+meth public abstract float floatValue()
+meth public abstract int intValue()
+meth public abstract long longValue()
+meth public byte byteValue()
+meth public short shortValue()
+supr java.lang.Object
 
 CLSS public java.lang.Object
 cons public init()
@@ -114,6 +133,33 @@ CLSS public abstract interface !annotation java.lang.annotation.Target
 intf java.lang.annotation.Annotation
 meth public abstract java.lang.annotation.ElementType[] value()
 
+CLSS public java.util.concurrent.atomic.AtomicLong
+cons public init()
+cons public init(long)
+intf java.io.Serializable
+meth public double doubleValue()
+meth public final boolean compareAndSet(long,long)
+meth public final boolean weakCompareAndSet(long,long)
+meth public final long accumulateAndGet(long,java.util.function.LongBinaryOperator)
+meth public final long addAndGet(long)
+meth public final long decrementAndGet()
+meth public final long get()
+meth public final long getAndAccumulate(long,java.util.function.LongBinaryOperator)
+meth public final long getAndAdd(long)
+meth public final long getAndDecrement()
+meth public final long getAndIncrement()
+meth public final long getAndSet(long)
+meth public final long getAndUpdate(java.util.function.LongUnaryOperator)
+meth public final long incrementAndGet()
+meth public final long updateAndGet(java.util.function.LongUnaryOperator)
+meth public final void lazySet(long)
+meth public final void set(long)
+meth public float floatValue()
+meth public int intValue()
+meth public java.lang.String toString()
+meth public long longValue()
+supr java.lang.Number
+
 CLSS public abstract interface org.graalvm.collections.EconomicMap<%0 extends java.lang.Object, %1 extends java.lang.Object>
 intf org.graalvm.collections.UnmodifiableEconomicMap<{org.graalvm.collections.EconomicMap%0},{org.graalvm.collections.EconomicMap%1}>
 meth public abstract org.graalvm.collections.MapCursor<{org.graalvm.collections.EconomicMap%0},{org.graalvm.collections.EconomicMap%1}> getEntries()
@@ -127,10 +173,40 @@ meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> or
 meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.EconomicMap<{%%0},{%%1}> create(org.graalvm.collections.Equivalence,int)
 meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.EconomicMap<{%%0},{%%1}> create(org.graalvm.collections.Equivalence,org.graalvm.collections.UnmodifiableEconomicMap<{%%0},{%%1}>)
 meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.EconomicMap<{%%0},{%%1}> create(org.graalvm.collections.UnmodifiableEconomicMap<{%%0},{%%1}>)
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.EconomicMap<{%%0},{%%1}> emptyMap()
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.EconomicMap<{%%0},{%%1}> of({%%0},{%%1})
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.EconomicMap<{%%0},{%%1}> of({%%0},{%%1},{%%0},{%%1})
 meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.EconomicMap<{%%0},{%%1}> wrapMap(java.util.Map<{%%0},{%%1}>)
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.MapCursor<{%%0},{%%1}> emptyCursor()
 meth public void putAll(org.graalvm.collections.EconomicMap<{org.graalvm.collections.EconomicMap%0},{org.graalvm.collections.EconomicMap%1}>)
 meth public void putAll(org.graalvm.collections.UnmodifiableEconomicMap<? extends {org.graalvm.collections.EconomicMap%0},? extends {org.graalvm.collections.EconomicMap%1}>)
 meth public {org.graalvm.collections.EconomicMap%1} putIfAbsent({org.graalvm.collections.EconomicMap%0},{org.graalvm.collections.EconomicMap%1})
+
+CLSS public final org.graalvm.collections.EconomicMapUtil
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> boolean equals(org.graalvm.collections.UnmodifiableEconomicMap<{%%0},{%%1}>,org.graalvm.collections.UnmodifiableEconomicMap<{%%0},{%%1}>)
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> int hashCode(org.graalvm.collections.UnmodifiableEconomicMap<{%%0},{%%1}>)
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> java.util.Comparator<org.graalvm.collections.UnmodifiableEconomicMap<{%%0},{%%1}>> lexicographicalComparator(java.util.Comparator<{%%0}>,java.util.Comparator<{%%1}>)
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.collections.EconomicSet<{%%0}> keySet(org.graalvm.collections.EconomicMap<{%%0},{%%1}>)
+supr java.lang.Object
+
+CLSS public org.graalvm.collections.EconomicMapWrap<%0 extends java.lang.Object, %1 extends java.lang.Object>
+cons public init(java.util.Map<{org.graalvm.collections.EconomicMapWrap%0},{org.graalvm.collections.EconomicMapWrap%1}>)
+intf org.graalvm.collections.EconomicMap<{org.graalvm.collections.EconomicMapWrap%0},{org.graalvm.collections.EconomicMapWrap%1}>
+meth public boolean containsKey({org.graalvm.collections.EconomicMapWrap%0})
+meth public boolean isEmpty()
+meth public int size()
+meth public java.lang.Iterable<{org.graalvm.collections.EconomicMapWrap%0}> getKeys()
+meth public java.lang.Iterable<{org.graalvm.collections.EconomicMapWrap%1}> getValues()
+meth public java.lang.String toString()
+meth public org.graalvm.collections.MapCursor<{org.graalvm.collections.EconomicMapWrap%0},{org.graalvm.collections.EconomicMapWrap%1}> getEntries()
+meth public void clear()
+meth public void replaceAll(java.util.function.BiFunction<? super {org.graalvm.collections.EconomicMapWrap%0},? super {org.graalvm.collections.EconomicMapWrap%1},? extends {org.graalvm.collections.EconomicMapWrap%1}>)
+meth public {org.graalvm.collections.EconomicMapWrap%1} get({org.graalvm.collections.EconomicMapWrap%0})
+meth public {org.graalvm.collections.EconomicMapWrap%1} put({org.graalvm.collections.EconomicMapWrap%0},{org.graalvm.collections.EconomicMapWrap%1})
+meth public {org.graalvm.collections.EconomicMapWrap%1} putIfAbsent({org.graalvm.collections.EconomicMapWrap%0},{org.graalvm.collections.EconomicMapWrap%1})
+meth public {org.graalvm.collections.EconomicMapWrap%1} removeKey({org.graalvm.collections.EconomicMapWrap%0})
+supr java.lang.Object
+hfds map
 
 CLSS public abstract interface org.graalvm.collections.EconomicSet<%0 extends java.lang.Object>
 intf org.graalvm.collections.UnmodifiableEconomicSet<{org.graalvm.collections.EconomicSet%0}>
@@ -160,9 +236,75 @@ meth public abstract boolean equals(java.lang.Object,java.lang.Object)
 meth public abstract int hashCode(java.lang.Object)
 supr java.lang.Object
 
+CLSS public org.graalvm.collections.LockFreePool<%0 extends java.lang.Object>
+cons public init()
+meth public void add({org.graalvm.collections.LockFreePool%0})
+meth public {org.graalvm.collections.LockFreePool%0} get()
+supr java.lang.Object
+hfds head
+hcls Node
+
+CLSS public org.graalvm.collections.LockFreePrefixTree
+cons public init(org.graalvm.collections.LockFreePrefixTree$Allocator)
+innr public abstract static Allocator
+innr public static HeapAllocator
+innr public static Node
+innr public static ObjectPoolingAllocator
+meth public <%0 extends java.lang.Object> void topDown({%%0},java.util.function.BiFunction<{%%0},java.lang.Long,{%%0}>,java.util.function.BiConsumer<{%%0},java.lang.Long>)
+meth public org.graalvm.collections.LockFreePrefixTree$Allocator allocator()
+meth public org.graalvm.collections.LockFreePrefixTree$Node root()
+meth public void reset()
+supr java.lang.Object
+hfds allocator,root
+hcls FailedAllocationException
+
+CLSS public abstract static org.graalvm.collections.LockFreePrefixTree$Allocator
+ outer org.graalvm.collections.LockFreePrefixTree
+cons public init()
+meth public abstract java.util.concurrent.atomic.AtomicReferenceArray newHashChildren(int)
+meth public abstract java.util.concurrent.atomic.AtomicReferenceArray newLinearChildren(int)
+meth public abstract org.graalvm.collections.LockFreePrefixTree$Node newNode(long)
+meth public abstract void shutdown()
+supr java.lang.Object
+
+CLSS public static org.graalvm.collections.LockFreePrefixTree$HeapAllocator
+ outer org.graalvm.collections.LockFreePrefixTree
+cons public init()
+meth public java.util.concurrent.atomic.AtomicReferenceArray newHashChildren(int)
+meth public java.util.concurrent.atomic.AtomicReferenceArray newLinearChildren(int)
+meth public org.graalvm.collections.LockFreePrefixTree$Node newNode(long)
+meth public void shutdown()
+supr org.graalvm.collections.LockFreePrefixTree$Allocator
+
+CLSS public static org.graalvm.collections.LockFreePrefixTree$Node
+ outer org.graalvm.collections.LockFreePrefixTree
+meth public java.lang.String toString()
+meth public long bitwiseOrValue(long)
+meth public long incValue()
+meth public long value()
+meth public org.graalvm.collections.LockFreePrefixTree$Node at(org.graalvm.collections.LockFreePrefixTree$Allocator,long)
+meth public void setValue(long)
+supr java.util.concurrent.atomic.AtomicLong
+hfds CHILDREN_UPDATER,FROZEN_NODE,INITIAL_HASH_NODE_SIZE,INITIAL_LINEAR_NODE_SIZE,MAX_HASH_SKIPS,MAX_LINEAR_NODE_SIZE,children,key,serialVersionUID
+hcls FrozenNode,HashChildren,LinearChildren
+
+CLSS public static org.graalvm.collections.LockFreePrefixTree$ObjectPoolingAllocator
+ outer org.graalvm.collections.LockFreePrefixTree
+cons public init()
+cons public init(int)
+meth public java.lang.String status()
+meth public java.util.concurrent.atomic.AtomicReferenceArray newHashChildren(int)
+meth public java.util.concurrent.atomic.AtomicReferenceArray newLinearChildren(int)
+meth public org.graalvm.collections.LockFreePrefixTree$Node newNode(long)
+meth public void shutdown()
+supr org.graalvm.collections.LockFreePrefixTree$Allocator
+hfds DEFAULT_HOUSEKEEPING_PERIOD_MILLIS,EXPECTED_MAX_HASH_NODE_SIZE,FAILED_ALLOCATION_EXCEPTION,INITIAL_HASH_CHILDREN_PREALLOCATION_COUNT,INITIAL_LINEAR_CHILDREN_PREALLOCATION_COUNT,INITIAL_NODE_PREALLOCATION_COUNT,INTERNAL_FAILURE_EXCEPTION,LOGGING,MAX_CHILDREN_PREALLOCATION_COUNT,MAX_NODE_PREALLOCATION_COUNT,MIN_HOUSEKEEPING_PERIOD_MILLIS,SIZE_CLASS_COUNT,UNSUPPORTED_SIZE_EXCEPTION,hashChildrenPool,housekeepingThread,linearChildrenPool,missedHashChildrenRequestCounts,missedLinearChildrenRequestCounts,missedNodePoolRequestCount,nodePool
+hcls HousekeepingThread
+
 CLSS public abstract interface org.graalvm.collections.MapCursor<%0 extends java.lang.Object, %1 extends java.lang.Object>
 intf org.graalvm.collections.UnmodifiableMapCursor<{org.graalvm.collections.MapCursor%0},{org.graalvm.collections.MapCursor%1}>
 meth public abstract void remove()
+meth public {org.graalvm.collections.MapCursor%1} setValue({org.graalvm.collections.MapCursor%1})
 
 CLSS public final org.graalvm.collections.Pair<%0 extends java.lang.Object, %1 extends java.lang.Object>
 meth public boolean equals(java.lang.Object)
@@ -177,6 +319,26 @@ meth public {org.graalvm.collections.Pair%1} getRight()
 supr java.lang.Object
 hfds EMPTY,left,right
 
+CLSS public org.graalvm.collections.SeqLockPrefixTree
+cons public init()
+innr public final static Node
+meth public org.graalvm.collections.SeqLockPrefixTree$Node root()
+supr java.lang.Object
+hfds EMPTY_KEY,HASH_NODE_LOAD_FACTOR,INITIAL_HASH_NODE_SIZE,INITIAL_LINEAR_NODE_SIZE,MAX_LINEAR_NODE_SIZE,root
+hcls Visitor
+
+CLSS public final static org.graalvm.collections.SeqLockPrefixTree$Node
+ outer org.graalvm.collections.SeqLockPrefixTree
+meth public <%0 extends java.lang.Object> void topDown({%%0},java.util.function.BiFunction<{%%0},java.lang.Long,{%%0}>,java.util.function.BiConsumer<{%%0},java.lang.Long>)
+meth public java.lang.String toString()
+meth public long incValue()
+meth public long seqlockValue()
+meth public long value()
+meth public org.graalvm.collections.SeqLockPrefixTree$Node at(long)
+meth public void setValue(long)
+supr java.util.concurrent.atomic.AtomicLong
+hfds arity,children,keys,seqlock,serialVersionUID
+
 CLSS public abstract interface org.graalvm.collections.UnmodifiableEconomicMap<%0 extends java.lang.Object, %1 extends java.lang.Object>
 meth public abstract boolean containsKey({org.graalvm.collections.UnmodifiableEconomicMap%0})
 meth public abstract boolean isEmpty()
@@ -185,6 +347,7 @@ meth public abstract java.lang.Iterable<{org.graalvm.collections.UnmodifiableEco
 meth public abstract java.lang.Iterable<{org.graalvm.collections.UnmodifiableEconomicMap%1}> getValues()
 meth public abstract org.graalvm.collections.UnmodifiableMapCursor<{org.graalvm.collections.UnmodifiableEconomicMap%0},{org.graalvm.collections.UnmodifiableEconomicMap%1}> getEntries()
 meth public abstract {org.graalvm.collections.UnmodifiableEconomicMap%1} get({org.graalvm.collections.UnmodifiableEconomicMap%0})
+meth public org.graalvm.collections.Equivalence getEquivalenceStrategy()
 meth public {org.graalvm.collections.UnmodifiableEconomicMap%1} get({org.graalvm.collections.UnmodifiableEconomicMap%0},{org.graalvm.collections.UnmodifiableEconomicMap%1})
 
 CLSS public abstract interface org.graalvm.collections.UnmodifiableEconomicSet<%0 extends java.lang.Object>
@@ -217,11 +380,18 @@ meth public boolean isRelease()
 meth public boolean isSnapshot()
 meth public int compareTo(org.graalvm.home.Version)
 meth public int hashCode()
+meth public java.lang.String format(java.lang.String)
 meth public java.lang.String toString()
 meth public static org.graalvm.home.Version getCurrent()
 meth public static org.graalvm.home.Version parse(java.lang.String)
 supr java.lang.Object
 hfds MIN_VERSION_DIGITS,SNAPSHOT_STRING,SNAPSHOT_SUFFIX,snapshot,suffix,versions
+
+CLSS public final org.graalvm.nativeimage.AnnotationAccess
+meth public static <%0 extends java.lang.annotation.Annotation> {%%0} getAnnotation(java.lang.reflect.AnnotatedElement,java.lang.Class<{%%0}>)
+meth public static boolean isAnnotationPresent(java.lang.reflect.AnnotatedElement,java.lang.Class<? extends java.lang.annotation.Annotation>)
+meth public static java.lang.Class<? extends java.lang.annotation.Annotation>[] getAnnotationTypes(java.lang.reflect.AnnotatedElement)
+supr java.lang.Object
 
 CLSS public final org.graalvm.nativeimage.CurrentIsolate
 meth public static org.graalvm.nativeimage.Isolate getIsolate()
@@ -255,6 +425,7 @@ CLSS public abstract interface org.graalvm.nativeimage.IsolateThread
 intf org.graalvm.word.PointerBase
 
 CLSS public final org.graalvm.nativeimage.Isolates
+innr public abstract interface static ProtectionDomain
 innr public final static CreateIsolateParameters
 innr public final static IsolateException
 meth public static org.graalvm.nativeimage.Isolate getIsolate(org.graalvm.nativeimage.IsolateThread)
@@ -269,21 +440,25 @@ CLSS public final static org.graalvm.nativeimage.Isolates$CreateIsolateParameter
  outer org.graalvm.nativeimage.Isolates
 innr public final static Builder
 meth public java.lang.String getAuxiliaryImagePath()
+meth public java.util.List<java.lang.String> getArguments()
+meth public org.graalvm.nativeimage.Isolates$ProtectionDomain getProtectionDomain()
 meth public org.graalvm.word.UnsignedWord getAuxiliaryImageReservedSpaceSize()
 meth public org.graalvm.word.UnsignedWord getReservedAddressSpaceSize()
 meth public static org.graalvm.nativeimage.Isolates$CreateIsolateParameters getDefault()
 supr java.lang.Object
-hfds DEFAULT,auxiliaryImagePath,auxiliaryImageReservedSpaceSize,reservedAddressSpaceSize
+hfds DEFAULT,arguments,auxiliaryImagePath,auxiliaryImageReservedSpaceSize,protectionDomain,reservedAddressSpaceSize
 
 CLSS public final static org.graalvm.nativeimage.Isolates$CreateIsolateParameters$Builder
  outer org.graalvm.nativeimage.Isolates$CreateIsolateParameters
 cons public init()
 meth public org.graalvm.nativeimage.Isolates$CreateIsolateParameters build()
+meth public org.graalvm.nativeimage.Isolates$CreateIsolateParameters$Builder appendArgument(java.lang.String)
 meth public org.graalvm.nativeimage.Isolates$CreateIsolateParameters$Builder auxiliaryImagePath(java.lang.String)
 meth public org.graalvm.nativeimage.Isolates$CreateIsolateParameters$Builder auxiliaryImageReservedSpaceSize(org.graalvm.word.UnsignedWord)
 meth public org.graalvm.nativeimage.Isolates$CreateIsolateParameters$Builder reservedAddressSpaceSize(org.graalvm.word.UnsignedWord)
+meth public org.graalvm.nativeimage.Isolates$CreateIsolateParameters$Builder setProtectionDomain(org.graalvm.nativeimage.Isolates$ProtectionDomain)
 supr java.lang.Object
-hfds auxiliaryImagePath,auxiliaryImageReservedSpaceSize,reservedAddressSpaceSize
+hfds arguments,auxiliaryImagePath,auxiliaryImageReservedSpaceSize,protectionDomain,reservedAddressSpaceSize
 
 CLSS public final static org.graalvm.nativeimage.Isolates$IsolateException
  outer org.graalvm.nativeimage.Isolates
@@ -291,10 +466,24 @@ cons public init(java.lang.String)
 supr java.lang.RuntimeException
 hfds serialVersionUID
 
+CLSS public abstract interface static org.graalvm.nativeimage.Isolates$ProtectionDomain
+ outer org.graalvm.nativeimage.Isolates
+fld public final static org.graalvm.nativeimage.Isolates$ProtectionDomain NEW_DOMAIN
+fld public final static org.graalvm.nativeimage.Isolates$ProtectionDomain NO_DOMAIN
+
 CLSS public abstract interface org.graalvm.nativeimage.LogHandler
 meth public abstract void fatalError()
 meth public abstract void flush()
 meth public abstract void log(org.graalvm.nativeimage.c.type.CCharPointer,org.graalvm.word.UnsignedWord)
+
+CLSS public final org.graalvm.nativeimage.MissingReflectionRegistrationError
+cons public init(java.lang.String,java.lang.Class<?>,java.lang.Class<?>,java.lang.String,java.lang.Class<?>[])
+meth public java.lang.Class<?> getDeclaringClass()
+meth public java.lang.Class<?> getElementType()
+meth public java.lang.Class<?>[] getParameterTypes()
+meth public java.lang.String getElementName()
+supr java.lang.Error
+hfds declaringClass,elementName,elementType,parameterTypes,serialVersionUID
 
 CLSS public abstract interface org.graalvm.nativeimage.ObjectHandle
 intf org.graalvm.word.ComparableWord
@@ -318,71 +507,170 @@ CLSS public abstract interface org.graalvm.nativeimage.Platform
 fld public final static java.lang.String PLATFORM_PROPERTY_NAME = "svm.platform"
 innr public abstract interface static AARCH64
 innr public abstract interface static AMD64
+innr public abstract interface static ANDROID
 innr public abstract interface static DARWIN
+innr public abstract interface static DARWIN_AARCH64
+innr public abstract interface static DARWIN_AMD64
+innr public abstract interface static IOS
 innr public abstract interface static LINUX
+innr public abstract interface static LINUX_AARCH64_BASE
+innr public abstract interface static LINUX_AMD64_BASE
+innr public abstract interface static MACOS
+innr public abstract interface static RISCV64
 innr public abstract interface static WINDOWS
-innr public final static DARWIN_AARCH64
+innr public final static ANDROID_AARCH64
 innr public final static HOSTED_ONLY
+innr public final static IOS_AARCH64
+innr public final static IOS_AMD64
 innr public final static LINUX_AARCH64
-innr public static DARWIN_AMD64
+innr public final static LINUX_RISCV64
+innr public final static MACOS_AARCH64
+innr public final static MACOS_AMD64
+innr public final static WINDOWS_AARCH64
+innr public final static WINDOWS_AMD64
 innr public static LINUX_AMD64
-innr public static WINDOWS_AMD64
+meth public java.lang.String getArchitecture()
+meth public java.lang.String getOS()
 meth public static boolean includedIn(java.lang.Class<? extends org.graalvm.nativeimage.Platform>)
 
 CLSS public abstract interface static org.graalvm.nativeimage.Platform$AARCH64
  outer org.graalvm.nativeimage.Platform
 intf org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.impl.InternalPlatform$NATIVE_ONLY
+meth public java.lang.String getArchitecture()
 
 CLSS public abstract interface static org.graalvm.nativeimage.Platform$AMD64
  outer org.graalvm.nativeimage.Platform
 intf org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.impl.InternalPlatform$NATIVE_ONLY
+meth public java.lang.String getArchitecture()
+
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$ANDROID
+ outer org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.Platform$LINUX
+meth public java.lang.String getOS()
+
+CLSS public final static org.graalvm.nativeimage.Platform$ANDROID_AARCH64
+ outer org.graalvm.nativeimage.Platform
+cons public init()
+intf org.graalvm.nativeimage.Platform$ANDROID
+intf org.graalvm.nativeimage.Platform$LINUX_AARCH64_BASE
+supr java.lang.Object
 
 CLSS public abstract interface static org.graalvm.nativeimage.Platform$DARWIN
  outer org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.impl.InternalPlatform$NATIVE_ONLY
 intf org.graalvm.nativeimage.impl.InternalPlatform$PLATFORM_JNI
 
-CLSS public final static org.graalvm.nativeimage.Platform$DARWIN_AARCH64
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$DARWIN_AARCH64
  outer org.graalvm.nativeimage.Platform
-cons public init()
 intf org.graalvm.nativeimage.Platform$AARCH64
 intf org.graalvm.nativeimage.Platform$DARWIN
-supr java.lang.Object
 
-CLSS public static org.graalvm.nativeimage.Platform$DARWIN_AMD64
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$DARWIN_AMD64
  outer org.graalvm.nativeimage.Platform
-cons public init()
 intf org.graalvm.nativeimage.Platform$AMD64
 intf org.graalvm.nativeimage.Platform$DARWIN
-supr java.lang.Object
 
 CLSS public final static org.graalvm.nativeimage.Platform$HOSTED_ONLY
  outer org.graalvm.nativeimage.Platform
 intf org.graalvm.nativeimage.Platform
 supr java.lang.Object
 
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$IOS
+ outer org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.Platform$DARWIN
+meth public java.lang.String getOS()
+
+CLSS public final static org.graalvm.nativeimage.Platform$IOS_AARCH64
+ outer org.graalvm.nativeimage.Platform
+cons public init()
+intf org.graalvm.nativeimage.Platform$DARWIN_AARCH64
+intf org.graalvm.nativeimage.Platform$IOS
+supr java.lang.Object
+
+CLSS public final static org.graalvm.nativeimage.Platform$IOS_AMD64
+ outer org.graalvm.nativeimage.Platform
+cons public init()
+intf org.graalvm.nativeimage.Platform$DARWIN_AMD64
+intf org.graalvm.nativeimage.Platform$IOS
+supr java.lang.Object
+
 CLSS public abstract interface static org.graalvm.nativeimage.Platform$LINUX
  outer org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.impl.InternalPlatform$NATIVE_ONLY
 intf org.graalvm.nativeimage.impl.InternalPlatform$PLATFORM_JNI
+meth public java.lang.String getOS()
 
 CLSS public final static org.graalvm.nativeimage.Platform$LINUX_AARCH64
  outer org.graalvm.nativeimage.Platform
 cons public init()
+intf org.graalvm.nativeimage.Platform$LINUX
+intf org.graalvm.nativeimage.Platform$LINUX_AARCH64_BASE
+supr java.lang.Object
+
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$LINUX_AARCH64_BASE
+ outer org.graalvm.nativeimage.Platform
 intf org.graalvm.nativeimage.Platform$AARCH64
 intf org.graalvm.nativeimage.Platform$LINUX
-supr java.lang.Object
 
 CLSS public static org.graalvm.nativeimage.Platform$LINUX_AMD64
  outer org.graalvm.nativeimage.Platform
 cons public init()
+intf org.graalvm.nativeimage.Platform$LINUX
+intf org.graalvm.nativeimage.Platform$LINUX_AMD64_BASE
+supr java.lang.Object
+
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$LINUX_AMD64_BASE
+ outer org.graalvm.nativeimage.Platform
 intf org.graalvm.nativeimage.Platform$AMD64
 intf org.graalvm.nativeimage.Platform$LINUX
+
+CLSS public final static org.graalvm.nativeimage.Platform$LINUX_RISCV64
+ outer org.graalvm.nativeimage.Platform
+cons public init()
+intf org.graalvm.nativeimage.Platform$LINUX
+intf org.graalvm.nativeimage.Platform$RISCV64
 supr java.lang.Object
+
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$MACOS
+ outer org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.Platform$DARWIN
+meth public java.lang.String getOS()
+
+CLSS public final static org.graalvm.nativeimage.Platform$MACOS_AARCH64
+ outer org.graalvm.nativeimage.Platform
+cons public init()
+intf org.graalvm.nativeimage.Platform$DARWIN_AARCH64
+intf org.graalvm.nativeimage.Platform$MACOS
+supr java.lang.Object
+
+CLSS public final static org.graalvm.nativeimage.Platform$MACOS_AMD64
+ outer org.graalvm.nativeimage.Platform
+cons public init()
+intf org.graalvm.nativeimage.Platform$DARWIN_AMD64
+intf org.graalvm.nativeimage.Platform$MACOS
+supr java.lang.Object
+
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$RISCV64
+ outer org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.Platform
+meth public java.lang.String getArchitecture()
 
 CLSS public abstract interface static org.graalvm.nativeimage.Platform$WINDOWS
  outer org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.impl.InternalPlatform$NATIVE_ONLY
 intf org.graalvm.nativeimage.impl.InternalPlatform$PLATFORM_JNI
+meth public java.lang.String getOS()
 
-CLSS public static org.graalvm.nativeimage.Platform$WINDOWS_AMD64
+CLSS public final static org.graalvm.nativeimage.Platform$WINDOWS_AARCH64
+ outer org.graalvm.nativeimage.Platform
+cons public init()
+intf org.graalvm.nativeimage.Platform$AARCH64
+intf org.graalvm.nativeimage.Platform$WINDOWS
+supr java.lang.Object
+
+CLSS public final static org.graalvm.nativeimage.Platform$WINDOWS_AMD64
  outer org.graalvm.nativeimage.Platform
 cons public init()
 intf org.graalvm.nativeimage.Platform$AMD64
@@ -410,23 +698,26 @@ meth public static java.lang.String getObjectFile(org.graalvm.nativeimage.c.func
 meth public static java.lang.String setLocale(java.lang.String,java.lang.String)
 meth public static long getProcessID()
 meth public static long getProcessID(java.lang.Process)
+meth public static void exec(java.nio.file.Path,java.lang.String[],java.util.Map<java.lang.String,java.lang.String>)
 supr java.lang.Object
 
 CLSS public final org.graalvm.nativeimage.RuntimeOptions
-innr public final static !enum OptionClass
+innr public abstract interface static Descriptor
 meth public static <%0 extends java.lang.Object> {%%0} get(java.lang.String)
-meth public static org.graalvm.options.OptionDescriptors getOptions()
-meth public static org.graalvm.options.OptionDescriptors getOptions(java.util.EnumSet<org.graalvm.nativeimage.RuntimeOptions$OptionClass>)
+meth public static java.util.List<org.graalvm.nativeimage.RuntimeOptions$Descriptor> listDescriptors()
+meth public static org.graalvm.nativeimage.RuntimeOptions$Descriptor getDescriptor(java.lang.String)
 meth public static void set(java.lang.String,java.lang.Object)
 supr java.lang.Object
 
-CLSS public final static !enum org.graalvm.nativeimage.RuntimeOptions$OptionClass
+CLSS public abstract interface static org.graalvm.nativeimage.RuntimeOptions$Descriptor
  outer org.graalvm.nativeimage.RuntimeOptions
-fld public final static org.graalvm.nativeimage.RuntimeOptions$OptionClass Compiler
-fld public final static org.graalvm.nativeimage.RuntimeOptions$OptionClass VM
-meth public static org.graalvm.nativeimage.RuntimeOptions$OptionClass valueOf(java.lang.String)
-meth public static org.graalvm.nativeimage.RuntimeOptions$OptionClass[] values()
-supr java.lang.Enum<org.graalvm.nativeimage.RuntimeOptions$OptionClass>
+meth public abstract boolean deprecated()
+meth public abstract java.lang.Class<?> valueType()
+meth public abstract java.lang.Object convertValue(java.lang.String)
+meth public abstract java.lang.Object defaultValue()
+meth public abstract java.lang.String deprecatedMessage()
+meth public abstract java.lang.String help()
+meth public abstract java.lang.String name()
 
 CLSS public final org.graalvm.nativeimage.StackValue
 meth public static <%0 extends org.graalvm.word.PointerBase> {%%0} get(int)
@@ -474,7 +765,12 @@ meth public abstract !hasdefault boolean isIncomplete()
 meth public abstract !hasdefault java.lang.String value()
 
 CLSS public abstract interface org.graalvm.nativeimage.impl.InternalPlatform
+innr public abstract interface static NATIVE_ONLY
 innr public abstract interface static PLATFORM_JNI
+
+CLSS public abstract interface static org.graalvm.nativeimage.impl.InternalPlatform$NATIVE_ONLY
+ outer org.graalvm.nativeimage.impl.InternalPlatform
+intf org.graalvm.nativeimage.Platform
 
 CLSS public abstract interface static org.graalvm.nativeimage.impl.InternalPlatform$PLATFORM_JNI
  outer org.graalvm.nativeimage.impl.InternalPlatform
@@ -497,13 +793,14 @@ meth public int hashCode()
 meth public java.lang.String getDeprecationMessage()
 meth public java.lang.String getHelp()
 meth public java.lang.String getName()
+meth public java.lang.String getUsageSyntax()
 meth public java.lang.String toString()
 meth public org.graalvm.options.OptionCategory getCategory()
 meth public org.graalvm.options.OptionKey<?> getKey()
 meth public org.graalvm.options.OptionStability getStability()
 meth public static <%0 extends java.lang.Object> org.graalvm.options.OptionDescriptor$Builder newBuilder(org.graalvm.options.OptionKey<{%%0}>,java.lang.String)
 supr java.lang.Object
-hfds EMPTY,category,deprecated,deprecationMessage,help,key,name,stability
+hfds EMPTY,category,deprecated,deprecationMessage,help,key,name,stability,usageSyntax
 
 CLSS public final org.graalvm.options.OptionDescriptor$Builder
  outer org.graalvm.options.OptionDescriptor
@@ -513,8 +810,9 @@ meth public org.graalvm.options.OptionDescriptor$Builder deprecated(boolean)
 meth public org.graalvm.options.OptionDescriptor$Builder deprecationMessage(java.lang.String)
 meth public org.graalvm.options.OptionDescriptor$Builder help(java.lang.String)
 meth public org.graalvm.options.OptionDescriptor$Builder stability(org.graalvm.options.OptionStability)
+meth public org.graalvm.options.OptionDescriptor$Builder usageSyntax(java.lang.String)
 supr java.lang.Object
-hfds category,deprecated,deprecationMessage,help,key,name,stability
+hfds category,deprecated,deprecationMessage,help,key,name,stability,usageSyntax
 
 CLSS public abstract interface org.graalvm.options.OptionDescriptors
 fld public final static org.graalvm.options.OptionDescriptors EMPTY
@@ -555,9 +853,9 @@ CLSS public final org.graalvm.options.OptionType<%0 extends java.lang.Object>
 cons public init(java.lang.String,java.util.function.Function<java.lang.String,{org.graalvm.options.OptionType%0}>)
 cons public init(java.lang.String,java.util.function.Function<java.lang.String,{org.graalvm.options.OptionType%0}>,java.util.function.Consumer<{org.graalvm.options.OptionType%0}>)
 cons public init(java.lang.String,{org.graalvm.options.OptionType%0},java.util.function.Function<java.lang.String,{org.graalvm.options.OptionType%0}>)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="19.0")
 cons public init(java.lang.String,{org.graalvm.options.OptionType%0},java.util.function.Function<java.lang.String,{org.graalvm.options.OptionType%0}>,java.util.function.Consumer<{org.graalvm.options.OptionType%0}>)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="19.0")
 meth public java.lang.String getName()
 meth public java.lang.String toString()
 meth public static <%0 extends java.lang.Object> org.graalvm.options.OptionType<{%%0}> defaultType(java.lang.Class<{%%0}>)
@@ -566,14 +864,14 @@ meth public void validate({org.graalvm.options.OptionType%0})
 meth public {org.graalvm.options.OptionType%0} convert(java.lang.Object,java.lang.String,java.lang.String)
 meth public {org.graalvm.options.OptionType%0} convert(java.lang.String)
 meth public {org.graalvm.options.OptionType%0} getDefaultValue()
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="19.0")
 supr java.lang.Object
-hfds DEFAULTTYPES,EMPTY_VALIDATOR,converter,isOptionMap,name,validator
+hfds DEFAULTTYPES,EMPTY_VALIDATOR,converter,isDefaultType,isOptionMap,name,validator
 hcls Converter
 
 CLSS public abstract interface org.graalvm.options.OptionValues
-meth public abstract <%0 extends java.lang.Object> void set(org.graalvm.options.OptionKey<{%%0}>,{%%0})
- anno 0 java.lang.Deprecated()
+meth public <%0 extends java.lang.Object> void set(org.graalvm.options.OptionKey<{%%0}>,{%%0})
+ anno 0 java.lang.Deprecated(null since="22.0")
 meth public abstract <%0 extends java.lang.Object> {%%0} get(org.graalvm.options.OptionKey<{%%0}>)
 meth public abstract boolean hasBeenSet(org.graalvm.options.OptionKey<?>)
 meth public abstract org.graalvm.options.OptionDescriptors getDescriptors()
@@ -602,8 +900,9 @@ meth public void enter()
 meth public void interrupt(java.time.Duration) throws java.util.concurrent.TimeoutException
 meth public void leave()
 meth public void resetLimits()
+meth public void safepoint()
 supr java.lang.Object
-hfds ALL_HOST_CLASSES,EMPTY,NO_HOST_CLASSES,UNSET_HOST_LOOKUP,impl
+hfds ALL_HOST_CLASSES,EMPTY,NO_HOST_CLASSES,UNSET_HOST_LOOKUP,currentAPI,dispatch,engine,receiver
 
 CLSS public final org.graalvm.polyglot.Context$Builder
  outer org.graalvm.polyglot.Context
@@ -614,13 +913,17 @@ meth public org.graalvm.polyglot.Context$Builder allowCreateThread(boolean)
 meth public org.graalvm.polyglot.Context$Builder allowEnvironmentAccess(org.graalvm.polyglot.EnvironmentAccess)
 meth public org.graalvm.polyglot.Context$Builder allowExperimentalOptions(boolean)
 meth public org.graalvm.polyglot.Context$Builder allowHostAccess(boolean)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="19.0")
 meth public org.graalvm.polyglot.Context$Builder allowHostAccess(org.graalvm.polyglot.HostAccess)
 meth public org.graalvm.polyglot.Context$Builder allowHostClassLoading(boolean)
 meth public org.graalvm.polyglot.Context$Builder allowHostClassLookup(java.util.function.Predicate<java.lang.String>)
 meth public org.graalvm.polyglot.Context$Builder allowIO(boolean)
+ anno 0 java.lang.Deprecated(null since="23.0")
+meth public org.graalvm.polyglot.Context$Builder allowIO(org.graalvm.polyglot.io.IOAccess)
+meth public org.graalvm.polyglot.Context$Builder allowInnerContextOptions(boolean)
 meth public org.graalvm.polyglot.Context$Builder allowNativeAccess(boolean)
 meth public org.graalvm.polyglot.Context$Builder allowPolyglotAccess(org.graalvm.polyglot.PolyglotAccess)
+meth public org.graalvm.polyglot.Context$Builder allowValueSharing(boolean)
 meth public org.graalvm.polyglot.Context$Builder arguments(java.lang.String,java.lang.String[])
 meth public org.graalvm.polyglot.Context$Builder currentWorkingDirectory(java.nio.file.Path)
 meth public org.graalvm.polyglot.Context$Builder engine(org.graalvm.polyglot.Engine)
@@ -628,8 +931,9 @@ meth public org.graalvm.polyglot.Context$Builder environment(java.lang.String,ja
 meth public org.graalvm.polyglot.Context$Builder environment(java.util.Map<java.lang.String,java.lang.String>)
 meth public org.graalvm.polyglot.Context$Builder err(java.io.OutputStream)
 meth public org.graalvm.polyglot.Context$Builder fileSystem(org.graalvm.polyglot.io.FileSystem)
+ anno 0 java.lang.Deprecated(null since="23.0")
 meth public org.graalvm.polyglot.Context$Builder hostClassFilter(java.util.function.Predicate<java.lang.String>)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="19.0")
 meth public org.graalvm.polyglot.Context$Builder hostClassLoader(java.lang.ClassLoader)
 meth public org.graalvm.polyglot.Context$Builder in(java.io.InputStream)
 meth public org.graalvm.polyglot.Context$Builder logHandler(java.io.OutputStream)
@@ -639,14 +943,19 @@ meth public org.graalvm.polyglot.Context$Builder options(java.util.Map<java.lang
 meth public org.graalvm.polyglot.Context$Builder out(java.io.OutputStream)
 meth public org.graalvm.polyglot.Context$Builder processHandler(org.graalvm.polyglot.io.ProcessHandler)
 meth public org.graalvm.polyglot.Context$Builder resourceLimits(org.graalvm.polyglot.ResourceLimits)
+meth public org.graalvm.polyglot.Context$Builder sandbox(org.graalvm.polyglot.SandboxPolicy)
 meth public org.graalvm.polyglot.Context$Builder serverTransport(org.graalvm.polyglot.io.MessageTransport)
 meth public org.graalvm.polyglot.Context$Builder timeZone(java.time.ZoneId)
+meth public org.graalvm.polyglot.Context$Builder useSystemExit(boolean)
 supr java.lang.Object
-hfds allowAllAccess,allowCreateProcess,allowCreateThread,allowExperimentalOptions,allowHostAccess,allowHostClassLoading,allowIO,allowNativeAccess,arguments,currentWorkingDirectory,customFileSystem,customLogHandler,environment,environmentAccess,err,hostAccess,hostClassFilter,hostClassLoader,in,messageTransport,onlyLanguages,options,out,polyglotAccess,processHandler,resourceLimits,sharedEngine,zone
+hfds allowAllAccess,allowCreateProcess,allowCreateThread,allowExperimentalOptions,allowHostAccess,allowHostClassLoading,allowIO,allowInnerContextOptions,allowNativeAccess,allowValueSharing,arguments,currentWorkingDirectory,customFileSystem,customLogHandler,environment,environmentAccess,err,hostAccess,hostClassFilter,hostClassLoader,in,ioAccess,messageTransport,options,out,permittedLanguages,polyglotAccess,processHandler,resourceLimits,sandboxPolicy,sharedEngine,useSystemExit,zone
 
 CLSS public final org.graalvm.polyglot.Engine
 innr public final Builder
 intf java.lang.AutoCloseable
+meth public !varargs static boolean copyResources(java.nio.file.Path,java.lang.String[]) throws java.io.IOException
+meth public !varargs static org.graalvm.polyglot.Engine create(java.lang.String[])
+meth public !varargs static org.graalvm.polyglot.Engine$Builder newBuilder(java.lang.String[])
 meth public java.lang.String getImplementationName()
 meth public java.lang.String getVersion()
 meth public java.util.Map<java.lang.String,org.graalvm.polyglot.Instrument> getInstruments()
@@ -659,8 +968,8 @@ meth public static org.graalvm.polyglot.Engine$Builder newBuilder()
 meth public void close()
 meth public void close(boolean)
 supr java.lang.Object
-hfds EMPTY,JDK8_OR_EARLIER,impl
-hcls APIAccessImpl,ImplHolder,PolyglotInvalid
+hfds EMPTY,ENGINES,currentAPI,dispatch,initializationException,receiver,shutdownHookInitialized
+hcls APIAccessImpl,ClassPathIsolation,EngineShutDownHook,ImplHolder,PolyglotInvalid
 
 CLSS public final org.graalvm.polyglot.Engine$Builder
  outer org.graalvm.polyglot.Engine
@@ -673,23 +982,32 @@ meth public org.graalvm.polyglot.Engine$Builder logHandler(java.util.logging.Han
 meth public org.graalvm.polyglot.Engine$Builder option(java.lang.String,java.lang.String)
 meth public org.graalvm.polyglot.Engine$Builder options(java.util.Map<java.lang.String,java.lang.String>)
 meth public org.graalvm.polyglot.Engine$Builder out(java.io.OutputStream)
+meth public org.graalvm.polyglot.Engine$Builder sandbox(org.graalvm.polyglot.SandboxPolicy)
 meth public org.graalvm.polyglot.Engine$Builder serverTransport(org.graalvm.polyglot.io.MessageTransport)
 meth public org.graalvm.polyglot.Engine$Builder useSystemProperties(boolean)
 supr java.lang.Object
-hfds allowExperimentalOptions,boundEngine,customLogHandler,err,in,messageTransport,options,out,useSystemProperties
+hfds allowExperimentalOptionSystemPropertyValue,allowExperimentalOptions,boundEngine,customLogHandler,err,in,messageTransport,options,out,permittedLanguages,sandboxPolicy,useSystemProperties
 
 CLSS public final org.graalvm.polyglot.EnvironmentAccess
 fld public final static org.graalvm.polyglot.EnvironmentAccess INHERIT
 fld public final static org.graalvm.polyglot.EnvironmentAccess NONE
+meth public java.lang.String toString()
 supr java.lang.Object
+hfds name
 
 CLSS public final org.graalvm.polyglot.HostAccess
 fld public final static org.graalvm.polyglot.HostAccess ALL
+fld public final static org.graalvm.polyglot.HostAccess CONSTRAINED
 fld public final static org.graalvm.polyglot.HostAccess EXPLICIT
+fld public final static org.graalvm.polyglot.HostAccess ISOLATED
 fld public final static org.graalvm.polyglot.HostAccess NONE
+fld public final static org.graalvm.polyglot.HostAccess SCOPED
+fld public final static org.graalvm.polyglot.HostAccess UNTRUSTED
+innr public abstract interface static !annotation DisableMethodScoping
 innr public abstract interface static !annotation Export
 innr public abstract interface static !annotation Implementable
 innr public final Builder
+innr public final static !enum MutableTargetMapping
 innr public final static !enum TargetMappingPrecedence
 meth public boolean equals(java.lang.Object)
 meth public int hashCode()
@@ -697,27 +1015,44 @@ meth public java.lang.String toString()
 meth public static org.graalvm.polyglot.HostAccess$Builder newBuilder()
 meth public static org.graalvm.polyglot.HostAccess$Builder newBuilder(org.graalvm.polyglot.HostAccess)
 supr java.lang.Object
-hfds EMPTY,accessAnnotations,allowAllClassImplementations,allowAllInterfaceImplementations,allowArrayAccess,allowListAccess,allowPublic,excludeTypes,impl,implementableAnnotations,implementableTypes,members,name,targetMappings
+hfds EMPTY,accessAnnotations,allowAccessInheritance,allowAllClassImplementations,allowAllInterfaceImplementations,allowArrayAccess,allowBigIntegerNumberAccess,allowBufferAccess,allowIterableAccess,allowIteratorAccess,allowListAccess,allowMapAccess,allowMutableTargetMappings,allowPublic,disableMethodScoping,disableMethodScopingAnnotations,excludeTypes,impl,implementableAnnotations,implementableTypes,members,methodLookup,methodScopingDefault,name,targetMappings
 
 CLSS public final org.graalvm.polyglot.HostAccess$Builder
  outer org.graalvm.polyglot.HostAccess
+meth public !varargs org.graalvm.polyglot.HostAccess$Builder allowMutableTargetMappings(org.graalvm.polyglot.HostAccess$MutableTargetMapping[])
 meth public <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.polyglot.HostAccess$Builder targetTypeMapping(java.lang.Class<{%%0}>,java.lang.Class<{%%1}>,java.util.function.Predicate<{%%0}>,java.util.function.Function<{%%0},{%%1}>)
 meth public <%0 extends java.lang.Object, %1 extends java.lang.Object> org.graalvm.polyglot.HostAccess$Builder targetTypeMapping(java.lang.Class<{%%0}>,java.lang.Class<{%%1}>,java.util.function.Predicate<{%%0}>,java.util.function.Function<{%%0},{%%1}>,org.graalvm.polyglot.HostAccess$TargetMappingPrecedence)
 meth public org.graalvm.polyglot.HostAccess build()
 meth public org.graalvm.polyglot.HostAccess$Builder allowAccess(java.lang.reflect.Executable)
 meth public org.graalvm.polyglot.HostAccess$Builder allowAccess(java.lang.reflect.Field)
 meth public org.graalvm.polyglot.HostAccess$Builder allowAccessAnnotatedBy(java.lang.Class<? extends java.lang.annotation.Annotation>)
+meth public org.graalvm.polyglot.HostAccess$Builder allowAccessInheritance(boolean)
 meth public org.graalvm.polyglot.HostAccess$Builder allowAllClassImplementations(boolean)
 meth public org.graalvm.polyglot.HostAccess$Builder allowAllImplementations(boolean)
 meth public org.graalvm.polyglot.HostAccess$Builder allowArrayAccess(boolean)
+meth public org.graalvm.polyglot.HostAccess$Builder allowBigIntegerNumberAccess(boolean)
+meth public org.graalvm.polyglot.HostAccess$Builder allowBufferAccess(boolean)
 meth public org.graalvm.polyglot.HostAccess$Builder allowImplementations(java.lang.Class<?>)
 meth public org.graalvm.polyglot.HostAccess$Builder allowImplementationsAnnotatedBy(java.lang.Class<? extends java.lang.annotation.Annotation>)
+meth public org.graalvm.polyglot.HostAccess$Builder allowIterableAccess(boolean)
+meth public org.graalvm.polyglot.HostAccess$Builder allowIteratorAccess(boolean)
 meth public org.graalvm.polyglot.HostAccess$Builder allowListAccess(boolean)
+meth public org.graalvm.polyglot.HostAccess$Builder allowMapAccess(boolean)
 meth public org.graalvm.polyglot.HostAccess$Builder allowPublicAccess(boolean)
 meth public org.graalvm.polyglot.HostAccess$Builder denyAccess(java.lang.Class<?>)
 meth public org.graalvm.polyglot.HostAccess$Builder denyAccess(java.lang.Class<?>,boolean)
+meth public org.graalvm.polyglot.HostAccess$Builder disableMethodScoping(java.lang.reflect.Executable)
+meth public org.graalvm.polyglot.HostAccess$Builder disableMethodScopingAnnotatedBy(java.lang.Class<? extends java.lang.annotation.Annotation>)
+meth public org.graalvm.polyglot.HostAccess$Builder methodScoping(boolean)
+meth public org.graalvm.polyglot.HostAccess$Builder useModuleLookup(java.lang.invoke.MethodHandles$Lookup)
 supr java.lang.Object
-hfds accessAnnotations,allowAllClassImplementations,allowAllImplementations,allowArrayAccess,allowListAccess,allowPublic,excludeTypes,implementableTypes,implementationAnnotations,members,name,targetMappings
+hfds accessAnnotations,allowAccessInheritance,allowAllClassImplementations,allowAllImplementations,allowArrayAccess,allowBigIntegerNumberAccess,allowBufferAccess,allowIterableAccess,allowIteratorAccess,allowListAccess,allowMapAccess,allowMutableTargetMappings,allowPublic,disableMethodScoping,disableMethodScopingAnnotations,excludeTypes,implementableTypes,implementationAnnotations,members,methodLookup,methodScopingDefault,name,targetMappings
+
+CLSS public abstract interface static !annotation org.graalvm.polyglot.HostAccess$DisableMethodScoping
+ outer org.graalvm.polyglot.HostAccess
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[CONSTRUCTOR, METHOD])
+intf java.lang.annotation.Annotation
 
 CLSS public abstract interface static !annotation org.graalvm.polyglot.HostAccess$Export
  outer org.graalvm.polyglot.HostAccess
@@ -730,6 +1065,19 @@ CLSS public abstract interface static !annotation org.graalvm.polyglot.HostAcces
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
+
+CLSS public final static !enum org.graalvm.polyglot.HostAccess$MutableTargetMapping
+ outer org.graalvm.polyglot.HostAccess
+fld public final static org.graalvm.polyglot.HostAccess$MutableTargetMapping ARRAY_TO_JAVA_LIST
+fld public final static org.graalvm.polyglot.HostAccess$MutableTargetMapping EXECUTABLE_TO_JAVA_INTERFACE
+fld public final static org.graalvm.polyglot.HostAccess$MutableTargetMapping HASH_TO_JAVA_MAP
+fld public final static org.graalvm.polyglot.HostAccess$MutableTargetMapping ITERABLE_TO_JAVA_ITERABLE
+fld public final static org.graalvm.polyglot.HostAccess$MutableTargetMapping ITERATOR_TO_JAVA_ITERATOR
+fld public final static org.graalvm.polyglot.HostAccess$MutableTargetMapping MEMBERS_TO_JAVA_INTERFACE
+fld public final static org.graalvm.polyglot.HostAccess$MutableTargetMapping MEMBERS_TO_JAVA_MAP
+meth public static org.graalvm.polyglot.HostAccess$MutableTargetMapping valueOf(java.lang.String)
+meth public static org.graalvm.polyglot.HostAccess$MutableTargetMapping[] values()
+supr java.lang.Enum<org.graalvm.polyglot.HostAccess$MutableTargetMapping>
 
 CLSS public final static !enum org.graalvm.polyglot.HostAccess$TargetMappingPrecedence
  outer org.graalvm.polyglot.HostAccess
@@ -746,9 +1094,10 @@ meth public <%0 extends java.lang.Object> {%%0} lookup(java.lang.Class<{%%0}>)
 meth public java.lang.String getId()
 meth public java.lang.String getName()
 meth public java.lang.String getVersion()
+meth public java.lang.String getWebsite()
 meth public org.graalvm.options.OptionDescriptors getOptions()
 supr java.lang.Object
-hfds impl
+hfds dispatch,receiver
 
 CLSS public final org.graalvm.polyglot.Language
 meth public boolean isInteractive()
@@ -757,10 +1106,11 @@ meth public java.lang.String getId()
 meth public java.lang.String getImplementationName()
 meth public java.lang.String getName()
 meth public java.lang.String getVersion()
+meth public java.lang.String getWebsite()
 meth public java.util.Set<java.lang.String> getMimeTypes()
 meth public org.graalvm.options.OptionDescriptors getOptions()
 supr java.lang.Object
-hfds impl
+hfds dispatch,receiver
 
 CLSS public final org.graalvm.polyglot.PolyglotAccess
 fld public final static org.graalvm.polyglot.PolyglotAccess ALL
@@ -768,7 +1118,7 @@ fld public final static org.graalvm.polyglot.PolyglotAccess NONE
 innr public final Builder
 meth public static org.graalvm.polyglot.PolyglotAccess$Builder newBuilder()
 supr java.lang.Object
-hfds EMPTY,allAccess,bindingsAccess,evalAccess
+hfds allAccess,bindingsAccess,evalAccess
 
 CLSS public final org.graalvm.polyglot.PolyglotAccess$Builder
  outer org.graalvm.polyglot.PolyglotAccess
@@ -808,7 +1158,7 @@ meth public void printStackTrace(java.io.PrintStream)
 meth public void printStackTrace(java.io.PrintWriter)
 meth public void setStackTrace(java.lang.StackTraceElement[])
 supr java.lang.RuntimeException
-hfds impl
+hfds dispatch,impl
 
 CLSS public final org.graalvm.polyglot.PolyglotException$StackFrame
  outer org.graalvm.polyglot.PolyglotException
@@ -826,13 +1176,13 @@ CLSS public final org.graalvm.polyglot.ResourceLimitEvent
 meth public java.lang.String toString()
 meth public org.graalvm.polyglot.Context getContext()
 supr java.lang.Object
-hfds impl
+hfds context
 
 CLSS public final org.graalvm.polyglot.ResourceLimits
 innr public final Builder
 meth public static org.graalvm.polyglot.ResourceLimits$Builder newBuilder()
 supr java.lang.Object
-hfds EMPTY,impl
+hfds EMPTY,receiver
 
 CLSS public final org.graalvm.polyglot.ResourceLimits$Builder
  outer org.graalvm.polyglot.ResourceLimits
@@ -840,7 +1190,18 @@ meth public org.graalvm.polyglot.ResourceLimits build()
 meth public org.graalvm.polyglot.ResourceLimits$Builder onLimit(java.util.function.Consumer<org.graalvm.polyglot.ResourceLimitEvent>)
 meth public org.graalvm.polyglot.ResourceLimits$Builder statementLimit(long,java.util.function.Predicate<org.graalvm.polyglot.Source>)
 supr java.lang.Object
-hfds onLimit,statementLimit,statementLimitSourceFilter,timeLimit,timeLimitAccuracy
+hfds onLimit,statementLimit,statementLimitSourceFilter
+
+CLSS public final !enum org.graalvm.polyglot.SandboxPolicy
+fld public final static org.graalvm.polyglot.SandboxPolicy CONSTRAINED
+fld public final static org.graalvm.polyglot.SandboxPolicy ISOLATED
+fld public final static org.graalvm.polyglot.SandboxPolicy TRUSTED
+fld public final static org.graalvm.polyglot.SandboxPolicy UNTRUSTED
+meth public boolean isStricterOrEqual(org.graalvm.polyglot.SandboxPolicy)
+meth public boolean isStricterThan(org.graalvm.polyglot.SandboxPolicy)
+meth public static org.graalvm.polyglot.SandboxPolicy valueOf(java.lang.String)
+meth public static org.graalvm.polyglot.SandboxPolicy[] values()
+supr java.lang.Enum<org.graalvm.polyglot.SandboxPolicy>
 
 CLSS public final org.graalvm.polyglot.Source
 innr public Builder
@@ -857,7 +1218,7 @@ meth public int getLineNumber(int)
 meth public int getLineStartOffset(int)
 meth public int hashCode()
 meth public java.io.InputStream getInputStream()
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="19.0")
 meth public java.io.Reader getReader()
 meth public java.lang.CharSequence getCharacters()
 meth public java.lang.CharSequence getCharacters(int)
@@ -881,7 +1242,7 @@ meth public static org.graalvm.polyglot.Source$Builder newBuilder(java.lang.Stri
 meth public static org.graalvm.polyglot.Source$Builder newBuilder(java.lang.String,java.net.URL)
 meth public static org.graalvm.polyglot.Source$Builder newBuilder(java.lang.String,org.graalvm.polyglot.io.ByteSequence,java.lang.String)
 supr java.lang.Object
-hfds EMPTY,IMPL,impl
+hfds EMPTY,IMPL,dispatch,receiver
 
 CLSS public org.graalvm.polyglot.Source$Builder
  outer org.graalvm.polyglot.Source
@@ -916,11 +1277,11 @@ meth public int getStartLine()
 meth public int hashCode()
 meth public java.lang.CharSequence getCharacters()
 meth public java.lang.CharSequence getCode()
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="19.0")
 meth public java.lang.String toString()
 meth public org.graalvm.polyglot.Source getSource()
 supr java.lang.Object
-hfds IMPL,impl,source
+hfds dispatch,receiver,source
 
 CLSS public abstract org.graalvm.polyglot.TypeLiteral<%0 extends java.lang.Object>
 cons protected init()
@@ -946,6 +1307,7 @@ meth public boolean canExecute()
 meth public boolean canInstantiate()
 meth public boolean canInvokeMember(java.lang.String)
 meth public boolean equals(java.lang.Object)
+meth public boolean fitsInBigInteger()
 meth public boolean fitsInByte()
 meth public boolean fitsInDouble()
 meth public boolean fitsInFloat()
@@ -953,14 +1315,22 @@ meth public boolean fitsInInt()
 meth public boolean fitsInLong()
 meth public boolean fitsInShort()
 meth public boolean hasArrayElements()
+meth public boolean hasBufferElements()
+meth public boolean hasHashEntries()
+meth public boolean hasHashEntry(java.lang.Object)
+meth public boolean hasIterator()
+meth public boolean hasIteratorNextElement()
 meth public boolean hasMember(java.lang.String)
 meth public boolean hasMembers()
+meth public boolean hasMetaParents()
 meth public boolean isBoolean()
+meth public boolean isBufferWritable()
 meth public boolean isDate()
 meth public boolean isDuration()
 meth public boolean isException()
 meth public boolean isHostObject()
 meth public boolean isInstant()
+meth public boolean isIterator()
 meth public boolean isMetaInstance(java.lang.Object)
 meth public boolean isMetaObject()
 meth public boolean isNativePointer()
@@ -971,17 +1341,23 @@ meth public boolean isString()
 meth public boolean isTime()
 meth public boolean isTimeZone()
 meth public boolean removeArrayElement(long)
+meth public boolean removeHashEntry(java.lang.Object)
 meth public boolean removeMember(java.lang.String)
 meth public byte asByte()
+meth public byte readBufferByte(long)
 meth public double asDouble()
+meth public double readBufferDouble(java.nio.ByteOrder,long)
 meth public float asFloat()
+meth public float readBufferFloat(java.nio.ByteOrder,long)
 meth public int asInt()
 meth public int hashCode()
+meth public int readBufferInt(java.nio.ByteOrder,long)
 meth public java.lang.RuntimeException throwException()
 meth public java.lang.String asString()
 meth public java.lang.String getMetaQualifiedName()
 meth public java.lang.String getMetaSimpleName()
 meth public java.lang.String toString()
+meth public java.math.BigInteger asBigInteger()
 meth public java.time.Duration asDuration()
 meth public java.time.Instant asInstant()
 meth public java.time.LocalDate asDate()
@@ -991,192 +1367,454 @@ meth public java.util.Set<java.lang.String> getMemberKeys()
 meth public long asLong()
 meth public long asNativePointer()
 meth public long getArraySize()
+meth public long getBufferSize()
+meth public long getHashSize()
+meth public long readBufferLong(java.nio.ByteOrder,long)
 meth public org.graalvm.polyglot.Context getContext()
 meth public org.graalvm.polyglot.SourceSection getSourceLocation()
 meth public org.graalvm.polyglot.Value getArrayElement(long)
+meth public org.graalvm.polyglot.Value getHashEntriesIterator()
+meth public org.graalvm.polyglot.Value getHashKeysIterator()
+meth public org.graalvm.polyglot.Value getHashValue(java.lang.Object)
+meth public org.graalvm.polyglot.Value getHashValueOrDefault(java.lang.Object,java.lang.Object)
+meth public org.graalvm.polyglot.Value getHashValuesIterator()
+meth public org.graalvm.polyglot.Value getIterator()
+meth public org.graalvm.polyglot.Value getIteratorNextElement()
 meth public org.graalvm.polyglot.Value getMember(java.lang.String)
 meth public org.graalvm.polyglot.Value getMetaObject()
+meth public org.graalvm.polyglot.Value getMetaParents()
 meth public short asShort()
+meth public short readBufferShort(java.nio.ByteOrder,long)
 meth public static org.graalvm.polyglot.Value asValue(java.lang.Object)
+meth public void pin()
+meth public void putHashEntry(java.lang.Object,java.lang.Object)
 meth public void putMember(java.lang.String,java.lang.Object)
+meth public void readBuffer(long,byte[],int,int)
 meth public void setArrayElement(long,java.lang.Object)
+meth public void writeBufferByte(long,byte)
+meth public void writeBufferDouble(java.nio.ByteOrder,long,double)
+meth public void writeBufferFloat(java.nio.ByteOrder,long,float)
+meth public void writeBufferInt(java.nio.ByteOrder,long,int)
+meth public void writeBufferLong(java.nio.ByteOrder,long,long)
+meth public void writeBufferShort(java.nio.ByteOrder,long,short)
 supr java.lang.Object
-hfds impl,receiver
 
 CLSS public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl
 cons protected init()
 innr public abstract static APIAccess
-innr public abstract static AbstractContextImpl
-innr public abstract static AbstractEngineImpl
-innr public abstract static AbstractExceptionImpl
-innr public abstract static AbstractInstrumentImpl
-innr public abstract static AbstractLanguageImpl
-innr public abstract static AbstractManagementImpl
-innr public abstract static AbstractSourceImpl
-innr public abstract static AbstractSourceSectionImpl
+innr public abstract static AbstractContextDispatch
+innr public abstract static AbstractDispatchClass
+innr public abstract static AbstractEngineDispatch
+innr public abstract static AbstractExceptionDispatch
+innr public abstract static AbstractExecutionEventDispatch
+innr public abstract static AbstractExecutionListenerDispatch
+innr public abstract static AbstractHostAccess
+innr public abstract static AbstractHostLanguageService
+innr public abstract static AbstractInstrumentDispatch
+innr public abstract static AbstractLanguageDispatch
+innr public abstract static AbstractPolyglotHostService
+innr public abstract static AbstractSourceDispatch
+innr public abstract static AbstractSourceSectionDispatch
 innr public abstract static AbstractStackFrameImpl
-innr public abstract static AbstractValueImpl
-innr public abstract static IOAccess
+innr public abstract static AbstractValueDispatch
+innr public abstract static IOAccessor
+innr public abstract static LogHandler
 innr public abstract static ManagementAccess
-meth protected void initialize()
-meth public abstract <%0 extends java.lang.Object, %1 extends java.lang.Object> java.lang.Object newTargetTypeMapping(java.lang.Class<{%%0}>,java.lang.Class<{%%1}>,java.util.function.Predicate<{%%0}>,java.util.function.Function<{%%0},{%%1}>,org.graalvm.polyglot.HostAccess$TargetMappingPrecedence)
-meth public abstract java.lang.Class<?> loadLanguageClass(java.lang.String)
-meth public abstract java.lang.Object buildLimits(long,java.util.function.Predicate<org.graalvm.polyglot.Source>,java.util.function.Consumer<org.graalvm.polyglot.ResourceLimitEvent>)
-meth public abstract java.util.Collection<org.graalvm.polyglot.Engine> findActiveEngines()
-meth public abstract org.graalvm.polyglot.Context getCurrentContext()
-meth public abstract org.graalvm.polyglot.Context getLimitEventContext(java.lang.Object)
-meth public abstract org.graalvm.polyglot.Engine buildEngine(java.io.OutputStream,java.io.OutputStream,java.io.InputStream,java.util.Map<java.lang.String,java.lang.String>,boolean,boolean,boolean,org.graalvm.polyglot.io.MessageTransport,java.lang.Object,org.graalvm.polyglot.HostAccess)
-meth public abstract org.graalvm.polyglot.Value asValue(java.lang.Object)
-meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractManagementImpl getManagementImpl()
-meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractSourceImpl getSourceImpl()
-meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractSourceSectionImpl getSourceSectionImpl()
-meth public abstract org.graalvm.polyglot.io.FileSystem newDefaultFileSystem()
-meth public abstract void preInitializeEngine()
-meth public abstract void resetPreInitializedEngine()
-meth public final org.graalvm.polyglot.impl.AbstractPolyglotImpl$IOAccess getIO()
+innr public abstract static ThreadScope
+meth protected final org.graalvm.options.OptionDescriptors createAllEngineOptionDescriptors()
+meth protected org.graalvm.options.OptionDescriptors createEngineOptionDescriptors()
+meth public !varargs boolean copyResources(java.nio.file.Path,java.lang.String[]) throws java.io.IOException
+meth public !varargs org.graalvm.options.OptionDescriptors createUnionOptionDescriptors(org.graalvm.options.OptionDescriptors[])
+meth public <%0 extends java.lang.Object, %1 extends java.lang.Object> java.lang.Object newTargetTypeMapping(java.lang.Class<{%%0}>,java.lang.Class<{%%1}>,java.util.function.Predicate<{%%0}>,java.util.function.Function<{%%0},{%%1}>,org.graalvm.polyglot.HostAccess$TargetMappingPrecedence)
+meth public abstract int getPriority()
+meth public boolean isDefaultProcessHandler(org.graalvm.polyglot.io.ProcessHandler)
+meth public boolean isHostFileSystem(org.graalvm.polyglot.io.FileSystem)
+meth public boolean isInCurrentEngineHostCallback(java.lang.Object)
+meth public boolean isInternalFileSystem(org.graalvm.polyglot.io.FileSystem)
+meth public final org.graalvm.polyglot.impl.AbstractPolyglotImpl getNext()
+meth public final org.graalvm.polyglot.impl.AbstractPolyglotImpl getNextOrNull()
+meth public final org.graalvm.polyglot.impl.AbstractPolyglotImpl getRootImpl()
+meth public final org.graalvm.polyglot.impl.AbstractPolyglotImpl$APIAccess getAPIAccess()
+meth public final org.graalvm.polyglot.impl.AbstractPolyglotImpl$IOAccessor getIO()
+meth public final org.graalvm.polyglot.impl.AbstractPolyglotImpl$ManagementAccess getManagement()
 meth public final void setConstructors(org.graalvm.polyglot.impl.AbstractPolyglotImpl$APIAccess)
-meth public final void setIO(org.graalvm.polyglot.impl.AbstractPolyglotImpl$IOAccess)
+meth public final void setIO(org.graalvm.polyglot.impl.AbstractPolyglotImpl$IOAccessor)
 meth public final void setMonitoring(org.graalvm.polyglot.impl.AbstractPolyglotImpl$ManagementAccess)
-meth public org.graalvm.polyglot.impl.AbstractPolyglotImpl$APIAccess getAPIAccess()
-meth public org.graalvm.polyglot.impl.AbstractPolyglotImpl$ManagementAccess getManagement()
+meth public final void setNext(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public java.lang.Class<?> loadLanguageClass(java.lang.String)
+meth public java.lang.Object asValue(java.lang.Object)
+meth public java.lang.Object buildEngine(java.lang.String[],org.graalvm.polyglot.SandboxPolicy,java.io.OutputStream,java.io.OutputStream,java.io.InputStream,java.util.Map<java.lang.String,java.lang.String>,boolean,boolean,org.graalvm.polyglot.io.MessageTransport,java.lang.Object,java.lang.Object,boolean,boolean,java.lang.Object)
+meth public java.lang.Object buildLimits(long,java.util.function.Predicate<java.lang.Object>,java.util.function.Consumer<java.lang.Object>)
+meth public java.lang.Object buildSource(java.lang.String,java.lang.Object,java.net.URI,java.lang.String,java.lang.String,java.lang.Object,boolean,boolean,boolean,java.nio.charset.Charset,java.net.URL,java.lang.String) throws java.io.IOException
+meth public java.lang.Object createHostAccess()
+meth public java.lang.Object createHostLanguage(java.lang.Object)
+meth public java.lang.Object getCurrentContext()
+meth public java.lang.Object initializeModuleToUnnamedAccess(java.lang.invoke.MethodHandles$Lookup,java.lang.Object,java.lang.Object,java.lang.Object,java.lang.Object)
+meth public java.lang.Object newFileSystem(org.graalvm.polyglot.io.FileSystem)
+meth public java.lang.Object newIOAccess(java.lang.String,boolean,boolean,org.graalvm.polyglot.io.FileSystem)
+meth public java.lang.Object newLogHandler(java.lang.Object)
+meth public java.lang.String findLanguage(java.io.File) throws java.io.IOException
+meth public java.lang.String findLanguage(java.lang.String)
+meth public java.lang.String findLanguage(java.net.URL) throws java.io.IOException
+meth public java.lang.String findMimeType(java.io.File) throws java.io.IOException
+meth public java.lang.String findMimeType(java.net.URL) throws java.io.IOException
+meth public java.lang.String getTruffleVersion()
+meth public org.graalvm.polyglot.impl.AbstractPolyglotImpl$ThreadScope createThreadScope()
+meth public org.graalvm.polyglot.io.ByteSequence asByteSequence(java.lang.Object)
+meth public org.graalvm.polyglot.io.FileSystem allowInternalResourceAccess(org.graalvm.polyglot.io.FileSystem)
+meth public org.graalvm.polyglot.io.FileSystem newDefaultFileSystem(java.lang.String)
+meth public org.graalvm.polyglot.io.FileSystem newNIOFileSystem(java.nio.file.FileSystem)
+meth public org.graalvm.polyglot.io.FileSystem newReadOnlyFileSystem(org.graalvm.polyglot.io.FileSystem)
+meth public org.graalvm.polyglot.io.ProcessHandler newDefaultProcessHandler()
+meth public void initialize()
+meth public void preInitializeEngine()
+meth public void resetPreInitializedEngine()
 supr java.lang.Object
-hfds api,io,management
+hfds api,io,management,next,prev
 
 CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$APIAccess
  outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
 cons protected init()
-meth public abstract boolean allowsAccess(org.graalvm.polyglot.HostAccess,java.lang.reflect.AnnotatedElement)
-meth public abstract boolean allowsImplementation(org.graalvm.polyglot.HostAccess,java.lang.Class<?>)
-meth public abstract boolean isArrayAccessible(org.graalvm.polyglot.HostAccess)
-meth public abstract boolean isListAccessible(org.graalvm.polyglot.HostAccess)
-meth public abstract java.lang.Object getHostAccessImpl(org.graalvm.polyglot.HostAccess)
-meth public abstract java.lang.Object getImpl(org.graalvm.polyglot.ResourceLimits)
-meth public abstract java.lang.Object getReceiver(org.graalvm.polyglot.Value)
-meth public abstract java.lang.String validatePolyglotAccess(org.graalvm.polyglot.PolyglotAccess,org.graalvm.collections.UnmodifiableEconomicSet<java.lang.String>)
-meth public abstract java.util.List<java.lang.Object> getTargetMappings(org.graalvm.polyglot.HostAccess)
-meth public abstract org.graalvm.collections.UnmodifiableEconomicSet<java.lang.String> getBindingsAccess(org.graalvm.polyglot.PolyglotAccess)
-meth public abstract org.graalvm.collections.UnmodifiableEconomicSet<java.lang.String> getEvalAccess(org.graalvm.polyglot.PolyglotAccess,java.lang.String)
-meth public abstract org.graalvm.polyglot.Context newContext(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractContextImpl)
-meth public abstract org.graalvm.polyglot.Engine newEngine(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractEngineImpl)
-meth public abstract org.graalvm.polyglot.Instrument newInstrument(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractInstrumentImpl)
-meth public abstract org.graalvm.polyglot.Language newLanguage(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractLanguageImpl)
-meth public abstract org.graalvm.polyglot.PolyglotException newLanguageException(java.lang.String,org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractExceptionImpl)
-meth public abstract org.graalvm.polyglot.PolyglotException$StackFrame newPolyglotStackTraceElement(org.graalvm.polyglot.PolyglotException,org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractStackFrameImpl)
-meth public abstract org.graalvm.polyglot.ResourceLimitEvent newResourceLimitsEvent(java.lang.Object)
-meth public abstract org.graalvm.polyglot.Source newSource(java.lang.Object)
-meth public abstract org.graalvm.polyglot.SourceSection newSourceSection(org.graalvm.polyglot.Source,java.lang.Object)
-meth public abstract org.graalvm.polyglot.Value newValue(java.lang.Object,org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractValueImpl)
-meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractContextImpl getImpl(org.graalvm.polyglot.Context)
-meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractEngineImpl getImpl(org.graalvm.polyglot.Engine)
-meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractExceptionImpl getImpl(org.graalvm.polyglot.PolyglotException)
-meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractInstrumentImpl getImpl(org.graalvm.polyglot.Instrument)
-meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractLanguageImpl getImpl(org.graalvm.polyglot.Language)
-meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractStackFrameImpl getImpl(org.graalvm.polyglot.PolyglotException$StackFrame)
-meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractValueImpl getImpl(org.graalvm.polyglot.Value)
-meth public abstract void setHostAccessImpl(org.graalvm.polyglot.HostAccess,java.lang.Object)
+meth public abstract <%0 extends java.lang.Object> {%%0} callValueAs(java.lang.Object,java.lang.Class<{%%0}>)
+meth public abstract <%0 extends java.lang.Object> {%%0} callValueAs(java.lang.Object,java.lang.Class<{%%0}>,java.lang.reflect.Type)
+meth public abstract boolean allowsAccess(java.lang.Object,java.lang.reflect.AnnotatedElement)
+meth public abstract boolean allowsAccessInheritance(java.lang.Object)
+meth public abstract boolean allowsImplementation(java.lang.Object,java.lang.Class<?>)
+meth public abstract boolean allowsPublicAccess(java.lang.Object)
+meth public abstract boolean callProxyArrayRemove(java.lang.Object,long)
+meth public abstract boolean callProxyObjectRemoveMember(java.lang.Object,java.lang.String)
+meth public abstract boolean callValueIsString(java.lang.Object)
+meth public abstract boolean isArrayAccessible(java.lang.Object)
+meth public abstract boolean isBigIntegerAccessibleAsNumber(java.lang.Object)
+meth public abstract boolean isBufferAccessible(java.lang.Object)
+meth public abstract boolean isByteSequence(java.lang.Object)
+meth public abstract boolean isContext(java.lang.Object)
+meth public abstract boolean isEngine(java.lang.Object)
+meth public abstract boolean isInstrument(java.lang.Object)
+meth public abstract boolean isIterableAccessible(java.lang.Object)
+meth public abstract boolean isIteratorAccessible(java.lang.Object)
+meth public abstract boolean isLanguage(java.lang.Object)
+meth public abstract boolean isListAccessible(java.lang.Object)
+meth public abstract boolean isMapAccessible(java.lang.Object)
+meth public abstract boolean isMethodScoped(java.lang.Object,java.lang.reflect.Executable)
+meth public abstract boolean isMethodScopingEnabled(java.lang.Object)
+meth public abstract boolean isPolyglotException(java.lang.Object)
+meth public abstract boolean isProxy(java.lang.Object)
+meth public abstract boolean isProxyArray(java.lang.Object)
+meth public abstract boolean isProxyDate(java.lang.Object)
+meth public abstract boolean isProxyDuration(java.lang.Object)
+meth public abstract boolean isProxyExecutable(java.lang.Object)
+meth public abstract boolean isProxyHashMap(java.lang.Object)
+meth public abstract boolean isProxyInstant(java.lang.Object)
+meth public abstract boolean isProxyInstantiable(java.lang.Object)
+meth public abstract boolean isProxyIterable(java.lang.Object)
+meth public abstract boolean isProxyIterator(java.lang.Object)
+meth public abstract boolean isProxyNativeObject(java.lang.Object)
+meth public abstract boolean isProxyObject(java.lang.Object)
+meth public abstract boolean isProxyTime(java.lang.Object)
+meth public abstract boolean isProxyTimeZone(java.lang.Object)
+meth public abstract boolean isSource(java.lang.Object)
+meth public abstract boolean isSourceSection(java.lang.Object)
+meth public abstract boolean isValue(java.lang.Object)
+meth public abstract byte byteSequenceByteAt(java.lang.Object,int)
+meth public abstract int byteSequenceLength(java.lang.Object)
+meth public abstract java.lang.Class<?> getByteSequenceClass()
+meth public abstract java.lang.Class<?> getPolyglotExceptionClass()
+meth public abstract java.lang.Class<?> getProxyArrayClass()
+meth public abstract java.lang.Class<?> getProxyClass()
+meth public abstract java.lang.Class<?> getProxyDateClass()
+meth public abstract java.lang.Class<?> getProxyDurationClass()
+meth public abstract java.lang.Class<?> getProxyExecutableClass()
+meth public abstract java.lang.Class<?> getProxyHashMapClass()
+meth public abstract java.lang.Class<?> getProxyInstantClass()
+meth public abstract java.lang.Class<?> getProxyInstantiableClass()
+meth public abstract java.lang.Class<?> getProxyIterableClass()
+meth public abstract java.lang.Class<?> getProxyIteratorClass()
+meth public abstract java.lang.Class<?> getProxyNativeObjectClass()
+meth public abstract java.lang.Class<?> getProxyObjectClass()
+meth public abstract java.lang.Class<?> getProxyTimeClass()
+meth public abstract java.lang.Class<?> getProxyTimeZoneClass()
+meth public abstract java.lang.Class<?> getValueClass()
+meth public abstract java.lang.Object callContextAsValue(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object callContextGetCurrent()
+meth public abstract java.lang.Object callProxyArrayGet(java.lang.Object,long)
+meth public abstract java.lang.Object callProxyArraySize(java.lang.Object)
+meth public abstract java.lang.Object callProxyExecutableExecute(java.lang.Object,java.lang.Object[])
+meth public abstract java.lang.Object callProxyHashMapGetEntriesIterator(java.lang.Object)
+meth public abstract java.lang.Object callProxyHashMapGetHashSize(java.lang.Object)
+meth public abstract java.lang.Object callProxyHashMapGetHashValue(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object callProxyHashMapHasHashEntry(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object callProxyHashMapRemoveHashEntry(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object callProxyInstantiableNewInstance(java.lang.Object,java.lang.Object[])
+meth public abstract java.lang.Object callProxyIterableGetIterator(java.lang.Object)
+meth public abstract java.lang.Object callProxyIteratorGetNext(java.lang.Object)
+meth public abstract java.lang.Object callProxyIteratorHasNext(java.lang.Object)
+meth public abstract java.lang.Object callProxyNativeObjectAsPointer(java.lang.Object)
+meth public abstract java.lang.Object callProxyObjectGetMember(java.lang.Object,java.lang.String)
+meth public abstract java.lang.Object callProxyObjectHasMember(java.lang.Object,java.lang.String)
+meth public abstract java.lang.Object callProxyObjectMemberKeys(java.lang.Object)
+meth public abstract java.lang.Object callValueGetArrayElement(java.lang.Object,int)
+meth public abstract java.lang.Object callValueGetMetaObject(java.lang.Object)
+meth public abstract java.lang.Object contextAsValue(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object createPolyglotAccess(java.util.Set<java.lang.String>,java.util.Map<java.lang.String,java.util.Set<java.lang.String>>)
+meth public abstract java.lang.Object getContextEngine(java.lang.Object)
+meth public abstract java.lang.Object getContextReceiver(java.lang.Object)
+meth public abstract java.lang.Object getEngineReceiver(java.lang.Object)
+meth public abstract java.lang.Object getEnvironmentAccessInherit()
+meth public abstract java.lang.Object getEnvironmentAccessNone()
+meth public abstract java.lang.Object getHostAccessImpl(java.lang.Object)
+meth public abstract java.lang.Object getHostAccessNone()
+meth public abstract java.lang.Object getIOAccessAll()
+meth public abstract java.lang.Object getIOAccessNone()
+meth public abstract java.lang.Object getInstrumentReceiver(java.lang.Object)
+meth public abstract java.lang.Object getLanguageReceiver(java.lang.Object)
+meth public abstract java.lang.Object getPolyglotAccessAll()
+meth public abstract java.lang.Object getPolyglotAccessNone()
+meth public abstract java.lang.Object getPolyglotExceptionReceiver(java.lang.RuntimeException)
+meth public abstract java.lang.Object getResourceLimitsReceiver(java.lang.Object)
+meth public abstract java.lang.Object getSourceReceiver(java.lang.Object)
+meth public abstract java.lang.Object getSourceSectionReceiver(java.lang.Object)
+meth public abstract java.lang.Object getSourceSectionSource(java.lang.Object)
+meth public abstract java.lang.Object getValueContext(java.lang.Object)
+meth public abstract java.lang.Object getValueReceiver(java.lang.Object)
+meth public abstract java.lang.Object newContext(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractContextDispatch,java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object newEngine(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractEngineDispatch,java.lang.Object,boolean)
+meth public abstract java.lang.Object newInstrument(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractInstrumentDispatch,java.lang.Object)
+meth public abstract java.lang.Object newLanguage(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractLanguageDispatch,java.lang.Object)
+meth public abstract java.lang.Object newPolyglotStackTraceElement(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractStackFrameImpl,java.lang.RuntimeException)
+meth public abstract java.lang.Object newResourceLimitsEvent(java.lang.Object)
+meth public abstract java.lang.Object newSource(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractSourceDispatch,java.lang.Object)
+meth public abstract java.lang.Object newSourceSection(java.lang.Object,org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractSourceSectionDispatch,java.lang.Object)
+meth public abstract java.lang.Object newValue(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractValueDispatch,java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object toByteSequence(java.lang.Object)
+meth public abstract java.lang.Object[] newValueArray(int)
+meth public abstract java.lang.RuntimeException newLanguageException(java.lang.String,org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractExceptionDispatch,java.lang.Object)
+meth public abstract java.lang.String callValueAsString(java.lang.Object)
+meth public abstract java.lang.String validatePolyglotAccess(java.lang.Object,java.util.Set<java.lang.String>)
+meth public abstract java.lang.invoke.MethodHandles$Lookup getMethodLookup(java.lang.Object)
+meth public abstract java.time.Duration callProxyDurationAsDuration(java.lang.Object)
+meth public abstract java.time.Instant callProxyInstantAsInstant(java.lang.Object)
+meth public abstract java.time.LocalDate callProxyDateAsDate(java.lang.Object)
+meth public abstract java.time.LocalTime callProxyTimeAsTime(java.lang.Object)
+meth public abstract java.time.ZoneId callProxyTimeZoneAsTimeZone(java.lang.Object)
+meth public abstract java.util.List<java.lang.Object> getTargetMappings(java.lang.Object)
+meth public abstract java.util.Map<java.lang.String,java.lang.String> readOptionsFromSystemProperties()
+meth public abstract java.util.Map<java.lang.String,java.util.Set<java.lang.String>> getEvalAccess(java.lang.Object)
+meth public abstract java.util.Set<java.lang.String> getBindingsAccess(java.lang.Object)
+meth public abstract java.util.Set<java.lang.String> getEvalAccess(java.lang.Object,java.lang.String)
+meth public abstract long callValueGetArraySize(java.lang.Object)
+meth public abstract org.graalvm.polyglot.HostAccess$MutableTargetMapping[] getMutableTargetMappings(java.lang.Object)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractContextDispatch getContextDispatch(java.lang.Object)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractEngineDispatch getEngineDispatch(java.lang.Object)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractInstrumentDispatch getInstrumentDispatch(java.lang.Object)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractLanguageDispatch getLanguageDispatch(java.lang.Object)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractSourceDispatch getSourceDispatch(java.lang.Object)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractSourceSectionDispatch getSourceSectionDispatch(java.lang.Object)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractStackFrameImpl getStackFrameDispatch(java.lang.Object)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractStackFrameImpl getStackFrameReceiver(java.lang.Object)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractValueDispatch getValueDispatch(java.lang.Object)
+meth public abstract org.graalvm.polyglot.io.ByteSequence asByteSequence(java.lang.Object)
+meth public abstract void callProxyArraySet(java.lang.Object,long,java.lang.Object)
+meth public abstract void callProxyHashMapPutHashEntry(java.lang.Object,java.lang.Object,java.lang.Object)
+meth public abstract void callProxyObjectPutMember(java.lang.Object,java.lang.String,java.lang.Object)
+meth public abstract void contextClose(java.lang.Object,boolean)
+meth public abstract void contextEnter(java.lang.Object)
+meth public abstract void contextLeave(java.lang.Object)
+meth public abstract void engineClosed(java.lang.Object)
+meth public abstract void setHostAccessImpl(java.lang.Object,java.lang.Object)
 supr java.lang.Object
 
-CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractContextImpl
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractContextDispatch
  outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
 cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
-meth public abstract boolean initializeLanguage(java.lang.String)
-meth public abstract boolean interrupt(org.graalvm.polyglot.Context,java.time.Duration)
-meth public abstract org.graalvm.polyglot.Engine getEngineImpl(org.graalvm.polyglot.Context)
-meth public abstract org.graalvm.polyglot.Value asValue(java.lang.Object)
-meth public abstract org.graalvm.polyglot.Value eval(java.lang.String,java.lang.Object)
-meth public abstract org.graalvm.polyglot.Value getBindings(java.lang.String)
-meth public abstract org.graalvm.polyglot.Value getPolyglotBindings()
-meth public abstract org.graalvm.polyglot.Value parse(java.lang.String,java.lang.Object)
-meth public abstract void close(org.graalvm.polyglot.Context,boolean)
-meth public abstract void explicitEnter(org.graalvm.polyglot.Context)
-meth public abstract void explicitLeave(org.graalvm.polyglot.Context)
-meth public abstract void resetLimits()
+meth public abstract boolean initializeLanguage(java.lang.Object,java.lang.String)
+meth public abstract boolean interrupt(java.lang.Object,java.time.Duration)
+meth public abstract java.lang.Object asValue(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object eval(java.lang.Object,java.lang.String,java.lang.Object)
+meth public abstract java.lang.Object getBindings(java.lang.Object,java.lang.String)
+meth public abstract java.lang.Object getPolyglotBindings(java.lang.Object)
+meth public abstract java.lang.Object parse(java.lang.Object,java.lang.String,java.lang.Object)
+meth public abstract void close(java.lang.Object,boolean)
+meth public abstract void explicitEnter(java.lang.Object)
+meth public abstract void explicitLeave(java.lang.Object)
+meth public abstract void resetLimits(java.lang.Object)
+meth public abstract void safepoint(java.lang.Object)
+meth public abstract void setAPI(java.lang.Object,java.lang.Object)
+supr org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractDispatchClass
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractDispatchClass
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons public init()
 supr java.lang.Object
 
-CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractEngineImpl
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractEngineDispatch
  outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
 cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
-meth public abstract java.lang.String getImplementationName()
-meth public abstract java.util.Map<java.lang.String,org.graalvm.polyglot.Instrument> getInstruments()
-meth public abstract java.util.Map<java.lang.String,org.graalvm.polyglot.Language> getLanguages()
-meth public abstract java.util.Set<org.graalvm.polyglot.Source> getCachedSources()
-meth public abstract org.graalvm.options.OptionDescriptors getOptions()
-meth public abstract org.graalvm.polyglot.Context createContext(java.io.OutputStream,java.io.OutputStream,java.io.InputStream,boolean,org.graalvm.polyglot.HostAccess,org.graalvm.polyglot.PolyglotAccess,boolean,boolean,boolean,boolean,boolean,java.util.function.Predicate<java.lang.String>,java.util.Map<java.lang.String,java.lang.String>,java.util.Map<java.lang.String,java.lang.String[]>,java.lang.String[],org.graalvm.polyglot.io.FileSystem,java.lang.Object,boolean,org.graalvm.polyglot.io.ProcessHandler,org.graalvm.polyglot.EnvironmentAccess,java.util.Map<java.lang.String,java.lang.String>,java.time.ZoneId,java.lang.Object,java.lang.String,java.lang.ClassLoader)
-meth public abstract org.graalvm.polyglot.Instrument requirePublicInstrument(java.lang.String)
-meth public abstract org.graalvm.polyglot.Language requirePublicLanguage(java.lang.String)
-meth public abstract void close(org.graalvm.polyglot.Engine,boolean)
-supr java.lang.Object
+meth public abstract java.lang.Object attachExecutionListener(java.lang.Object,java.util.function.Consumer<java.lang.Object>,java.util.function.Consumer<java.lang.Object>,boolean,boolean,boolean,java.util.function.Predicate<java.lang.Object>,java.util.function.Predicate<java.lang.String>,boolean,boolean,boolean)
+meth public abstract java.lang.Object createContext(java.lang.Object,org.graalvm.polyglot.SandboxPolicy,java.io.OutputStream,java.io.OutputStream,java.io.InputStream,boolean,java.lang.Object,java.lang.Object,boolean,boolean,boolean,boolean,boolean,java.util.function.Predicate<java.lang.String>,java.util.Map<java.lang.String,java.lang.String>,java.util.Map<java.lang.String,java.lang.String[]>,java.lang.String[],java.lang.Object,java.lang.Object,boolean,org.graalvm.polyglot.io.ProcessHandler,java.lang.Object,java.util.Map<java.lang.String,java.lang.String>,java.time.ZoneId,java.lang.Object,java.lang.String,java.lang.String,java.lang.ClassLoader,boolean,boolean)
+meth public abstract java.lang.Object requirePublicInstrument(java.lang.Object,java.lang.String)
+meth public abstract java.lang.Object requirePublicLanguage(java.lang.Object,java.lang.String)
+meth public abstract java.lang.RuntimeException hostToGuestException(java.lang.Object,java.lang.Throwable)
+meth public abstract java.lang.String getImplementationName(java.lang.Object)
+meth public abstract java.lang.String getVersion(java.lang.Object)
+meth public abstract java.util.Map<java.lang.String,java.lang.Object> getInstruments(java.lang.Object)
+meth public abstract java.util.Map<java.lang.String,java.lang.Object> getLanguages(java.lang.Object)
+meth public abstract java.util.Set<java.lang.Object> getCachedSources(java.lang.Object)
+meth public abstract org.graalvm.options.OptionDescriptors getOptions(java.lang.Object)
+meth public abstract org.graalvm.polyglot.SandboxPolicy getSandboxPolicy(java.lang.Object)
+meth public abstract void close(java.lang.Object,java.lang.Object,boolean)
+meth public abstract void setAPI(java.lang.Object,java.lang.Object)
+meth public abstract void shutdown(java.lang.Object)
+supr org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractDispatchClass
 
-CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractExceptionImpl
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractExceptionDispatch
  outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
 cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
-meth public abstract boolean isCancelled()
-meth public abstract boolean isExit()
-meth public abstract boolean isHostException()
-meth public abstract boolean isIncompleteSource()
-meth public abstract boolean isInternalError()
-meth public abstract boolean isInterrupted()
-meth public abstract boolean isResourceExhausted()
-meth public abstract boolean isSyntaxError()
-meth public abstract int getExitStatus()
-meth public abstract java.lang.Iterable<org.graalvm.polyglot.PolyglotException$StackFrame> getPolyglotStackTrace()
-meth public abstract java.lang.StackTraceElement[] getStackTrace()
-meth public abstract java.lang.String getMessage()
-meth public abstract java.lang.Throwable asHostException()
-meth public abstract org.graalvm.polyglot.SourceSection getSourceLocation()
-meth public abstract org.graalvm.polyglot.Value getGuestObject()
-meth public abstract void onCreate(org.graalvm.polyglot.PolyglotException)
-meth public abstract void printStackTrace(java.io.PrintStream)
-meth public abstract void printStackTrace(java.io.PrintWriter)
-supr java.lang.Object
+meth public abstract boolean isCancelled(java.lang.Object)
+meth public abstract boolean isExit(java.lang.Object)
+meth public abstract boolean isHostException(java.lang.Object)
+meth public abstract boolean isIncompleteSource(java.lang.Object)
+meth public abstract boolean isInternalError(java.lang.Object)
+meth public abstract boolean isInterrupted(java.lang.Object)
+meth public abstract boolean isResourceExhausted(java.lang.Object)
+meth public abstract boolean isSyntaxError(java.lang.Object)
+meth public abstract int getExitStatus(java.lang.Object)
+meth public abstract java.lang.Iterable<java.lang.Object> getPolyglotStackTrace(java.lang.Object)
+meth public abstract java.lang.Object getGuestObject(java.lang.Object)
+meth public abstract java.lang.Object getSourceLocation(java.lang.Object)
+meth public abstract java.lang.StackTraceElement[] getStackTrace(java.lang.Object)
+meth public abstract java.lang.String getMessage(java.lang.Object)
+meth public abstract java.lang.Throwable asHostException(java.lang.Object)
+meth public abstract void onCreate(java.lang.Object,java.lang.RuntimeException)
+meth public abstract void printStackTrace(java.lang.Object,java.io.PrintStream)
+meth public abstract void printStackTrace(java.lang.Object,java.io.PrintWriter)
+supr org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractDispatchClass
 
-CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractInstrumentImpl
- outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
-cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
-meth public abstract <%0 extends java.lang.Object> {%%0} lookup(java.lang.Class<{%%0}>)
-meth public abstract java.lang.String getId()
-meth public abstract java.lang.String getName()
-meth public abstract java.lang.String getVersion()
-meth public abstract org.graalvm.options.OptionDescriptors getOptions()
-supr java.lang.Object
-
-CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractLanguageImpl
- outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
-cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
-meth public abstract boolean isInteractive()
-meth public abstract java.lang.String getDefaultMimeType()
-meth public abstract java.lang.String getId()
-meth public abstract java.lang.String getImplementationName()
-meth public abstract java.lang.String getName()
-meth public abstract java.lang.String getVersion()
-meth public abstract java.util.Set<java.lang.String> getMimeTypes()
-meth public abstract org.graalvm.options.OptionDescriptors getOptions()
-supr java.lang.Object
-
-CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractManagementImpl
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractExecutionEventDispatch
  outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
 cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
 meth public abstract boolean isExecutionEventExpression(java.lang.Object)
 meth public abstract boolean isExecutionEventRoot(java.lang.Object)
 meth public abstract boolean isExecutionEventStatement(java.lang.Object)
-meth public abstract java.lang.Object attachExecutionListener(org.graalvm.polyglot.Engine,java.util.function.Consumer<org.graalvm.polyglot.management.ExecutionEvent>,java.util.function.Consumer<org.graalvm.polyglot.management.ExecutionEvent>,boolean,boolean,boolean,java.util.function.Predicate<org.graalvm.polyglot.Source>,java.util.function.Predicate<java.lang.String>,boolean,boolean,boolean)
+meth public abstract java.lang.Object getExecutionEventLocation(java.lang.Object)
+meth public abstract java.lang.Object getExecutionEventReturnValue(java.lang.Object)
+meth public abstract java.lang.RuntimeException getExecutionEventException(java.lang.Object)
 meth public abstract java.lang.String getExecutionEventRootName(java.lang.Object)
-meth public abstract java.util.List<org.graalvm.polyglot.Value> getExecutionEventInputValues(java.lang.Object)
-meth public abstract org.graalvm.polyglot.PolyglotException getExecutionEventException(java.lang.Object)
-meth public abstract org.graalvm.polyglot.SourceSection getExecutionEventLocation(java.lang.Object)
-meth public abstract org.graalvm.polyglot.Value getExecutionEventReturnValue(java.lang.Object)
-meth public abstract void closeExecutionListener(java.lang.Object)
-supr java.lang.Object
+meth public abstract java.util.List<java.lang.Object> getExecutionEventInputValues(java.lang.Object)
+supr org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractDispatchClass
 
-CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractSourceImpl
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractExecutionListenerDispatch
  outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
 cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
-fld protected final org.graalvm.polyglot.impl.AbstractPolyglotImpl engineImpl
+meth public abstract void closeExecutionListener(java.lang.Object)
+supr org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractDispatchClass
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractHostAccess
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public abstract <%0 extends java.lang.Object, %1 extends java.lang.Object> java.util.Map$Entry<{%%0},{%%1}> toMapEntry(java.lang.Object,java.lang.Object,boolean,java.lang.Class<{%%0}>,java.lang.reflect.Type,java.lang.Class<{%%1}>,java.lang.reflect.Type)
+meth public abstract <%0 extends java.lang.Object, %1 extends java.lang.Object> java.util.Map<{%%0},{%%1}> toMap(java.lang.Object,java.lang.Object,boolean,java.lang.Class<{%%0}>,java.lang.reflect.Type,java.lang.Class<{%%1}>,java.lang.reflect.Type)
+meth public abstract <%0 extends java.lang.Object> java.lang.Iterable<{%%0}> toIterable(java.lang.Object,java.lang.Object,boolean,java.lang.Class<{%%0}>,java.lang.reflect.Type)
+meth public abstract <%0 extends java.lang.Object> java.util.Iterator<{%%0}> toIterator(java.lang.Object,java.lang.Object,boolean,java.lang.Class<{%%0}>,java.lang.reflect.Type)
+meth public abstract <%0 extends java.lang.Object> java.util.List<{%%0}> toList(java.lang.Object,java.lang.Object,boolean,java.lang.Class<{%%0}>,java.lang.reflect.Type)
+meth public abstract <%0 extends java.lang.Object> java.util.function.Function<?,?> toFunction(java.lang.Object,java.lang.Object,java.lang.Class<?>,java.lang.reflect.Type,java.lang.Class<?>,java.lang.reflect.Type)
+meth public abstract <%0 extends java.lang.Object> {%%0} toFunctionProxy(java.lang.Object,java.lang.Class<{%%0}>,java.lang.Object)
+meth public abstract boolean isEngineException(java.lang.RuntimeException)
+meth public abstract boolean isPolyglotException(java.lang.RuntimeException)
+meth public abstract java.lang.Class<?> getPoylglotExceptionClass()
+meth public abstract java.lang.Class<?> getValueClass()
+meth public abstract java.lang.Object toByteSequence(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object toGuestValue(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object toObjectProxy(java.lang.Object,java.lang.Class<?>,java.lang.Object)
+meth public abstract java.lang.Object toValue(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object[] toValues(java.lang.Object,java.lang.Object[])
+meth public abstract java.lang.Object[] toValues(java.lang.Object,java.lang.Object[],int)
+meth public abstract java.lang.RuntimeException toEngineException(java.lang.RuntimeException)
+meth public abstract java.lang.RuntimeException toPolyglotException(java.lang.Object,java.lang.Throwable)
+meth public abstract java.lang.RuntimeException unboxEngineException(java.lang.RuntimeException)
+meth public abstract java.lang.String getValueInfo(java.lang.Object,java.lang.Object)
+meth public abstract void rethrowPolyglotException(java.lang.Object,java.lang.RuntimeException)
+supr org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractDispatchClass
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractHostLanguageService
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public abstract <%0 extends java.lang.Object> {%%0} toHostType(java.lang.Object,java.lang.Object,java.lang.Object,java.lang.Object,java.lang.Class<{%%0}>,java.lang.reflect.Type)
+meth public abstract boolean allowsPublicAccess()
+meth public abstract boolean isHostException(java.lang.Object)
+meth public abstract boolean isHostFunction(java.lang.Object)
+meth public abstract boolean isHostObject(java.lang.Object)
+meth public abstract boolean isHostProxy(java.lang.Object)
+meth public abstract boolean isHostSymbol(java.lang.Object)
+meth public abstract boolean isHostValue(java.lang.Object)
+meth public abstract int findNextGuestToHostStackTraceElement(java.lang.StackTraceElement,java.lang.StackTraceElement[],int)
+meth public abstract java.lang.Error toHostResourceError(java.lang.Throwable)
+meth public abstract java.lang.Object asHostDynamicClass(java.lang.Object,java.lang.Class<?>)
+meth public abstract java.lang.Object asHostStaticClass(java.lang.Object,java.lang.Class<?>)
+meth public abstract java.lang.Object createHostAdapter(java.lang.Object,java.lang.Object[],java.lang.Object)
+meth public abstract java.lang.Object findDynamicClass(java.lang.Object,java.lang.String)
+meth public abstract java.lang.Object findStaticClass(java.lang.Object,java.lang.String)
+meth public abstract java.lang.Object migrateValue(java.lang.Object,java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object toGuestValue(java.lang.Object,java.lang.Object,boolean)
+meth public abstract java.lang.Object toHostObject(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object unboxHostObject(java.lang.Object)
+meth public abstract java.lang.Object unboxProxyObject(java.lang.Object)
+meth public abstract java.lang.RuntimeException toHostException(java.lang.Object,java.lang.Throwable)
+meth public abstract java.lang.Throwable unboxHostException(java.lang.Throwable)
+meth public abstract void addToHostClassPath(java.lang.Object,java.lang.Object)
+meth public abstract void hostExit(int)
+meth public abstract void initializeHostContext(java.lang.Object,java.lang.Object,java.lang.Object,java.lang.ClassLoader,java.util.function.Predicate<java.lang.String>,boolean,boolean)
+meth public abstract void pin(java.lang.Object)
+meth public abstract void release()
+meth public abstract void throwHostLanguageException(java.lang.String)
+meth public final boolean isHostStackTraceVisibleToGuest()
+supr org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractDispatchClass
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractInstrumentDispatch
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public abstract <%0 extends java.lang.Object> {%%0} lookup(java.lang.Object,java.lang.Class<{%%0}>)
+meth public abstract java.lang.String getId(java.lang.Object)
+meth public abstract java.lang.String getName(java.lang.Object)
+meth public abstract java.lang.String getVersion(java.lang.Object)
+meth public abstract java.lang.String getWebsite(java.lang.Object)
+meth public abstract org.graalvm.options.OptionDescriptors getOptions(java.lang.Object)
+supr org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractDispatchClass
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractLanguageDispatch
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public abstract boolean isInteractive(java.lang.Object)
+meth public abstract java.lang.String getDefaultMimeType(java.lang.Object)
+meth public abstract java.lang.String getId(java.lang.Object)
+meth public abstract java.lang.String getImplementationName(java.lang.Object)
+meth public abstract java.lang.String getName(java.lang.Object)
+meth public abstract java.lang.String getVersion(java.lang.Object)
+meth public abstract java.lang.String getWebsite(java.lang.Object)
+meth public abstract java.util.Set<java.lang.String> getMimeTypes(java.lang.Object)
+meth public abstract org.graalvm.options.OptionDescriptors getOptions(java.lang.Object)
+supr org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractDispatchClass
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractPolyglotHostService
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public abstract java.lang.RuntimeException hostToGuestException(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractHostLanguageService,java.lang.Throwable)
+meth public abstract void notifyClearExplicitContextStack(java.lang.Object)
+meth public abstract void notifyContextCancellingOrExiting(java.lang.Object,boolean,int,boolean,java.lang.String)
+meth public abstract void notifyContextClosed(java.lang.Object,boolean,boolean,java.lang.String)
+meth public abstract void notifyEngineClosed(java.lang.Object,boolean)
+supr org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractDispatchClass
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractSourceDispatch
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
 meth public abstract boolean equals(java.lang.Object,java.lang.Object)
 meth public abstract boolean hasBytes(java.lang.Object)
 meth public abstract boolean hasCharacters(java.lang.Object)
+meth public abstract boolean isCached(java.lang.Object)
 meth public abstract boolean isInteractive(java.lang.Object)
 meth public abstract boolean isInternal(java.lang.Object)
+meth public abstract byte[] getByteArray(java.lang.Object)
 meth public abstract int getColumnNumber(java.lang.Object,int)
 meth public abstract int getLength(java.lang.Object)
 meth public abstract int getLineCount(java.lang.Object)
@@ -1188,11 +1826,6 @@ meth public abstract java.io.InputStream getInputStream(java.lang.Object)
 meth public abstract java.io.Reader getReader(java.lang.Object)
 meth public abstract java.lang.CharSequence getCharacters(java.lang.Object)
 meth public abstract java.lang.CharSequence getCharacters(java.lang.Object,int)
-meth public abstract java.lang.String findLanguage(java.io.File) throws java.io.IOException
-meth public abstract java.lang.String findLanguage(java.lang.String)
-meth public abstract java.lang.String findLanguage(java.net.URL) throws java.io.IOException
-meth public abstract java.lang.String findMimeType(java.io.File) throws java.io.IOException
-meth public abstract java.lang.String findMimeType(java.net.URL) throws java.io.IOException
 meth public abstract java.lang.String getLanguage(java.lang.Object)
 meth public abstract java.lang.String getMimeType(java.lang.Object)
 meth public abstract java.lang.String getName(java.lang.Object)
@@ -1200,11 +1833,10 @@ meth public abstract java.lang.String getPath(java.lang.Object)
 meth public abstract java.lang.String toString(java.lang.Object)
 meth public abstract java.net.URI getURI(java.lang.Object)
 meth public abstract java.net.URL getURL(java.lang.Object)
-meth public abstract org.graalvm.polyglot.Source build(java.lang.String,java.lang.Object,java.net.URI,java.lang.String,java.lang.String,java.lang.Object,boolean,boolean,boolean,java.nio.charset.Charset) throws java.io.IOException
 meth public abstract org.graalvm.polyglot.io.ByteSequence getBytes(java.lang.Object)
-supr java.lang.Object
+supr org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractDispatchClass
 
-CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractSourceSectionImpl
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractSourceSectionDispatch
  outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
 cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
 meth public abstract boolean equals(java.lang.Object,java.lang.Object)
@@ -1222,105 +1854,181 @@ meth public abstract int getStartLine(java.lang.Object)
 meth public abstract int hashCode(java.lang.Object)
 meth public abstract java.lang.CharSequence getCode(java.lang.Object)
 meth public abstract java.lang.String toString(java.lang.Object)
-supr java.lang.Object
+supr org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractDispatchClass
 
 CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractStackFrameImpl
  outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
 cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
 meth public abstract boolean isHostFrame()
+meth public abstract java.lang.Object getLanguage()
+meth public abstract java.lang.Object getSourceLocation()
 meth public abstract java.lang.StackTraceElement toHostFrame()
 meth public abstract java.lang.String getRootName()
 meth public abstract java.lang.String toStringImpl(int)
-meth public abstract org.graalvm.polyglot.Language getLanguage()
-meth public abstract org.graalvm.polyglot.SourceSection getSourceLocation()
-supr java.lang.Object
+supr org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractDispatchClass
 
-CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractValueImpl
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractValueDispatch
  outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
 cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
-meth public abstract <%0 extends java.lang.Object> {%%0} as(java.lang.Object,java.lang.Class<{%%0}>)
-meth public abstract <%0 extends java.lang.Object> {%%0} as(java.lang.Object,org.graalvm.polyglot.TypeLiteral<{%%0}>)
-meth public abstract boolean asBoolean(java.lang.Object)
-meth public abstract boolean equalsImpl(java.lang.Object,java.lang.Object)
-meth public abstract boolean isMetaInstance(java.lang.Object,java.lang.Object)
-meth public abstract boolean removeArrayElement(java.lang.Object,long)
-meth public abstract boolean removeMember(java.lang.Object,java.lang.String)
-meth public abstract byte asByte(java.lang.Object)
-meth public abstract double asDouble(java.lang.Object)
-meth public abstract float asFloat(java.lang.Object)
-meth public abstract int asInt(java.lang.Object)
-meth public abstract int hashCodeImpl(java.lang.Object)
-meth public abstract java.lang.Object asHostObject(java.lang.Object)
-meth public abstract java.lang.Object asProxyObject(java.lang.Object)
-meth public abstract java.lang.RuntimeException throwException(java.lang.Object)
-meth public abstract java.lang.String asString(java.lang.Object)
-meth public abstract java.lang.String getMetaQualifiedName(java.lang.Object)
-meth public abstract java.lang.String getMetaSimpleName(java.lang.Object)
-meth public abstract java.lang.String toString(java.lang.Object)
-meth public abstract java.time.Duration asDuration(java.lang.Object)
-meth public abstract java.time.Instant asInstant(java.lang.Object)
-meth public abstract java.time.LocalDate asDate(java.lang.Object)
-meth public abstract java.time.LocalTime asTime(java.lang.Object)
-meth public abstract java.time.ZoneId asTimeZone(java.lang.Object)
-meth public abstract long asLong(java.lang.Object)
-meth public abstract long asNativePointer(java.lang.Object)
-meth public abstract long getArraySize(java.lang.Object)
-meth public abstract org.graalvm.polyglot.SourceSection getSourceLocation(java.lang.Object)
-meth public abstract org.graalvm.polyglot.Value execute(java.lang.Object)
-meth public abstract org.graalvm.polyglot.Value execute(java.lang.Object,java.lang.Object[])
-meth public abstract org.graalvm.polyglot.Value getArrayElement(java.lang.Object,long)
-meth public abstract org.graalvm.polyglot.Value getMember(java.lang.Object,java.lang.String)
-meth public abstract org.graalvm.polyglot.Value getMetaObject(java.lang.Object)
-meth public abstract org.graalvm.polyglot.Value invoke(java.lang.Object,java.lang.String)
-meth public abstract org.graalvm.polyglot.Value invoke(java.lang.Object,java.lang.String,java.lang.Object[])
-meth public abstract org.graalvm.polyglot.Value newInstance(java.lang.Object,java.lang.Object[])
-meth public abstract short asShort(java.lang.Object)
-meth public abstract void executeVoid(java.lang.Object)
-meth public abstract void executeVoid(java.lang.Object,java.lang.Object[])
-meth public abstract void putMember(java.lang.Object,java.lang.String,java.lang.Object)
-meth public abstract void setArrayElement(java.lang.Object,long,java.lang.Object)
-meth public boolean canExecute(java.lang.Object)
-meth public boolean canInstantiate(java.lang.Object)
-meth public boolean canInvoke(java.lang.String,java.lang.Object)
-meth public boolean fitsInByte(java.lang.Object)
-meth public boolean fitsInDouble(java.lang.Object)
-meth public boolean fitsInFloat(java.lang.Object)
-meth public boolean fitsInInt(java.lang.Object)
-meth public boolean fitsInLong(java.lang.Object)
-meth public boolean fitsInShort(java.lang.Object)
-meth public boolean hasArrayElements(java.lang.Object)
-meth public boolean hasMember(java.lang.Object,java.lang.String)
-meth public boolean hasMembers(java.lang.Object)
-meth public boolean isBoolean(java.lang.Object)
-meth public boolean isDate(java.lang.Object)
-meth public boolean isDuration(java.lang.Object)
-meth public boolean isException(java.lang.Object)
-meth public boolean isHostObject(java.lang.Object)
-meth public boolean isMetaObject(java.lang.Object)
-meth public boolean isNativePointer(java.lang.Object)
-meth public boolean isNull(java.lang.Object)
-meth public boolean isNumber(java.lang.Object)
-meth public boolean isProxyObject(java.lang.Object)
-meth public boolean isString(java.lang.Object)
-meth public boolean isTime(java.lang.Object)
-meth public boolean isTimeZone(java.lang.Object)
-meth public java.util.Set<java.lang.String> getMemberKeys(java.lang.Object)
-meth public org.graalvm.polyglot.Context getContext()
-supr java.lang.Object
+meth public abstract <%0 extends java.lang.Object> {%%0} asClass(java.lang.Object,java.lang.Object,java.lang.Class<{%%0}>)
+meth public abstract <%0 extends java.lang.Object> {%%0} asTypeLiteral(java.lang.Object,java.lang.Object,java.lang.Class<{%%0}>,java.lang.reflect.Type)
+meth public abstract boolean asBoolean(java.lang.Object,java.lang.Object)
+meth public abstract boolean equalsImpl(java.lang.Object,java.lang.Object,java.lang.Object)
+meth public abstract boolean hasIteratorNextElement(java.lang.Object,java.lang.Object)
+meth public abstract boolean hasMetaParents(java.lang.Object,java.lang.Object)
+meth public abstract boolean isBufferWritable(java.lang.Object,java.lang.Object)
+meth public abstract boolean isMetaInstance(java.lang.Object,java.lang.Object,java.lang.Object)
+meth public abstract boolean removeArrayElement(java.lang.Object,java.lang.Object,long)
+meth public abstract boolean removeHashEntry(java.lang.Object,java.lang.Object,java.lang.Object)
+meth public abstract boolean removeMember(java.lang.Object,java.lang.Object,java.lang.String)
+meth public abstract byte asByte(java.lang.Object,java.lang.Object)
+meth public abstract byte readBufferByte(java.lang.Object,java.lang.Object,long)
+meth public abstract double asDouble(java.lang.Object,java.lang.Object)
+meth public abstract double readBufferDouble(java.lang.Object,java.lang.Object,java.nio.ByteOrder,long)
+meth public abstract float asFloat(java.lang.Object,java.lang.Object)
+meth public abstract float readBufferFloat(java.lang.Object,java.lang.Object,java.nio.ByteOrder,long)
+meth public abstract int asInt(java.lang.Object,java.lang.Object)
+meth public abstract int hashCodeImpl(java.lang.Object,java.lang.Object)
+meth public abstract int readBufferInt(java.lang.Object,java.lang.Object,java.nio.ByteOrder,long)
+meth public abstract java.lang.Object asHostObject(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object asProxyObject(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object execute(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object execute(java.lang.Object,java.lang.Object,java.lang.Object[])
+meth public abstract java.lang.Object getArrayElement(java.lang.Object,java.lang.Object,long)
+meth public abstract java.lang.Object getHashEntriesIterator(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object getHashKeysIterator(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object getHashValue(java.lang.Object,java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object getHashValueOrDefault(java.lang.Object,java.lang.Object,java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object getHashValuesIterator(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object getIterator(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object getIteratorNextElement(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object getMember(java.lang.Object,java.lang.Object,java.lang.String)
+meth public abstract java.lang.Object getMetaObject(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object getMetaParents(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object getSourceLocation(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object invoke(java.lang.Object,java.lang.Object,java.lang.String)
+meth public abstract java.lang.Object invoke(java.lang.Object,java.lang.Object,java.lang.String,java.lang.Object[])
+meth public abstract java.lang.Object newInstance(java.lang.Object,java.lang.Object,java.lang.Object[])
+meth public abstract java.lang.RuntimeException throwException(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.String asString(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.String getMetaQualifiedName(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.String getMetaSimpleName(java.lang.Object,java.lang.Object)
+meth public abstract java.lang.String toString(java.lang.Object,java.lang.Object)
+meth public abstract java.math.BigInteger asBigInteger(java.lang.Object,java.lang.Object)
+meth public abstract java.time.Duration asDuration(java.lang.Object,java.lang.Object)
+meth public abstract java.time.Instant asInstant(java.lang.Object,java.lang.Object)
+meth public abstract java.time.LocalDate asDate(java.lang.Object,java.lang.Object)
+meth public abstract java.time.LocalTime asTime(java.lang.Object,java.lang.Object)
+meth public abstract java.time.ZoneId asTimeZone(java.lang.Object,java.lang.Object)
+meth public abstract long asLong(java.lang.Object,java.lang.Object)
+meth public abstract long asNativePointer(java.lang.Object,java.lang.Object)
+meth public abstract long getArraySize(java.lang.Object,java.lang.Object)
+meth public abstract long getBufferSize(java.lang.Object,java.lang.Object)
+meth public abstract long getHashSize(java.lang.Object,java.lang.Object)
+meth public abstract long readBufferLong(java.lang.Object,java.lang.Object,java.nio.ByteOrder,long)
+meth public abstract short asShort(java.lang.Object,java.lang.Object)
+meth public abstract short readBufferShort(java.lang.Object,java.lang.Object,java.nio.ByteOrder,long)
+meth public abstract void executeVoid(java.lang.Object,java.lang.Object)
+meth public abstract void executeVoid(java.lang.Object,java.lang.Object,java.lang.Object[])
+meth public abstract void pin(java.lang.Object,java.lang.Object)
+meth public abstract void putHashEntry(java.lang.Object,java.lang.Object,java.lang.Object,java.lang.Object)
+meth public abstract void putMember(java.lang.Object,java.lang.Object,java.lang.String,java.lang.Object)
+meth public abstract void readBuffer(java.lang.Object,java.lang.Object,long,byte[],int,int)
+meth public abstract void setArrayElement(java.lang.Object,java.lang.Object,long,java.lang.Object)
+meth public abstract void writeBufferByte(java.lang.Object,java.lang.Object,long,byte)
+meth public abstract void writeBufferDouble(java.lang.Object,java.lang.Object,java.nio.ByteOrder,long,double)
+meth public abstract void writeBufferFloat(java.lang.Object,java.lang.Object,java.nio.ByteOrder,long,float)
+meth public abstract void writeBufferInt(java.lang.Object,java.lang.Object,java.nio.ByteOrder,long,int)
+meth public abstract void writeBufferLong(java.lang.Object,java.lang.Object,java.nio.ByteOrder,long,long)
+meth public abstract void writeBufferShort(java.lang.Object,java.lang.Object,java.nio.ByteOrder,long,short)
+meth public boolean canExecute(java.lang.Object,java.lang.Object)
+meth public boolean canInstantiate(java.lang.Object,java.lang.Object)
+meth public boolean canInvoke(java.lang.Object,java.lang.String,java.lang.Object)
+meth public boolean fitsInBigInteger(java.lang.Object,java.lang.Object)
+meth public boolean fitsInByte(java.lang.Object,java.lang.Object)
+meth public boolean fitsInDouble(java.lang.Object,java.lang.Object)
+meth public boolean fitsInFloat(java.lang.Object,java.lang.Object)
+meth public boolean fitsInInt(java.lang.Object,java.lang.Object)
+meth public boolean fitsInLong(java.lang.Object,java.lang.Object)
+meth public boolean fitsInShort(java.lang.Object,java.lang.Object)
+meth public boolean hasArrayElements(java.lang.Object,java.lang.Object)
+meth public boolean hasBufferElements(java.lang.Object,java.lang.Object)
+meth public boolean hasHashEntries(java.lang.Object,java.lang.Object)
+meth public boolean hasHashEntry(java.lang.Object,java.lang.Object,java.lang.Object)
+meth public boolean hasIterator(java.lang.Object,java.lang.Object)
+meth public boolean hasMember(java.lang.Object,java.lang.Object,java.lang.String)
+meth public boolean hasMembers(java.lang.Object,java.lang.Object)
+meth public boolean isBoolean(java.lang.Object,java.lang.Object)
+meth public boolean isDate(java.lang.Object,java.lang.Object)
+meth public boolean isDuration(java.lang.Object,java.lang.Object)
+meth public boolean isException(java.lang.Object,java.lang.Object)
+meth public boolean isHostObject(java.lang.Object,java.lang.Object)
+meth public boolean isIterator(java.lang.Object,java.lang.Object)
+meth public boolean isMetaObject(java.lang.Object,java.lang.Object)
+meth public boolean isNativePointer(java.lang.Object,java.lang.Object)
+meth public boolean isNull(java.lang.Object,java.lang.Object)
+meth public boolean isNumber(java.lang.Object,java.lang.Object)
+meth public boolean isProxyObject(java.lang.Object,java.lang.Object)
+meth public boolean isString(java.lang.Object,java.lang.Object)
+meth public boolean isTime(java.lang.Object,java.lang.Object)
+meth public boolean isTimeZone(java.lang.Object,java.lang.Object)
+meth public java.lang.Object getContext(java.lang.Object)
+meth public java.util.Set<java.lang.String> getMemberKeys(java.lang.Object,java.lang.Object)
+supr org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractDispatchClass
 
-CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$IOAccess
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$IOAccessor
  outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
 cons protected init()
-meth public abstract java.io.OutputStream getOutputStream(org.graalvm.polyglot.io.ProcessHandler$Redirect)
-meth public abstract org.graalvm.polyglot.io.ProcessHandler$ProcessCommand newProcessCommand(java.util.List<java.lang.String>,java.lang.String,java.util.Map<java.lang.String,java.lang.String>,boolean,org.graalvm.polyglot.io.ProcessHandler$Redirect,org.graalvm.polyglot.io.ProcessHandler$Redirect,org.graalvm.polyglot.io.ProcessHandler$Redirect)
-meth public abstract org.graalvm.polyglot.io.ProcessHandler$Redirect createRedirectToStream(java.io.OutputStream)
+meth public abstract boolean hasHostFileAccess(java.lang.Object)
+meth public abstract boolean hasHostSocketAccess(java.lang.Object)
+meth public abstract boolean isVetoException(java.lang.Throwable)
+meth public abstract java.lang.Exception createVetoException(java.lang.String)
+meth public abstract java.lang.Object createIOAccess(java.lang.String,boolean,boolean,org.graalvm.polyglot.io.FileSystem)
+meth public abstract org.graalvm.polyglot.io.FileSystem getFileSystem(java.lang.Object)
+supr java.lang.Object
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$LogHandler
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons public init()
+meth public abstract void close()
+meth public abstract void flush()
+meth public abstract void publish(java.util.logging.LogRecord)
 supr java.lang.Object
 
 CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$ManagementAccess
  outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
 cons protected init()
-meth public abstract org.graalvm.polyglot.management.ExecutionEvent newExecutionEvent(java.lang.Object)
+meth public abstract java.lang.Object getExecutionEventReceiver(java.lang.Object)
+meth public abstract java.lang.Object getExecutionListenerReceiver(java.lang.Object)
+meth public abstract java.lang.Object newExecutionEvent(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractExecutionEventDispatch,java.lang.Object)
+meth public abstract java.lang.Object newExecutionListener(org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractExecutionListenerDispatch,java.lang.Object)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractExecutionEventDispatch getExecutionEventDispatch(java.lang.Object)
+meth public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractExecutionListenerDispatch getExecutionListenerDispatch(java.lang.Object)
 supr java.lang.Object
+
+CLSS public abstract static org.graalvm.polyglot.impl.AbstractPolyglotImpl$ThreadScope
+ outer org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+intf java.lang.AutoCloseable
+meth public abstract void close()
+supr java.lang.Object
+
+CLSS public final org.graalvm.polyglot.impl.ModuleToUnnamedBridge
+meth public java.lang.Object getModuleAccess()
+meth public org.graalvm.polyglot.impl.AbstractPolyglotImpl$APIAccess getAPIAccess()
+meth public org.graalvm.polyglot.impl.AbstractPolyglotImpl$IOAccessor getIOAccess()
+meth public org.graalvm.polyglot.impl.AbstractPolyglotImpl$ManagementAccess getManagementAccess()
+meth public static org.graalvm.polyglot.impl.ModuleToUnnamedBridge create(java.lang.invoke.MethodHandles$Lookup,java.lang.Object,java.lang.Object,java.lang.Object,java.lang.Object)
+supr java.lang.Object
+hfds api,bridgeInitialized,instance,io,management,moduleAccess,unnamed,unnamedLookup
+hcls ModuleAccessImpl,ModuleToUnnamedAPIAccess,ModuleToUnnamedAccess,ModuleToUnnamedByteSequence,ModuleToUnnamedFileSystem,ModuleToUnnamedIOAccessor,ModuleToUnnamedLogHandler,ModuleToUnnamedManagementAccess,ModuleToUnnamedMessageEndpoint,ModuleToUnnamedMessageTransport,ModuleToUnnamedOptionDescriptors,ModuleToUnnamedProcessHandler,ModuleToUnnamedThreadScope
+
+CLSS public final org.graalvm.polyglot.impl.UnnamedToModuleBridge
+meth public org.graalvm.polyglot.impl.AbstractPolyglotImpl getPolyglot()
+meth public static org.graalvm.polyglot.impl.UnnamedToModuleBridge create(java.lang.Class<?>,java.lang.Object)
+supr java.lang.Object
+hfds bridgeInitialized,instance,moduleAccess,moduleLookup,polyglot
+hcls UnnamedAccessImpl,UnnamedToModuleAccess,UnnamedToModuleByteSequence,UnnamedToModuleContextDispatch,UnnamedToModuleEngineDispatch,UnnamedToModuleExceptionDispatch,UnnamedToModuleExecutionEventDispatch,UnnamedToModuleExecutionListenerDispatch,UnnamedToModuleFileSystem,UnnamedToModuleInstrumentDispatch,UnnamedToModuleLanguageDispatch,UnnamedToModuleMessageEndpoint,UnnamedToModuleOptionDescriptors,UnnamedToModulePolyglotImpl,UnnamedToModuleSourceDispatch,UnnamedToModuleSourceSectionDispatch,UnnamedToModuleStackFrameImpl,UnnamedToModuleValueDispatch
 
 CLSS public abstract interface org.graalvm.polyglot.io.ByteSequence
 meth public abstract byte byteAt(int)
@@ -1352,9 +2060,35 @@ meth public java.lang.String getSeparator()
 meth public java.nio.charset.Charset getEncoding(java.nio.file.Path)
 meth public java.nio.file.Path getTempDirectory()
 meth public java.nio.file.Path readSymbolicLink(java.nio.file.Path) throws java.io.IOException
+meth public static org.graalvm.polyglot.io.FileSystem allowInternalResourceAccess(org.graalvm.polyglot.io.FileSystem)
+meth public static org.graalvm.polyglot.io.FileSystem allowLanguageHomeAccess(org.graalvm.polyglot.io.FileSystem)
+ anno 0 java.lang.Deprecated()
 meth public static org.graalvm.polyglot.io.FileSystem newDefaultFileSystem()
+meth public static org.graalvm.polyglot.io.FileSystem newFileSystem(java.nio.file.FileSystem)
+meth public static org.graalvm.polyglot.io.FileSystem newReadOnlyFileSystem(org.graalvm.polyglot.io.FileSystem)
 meth public void createLink(java.nio.file.Path,java.nio.file.Path) throws java.io.IOException
 meth public void setCurrentWorkingDirectory(java.nio.file.Path)
+
+CLSS public final org.graalvm.polyglot.io.IOAccess
+fld public final static org.graalvm.polyglot.io.IOAccess ALL
+fld public final static org.graalvm.polyglot.io.IOAccess NONE
+innr public final static Builder
+meth public boolean equals(java.lang.Object)
+meth public int hashCode()
+meth public java.lang.String toString()
+meth public static org.graalvm.polyglot.io.IOAccess$Builder newBuilder()
+meth public static org.graalvm.polyglot.io.IOAccess$Builder newBuilder(org.graalvm.polyglot.io.IOAccess)
+supr java.lang.Object
+hfds allowHostFileAccess,allowHostSocketAccess,fileSystem,name
+
+CLSS public final static org.graalvm.polyglot.io.IOAccess$Builder
+ outer org.graalvm.polyglot.io.IOAccess
+meth public org.graalvm.polyglot.io.IOAccess build()
+meth public org.graalvm.polyglot.io.IOAccess$Builder allowHostFileAccess(boolean)
+meth public org.graalvm.polyglot.io.IOAccess$Builder allowHostSocketAccess(boolean)
+meth public org.graalvm.polyglot.io.IOAccess$Builder fileSystem(org.graalvm.polyglot.io.FileSystem)
+supr java.lang.Object
+hfds allowHostFileAccess,allowHostSocketAccess,customFileSystem,name
 
 CLSS public abstract interface org.graalvm.polyglot.io.MessageEndpoint
 meth public abstract void sendBinary(java.nio.ByteBuffer) throws java.io.IOException
@@ -1387,6 +2121,7 @@ meth public java.util.Map<java.lang.String,java.lang.String> getEnvironment()
 meth public org.graalvm.polyglot.io.ProcessHandler$Redirect getErrorRedirect()
 meth public org.graalvm.polyglot.io.ProcessHandler$Redirect getInputRedirect()
 meth public org.graalvm.polyglot.io.ProcessHandler$Redirect getOutputRedirect()
+meth public static org.graalvm.polyglot.io.ProcessHandler$ProcessCommand create(java.util.List<java.lang.String>,java.lang.String,java.util.Map<java.lang.String,java.lang.String>,boolean,org.graalvm.polyglot.io.ProcessHandler$Redirect,org.graalvm.polyglot.io.ProcessHandler$Redirect,org.graalvm.polyglot.io.ProcessHandler$Redirect)
 supr java.lang.Object
 hfds cmd,cwd,environment,errorRedirect,inputRedirect,outputRedirect,redirectErrorStream
 
@@ -1396,7 +2131,9 @@ fld public final static org.graalvm.polyglot.io.ProcessHandler$Redirect INHERIT
 fld public final static org.graalvm.polyglot.io.ProcessHandler$Redirect PIPE
 meth public boolean equals(java.lang.Object)
 meth public int hashCode()
+meth public java.io.OutputStream getOutputStream()
 meth public java.lang.String toString()
+meth public static org.graalvm.polyglot.io.ProcessHandler$Redirect createRedirectToStream(java.io.OutputStream)
 supr java.lang.Object
 hfds stream,type
 hcls Type
@@ -1412,7 +2149,7 @@ meth public org.graalvm.polyglot.PolyglotException getException()
 meth public org.graalvm.polyglot.SourceSection getLocation()
 meth public org.graalvm.polyglot.Value getReturnValue()
 supr java.lang.Object
-hfds impl
+hfds dispatch,receiver
 
 CLSS public final org.graalvm.polyglot.management.ExecutionListener
 innr public final Builder
@@ -1420,7 +2157,7 @@ intf java.lang.AutoCloseable
 meth public static org.graalvm.polyglot.management.ExecutionListener$Builder newBuilder()
 meth public void close()
 supr java.lang.Object
-hfds EMPTY,impl
+hfds EMPTY,dispatch,receiver
 
 CLSS public final org.graalvm.polyglot.management.ExecutionListener$Builder
  outer org.graalvm.polyglot.management.ExecutionListener
@@ -1441,12 +2178,13 @@ hfds collectExceptions,collectInputValues,collectReturnValues,expressions,onEnte
 CLSS public abstract interface org.graalvm.polyglot.proxy.Proxy
 
 CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyArray
-intf org.graalvm.polyglot.proxy.Proxy
+intf org.graalvm.polyglot.proxy.ProxyIterable
 meth public !varargs static org.graalvm.polyglot.proxy.ProxyArray fromArray(java.lang.Object[])
 meth public abstract java.lang.Object get(long)
 meth public abstract long getSize()
 meth public abstract void set(long,org.graalvm.polyglot.Value)
 meth public boolean remove(long)
+meth public java.lang.Object getIterator()
 meth public static org.graalvm.polyglot.proxy.ProxyArray fromList(java.util.List<java.lang.Object>)
 
 CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyDate
@@ -1464,6 +2202,16 @@ CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyExecutable
 intf org.graalvm.polyglot.proxy.Proxy
 meth public abstract !varargs java.lang.Object execute(org.graalvm.polyglot.Value[])
 
+CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyHashMap
+intf org.graalvm.polyglot.proxy.Proxy
+meth public abstract boolean hasHashEntry(org.graalvm.polyglot.Value)
+meth public abstract java.lang.Object getHashEntriesIterator()
+meth public abstract java.lang.Object getHashValue(org.graalvm.polyglot.Value)
+meth public abstract long getHashSize()
+meth public abstract void putHashEntry(org.graalvm.polyglot.Value,org.graalvm.polyglot.Value)
+meth public boolean removeHashEntry(org.graalvm.polyglot.Value)
+meth public static org.graalvm.polyglot.proxy.ProxyHashMap from(java.util.Map<java.lang.Object,java.lang.Object>)
+
 CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyInstant
 intf org.graalvm.polyglot.proxy.ProxyDate
 intf org.graalvm.polyglot.proxy.ProxyTime
@@ -1478,6 +2226,17 @@ CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyInstantiable
  anno 0 java.lang.FunctionalInterface()
 intf org.graalvm.polyglot.proxy.Proxy
 meth public abstract !varargs java.lang.Object newInstance(org.graalvm.polyglot.Value[])
+
+CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyIterable
+intf org.graalvm.polyglot.proxy.Proxy
+meth public abstract java.lang.Object getIterator()
+meth public static org.graalvm.polyglot.proxy.ProxyIterable from(java.lang.Iterable<java.lang.Object>)
+
+CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyIterator
+intf org.graalvm.polyglot.proxy.Proxy
+meth public abstract boolean hasNext()
+meth public abstract java.lang.Object getNext()
+meth public static org.graalvm.polyglot.proxy.ProxyIterator from(java.util.Iterator<?>)
 
 CLSS public abstract interface org.graalvm.polyglot.proxy.ProxyNativeObject
 intf org.graalvm.polyglot.proxy.Proxy

--- a/ide/libs.graalsdk/nbproject/project.properties
+++ b/ide/libs.graalsdk/nbproject/project.properties
@@ -19,8 +19,18 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 
-release.external/graal-sdk-20.3.0.jar=modules/ext/graal-sdk-20.3.0.jar
-release.external/launcher-common-20.3.0.jar=modules/ext/launcher-common-20.3.0.jar
+release.external/launcher-common-24.0.0.jar=modules/ext/launcher-common-24.0.0.jar
+release.external/jline-24.0.0.jar=modules/ext/jline-24.0.0.jar
+release.external/collections-24.0.0.jar=modules/ext/collections-24.0.0.jar
+release.external/jniutils-24.0.0.jar=modules/ext/jniutils-24.0.0.jar
+release.external/launcher-common-24.0.0.jar=modules/ext/launcher-common-24.0.0.jar
+release.external/nativeimage-24.0.0.jar=modules/ext/nativeimage-24.0.0.jar
+release.external/polyglot-24.0.0.jar=modules/ext/polyglot-24.0.0.jar
+release.external/word-24.0.0.jar=modules/ext/word-24.0.0.jar
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
+
+# gen-sigtest fails because it thinks methods on the allocators change their
+# return types - it is unclear why that happens, disassembled methods look sane
+sigtest.gen.fail.on.error=false

--- a/ide/libs.graalsdk/nbproject/project.xml
+++ b/ide/libs.graalsdk/nbproject/project.xml
@@ -57,6 +57,14 @@
                         <specification-version>8.36</specification-version>
                     </run-dependency>
                 </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util.ui</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.33</specification-version>
+                    </run-dependency>
+                </dependency>
             </module-dependencies>
             <test-dependencies>
                 <test-type>
@@ -86,24 +94,48 @@
                 </test-type>
             </test-dependencies>
             <public-packages>
-                <package>org.graalvm.home</package>
-                <package>org.graalvm.options</package>
-                <package>org.graalvm.nativeimage</package>
                 <package>org.graalvm.collections</package>
+                <package>org.graalvm.home</package>
+                <package>org.graalvm.nativeimage</package>
+                <package>org.graalvm.options</package>
                 <package>org.graalvm.polyglot</package>
+                <package>org.graalvm.polyglot.impl</package>
                 <package>org.graalvm.polyglot.io</package>
                 <package>org.graalvm.polyglot.management</package>
                 <package>org.graalvm.polyglot.proxy</package>
-                <package>org.graalvm.polyglot.impl</package>
                 <package>org.netbeans.libs.graalsdk</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/graal-sdk-20.3.0.jar</runtime-relative-path>
-                <binary-origin>external/graal-sdk-20.3.0.jar</binary-origin>
+                <runtime-relative-path>ext/launcher-common-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/launcher-common-24.0.0.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/launcher-common-20.3.0.jar</runtime-relative-path>
-                <binary-origin>external/launcher-common-20.3.0.jar</binary-origin>
+                <runtime-relative-path>ext/jline-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/jline-24.0.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/collections-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/collections-24.0.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/jniutils-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/jniutils-24.0.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/launcher-common-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/launcher-common-24.0.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/nativeimage-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/nativeimage-24.0.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/polyglot-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/polyglot-24.0.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/word-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/word-24.0.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/GraalEnginesProvider.java
+++ b/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/GraalEnginesProvider.java
@@ -117,7 +117,7 @@ public final class GraalEnginesProvider implements EngineProvider {
                     }
                 }
             }
-        } while (!added);
+        } while (added);
         
         ClassLoader created;
         try {

--- a/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/Installer.java
+++ b/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/Installer.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.libs.graalsdk.impl;
+
+import org.openide.modules.ModuleInstall;
+
+public class Installer extends ModuleInstall {
+
+    @Override
+    public void validate() {
+        super.validate();
+        // Truffle runtime is very vocal if it is run in interpreter only mode.
+        // That mode is the case in "normal" JDKs, which are the NetBeans
+        // baseline - the warnings should be silenced accordingly
+        if (!System.getProperties().contains("polyglot.engine.WarnInterpreterOnly")) { //NOI18N
+            System.setProperty("polyglot.engine.WarnInterpreterOnly", "false"); //NOI18N
+        }
+        // The default Truffle runtime uses a native library. That library fails
+        // hard when it shall be loaded by multiple classloaders. So for now
+        // use the fallback runtime
+        if (!System.getProperties().contains("truffle.UseFallbackRuntime")) { //NOI18N
+            System.setProperty( "truffle.UseFallbackRuntime", "true" ); //NOI18N
+        }
+    }
+}

--- a/ide/libs.truffleapi/external/binaries-list
+++ b/ide/libs.truffleapi/external/binaries-list
@@ -14,4 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-F20DA0BA9579D4152B57CF67538A1B8279C77CB0 org.graalvm.truffle:truffle-api:20.3.0
+BC925B49DCE52653AFBA11F65100CF9D83171D40 org.graalvm.truffle:truffle-api:24.0.0
+2F3EE79085E59314C8B4AB9D40AC2A118E8CBA15 org.graalvm.truffle:truffle-runtime:24.0.0
+1DFB80E64DCD92460C2ACCAC4C90935FE6CDDF12 org.graalvm.truffle:truffle-compiler:24.0.0

--- a/ide/libs.truffleapi/external/truffle-api-24.0.0-license.txt
+++ b/ide/libs.truffleapi/external/truffle-api-24.0.0-license.txt
@@ -1,11 +1,13 @@
-Name: Graal SDK and Truffle API
-Description: Graal SDK and Truffle API
-License: UPL
-Origin: https://github.com/oracle/graal
-Version: 20.3.0
-Files: graal-sdk-20.3.0.jar launcher-common-20.3.0.jar
+Name: Truffle API with shaded jcodings library
+Description: Truffle API with shaded jcodings library
+License: UPL-MIT-jcodings
+Origin: https://github.com/oracle/graal https://github.com/jruby/jcodings
+Version: 24.0.0
+Files: truffle-api-24.0.0.jar truffle-compiler-24.0.0.jar truffle-runtime-24.0.0.jar
 
-Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+GraalVM Community Edition - UPL
+
+Copyright (c) __YEARS__, __NAMES__
 
 The Universal Permissive License (UPL), Version 1.0
 
@@ -23,3 +25,24 @@ The above copyright notice and either this complete permission notice or at a mi
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+--------------------------------------------------------------------------------
+
+jcodings - MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ide/libs.truffleapi/manifest.mf
+++ b/ide/libs.truffleapi/manifest.mf
@@ -2,7 +2,8 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.libs.truffleapi
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/truffle/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.24
+OpenIDE-Module-Specification-Version: 1.25
 OpenIDE-Module-Provides: com.oracle.truffle.polyglot.PolyglotImpl
-OpenIDE-Module-Hide-Classpath-Packages: com.oracle.truffle.**,jdk.vm.ci.services.**
-
+OpenIDE-Module-Java-Dependencies: Java > 17
+OpenIDE-Module-Hide-Classpath-Packages: com.oracle.truffle.**,jdk.vm.ci.services.**, 
+    org.graalvm.shadowed.org.jcodings.**

--- a/ide/libs.truffleapi/nbproject/org-netbeans-libs-truffleapi.sig
+++ b/ide/libs.truffleapi/nbproject/org-netbeans-libs-truffleapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.23
+#Version 1.24
 
 CLSS public final com.oracle.truffle.api.ArrayUtils
 meth public !varargs static int indexOf(byte[],int,int,byte[])
@@ -12,14 +12,19 @@ meth public static int indexOfWithOrMask(byte[],int,int,byte[],byte[])
 meth public static int indexOfWithOrMask(char[],int,int,char[],char[])
 meth public static int indexOfWithOrMask(java.lang.String,int,int,java.lang.String,java.lang.String)
 supr java.lang.Object
+hfds UNSAFE,javaStringCoderFieldOffset,javaStringValueFieldOffset
 
 CLSS public abstract interface com.oracle.truffle.api.Assumption
+fld public final static com.oracle.truffle.api.Assumption ALWAYS_VALID
+fld public final static com.oracle.truffle.api.Assumption NEVER_VALID
 meth public abstract boolean isValid()
 meth public abstract java.lang.String getName()
 meth public abstract void check() throws com.oracle.truffle.api.nodes.InvalidAssumptionException
 meth public abstract void invalidate()
 meth public static boolean isValidAssumption(com.oracle.truffle.api.Assumption)
 meth public static boolean isValidAssumption(com.oracle.truffle.api.Assumption[])
+meth public static com.oracle.truffle.api.Assumption create()
+meth public static com.oracle.truffle.api.Assumption create(java.lang.String)
 meth public void invalidate(java.lang.String)
 
 CLSS public abstract interface com.oracle.truffle.api.CallTarget
@@ -47,17 +52,28 @@ innr public abstract interface static !annotation TruffleBoundary
 innr public abstract interface static !annotation ValueType
 meth public static <%0 extends java.lang.Object> {%%0} castExact(java.lang.Object,java.lang.Class<{%%0}>)
 meth public static <%0 extends java.lang.Object> {%%0} interpreterOnly(java.util.concurrent.Callable<{%%0}>) throws java.lang.Exception
+meth public static boolean hasNextTier()
 meth public static boolean inCompilationRoot()
 meth public static boolean inCompiledCode()
 meth public static boolean inInterpreter()
 meth public static boolean injectBranchProbability(double,boolean)
 meth public static boolean isCompilationConstant(java.lang.Object)
+meth public static boolean isExact(java.lang.Object,java.lang.Class<?>)
 meth public static boolean isPartialEvaluationConstant(java.lang.Object)
 meth public static java.lang.RuntimeException shouldNotReachHere()
 meth public static java.lang.RuntimeException shouldNotReachHere(java.lang.String)
 meth public static java.lang.RuntimeException shouldNotReachHere(java.lang.String,java.lang.Throwable)
 meth public static java.lang.RuntimeException shouldNotReachHere(java.lang.Throwable)
 meth public static void bailout(java.lang.String)
+meth public static void blackhole(boolean)
+meth public static void blackhole(byte)
+meth public static void blackhole(char)
+meth public static void blackhole(double)
+meth public static void blackhole(float)
+meth public static void blackhole(int)
+meth public static void blackhole(java.lang.Object)
+meth public static void blackhole(long)
+meth public static void blackhole(short)
 meth public static void ensureVirtualized(java.lang.Object)
 meth public static void ensureVirtualizedHere(java.lang.Object)
 meth public static void interpreterOnly(java.lang.Runnable)
@@ -88,10 +104,6 @@ CLSS public abstract interface static !annotation com.oracle.truffle.api.Compile
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
 
-CLSS public abstract interface com.oracle.truffle.api.CompilerOptions
-meth public abstract boolean supportsOption(java.lang.String)
-meth public abstract void setOption(java.lang.String,java.lang.Object)
-
 CLSS public abstract com.oracle.truffle.api.ContextLocal<%0 extends java.lang.Object>
 cons protected init(java.lang.Object)
 meth public abstract {com.oracle.truffle.api.ContextLocal%0} get()
@@ -107,11 +119,39 @@ meth public abstract {com.oracle.truffle.api.ContextThreadLocal%0} get(java.lang
 supr java.lang.Object
 
 CLSS public final com.oracle.truffle.api.ExactMath
+meth public static double truncate(double)
+meth public static float truncate(float)
 meth public static int multiplyHigh(int,int)
 meth public static int multiplyHighUnsigned(int,int)
 meth public static long multiplyHigh(long,long)
 meth public static long multiplyHighUnsigned(long,long)
 supr java.lang.Object
+
+CLSS public final com.oracle.truffle.api.HostCompilerDirectives
+innr public abstract interface static !annotation BytecodeInterpreterSwitch
+innr public abstract interface static !annotation BytecodeInterpreterSwitchBoundary
+innr public abstract interface static !annotation InliningCutoff
+meth public static boolean inInterpreterFastPath()
+supr java.lang.Object
+
+CLSS public abstract interface static !annotation com.oracle.truffle.api.HostCompilerDirectives$BytecodeInterpreterSwitch
+ outer com.oracle.truffle.api.HostCompilerDirectives
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, CONSTRUCTOR])
+intf java.lang.annotation.Annotation
+
+CLSS public abstract interface static !annotation com.oracle.truffle.api.HostCompilerDirectives$BytecodeInterpreterSwitchBoundary
+ outer com.oracle.truffle.api.HostCompilerDirectives
+ anno 0 java.lang.Deprecated(null since="22.2")
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, CONSTRUCTOR])
+intf java.lang.annotation.Annotation
+
+CLSS public abstract interface static !annotation com.oracle.truffle.api.HostCompilerDirectives$InliningCutoff
+ outer com.oracle.truffle.api.HostCompilerDirectives
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, CONSTRUCTOR])
+intf java.lang.annotation.Annotation
 
 CLSS public final com.oracle.truffle.api.InstrumentInfo
 meth public java.lang.String getId()
@@ -120,6 +160,57 @@ meth public java.lang.String getVersion()
 meth public java.lang.String toString()
 supr java.lang.Object
 hfds id,name,polyglotInstrument,version
+
+CLSS public abstract interface com.oracle.truffle.api.InternalResource
+innr public abstract interface static !annotation Id
+innr public final static !enum CPUArchitecture
+innr public final static !enum OS
+innr public final static Env
+meth public abstract java.lang.String versionHash(com.oracle.truffle.api.InternalResource$Env)
+meth public abstract void unpackFiles(com.oracle.truffle.api.InternalResource$Env,java.nio.file.Path) throws java.io.IOException
+
+CLSS public final static !enum com.oracle.truffle.api.InternalResource$CPUArchitecture
+ outer com.oracle.truffle.api.InternalResource
+fld public final static com.oracle.truffle.api.InternalResource$CPUArchitecture AARCH64
+fld public final static com.oracle.truffle.api.InternalResource$CPUArchitecture AMD64
+meth public java.lang.String toString()
+meth public static com.oracle.truffle.api.InternalResource$CPUArchitecture getCurrent()
+meth public static com.oracle.truffle.api.InternalResource$CPUArchitecture valueOf(java.lang.String)
+meth public static com.oracle.truffle.api.InternalResource$CPUArchitecture[] values()
+supr java.lang.Enum<com.oracle.truffle.api.InternalResource$CPUArchitecture>
+hfds id
+
+CLSS public final static com.oracle.truffle.api.InternalResource$Env
+ outer com.oracle.truffle.api.InternalResource
+meth public boolean inContextPreinitialization()
+meth public boolean inNativeImageBuild()
+meth public com.oracle.truffle.api.InternalResource$CPUArchitecture getCPUArchitecture()
+meth public com.oracle.truffle.api.InternalResource$OS getOS()
+meth public java.util.List<java.lang.String> readResourceLines(java.nio.file.Path) throws java.io.IOException
+meth public void unpackResourceFiles(java.nio.file.Path,java.nio.file.Path,java.nio.file.Path) throws java.io.IOException
+supr java.lang.Object
+hfds contextPreinitializationCheck,owner,resourceClass
+
+CLSS public abstract interface static !annotation com.oracle.truffle.api.InternalResource$Id
+ outer com.oracle.truffle.api.InternalResource
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+intf java.lang.annotation.Annotation
+meth public abstract !hasdefault boolean optional()
+meth public abstract !hasdefault java.lang.String componentId()
+meth public abstract java.lang.String value()
+
+CLSS public final static !enum com.oracle.truffle.api.InternalResource$OS
+ outer com.oracle.truffle.api.InternalResource
+fld public final static com.oracle.truffle.api.InternalResource$OS DARWIN
+fld public final static com.oracle.truffle.api.InternalResource$OS LINUX
+fld public final static com.oracle.truffle.api.InternalResource$OS WINDOWS
+meth public java.lang.String toString()
+meth public static com.oracle.truffle.api.InternalResource$OS getCurrent()
+meth public static com.oracle.truffle.api.InternalResource$OS valueOf(java.lang.String)
+meth public static com.oracle.truffle.api.InternalResource$OS[] values()
+supr java.lang.Enum<com.oracle.truffle.api.InternalResource$OS>
+hfds id
 
 CLSS public com.oracle.truffle.api.OptimizationFailedException
 cons public init(java.lang.Throwable,com.oracle.truffle.api.RootCallTarget)
@@ -135,7 +226,9 @@ intf java.lang.annotation.Annotation
 meth public abstract !hasdefault boolean deprecated()
 meth public abstract !hasdefault java.lang.String deprecationMessage()
 meth public abstract !hasdefault java.lang.String name()
+meth public abstract !hasdefault java.lang.String usageSyntax()
 meth public abstract !hasdefault org.graalvm.options.OptionStability stability()
+meth public abstract !hasdefault org.graalvm.polyglot.SandboxPolicy sandbox()
 meth public abstract java.lang.String help()
 meth public abstract org.graalvm.options.OptionCategory category()
 
@@ -153,30 +246,21 @@ CLSS public abstract interface com.oracle.truffle.api.RootCallTarget
 intf com.oracle.truffle.api.CallTarget
 meth public abstract com.oracle.truffle.api.nodes.RootNode getRootNode()
 
-CLSS public final com.oracle.truffle.api.Scope
- anno 0 java.lang.Deprecated()
-innr public final Builder
-meth public com.oracle.truffle.api.nodes.Node getNode()
-meth public java.lang.Object getArguments()
-meth public java.lang.Object getReceiver()
-meth public java.lang.Object getRootInstance()
-meth public java.lang.Object getVariables()
-meth public java.lang.String getName()
-meth public java.lang.String getReceiverName()
-meth public static com.oracle.truffle.api.Scope$Builder newBuilder(java.lang.String,java.lang.Object)
+CLSS public abstract com.oracle.truffle.api.ThreadLocalAction
+cons protected init(boolean,boolean)
+cons protected init(boolean,boolean,boolean)
+innr public abstract static Access
+meth protected abstract void perform(com.oracle.truffle.api.ThreadLocalAction$Access)
 supr java.lang.Object
-hfds EMPTY,arguments,name,node,receiver,receiverName,rootInstance,variables
+hfds hasSideEffects,recurring,synchronous
 
-CLSS public final com.oracle.truffle.api.Scope$Builder
- outer com.oracle.truffle.api.Scope
- anno 0 java.lang.Deprecated()
-meth public com.oracle.truffle.api.Scope build()
-meth public com.oracle.truffle.api.Scope$Builder arguments(java.lang.Object)
-meth public com.oracle.truffle.api.Scope$Builder node(com.oracle.truffle.api.nodes.Node)
-meth public com.oracle.truffle.api.Scope$Builder receiver(java.lang.String,java.lang.Object)
-meth public com.oracle.truffle.api.Scope$Builder rootInstance(java.lang.Object)
+CLSS public abstract static com.oracle.truffle.api.ThreadLocalAction$Access
+ outer com.oracle.truffle.api.ThreadLocalAction
+cons protected init(java.lang.Object)
+cons protected init(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public abstract com.oracle.truffle.api.nodes.Node getLocation()
+meth public abstract java.lang.Thread getThread()
 supr java.lang.Object
-hfds arguments,name,node,receiver,receiverName,rootInstance,variables
 
 CLSS public final com.oracle.truffle.api.Truffle
 meth public static com.oracle.truffle.api.TruffleRuntime getRuntime()
@@ -186,53 +270,62 @@ hfds RUNTIME
 CLSS public final com.oracle.truffle.api.TruffleContext
 innr public final Builder
 intf java.lang.AutoCloseable
+meth public <%0 extends java.lang.Object, %1 extends java.lang.Object> {%%1} leaveAndEnter(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.TruffleSafepoint$Interrupter,com.oracle.truffle.api.TruffleSafepoint$InterruptibleFunction<{%%0},{%%1}>,{%%0})
+meth public <%0 extends java.lang.Object> {%%0} leaveAndEnter(com.oracle.truffle.api.nodes.Node,java.util.function.Supplier<{%%0}>)
+ anno 0 java.lang.Deprecated()
 meth public boolean equals(java.lang.Object)
+meth public boolean initializeInternal(com.oracle.truffle.api.nodes.Node,java.lang.String)
+meth public boolean initializePublic(com.oracle.truffle.api.nodes.Node,java.lang.String)
 meth public boolean isActive()
+meth public boolean isCancelling()
 meth public boolean isClosed()
 meth public boolean isEntered()
+meth public boolean isExiting()
 meth public com.oracle.truffle.api.TruffleContext getParent()
 meth public int hashCode()
-meth public java.lang.Object enter()
- anno 0 java.lang.Deprecated()
 meth public java.lang.Object enter(com.oracle.truffle.api.nodes.Node)
+meth public java.lang.Object evalInternal(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.source.Source)
+meth public java.lang.Object evalPublic(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.source.Source)
+meth public java.util.concurrent.Future<java.lang.Void> pause()
 meth public void close()
 meth public void closeCancelled(com.oracle.truffle.api.nodes.Node,java.lang.String)
+meth public void closeExited(com.oracle.truffle.api.nodes.Node,int)
 meth public void closeResourceExhausted(com.oracle.truffle.api.nodes.Node,java.lang.String)
 meth public void leave(com.oracle.truffle.api.nodes.Node,java.lang.Object)
-meth public void leave(java.lang.Object)
- anno 0 java.lang.Deprecated()
+meth public void resume(java.util.concurrent.Future<java.lang.Void>)
 supr java.lang.Object
-hfds CONTEXT_ASSERT_STACK,EMPTY,closeable,polyglotContext
+hfds CONTEXT_ASSERT_STACK,EMPTY,creator,polyglotContext
 
 CLSS public final com.oracle.truffle.api.TruffleContext$Builder
  outer com.oracle.truffle.api.TruffleContext
 meth public com.oracle.truffle.api.TruffleContext build()
+meth public com.oracle.truffle.api.TruffleContext$Builder allowCreateProcess(boolean)
+meth public com.oracle.truffle.api.TruffleContext$Builder allowCreateThread(boolean)
+meth public com.oracle.truffle.api.TruffleContext$Builder allowHostClassLoading(boolean)
+meth public com.oracle.truffle.api.TruffleContext$Builder allowHostClassLookup(boolean)
+meth public com.oracle.truffle.api.TruffleContext$Builder allowIO(boolean)
+meth public com.oracle.truffle.api.TruffleContext$Builder allowInheritEnvironmentAccess(boolean)
+meth public com.oracle.truffle.api.TruffleContext$Builder allowInnerContextOptions(boolean)
+meth public com.oracle.truffle.api.TruffleContext$Builder allowNativeAccess(boolean)
+meth public com.oracle.truffle.api.TruffleContext$Builder allowPolyglotAccess(boolean)
+meth public com.oracle.truffle.api.TruffleContext$Builder arguments(java.lang.String,java.lang.String[])
 meth public com.oracle.truffle.api.TruffleContext$Builder config(java.lang.String,java.lang.Object)
+meth public com.oracle.truffle.api.TruffleContext$Builder environment(java.lang.String,java.lang.String)
+meth public com.oracle.truffle.api.TruffleContext$Builder environment(java.util.Map<java.lang.String,java.lang.String>)
+meth public com.oracle.truffle.api.TruffleContext$Builder err(java.io.OutputStream)
+meth public com.oracle.truffle.api.TruffleContext$Builder forceSharing(java.lang.Boolean)
+meth public com.oracle.truffle.api.TruffleContext$Builder in(java.io.InputStream)
+meth public com.oracle.truffle.api.TruffleContext$Builder inheritAllAccess(boolean)
+meth public com.oracle.truffle.api.TruffleContext$Builder initializeCreatorContext(boolean)
+meth public com.oracle.truffle.api.TruffleContext$Builder onCancelled(java.lang.Runnable)
+meth public com.oracle.truffle.api.TruffleContext$Builder onClosed(java.lang.Runnable)
+meth public com.oracle.truffle.api.TruffleContext$Builder onExited(java.util.function.Consumer<java.lang.Integer>)
+meth public com.oracle.truffle.api.TruffleContext$Builder option(java.lang.String,java.lang.String)
+meth public com.oracle.truffle.api.TruffleContext$Builder options(java.util.Map<java.lang.String,java.lang.String>)
+meth public com.oracle.truffle.api.TruffleContext$Builder out(java.io.OutputStream)
+meth public com.oracle.truffle.api.TruffleContext$Builder timeZone(java.time.ZoneId)
 supr java.lang.Object
-hfds config,sourceEnvironment
-
-CLSS public abstract interface com.oracle.truffle.api.TruffleException
- anno 0 java.lang.Deprecated()
-meth public abstract com.oracle.truffle.api.nodes.Node getLocation()
- anno 0 java.lang.Deprecated()
-meth public boolean isCancelled()
- anno 0 java.lang.Deprecated()
-meth public boolean isExit()
- anno 0 java.lang.Deprecated()
-meth public boolean isIncompleteSource()
- anno 0 java.lang.Deprecated()
-meth public boolean isInternalError()
- anno 0 java.lang.Deprecated()
-meth public boolean isSyntaxError()
- anno 0 java.lang.Deprecated()
-meth public com.oracle.truffle.api.source.SourceSection getSourceLocation()
- anno 0 java.lang.Deprecated()
-meth public int getExitStatus()
- anno 0 java.lang.Deprecated()
-meth public int getStackTraceElementLimit()
- anno 0 java.lang.Deprecated()
-meth public java.lang.Object getExceptionObject()
- anno 0 java.lang.Deprecated()
+hfds allowCreateProcess,allowCreateThread,allowEnvironmentAccess,allowHostClassLoading,allowHostLookup,allowIO,allowInnerContextOptions,allowNativeAccess,allowPolyglotAccess,arguments,config,environment,err,in,inheritAccess,initializeCreatorContext,onCancelled,onClosed,onExited,options,out,permittedLanguages,sharingEnabled,sourceEnvironment,timeZone
 
 CLSS public final com.oracle.truffle.api.TruffleFile
 fld public final static com.oracle.truffle.api.TruffleFile$AttributeDescriptor<java.lang.Boolean> IS_DIRECTORY
@@ -311,7 +404,7 @@ meth public java.io.BufferedReader newBufferedReader() throws java.io.IOExceptio
 meth public java.io.BufferedReader newBufferedReader(java.nio.charset.Charset) throws java.io.IOException
 meth public java.lang.String detectMimeType()
 meth public java.lang.String getMimeType() throws java.io.IOException
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="20.2")
 meth public java.lang.String getName()
 meth public java.lang.String getPath()
 meth public java.lang.String toString()
@@ -344,68 +437,62 @@ meth public abstract java.nio.charset.Charset findEncoding(com.oracle.truffle.ap
 
 CLSS public abstract com.oracle.truffle.api.TruffleLanguage<%0 extends java.lang.Object>
 cons protected init()
+fld protected final com.oracle.truffle.api.TruffleLanguage$ContextLocalProvider<{com.oracle.truffle.api.TruffleLanguage%0}> locals
 innr protected abstract interface static ContextLocalFactory
 innr protected abstract interface static ContextThreadLocalFactory
+innr protected final static ContextLocalProvider
 innr public abstract interface static !annotation Registration
 innr public abstract interface static Provider
 innr public abstract static ContextReference
 innr public abstract static LanguageReference
 innr public final static !enum ContextPolicy
+innr public final static !enum ExitMode
 innr public final static Env
 innr public final static InlineParsingRequest
 innr public final static ParsingRequest
 meth protected abstract {com.oracle.truffle.api.TruffleLanguage%0} createContext(com.oracle.truffle.api.TruffleLanguage$Env)
 meth protected boolean areOptionsCompatible(org.graalvm.options.OptionValues,org.graalvm.options.OptionValues)
-meth protected boolean initializeMultiContext()
- anno 0 java.lang.Deprecated()
-meth protected boolean isObjectOfLanguage(java.lang.Object)
- anno 0 java.lang.Deprecated()
 meth protected boolean isThreadAccessAllowed(java.lang.Thread,boolean)
 meth protected boolean isVisible({com.oracle.truffle.api.TruffleLanguage%0},java.lang.Object)
 meth protected boolean patchContext({com.oracle.truffle.api.TruffleLanguage%0},com.oracle.truffle.api.TruffleLanguage$Env)
 meth protected com.oracle.truffle.api.CallTarget parse(com.oracle.truffle.api.TruffleLanguage$ParsingRequest) throws java.lang.Exception
 meth protected com.oracle.truffle.api.nodes.ExecutableNode parse(com.oracle.truffle.api.TruffleLanguage$InlineParsingRequest) throws java.lang.Exception
-meth protected com.oracle.truffle.api.source.SourceSection findSourceLocation({com.oracle.truffle.api.TruffleLanguage%0},java.lang.Object)
- anno 0 java.lang.Deprecated()
 meth protected final <%0 extends java.lang.Object> com.oracle.truffle.api.ContextLocal<{%%0}> createContextLocal(com.oracle.truffle.api.TruffleLanguage$ContextLocalFactory<{com.oracle.truffle.api.TruffleLanguage%0},{%%0}>)
+ anno 0 java.lang.Deprecated()
 meth protected final <%0 extends java.lang.Object> com.oracle.truffle.api.ContextThreadLocal<{%%0}> createContextThreadLocal(com.oracle.truffle.api.TruffleLanguage$ContextThreadLocalFactory<{com.oracle.truffle.api.TruffleLanguage%0},{%%0}>)
+ anno 0 java.lang.Deprecated()
 meth protected final int getAsynchronousStackDepth()
 meth protected final java.lang.String getLanguageHome()
-meth protected java.lang.Iterable<com.oracle.truffle.api.Scope> findLocalScopes({com.oracle.truffle.api.TruffleLanguage%0},com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.frame.Frame)
- anno 0 java.lang.Deprecated()
-meth protected java.lang.Iterable<com.oracle.truffle.api.Scope> findTopScopes({com.oracle.truffle.api.TruffleLanguage%0})
- anno 0 java.lang.Deprecated()
-meth protected java.lang.Object findExportedSymbol({com.oracle.truffle.api.TruffleLanguage%0},java.lang.String,boolean)
- anno 0 java.lang.Deprecated()
-meth protected java.lang.Object findMetaObject({com.oracle.truffle.api.TruffleLanguage%0},java.lang.Object)
- anno 0 java.lang.Deprecated()
-meth protected java.lang.Object getLanguageGlobal({com.oracle.truffle.api.TruffleLanguage%0})
- anno 0 java.lang.Deprecated()
 meth protected java.lang.Object getLanguageView({com.oracle.truffle.api.TruffleLanguage%0},java.lang.Object)
 meth protected java.lang.Object getScope({com.oracle.truffle.api.TruffleLanguage%0})
-meth protected java.lang.Object getScopedView({com.oracle.truffle.api.TruffleLanguage%0},com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.frame.Frame,java.lang.Object)
- anno 0 java.lang.Deprecated()
-meth protected java.lang.String toString({com.oracle.truffle.api.TruffleLanguage%0},java.lang.Object)
- anno 0 java.lang.Deprecated()
 meth protected org.graalvm.options.OptionDescriptors getOptionDescriptors()
 meth protected static <%0 extends com.oracle.truffle.api.TruffleLanguage<?>> {%%0} getCurrentLanguage(java.lang.Class<{%%0}>)
+ anno 0 java.lang.Deprecated(null since="21.3")
 meth protected static <%0 extends java.lang.Object, %1 extends com.oracle.truffle.api.TruffleLanguage<{%%0}>> {%%0} getCurrentContext(java.lang.Class<{%%1}>)
+ anno 0 java.lang.Deprecated(null since="21.3")
 meth protected void disposeContext({com.oracle.truffle.api.TruffleLanguage%0})
 meth protected void disposeThread({com.oracle.truffle.api.TruffleLanguage%0},java.lang.Thread)
+meth protected void exitContext({com.oracle.truffle.api.TruffleLanguage%0},com.oracle.truffle.api.TruffleLanguage$ExitMode,int)
 meth protected void finalizeContext({com.oracle.truffle.api.TruffleLanguage%0})
+meth protected void finalizeThread({com.oracle.truffle.api.TruffleLanguage%0},java.lang.Thread)
 meth protected void initializeContext({com.oracle.truffle.api.TruffleLanguage%0}) throws java.lang.Exception
 meth protected void initializeMultiThreading({com.oracle.truffle.api.TruffleLanguage%0})
 meth protected void initializeMultipleContexts()
 meth protected void initializeThread({com.oracle.truffle.api.TruffleLanguage%0},java.lang.Thread)
-meth public final com.oracle.truffle.api.TruffleLanguage$ContextReference<{com.oracle.truffle.api.TruffleLanguage%0}> getContextReference()
- anno 0 java.lang.Deprecated()
 supr java.lang.Object
-hfds contextLocals,contextThreadLocals,languageInfo,polyglotLanguageInstance,reference
+hfds languageInfo,polyglotLanguageInstance
 
 CLSS protected abstract interface static com.oracle.truffle.api.TruffleLanguage$ContextLocalFactory<%0 extends java.lang.Object, %1 extends java.lang.Object>
  outer com.oracle.truffle.api.TruffleLanguage
  anno 0 java.lang.FunctionalInterface()
 meth public abstract {com.oracle.truffle.api.TruffleLanguage$ContextLocalFactory%1} create({com.oracle.truffle.api.TruffleLanguage$ContextLocalFactory%0})
+
+CLSS protected final static com.oracle.truffle.api.TruffleLanguage$ContextLocalProvider<%0 extends java.lang.Object>
+ outer com.oracle.truffle.api.TruffleLanguage
+meth public <%0 extends java.lang.Object> com.oracle.truffle.api.ContextLocal<{%%0}> createContextLocal(com.oracle.truffle.api.TruffleLanguage$ContextLocalFactory<{com.oracle.truffle.api.TruffleLanguage$ContextLocalProvider%0},{%%0}>)
+meth public <%0 extends java.lang.Object> com.oracle.truffle.api.ContextThreadLocal<{%%0}> createContextThreadLocal(com.oracle.truffle.api.TruffleLanguage$ContextThreadLocalFactory<{com.oracle.truffle.api.TruffleLanguage$ContextLocalProvider%0},{%%0}>)
+supr java.lang.Object
+hfds contextLocals,contextThreadLocals
 
 CLSS public final static !enum com.oracle.truffle.api.TruffleLanguage$ContextPolicy
  outer com.oracle.truffle.api.TruffleLanguage
@@ -419,7 +506,8 @@ supr java.lang.Enum<com.oracle.truffle.api.TruffleLanguage$ContextPolicy>
 CLSS public abstract static com.oracle.truffle.api.TruffleLanguage$ContextReference<%0 extends java.lang.Object>
  outer com.oracle.truffle.api.TruffleLanguage
 cons protected init()
-meth public abstract {com.oracle.truffle.api.TruffleLanguage$ContextReference%0} get()
+meth public abstract {com.oracle.truffle.api.TruffleLanguage$ContextReference%0} get(com.oracle.truffle.api.nodes.Node)
+meth public static <%0 extends com.oracle.truffle.api.TruffleLanguage<{%%1}>, %1 extends java.lang.Object> com.oracle.truffle.api.TruffleLanguage$ContextReference<{%%1}> create(java.lang.Class<{%%0}>)
 supr java.lang.Object
 
 CLSS protected abstract interface static com.oracle.truffle.api.TruffleLanguage$ContextThreadLocalFactory<%0 extends java.lang.Object, %1 extends java.lang.Object>
@@ -429,10 +517,9 @@ meth public abstract {com.oracle.truffle.api.TruffleLanguage$ContextThreadLocalF
 
 CLSS public final static com.oracle.truffle.api.TruffleLanguage$Env
  outer com.oracle.truffle.api.TruffleLanguage
-meth public !varargs com.oracle.truffle.api.CallTarget parse(com.oracle.truffle.api.source.Source,java.lang.String[])
- anno 0 java.lang.Deprecated()
 meth public !varargs com.oracle.truffle.api.CallTarget parseInternal(com.oracle.truffle.api.source.Source,java.lang.String[])
 meth public !varargs com.oracle.truffle.api.CallTarget parsePublic(com.oracle.truffle.api.source.Source,java.lang.String[])
+meth public !varargs com.oracle.truffle.api.TruffleContext$Builder newInnerContextBuilder(java.lang.String[])
 meth public !varargs com.oracle.truffle.api.TruffleFile createTempDirectory(com.oracle.truffle.api.TruffleFile,java.lang.String,java.nio.file.attribute.FileAttribute<?>[]) throws java.io.IOException
 meth public !varargs com.oracle.truffle.api.TruffleFile createTempFile(com.oracle.truffle.api.TruffleFile,java.lang.String,java.lang.String,java.nio.file.attribute.FileAttribute<?>[]) throws java.io.IOException
 meth public !varargs com.oracle.truffle.api.io.TruffleProcessBuilder newProcessBuilder(java.lang.String[])
@@ -442,29 +529,36 @@ meth public <%0 extends java.lang.Object> {%%0} lookup(java.lang.Class<{%%0}>)
 meth public boolean initializeLanguage(com.oracle.truffle.api.nodes.LanguageInfo)
 meth public boolean isCreateProcessAllowed()
 meth public boolean isCreateThreadAllowed()
+meth public boolean isFileIOAllowed()
 meth public boolean isHostException(java.lang.Throwable)
 meth public boolean isHostFunction(java.lang.Object)
 meth public boolean isHostLookupAllowed()
 meth public boolean isHostObject(java.lang.Object)
 meth public boolean isHostSymbol(java.lang.Object)
+meth public boolean isIOAllowed()
+ anno 0 java.lang.Deprecated(null since="23.0")
+meth public boolean isInnerContextOptionsAllowed()
 meth public boolean isMimeTypeSupported(java.lang.String)
 meth public boolean isNativeAccessAllowed()
-meth public boolean isPolyglotAccessAllowed()
- anno 0 java.lang.Deprecated()
 meth public boolean isPolyglotBindingsAccessAllowed()
 meth public boolean isPolyglotEvalAllowed()
 meth public boolean isPreInitialization()
+meth public boolean isSocketIOAllowed()
 meth public com.oracle.truffle.api.TruffleContext getContext()
 meth public com.oracle.truffle.api.TruffleContext$Builder newContextBuilder()
+ anno 0 java.lang.Deprecated()
 meth public com.oracle.truffle.api.TruffleFile getCurrentWorkingDirectory()
+meth public com.oracle.truffle.api.TruffleFile getInternalResource(java.lang.Class<? extends com.oracle.truffle.api.InternalResource>) throws java.io.IOException
+meth public com.oracle.truffle.api.TruffleFile getInternalResource(java.lang.String) throws java.io.IOException
 meth public com.oracle.truffle.api.TruffleFile getInternalTruffleFile(java.lang.String)
 meth public com.oracle.truffle.api.TruffleFile getInternalTruffleFile(java.net.URI)
 meth public com.oracle.truffle.api.TruffleFile getPublicTruffleFile(java.lang.String)
 meth public com.oracle.truffle.api.TruffleFile getPublicTruffleFile(java.net.URI)
-meth public com.oracle.truffle.api.TruffleFile getTruffleFile(java.lang.String)
- anno 0 java.lang.Deprecated()
-meth public com.oracle.truffle.api.TruffleFile getTruffleFile(java.net.URI)
- anno 0 java.lang.Deprecated()
+meth public com.oracle.truffle.api.TruffleFile getTruffleFileInternal(java.lang.String,java.util.function.Predicate<com.oracle.truffle.api.TruffleFile>)
+meth public com.oracle.truffle.api.TruffleFile getTruffleFileInternal(java.net.URI,java.util.function.Predicate<com.oracle.truffle.api.TruffleFile>)
+meth public com.oracle.truffle.api.TruffleLogger getLogger(java.lang.Class<?>)
+meth public com.oracle.truffle.api.TruffleLogger getLogger(java.lang.String)
+meth public com.oracle.truffle.api.TruffleThreadBuilder newTruffleThreadBuilder(java.lang.Runnable)
 meth public java.io.InputStream in()
 meth public java.io.OutputStream err()
 meth public java.io.OutputStream out()
@@ -472,8 +566,12 @@ meth public java.lang.Object asBoxedGuestValue(java.lang.Object)
 meth public java.lang.Object asGuestValue(java.lang.Object)
 meth public java.lang.Object asHostObject(java.lang.Object)
 meth public java.lang.Object asHostSymbol(java.lang.Class<?>)
+meth public java.lang.Object createHostAdapter(java.lang.Object[])
 meth public java.lang.Object createHostAdapterClass(java.lang.Class<?>[])
+ anno 0 java.lang.Deprecated(null since="22.1")
 meth public java.lang.Object createHostAdapterClassWithStaticOverrides(java.lang.Class<?>[],java.lang.Object)
+ anno 0 java.lang.Deprecated(null since="22.1")
+meth public java.lang.Object createHostAdapterWithClassOverrides(java.lang.Object[],java.lang.Object)
 meth public java.lang.Object findMetaObject(java.lang.Object)
 meth public java.lang.Object getPolyglotBindings()
 meth public java.lang.Object importSymbol(java.lang.String)
@@ -481,26 +579,42 @@ meth public java.lang.Object lookupHostSymbol(java.lang.String)
 meth public java.lang.String getFileNameSeparator()
 meth public java.lang.String getPathSeparator()
 meth public java.lang.String[] getApplicationArguments()
+meth public java.lang.Thread createSystemThread(java.lang.Runnable)
+meth public java.lang.Thread createSystemThread(java.lang.Runnable,java.lang.ThreadGroup)
 meth public java.lang.Thread createThread(java.lang.Runnable)
+ anno 0 java.lang.Deprecated()
 meth public java.lang.Thread createThread(java.lang.Runnable,com.oracle.truffle.api.TruffleContext)
+ anno 0 java.lang.Deprecated()
 meth public java.lang.Thread createThread(java.lang.Runnable,com.oracle.truffle.api.TruffleContext,java.lang.ThreadGroup)
+ anno 0 java.lang.Deprecated()
 meth public java.lang.Thread createThread(java.lang.Runnable,com.oracle.truffle.api.TruffleContext,java.lang.ThreadGroup,long)
+ anno 0 java.lang.Deprecated()
 meth public java.lang.Throwable asHostException(java.lang.Throwable)
 meth public java.time.ZoneId getTimeZone()
 meth public java.util.Map<java.lang.String,com.oracle.truffle.api.InstrumentInfo> getInstruments()
 meth public java.util.Map<java.lang.String,com.oracle.truffle.api.nodes.LanguageInfo> getInternalLanguages()
-meth public java.util.Map<java.lang.String,com.oracle.truffle.api.nodes.LanguageInfo> getLanguages()
- anno 0 java.lang.Deprecated()
 meth public java.util.Map<java.lang.String,com.oracle.truffle.api.nodes.LanguageInfo> getPublicLanguages()
 meth public java.util.Map<java.lang.String,java.lang.Object> getConfig()
 meth public java.util.Map<java.lang.String,java.lang.String> getEnvironment()
+meth public java.util.concurrent.Future<java.lang.Void> submitThreadLocal(java.lang.Thread[],com.oracle.truffle.api.ThreadLocalAction)
 meth public org.graalvm.options.OptionValues getOptions()
+meth public org.graalvm.polyglot.SandboxPolicy getSandboxPolicy()
 meth public void addToHostClassPath(com.oracle.truffle.api.TruffleFile)
 meth public void exportSymbol(java.lang.String,java.lang.Object)
+meth public void registerOnDispose(java.io.Closeable)
 meth public void registerService(java.lang.Object)
 meth public void setCurrentWorkingDirectory(com.oracle.truffle.api.TruffleFile)
 supr java.lang.Object
 hfds UNSET_CONTEXT,applicationArguments,config,context,contextUnchangedAssumption,err,in,initialized,initializedUnchangedAssumption,languageServicesCollector,options,out,polyglotLanguageContext,services,spi,valid
+hcls TruffleFileFactory
+
+CLSS public final static !enum com.oracle.truffle.api.TruffleLanguage$ExitMode
+ outer com.oracle.truffle.api.TruffleLanguage
+fld public final static com.oracle.truffle.api.TruffleLanguage$ExitMode HARD
+fld public final static com.oracle.truffle.api.TruffleLanguage$ExitMode NATURAL
+meth public static com.oracle.truffle.api.TruffleLanguage$ExitMode valueOf(java.lang.String)
+meth public static com.oracle.truffle.api.TruffleLanguage$ExitMode[] values()
+supr java.lang.Enum<com.oracle.truffle.api.TruffleLanguage$ExitMode>
 
 CLSS public final static com.oracle.truffle.api.TruffleLanguage$InlineParsingRequest
  outer com.oracle.truffle.api.TruffleLanguage
@@ -513,7 +627,8 @@ hfds disposed,frame,node,source
 CLSS public abstract static com.oracle.truffle.api.TruffleLanguage$LanguageReference<%0 extends com.oracle.truffle.api.TruffleLanguage>
  outer com.oracle.truffle.api.TruffleLanguage
 cons protected init()
-meth public abstract {com.oracle.truffle.api.TruffleLanguage$LanguageReference%0} get()
+meth public abstract {com.oracle.truffle.api.TruffleLanguage$LanguageReference%0} get(com.oracle.truffle.api.nodes.Node)
+meth public static <%0 extends com.oracle.truffle.api.TruffleLanguage<?>> com.oracle.truffle.api.TruffleLanguage$LanguageReference<{%%0}> create(java.lang.Class<{%%0}>)
 supr java.lang.Object
 
 CLSS public final static com.oracle.truffle.api.TruffleLanguage$ParsingRequest
@@ -525,6 +640,7 @@ hfds argumentNames,disposed,source
 
 CLSS public abstract interface static com.oracle.truffle.api.TruffleLanguage$Provider
  outer com.oracle.truffle.api.TruffleLanguage
+ anno 0 java.lang.Deprecated(null since="23.1")
 meth public abstract com.oracle.truffle.api.TruffleLanguage<?> create()
 meth public abstract java.lang.String getLanguageClassName()
 meth public abstract java.util.Collection<java.lang.String> getServicesClassNames()
@@ -537,19 +653,21 @@ CLSS public abstract interface static !annotation com.oracle.truffle.api.Truffle
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault boolean interactive()
 meth public abstract !hasdefault boolean internal()
+meth public abstract !hasdefault boolean needsAllEncodings()
 meth public abstract !hasdefault com.oracle.truffle.api.TruffleLanguage$ContextPolicy contextPolicy()
+meth public abstract !hasdefault java.lang.Class<? extends com.oracle.truffle.api.InternalResource>[] internalResources()
 meth public abstract !hasdefault java.lang.Class<? extends com.oracle.truffle.api.TruffleFile$FileTypeDetector>[] fileTypeDetectors()
 meth public abstract !hasdefault java.lang.Class<?>[] services()
 meth public abstract !hasdefault java.lang.String defaultMimeType()
 meth public abstract !hasdefault java.lang.String id()
 meth public abstract !hasdefault java.lang.String implementationName()
+meth public abstract !hasdefault java.lang.String name()
 meth public abstract !hasdefault java.lang.String version()
+meth public abstract !hasdefault java.lang.String website()
 meth public abstract !hasdefault java.lang.String[] byteMimeTypes()
 meth public abstract !hasdefault java.lang.String[] characterMimeTypes()
 meth public abstract !hasdefault java.lang.String[] dependentLanguages()
-meth public abstract !hasdefault java.lang.String[] mimeType()
- anno 0 java.lang.Deprecated()
-meth public abstract java.lang.String name()
+meth public abstract !hasdefault org.graalvm.polyglot.SandboxPolicy sandbox()
 
 CLSS public final com.oracle.truffle.api.TruffleLogger
 meth public <%0 extends java.lang.Throwable> {%%0} throwing(java.lang.String,java.lang.String,{%%0})
@@ -594,6 +712,10 @@ supr java.lang.Object
 hfds DEFAULT_VALUE,MAX_CLEANED_REFS,OFF_VALUE,ROOT_NAME,children,childrenLock,levelNum,levelNumStable,levelObj,loggerCache,loggersRefQueue,name,parent
 hcls AbstractLoggerRef,ChildLoggerRef,LoggerCache
 
+CLSS public abstract interface com.oracle.truffle.api.TruffleOptionDescriptors
+intf org.graalvm.options.OptionDescriptors
+meth public abstract org.graalvm.polyglot.SandboxPolicy getSandboxPolicy(java.lang.String)
+
 CLSS public final com.oracle.truffle.api.TruffleOptions
 fld public final static boolean AOT
 fld public final static boolean DetailedRewriteReasons
@@ -604,15 +726,12 @@ fld public final static java.lang.String TraceRewritesFilterClass
 supr java.lang.Object
 
 CLSS public abstract interface com.oracle.truffle.api.TruffleRuntime
+meth public <%0 extends java.lang.Object> {%%0} iterateFrames(com.oracle.truffle.api.frame.FrameInstanceVisitor<{%%0}>)
+meth public <%0 extends java.lang.Object> {%%0} iterateFrames(com.oracle.truffle.api.frame.FrameInstanceVisitor<{%%0}>,int)
 meth public abstract <%0 extends java.lang.Object> {%%0} getCapability(java.lang.Class<{%%0}>)
-meth public abstract <%0 extends java.lang.Object> {%%0} iterateFrames(com.oracle.truffle.api.frame.FrameInstanceVisitor<{%%0}>)
 meth public abstract boolean isProfilingEnabled()
 meth public abstract com.oracle.truffle.api.Assumption createAssumption()
 meth public abstract com.oracle.truffle.api.Assumption createAssumption(java.lang.String)
-meth public abstract com.oracle.truffle.api.CompilerOptions createCompilerOptions()
-meth public abstract com.oracle.truffle.api.RootCallTarget createCallTarget(com.oracle.truffle.api.nodes.RootNode)
-meth public abstract com.oracle.truffle.api.frame.FrameInstance getCallerFrame()
-meth public abstract com.oracle.truffle.api.frame.FrameInstance getCurrentFrame()
 meth public abstract com.oracle.truffle.api.frame.MaterializedFrame createMaterializedFrame(java.lang.Object[])
 meth public abstract com.oracle.truffle.api.frame.MaterializedFrame createMaterializedFrame(java.lang.Object[],com.oracle.truffle.api.frame.FrameDescriptor)
 meth public abstract com.oracle.truffle.api.frame.VirtualFrame createVirtualFrame(java.lang.Object[],com.oracle.truffle.api.frame.FrameDescriptor)
@@ -626,6 +745,56 @@ CLSS public abstract interface com.oracle.truffle.api.TruffleRuntimeAccess
 meth public abstract com.oracle.truffle.api.TruffleRuntime getRuntime()
 meth public int getPriority()
 
+CLSS public abstract com.oracle.truffle.api.TruffleSafepoint
+cons protected init(com.oracle.truffle.api.impl.Accessor$EngineSupport)
+innr public abstract interface static CompiledInterruptible
+innr public abstract interface static CompiledInterruptibleFunction
+innr public abstract interface static Interrupter
+innr public abstract interface static Interruptible
+innr public abstract interface static InterruptibleFunction
+meth public <%0 extends java.lang.Object> void setBlockedWithException(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.TruffleSafepoint$Interrupter,com.oracle.truffle.api.TruffleSafepoint$Interruptible<{%%0}>,{%%0},java.lang.Runnable,java.util.function.Consumer<java.lang.Throwable>)
+ anno 0 java.lang.Deprecated()
+meth public abstract <%0 extends java.lang.Object, %1 extends java.lang.Object> {%%1} setBlockedFunction(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.TruffleSafepoint$Interrupter,com.oracle.truffle.api.TruffleSafepoint$InterruptibleFunction<{%%0},{%%1}>,{%%0},java.lang.Runnable,java.util.function.Consumer<java.lang.Throwable>)
+meth public abstract <%0 extends java.lang.Object> void setBlocked(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.TruffleSafepoint$Interrupter,com.oracle.truffle.api.TruffleSafepoint$Interruptible<{%%0}>,{%%0},java.lang.Runnable,java.util.function.Consumer<java.lang.Throwable>)
+meth public abstract boolean hasPendingSideEffectingActions()
+meth public abstract boolean setAllowActions(boolean)
+meth public abstract boolean setAllowSideEffects(boolean)
+meth public static <%0 extends java.lang.Object, %1 extends java.lang.Object> {%%1} setBlockedThreadInterruptibleFunction(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.TruffleSafepoint$InterruptibleFunction<{%%0},{%%1}>,{%%0})
+meth public static <%0 extends java.lang.Object> void setBlockedThreadInterruptible(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.TruffleSafepoint$Interruptible<{%%0}>,{%%0})
+meth public static com.oracle.truffle.api.TruffleSafepoint getCurrent()
+meth public static void poll(com.oracle.truffle.api.nodes.Node)
+meth public static void pollHere(com.oracle.truffle.api.nodes.Node)
+supr java.lang.Object
+hfds HANDSHAKE
+
+CLSS public abstract interface static com.oracle.truffle.api.TruffleSafepoint$CompiledInterruptible<%0 extends java.lang.Object>
+ outer com.oracle.truffle.api.TruffleSafepoint
+ anno 0 java.lang.FunctionalInterface()
+intf com.oracle.truffle.api.TruffleSafepoint$Interruptible<{com.oracle.truffle.api.TruffleSafepoint$CompiledInterruptible%0}>
+meth public abstract void apply({com.oracle.truffle.api.TruffleSafepoint$CompiledInterruptible%0}) throws java.lang.InterruptedException
+
+CLSS public abstract interface static com.oracle.truffle.api.TruffleSafepoint$CompiledInterruptibleFunction<%0 extends java.lang.Object, %1 extends java.lang.Object>
+ outer com.oracle.truffle.api.TruffleSafepoint
+ anno 0 java.lang.FunctionalInterface()
+intf com.oracle.truffle.api.TruffleSafepoint$InterruptibleFunction<{com.oracle.truffle.api.TruffleSafepoint$CompiledInterruptibleFunction%0},{com.oracle.truffle.api.TruffleSafepoint$CompiledInterruptibleFunction%1}>
+meth public abstract {com.oracle.truffle.api.TruffleSafepoint$CompiledInterruptibleFunction%1} apply({com.oracle.truffle.api.TruffleSafepoint$CompiledInterruptibleFunction%0}) throws java.lang.InterruptedException
+
+CLSS public abstract interface static com.oracle.truffle.api.TruffleSafepoint$Interrupter
+ outer com.oracle.truffle.api.TruffleSafepoint
+fld public final static com.oracle.truffle.api.TruffleSafepoint$Interrupter THREAD_INTERRUPT
+meth public abstract void interrupt(java.lang.Thread)
+meth public abstract void resetInterrupted()
+
+CLSS public abstract interface static com.oracle.truffle.api.TruffleSafepoint$Interruptible<%0 extends java.lang.Object>
+ outer com.oracle.truffle.api.TruffleSafepoint
+ anno 0 java.lang.FunctionalInterface()
+meth public abstract void apply({com.oracle.truffle.api.TruffleSafepoint$Interruptible%0}) throws java.lang.InterruptedException
+
+CLSS public abstract interface static com.oracle.truffle.api.TruffleSafepoint$InterruptibleFunction<%0 extends java.lang.Object, %1 extends java.lang.Object>
+ outer com.oracle.truffle.api.TruffleSafepoint
+ anno 0 java.lang.FunctionalInterface()
+meth public abstract {com.oracle.truffle.api.TruffleSafepoint$InterruptibleFunction%1} apply({com.oracle.truffle.api.TruffleSafepoint$InterruptibleFunction%0}) throws java.lang.InterruptedException
+
 CLSS public final com.oracle.truffle.api.TruffleStackTrace
 meth public java.lang.String toString()
 meth public java.lang.Throwable fillInStackTrace()
@@ -633,7 +802,7 @@ meth public static com.oracle.truffle.api.TruffleStackTrace fillIn(java.lang.Thr
 meth public static java.util.List<com.oracle.truffle.api.TruffleStackTraceElement> getAsynchronousStackTrace(com.oracle.truffle.api.CallTarget,com.oracle.truffle.api.frame.Frame)
 meth public static java.util.List<com.oracle.truffle.api.TruffleStackTraceElement> getStackTrace(java.lang.Throwable)
 supr java.lang.Exception
-hfds EMPTY,UNSAFE,causeFieldIndex,frames,lazyFrames,materializedHostException
+hfds EMPTY,frames,lazyFrames,materializedHostException
 hcls LazyStackTrace,TracebackElement
 
 CLSS public final com.oracle.truffle.api.TruffleStackTraceElement
@@ -644,6 +813,16 @@ meth public java.lang.Object getGuestObject()
 meth public static com.oracle.truffle.api.TruffleStackTraceElement create(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.RootCallTarget,com.oracle.truffle.api.frame.Frame)
 supr java.lang.Object
 hfds frame,location,target
+
+CLSS public final com.oracle.truffle.api.TruffleThreadBuilder
+meth public com.oracle.truffle.api.TruffleThreadBuilder afterLeave(java.lang.Runnable)
+meth public com.oracle.truffle.api.TruffleThreadBuilder beforeEnter(java.lang.Runnable)
+meth public com.oracle.truffle.api.TruffleThreadBuilder context(com.oracle.truffle.api.TruffleContext)
+meth public com.oracle.truffle.api.TruffleThreadBuilder stackSize(long)
+meth public com.oracle.truffle.api.TruffleThreadBuilder threadGroup(java.lang.ThreadGroup)
+meth public java.lang.Thread build()
+supr java.lang.Object
+hfds afterLeave,beforeEnter,polyglotLanguageContext,runnable,stackSize,threadGroup,truffleContext
 
 CLSS public com.oracle.truffle.api.debug.Breakpoint
 innr public abstract interface static ResolveListener
@@ -671,8 +850,8 @@ meth public void setCondition(java.lang.String)
 meth public void setEnabled(boolean)
 meth public void setIgnoreCount(int)
 supr java.lang.Object
-hfds BUILDER_INSTANCE,breakpointBinding,breakpointBindingAttaching,breakpointBindingReady,condition,conditionExistsUnchanged,conditionUnchanged,debugger,disposed,enabled,exceptionFilter,global,hitCount,ignoreCount,locationKey,oneShot,resolveListener,resolved,roWrapper,rootInstanceRef,sessions,sessionsUnchanged,sourceBinding,sourcePredicate,suspendAnchor
-hcls AbstractBreakpointNode,BreakpointAfterNode,BreakpointAfterNodeException,BreakpointBeforeNode,BreakpointConditionFailure,BreakpointNodeFactory,ConditionalBreakNode,GlobalBreakpoint,SessionList
+hfds BUILDER_INSTANCE,breakpointBindingReady,condition,conditionExistsUnchanged,conditionUnchanged,debugger,disposed,enabled,exceptionFilter,execBindings,global,hitCount,ignoreCount,locationKey,locationsInExecutedSources,oneShot,resolveListener,roWrapper,rootInstanceRef,sessions,sessionsUnchanged,sourceBinding,suspendAnchor
+hcls AbstractBreakpointNode,BreakpointAfterNode,BreakpointAfterNodeException,BreakpointBeforeNode,BreakpointConditionFailure,BreakpointNodeFactory,ConditionalBreakNode,GlobalBreakpoint,LocationsInExecutedSources,SessionList
 
 CLSS public final com.oracle.truffle.api.debug.Breakpoint$Builder
  outer com.oracle.truffle.api.debug.Breakpoint
@@ -741,7 +920,7 @@ meth public void printStackTrace(java.io.PrintStream)
 meth public void printStackTrace(java.io.PrintWriter)
 meth public void setStackTrace(java.lang.StackTraceElement[])
 supr java.lang.RuntimeException
-hfds CAUSE_CAPTION,catchLocation,debugAsyncStacks,debugStackTrace,exception,isCatchNodeComputed,javaLikeStackTrace,preferredLanguage,serialVersionUID,session,suspendedEvent,throwLocation
+hfds CAUSE_CAPTION,catchLocation,debugAsyncStacks,debugStackTrace,exception,isCatchNodeComputed,javaLikeStackTrace,preferredLanguage,rawStackTrace,serialVersionUID,session,suspendedEvent,throwLocation
 
 CLSS public final static com.oracle.truffle.api.debug.DebugException$CatchLocation
  outer com.oracle.truffle.api.debug.DebugException
@@ -753,12 +932,13 @@ hfds depth,frame,frameInstance,section,session
 CLSS public final com.oracle.truffle.api.debug.DebugScope
 meth public boolean isFunctionScope()
 meth public com.oracle.truffle.api.debug.DebugScope getParent()
+meth public com.oracle.truffle.api.debug.DebugValue convertRawValue(java.lang.Class<? extends com.oracle.truffle.api.TruffleLanguage<?>>,java.lang.Object)
 meth public com.oracle.truffle.api.debug.DebugValue getDeclaredValue(java.lang.String)
 meth public com.oracle.truffle.api.debug.DebugValue getReceiver()
 meth public com.oracle.truffle.api.debug.DebugValue getRootInstance()
 meth public com.oracle.truffle.api.source.SourceSection getSourceSection()
 meth public java.lang.Iterable<com.oracle.truffle.api.debug.DebugValue> getArguments()
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="20.3")
 meth public java.lang.Iterable<com.oracle.truffle.api.debug.DebugValue> getDeclaredValues()
 meth public java.lang.String getName()
 supr java.lang.Object
@@ -779,7 +959,7 @@ meth public int hashCode()
 meth public java.lang.StackTraceElement getHostTraceElement()
 meth public java.lang.String getName()
 supr java.lang.Object
-hfds currentFrame,depth,event,hostTraceElement
+hfds currentFrame,depth,event,hostTraceElement,name,nameEx
 
 CLSS public final com.oracle.truffle.api.debug.DebugStackTraceElement
 meth public boolean isHost()
@@ -798,34 +978,56 @@ meth public abstract void threadInitialized(com.oracle.truffle.api.debug.DebugCo
 CLSS public abstract com.oracle.truffle.api.debug.DebugValue
 meth public !varargs final com.oracle.truffle.api.debug.DebugValue execute(com.oracle.truffle.api.debug.DebugValue[])
 meth public abstract <%0 extends java.lang.Object> {%%0} as(java.lang.Class<{%%0}>)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="20.1")
 meth public abstract boolean hasReadSideEffects()
 meth public abstract boolean hasWriteSideEffects()
 meth public abstract boolean isInternal()
 meth public abstract boolean isReadable()
 meth public abstract boolean isWritable()
+meth public abstract com.oracle.truffle.api.debug.DebuggerSession getSession()
 meth public abstract java.lang.String getName()
 meth public abstract void set(com.oracle.truffle.api.debug.DebugValue)
 meth public abstract void set(java.lang.Object)
+ anno 0 java.lang.Deprecated(null since="21.2")
 meth public boolean asBoolean()
+meth public boolean equals(java.lang.Object)
+meth public boolean fitsInBigInteger()
 meth public boolean fitsInByte()
 meth public boolean fitsInDouble()
 meth public boolean fitsInFloat()
 meth public boolean fitsInInt()
 meth public boolean fitsInLong()
 meth public boolean fitsInShort()
+meth public boolean hasHashEntries()
+meth public boolean hasIterator()
+meth public boolean hasIteratorNextElement()
 meth public boolean isBoolean()
 meth public boolean isDate()
 meth public boolean isDuration()
+meth public boolean isHashEntryExisting(com.oracle.truffle.api.debug.DebugValue)
+meth public boolean isHashEntryInsertable(com.oracle.truffle.api.debug.DebugValue)
+meth public boolean isHashEntryModifiable(com.oracle.truffle.api.debug.DebugValue)
+meth public boolean isHashEntryReadable(com.oracle.truffle.api.debug.DebugValue)
+meth public boolean isHashEntryRemovable(com.oracle.truffle.api.debug.DebugValue)
+meth public boolean isHashEntryWritable(com.oracle.truffle.api.debug.DebugValue)
 meth public boolean isInstant()
+meth public boolean isIterator()
 meth public boolean isMetaInstance(com.oracle.truffle.api.debug.DebugValue)
 meth public boolean isMetaObject()
 meth public boolean isNumber()
 meth public boolean isString()
 meth public boolean isTime()
 meth public boolean isTimeZone()
+meth public boolean removeHashEntry(com.oracle.truffle.api.debug.DebugValue)
 meth public byte asByte()
 meth public com.oracle.truffle.api.debug.DebugScope getScope()
+meth public com.oracle.truffle.api.debug.DebugValue getHashEntriesIterator()
+meth public com.oracle.truffle.api.debug.DebugValue getHashKeysIterator()
+meth public com.oracle.truffle.api.debug.DebugValue getHashValue(com.oracle.truffle.api.debug.DebugValue)
+meth public com.oracle.truffle.api.debug.DebugValue getHashValueOrDefault(com.oracle.truffle.api.debug.DebugValue,com.oracle.truffle.api.debug.DebugValue)
+meth public com.oracle.truffle.api.debug.DebugValue getHashValuesIterator()
+meth public com.oracle.truffle.api.debug.DebugValue getIterator()
+meth public com.oracle.truffle.api.debug.DebugValue getIteratorNextElement()
 meth public double asDouble()
 meth public final boolean canExecute()
 meth public final boolean isArray()
@@ -840,23 +1042,27 @@ meth public final java.lang.String toDisplayString()
 meth public final java.lang.String toDisplayString(boolean)
 meth public final java.util.Collection<com.oracle.truffle.api.debug.DebugValue> getProperties()
 meth public final java.util.List<com.oracle.truffle.api.debug.Breakpoint> getRootInstanceBreakpoints()
-meth public final java.util.List<com.oracle.truffle.api.debug.DebugValue> getArray()
 meth public float asFloat()
 meth public int asInt()
+meth public int hashCode()
 meth public java.lang.Object getRawValue(java.lang.Class<? extends com.oracle.truffle.api.TruffleLanguage<?>>)
 meth public java.lang.String getMetaQualifiedName()
 meth public java.lang.String getMetaSimpleName()
 meth public java.lang.String toString()
+meth public java.math.BigInteger asBigInteger()
 meth public java.time.Duration asDuration()
 meth public java.time.Instant asInstant()
 meth public java.time.LocalDate asDate()
 meth public java.time.LocalTime asTime()
 meth public java.time.ZoneId asTimeZone()
+meth public java.util.List<com.oracle.truffle.api.debug.DebugValue> getArray()
 meth public long asLong()
+meth public long getHashSize()
 meth public short asShort()
+meth public void putHashEntry(com.oracle.truffle.api.debug.DebugValue,com.oracle.truffle.api.debug.DebugValue)
 supr java.lang.Object
 hfds INTEROP,preferredLanguage
-hcls AbstractDebugCachedValue,AbstractDebugValue,ArrayElementValue,HeapValue,ObjectMemberValue
+hcls AbstractDebugCachedValue,AbstractDebugValue,ArrayElementValue,HashEntriesIteratorValue,HashEntryArrayValue,HashEntryValue,HeapValue,ObjectMemberValue
 
 CLSS public final com.oracle.truffle.api.debug.Debugger
 meth public !varargs com.oracle.truffle.api.debug.DebuggerSession startSession(com.oracle.truffle.api.debug.SuspendedCallback,com.oracle.truffle.api.debug.SourceElement[])
@@ -869,20 +1075,23 @@ meth public static com.oracle.truffle.api.debug.Debugger find(com.oracle.truffle
 meth public static com.oracle.truffle.api.debug.Debugger find(org.graalvm.polyglot.Engine)
 meth public void addBreakpointAddedListener(java.util.function.Consumer<com.oracle.truffle.api.debug.Breakpoint>)
 meth public void addBreakpointRemovedListener(java.util.function.Consumer<com.oracle.truffle.api.debug.Breakpoint>)
+meth public void disableStepping()
 meth public void removeBreakpointAddedListener(java.util.function.Consumer<com.oracle.truffle.api.debug.Breakpoint>)
 meth public void removeBreakpointRemovedListener(java.util.function.Consumer<com.oracle.truffle.api.debug.Breakpoint>)
+meth public void restoreStepping()
 supr java.lang.Object
-hfds ACCESSOR,TRACE,alwaysHaltBreakpoint,breakpointAddedListeners,breakpointRemovedListeners,breakpoints,env,propSupport,sessions
+hfds ACCESSOR,TRACE,alwaysHaltBreakpoint,breakpointAddedListeners,breakpointRemovedListeners,breakpoints,disabledSteppingCount,env,propSupport,sessions
 hcls AccessorDebug
 
 CLSS public final com.oracle.truffle.api.debug.DebuggerSession
 intf java.io.Closeable
 meth public boolean isBreakpointsActive()
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="19.0")
 meth public boolean isBreakpointsActive(com.oracle.truffle.api.debug.Breakpoint$Kind)
 meth public boolean suspendHere(com.oracle.truffle.api.nodes.Node)
 meth public com.oracle.truffle.api.debug.Breakpoint install(com.oracle.truffle.api.debug.Breakpoint)
 meth public com.oracle.truffle.api.debug.DebugScope getTopScope(java.lang.String)
+meth public com.oracle.truffle.api.debug.DebugValue createPrimitiveValue(java.lang.Object,com.oracle.truffle.api.nodes.LanguageInfo)
 meth public com.oracle.truffle.api.debug.Debugger getDebugger()
 meth public com.oracle.truffle.api.source.Source resolveSource(com.oracle.truffle.api.source.Source)
 meth public java.lang.String toString()
@@ -893,7 +1102,7 @@ meth public void resume(java.lang.Thread)
 meth public void resumeAll()
 meth public void setAsynchronousStackDepth(int)
 meth public void setBreakpointsActive(boolean)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="19.0")
 meth public void setBreakpointsActive(com.oracle.truffle.api.debug.Breakpoint$Kind,boolean)
 meth public void setContextsListener(com.oracle.truffle.api.debug.DebugContextsListener,boolean)
 meth public void setShowHostStackFrames(boolean)
@@ -904,8 +1113,8 @@ meth public void suspend(java.lang.Thread)
 meth public void suspendAll()
 meth public void suspendNextExecution()
 supr java.lang.Object
-hfds ANCHOR_SET_AFTER,ANCHOR_SET_ALL,ANCHOR_SET_BEFORE,SESSIONS,allBindings,alwaysHaltBreakpointsActive,breakpoints,breakpointsUnresolved,breakpointsUnresolvedEmpty,callback,closed,currentSuspendedEventMap,debugger,exceptionBreakpointsActive,executionLifecycle,hasExpressionElement,hasRootElement,ignoreLanguageContextInitialization,inEvalInContext,includeInternal,locationBreakpointsActive,sessionId,showHostStackFrames,sourceElements,sourceFilter,sources,stepping,strategyMap,suspendAll,suspendNext,suspensionFilterUnchanged,syntaxElementsBinding,threadSuspensions
-hcls Caller,RootSteppingDepthNode,StableBoolean,SteppingNode,ThreadSuspension
+hfds ANCHOR_SET_AFTER,ANCHOR_SET_ALL,ANCHOR_SET_BEFORE,SESSIONS,allBindings,alwaysHaltBreakpointsActive,breakpoints,callback,closed,currentSuspendedEventMap,debugger,exceptionBreakpointsActive,executionLifecycle,hasExpressionElement,hasRootElement,ignoreLanguageContextInitialization,inEvalInContext,includeInternal,locationBreakpointsActive,sessionId,showHostStackFrames,sourceElements,sourceFilter,sources,stepping,steppingEnabledSlots,strategyMap,suspendAll,suspendNext,suspensionFilterUnchanged,syntaxElementsBinding,threadSuspensions
+hcls Caller,RootSteppingDepthNode,StableBoolean,SteppingNode,SuspendContextAndFrame,ThreadSuspension
 
 CLSS public final com.oracle.truffle.api.debug.DebuggerTags
 innr public final AlwaysHalt
@@ -973,6 +1182,7 @@ meth public java.util.List<java.util.List<com.oracle.truffle.api.debug.DebugStac
 meth public void prepareContinue()
 meth public void prepareKill()
 meth public void prepareUnwindFrame(com.oracle.truffle.api.debug.DebugStackFrame)
+meth public void prepareUnwindFrame(com.oracle.truffle.api.debug.DebugStackFrame,com.oracle.truffle.api.debug.DebugValue)
 meth public void setReturnValue(com.oracle.truffle.api.debug.DebugValue)
 supr java.lang.Object
 hfds HOST_INTEROP_NODE_NAME,breakpoints,cachedAsyncFrames,cachedFrames,conditionFailures,context,disposed,exception,inputValuesProvider,insertableNode,materializedFrame,nextStrategy,returnValue,session,sourceSection,suspendAnchor,thread
@@ -994,6 +1204,10 @@ meth public com.oracle.truffle.api.debug.SuspensionFilter$Builder sourceIs(java.
 supr java.lang.Object
 hfds ignoreLanguageContextInitialization,includeInternal,sourcePredicate
 
+CLSS public final com.oracle.truffle.api.dsl.AOTSupport
+meth public static void prepareForAOT(com.oracle.truffle.api.nodes.RootNode)
+supr java.lang.Object
+
 CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.Bind
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PARAMETER])
@@ -1008,8 +1222,11 @@ innr public abstract interface static !annotation Shared
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault boolean adopt()
 meth public abstract !hasdefault boolean allowUncached()
+meth public abstract !hasdefault boolean inline()
+meth public abstract !hasdefault boolean neverDefault()
 meth public abstract !hasdefault boolean weak()
 meth public abstract !hasdefault int dimensions()
+meth public abstract !hasdefault java.lang.String inlineMethod()
 meth public abstract !hasdefault java.lang.String uncached()
 meth public abstract !hasdefault java.lang.String value()
 meth public abstract !hasdefault java.lang.String[] parameters()
@@ -1025,24 +1242,31 @@ CLSS public abstract interface static !annotation com.oracle.truffle.api.dsl.Cac
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PARAMETER])
 intf java.lang.annotation.Annotation
-meth public abstract java.lang.String value()
-
-CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.CachedContext
- anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
- anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PARAMETER])
-intf java.lang.annotation.Annotation
-meth public abstract java.lang.Class<? extends com.oracle.truffle.api.TruffleLanguage> value()
-
-CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.CachedLanguage
- anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
- anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PARAMETER])
-intf java.lang.annotation.Annotation
+meth public abstract !hasdefault java.lang.String value()
 
 CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.CreateCast
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
 intf java.lang.annotation.Annotation
 meth public abstract java.lang.String[] value()
+
+CLSS public abstract com.oracle.truffle.api.dsl.DSLSupport
+innr public abstract interface static SpecializationDataNode
+meth public static <%0 extends com.oracle.truffle.api.nodes.NodeInterface> {%%0} maybeInsert(com.oracle.truffle.api.nodes.Node,{%%0})
+meth public static <%0 extends com.oracle.truffle.api.nodes.NodeInterface> {%%0}[] maybeInsert(com.oracle.truffle.api.nodes.Node,{%%0}[])
+meth public static <%0 extends java.lang.Enum<?>> {%%0}[] lookupEnumConstants(java.lang.Class<{%%0}>)
+meth public static boolean assertIdempotence(boolean)
+supr java.lang.Object
+hfds ENUM_CONSTANTS
+
+CLSS public abstract interface static com.oracle.truffle.api.dsl.DSLSupport$SpecializationDataNode
+ outer com.oracle.truffle.api.dsl.DSLSupport
+
+CLSS public abstract interface com.oracle.truffle.api.dsl.ExecuteTracingSupport
+meth public abstract boolean isTracingEnabled()
+meth public void traceOnEnter(java.lang.Object[])
+meth public void traceOnException(java.lang.Throwable)
+meth public void traceOnReturn(java.lang.Object)
 
 CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.Executed
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
@@ -1055,8 +1279,49 @@ CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.Fallback
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
 intf java.lang.annotation.Annotation
 
+CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.GenerateAOT
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+innr public abstract interface static !annotation Exclude
+innr public abstract interface static Provider
+intf java.lang.annotation.Annotation
+
+CLSS public abstract interface static !annotation com.oracle.truffle.api.dsl.GenerateAOT$Exclude
+ outer com.oracle.truffle.api.dsl.GenerateAOT
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
+intf java.lang.annotation.Annotation
+
+CLSS public abstract interface static com.oracle.truffle.api.dsl.GenerateAOT$Provider
+ outer com.oracle.truffle.api.dsl.GenerateAOT
+meth public void prepareForAOT(com.oracle.truffle.api.TruffleLanguage<?>,com.oracle.truffle.api.nodes.RootNode)
+meth public void prepareForAOT(com.oracle.truffle.api.TruffleLanguage<?>,com.oracle.truffle.api.nodes.RootNode,com.oracle.truffle.api.nodes.Node)
+
+CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.GenerateCached
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+intf java.lang.annotation.Annotation
+meth public abstract !hasdefault boolean alwaysInlineCached()
+meth public abstract !hasdefault boolean inherit()
+meth public abstract !hasdefault boolean value()
+
+CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.GenerateInline
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+intf java.lang.annotation.Annotation
+meth public abstract !hasdefault boolean inherit()
+meth public abstract !hasdefault boolean inlineByDefault()
+meth public abstract !hasdefault boolean value()
+
 CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.GenerateNodeFactory
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+intf java.lang.annotation.Annotation
+meth public abstract !hasdefault boolean inherit()
+meth public abstract !hasdefault boolean value()
+
+CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.GeneratePackagePrivate
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
 
@@ -1065,6 +1330,7 @@ CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.GenerateUn
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault boolean inherit()
+meth public abstract !hasdefault boolean value()
 
 CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.GeneratedBy
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
@@ -1072,6 +1338,11 @@ CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.GeneratedB
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault java.lang.String methodName()
 meth public abstract java.lang.Class<?> value()
+
+CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.Idempotent
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
+intf java.lang.annotation.Annotation
 
 CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.ImplicitCast
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
@@ -1084,6 +1355,163 @@ CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.ImportStat
 intf java.lang.annotation.Annotation
 meth public abstract java.lang.Class<?>[] value()
 
+CLSS public final com.oracle.truffle.api.dsl.InlineSupport
+innr public abstract interface static !annotation RequiredField
+innr public abstract interface static !annotation RequiredFields
+innr public abstract interface static !annotation UnsafeAccessedField
+innr public abstract static InlinableField
+innr public final static BooleanField
+innr public final static ByteField
+innr public final static CharField
+innr public final static DoubleField
+innr public final static FloatField
+innr public final static InlineTarget
+innr public final static IntField
+innr public final static LongField
+innr public final static ReferenceField
+innr public final static ShortField
+innr public final static StateField
+meth public !varargs static boolean validate(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.dsl.InlineSupport$InlinableField,com.oracle.truffle.api.dsl.InlineSupport$InlinableField,com.oracle.truffle.api.dsl.InlineSupport$InlinableField[])
+meth public static boolean validate(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.dsl.InlineSupport$InlinableField)
+meth public static boolean validate(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.dsl.InlineSupport$InlinableField,com.oracle.truffle.api.dsl.InlineSupport$InlinableField)
+supr java.lang.Object
+hfds PARENT
+hcls UnsafeField,VarHandleField
+
+CLSS public final static com.oracle.truffle.api.dsl.InlineSupport$BooleanField
+ outer com.oracle.truffle.api.dsl.InlineSupport
+meth public boolean get(com.oracle.truffle.api.nodes.Node)
+meth public com.oracle.truffle.api.dsl.InlineSupport$BooleanField createParentAccessor(java.lang.Class<? extends com.oracle.truffle.api.nodes.Node>)
+ anno 0 java.lang.Deprecated()
+meth public static com.oracle.truffle.api.dsl.InlineSupport$BooleanField create(java.lang.invoke.MethodHandles$Lookup,java.lang.String)
+meth public void set(com.oracle.truffle.api.nodes.Node,boolean)
+supr com.oracle.truffle.api.dsl.InlineSupport$InlinableField
+
+CLSS public final static com.oracle.truffle.api.dsl.InlineSupport$ByteField
+ outer com.oracle.truffle.api.dsl.InlineSupport
+meth public byte get(com.oracle.truffle.api.nodes.Node)
+meth public com.oracle.truffle.api.dsl.InlineSupport$ByteField createParentAccessor(java.lang.Class<? extends com.oracle.truffle.api.nodes.Node>)
+ anno 0 java.lang.Deprecated()
+meth public static com.oracle.truffle.api.dsl.InlineSupport$ByteField create(java.lang.invoke.MethodHandles$Lookup,java.lang.String)
+meth public void set(com.oracle.truffle.api.nodes.Node,byte)
+supr com.oracle.truffle.api.dsl.InlineSupport$InlinableField
+
+CLSS public final static com.oracle.truffle.api.dsl.InlineSupport$CharField
+ outer com.oracle.truffle.api.dsl.InlineSupport
+meth public char get(com.oracle.truffle.api.nodes.Node)
+meth public com.oracle.truffle.api.dsl.InlineSupport$CharField createParentAccessor(java.lang.Class<? extends com.oracle.truffle.api.nodes.Node>)
+ anno 0 java.lang.Deprecated()
+meth public static com.oracle.truffle.api.dsl.InlineSupport$CharField create(java.lang.invoke.MethodHandles$Lookup,java.lang.String)
+meth public void set(com.oracle.truffle.api.nodes.Node,char)
+supr com.oracle.truffle.api.dsl.InlineSupport$InlinableField
+
+CLSS public final static com.oracle.truffle.api.dsl.InlineSupport$DoubleField
+ outer com.oracle.truffle.api.dsl.InlineSupport
+meth public com.oracle.truffle.api.dsl.InlineSupport$DoubleField createParentAccessor(java.lang.Class<? extends com.oracle.truffle.api.nodes.Node>)
+ anno 0 java.lang.Deprecated()
+meth public double get(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.dsl.InlineSupport$DoubleField create(java.lang.invoke.MethodHandles$Lookup,java.lang.String)
+meth public void set(com.oracle.truffle.api.nodes.Node,double)
+supr com.oracle.truffle.api.dsl.InlineSupport$InlinableField
+
+CLSS public final static com.oracle.truffle.api.dsl.InlineSupport$FloatField
+ outer com.oracle.truffle.api.dsl.InlineSupport
+meth public com.oracle.truffle.api.dsl.InlineSupport$FloatField createParentAccessor(java.lang.Class<? extends com.oracle.truffle.api.nodes.Node>)
+ anno 0 java.lang.Deprecated()
+meth public float get(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.dsl.InlineSupport$FloatField create(java.lang.invoke.MethodHandles$Lookup,java.lang.String)
+meth public void set(com.oracle.truffle.api.nodes.Node,float)
+supr com.oracle.truffle.api.dsl.InlineSupport$InlinableField
+
+CLSS public abstract static com.oracle.truffle.api.dsl.InlineSupport$InlinableField
+ outer com.oracle.truffle.api.dsl.InlineSupport
+meth public final boolean validate(com.oracle.truffle.api.nodes.Node)
+supr java.lang.Object
+
+CLSS public final static com.oracle.truffle.api.dsl.InlineSupport$InlineTarget
+ outer com.oracle.truffle.api.dsl.InlineSupport
+meth public !varargs static com.oracle.truffle.api.dsl.InlineSupport$InlineTarget create(java.lang.Class<?>,com.oracle.truffle.api.dsl.InlineSupport$InlinableField[])
+meth public <%0 extends com.oracle.truffle.api.dsl.InlineSupport$InlinableField> {%%0} getPrimitive(int,java.lang.Class<{%%0}>)
+meth public <%0 extends java.lang.Object> com.oracle.truffle.api.dsl.InlineSupport$ReferenceField<{%%0}> getReference(int,java.lang.Class<?>)
+meth public com.oracle.truffle.api.dsl.InlineSupport$StateField getState(int,int)
+meth public java.lang.Class<?> getTargetClass()
+supr java.lang.Object
+hfds targetClass,updaters
+
+CLSS public final static com.oracle.truffle.api.dsl.InlineSupport$IntField
+ outer com.oracle.truffle.api.dsl.InlineSupport
+meth public com.oracle.truffle.api.dsl.InlineSupport$IntField createParentAccessor(java.lang.Class<? extends com.oracle.truffle.api.nodes.Node>)
+ anno 0 java.lang.Deprecated()
+meth public int get(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.dsl.InlineSupport$IntField create(java.lang.invoke.MethodHandles$Lookup,java.lang.String)
+meth public void set(com.oracle.truffle.api.nodes.Node,int)
+supr com.oracle.truffle.api.dsl.InlineSupport$InlinableField
+
+CLSS public final static com.oracle.truffle.api.dsl.InlineSupport$LongField
+ outer com.oracle.truffle.api.dsl.InlineSupport
+meth public com.oracle.truffle.api.dsl.InlineSupport$LongField createParentAccessor(java.lang.Class<? extends com.oracle.truffle.api.nodes.Node>)
+ anno 0 java.lang.Deprecated()
+meth public long get(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.dsl.InlineSupport$LongField create(java.lang.invoke.MethodHandles$Lookup,java.lang.String)
+meth public void set(com.oracle.truffle.api.nodes.Node,long)
+supr com.oracle.truffle.api.dsl.InlineSupport$InlinableField
+
+CLSS public final static com.oracle.truffle.api.dsl.InlineSupport$ReferenceField<%0 extends java.lang.Object>
+ outer com.oracle.truffle.api.dsl.InlineSupport
+meth public boolean compareAndSet(com.oracle.truffle.api.nodes.Node,{com.oracle.truffle.api.dsl.InlineSupport$ReferenceField%0},{com.oracle.truffle.api.dsl.InlineSupport$ReferenceField%0})
+meth public com.oracle.truffle.api.dsl.InlineSupport$ReferenceField<{com.oracle.truffle.api.dsl.InlineSupport$ReferenceField%0}> createParentAccessor(java.lang.Class<? extends com.oracle.truffle.api.nodes.Node>)
+ anno 0 java.lang.Deprecated()
+meth public static <%0 extends java.lang.Object> com.oracle.truffle.api.dsl.InlineSupport$ReferenceField<{%%0}> create(java.lang.invoke.MethodHandles$Lookup,java.lang.String,java.lang.Class<{%%0}>)
+meth public void set(com.oracle.truffle.api.nodes.Node,{com.oracle.truffle.api.dsl.InlineSupport$ReferenceField%0})
+meth public {com.oracle.truffle.api.dsl.InlineSupport$ReferenceField%0} get(com.oracle.truffle.api.nodes.Node)
+meth public {com.oracle.truffle.api.dsl.InlineSupport$ReferenceField%0} getVolatile(com.oracle.truffle.api.nodes.Node)
+supr com.oracle.truffle.api.dsl.InlineSupport$InlinableField
+hfds valueClass
+
+CLSS public abstract interface static !annotation com.oracle.truffle.api.dsl.InlineSupport$RequiredField
+ outer com.oracle.truffle.api.dsl.InlineSupport
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class com.oracle.truffle.api.dsl.InlineSupport$RequiredFields)
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PARAMETER])
+intf java.lang.annotation.Annotation
+meth public abstract !hasdefault int bits()
+meth public abstract !hasdefault int dimensions()
+meth public abstract !hasdefault java.lang.Class<?> type()
+meth public abstract java.lang.Class<? extends com.oracle.truffle.api.dsl.InlineSupport$InlinableField> value()
+
+CLSS public abstract interface static !annotation com.oracle.truffle.api.dsl.InlineSupport$RequiredFields
+ outer com.oracle.truffle.api.dsl.InlineSupport
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PARAMETER])
+intf java.lang.annotation.Annotation
+meth public abstract com.oracle.truffle.api.dsl.InlineSupport$RequiredField[] value()
+
+CLSS public final static com.oracle.truffle.api.dsl.InlineSupport$ShortField
+ outer com.oracle.truffle.api.dsl.InlineSupport
+meth public com.oracle.truffle.api.dsl.InlineSupport$ShortField createParentAccessor(java.lang.Class<? extends com.oracle.truffle.api.nodes.Node>)
+ anno 0 java.lang.Deprecated()
+meth public short get(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.dsl.InlineSupport$ShortField create(java.lang.invoke.MethodHandles$Lookup,java.lang.String)
+meth public void set(com.oracle.truffle.api.nodes.Node,short)
+supr com.oracle.truffle.api.dsl.InlineSupport$InlinableField
+
+CLSS public final static com.oracle.truffle.api.dsl.InlineSupport$StateField
+ outer com.oracle.truffle.api.dsl.InlineSupport
+meth public com.oracle.truffle.api.dsl.InlineSupport$StateField createParentAccessor(java.lang.Class<? extends com.oracle.truffle.api.nodes.Node>)
+ anno 0 java.lang.Deprecated()
+meth public com.oracle.truffle.api.dsl.InlineSupport$StateField subUpdater(int,int)
+meth public int get(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.dsl.InlineSupport$StateField create(java.lang.invoke.MethodHandles$Lookup,java.lang.String)
+meth public void set(com.oracle.truffle.api.nodes.Node,int)
+supr com.oracle.truffle.api.dsl.InlineSupport$InlinableField
+hfds bitLength,bitMask,bitOffset
+
+CLSS public abstract interface static !annotation com.oracle.truffle.api.dsl.InlineSupport$UnsafeAccessedField
+ outer com.oracle.truffle.api.dsl.InlineSupport
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD])
+intf java.lang.annotation.Annotation
+
 CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.Introspectable
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
@@ -1093,15 +1521,18 @@ CLSS public final com.oracle.truffle.api.dsl.Introspection
 innr public abstract interface static Provider
 innr public final static SpecializationInfo
 meth public static boolean isIntrospectable(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.dsl.Introspection$SpecializationInfo getSpecialization(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.nodes.Node,java.lang.String)
 meth public static com.oracle.truffle.api.dsl.Introspection$SpecializationInfo getSpecialization(com.oracle.truffle.api.nodes.Node,java.lang.String)
 meth public static java.util.List<com.oracle.truffle.api.dsl.Introspection$SpecializationInfo> getSpecializations(com.oracle.truffle.api.nodes.Node)
+meth public static java.util.List<com.oracle.truffle.api.dsl.Introspection$SpecializationInfo> getSpecializations(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.nodes.Node)
 supr java.lang.Object
 hfds EMPTY_CACHED,NO_CACHED,data
 
 CLSS public abstract interface static com.oracle.truffle.api.dsl.Introspection$Provider
  outer com.oracle.truffle.api.dsl.Introspection
 meth public !varargs static com.oracle.truffle.api.dsl.Introspection create(java.lang.Object[])
-meth public abstract com.oracle.truffle.api.dsl.Introspection getIntrospectionData()
+meth public com.oracle.truffle.api.dsl.Introspection getIntrospectionData()
+meth public com.oracle.truffle.api.dsl.Introspection getIntrospectionData(com.oracle.truffle.api.nodes.Node)
 
 CLSS public final static com.oracle.truffle.api.dsl.Introspection$SpecializationInfo
  outer com.oracle.truffle.api.dsl.Introspection
@@ -1109,16 +1540,26 @@ meth public boolean isActive()
 meth public boolean isExcluded()
 meth public int getInstances()
 meth public java.lang.String getMethodName()
+meth public java.lang.String toString()
 meth public java.util.List<java.lang.Object> getCachedData(int)
 supr java.lang.Object
 hfds cachedData,methodName,state
+
+CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.NeverDefault
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD, FIELD, PARAMETER])
+intf java.lang.annotation.Annotation
 
 CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.NodeChild
  anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class com.oracle.truffle.api.dsl.NodeChildren)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
+meth public abstract !hasdefault boolean allowUncached()
+meth public abstract !hasdefault boolean implicit()
 meth public abstract !hasdefault java.lang.Class<?> type()
+meth public abstract !hasdefault java.lang.String implicitCreate()
+meth public abstract !hasdefault java.lang.String uncached()
 meth public abstract !hasdefault java.lang.String value()
 meth public abstract !hasdefault java.lang.String[] executeWith()
 
@@ -1149,6 +1590,11 @@ CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.NodeFields
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault com.oracle.truffle.api.dsl.NodeField[] value()
 
+CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.NonIdempotent
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
+intf java.lang.annotation.Annotation
+
 CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.ReportPolymorphism
  anno 0 java.lang.annotation.Inherited()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
@@ -1174,6 +1620,7 @@ CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.Specializa
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
 intf java.lang.annotation.Annotation
+meth public abstract !hasdefault int unroll()
 meth public abstract !hasdefault java.lang.Class<? extends java.lang.Throwable>[] rewriteOn()
 meth public abstract !hasdefault java.lang.String insertBefore()
 meth public abstract !hasdefault java.lang.String limit()
@@ -1208,6 +1655,12 @@ meth public abstract void acceptExecute(int,java.lang.Class<?>)
 meth public abstract void acceptExecute(int,java.lang.Class<?>,java.lang.Class<?>)
 meth public static com.oracle.truffle.api.dsl.SpecializationStatistics$NodeStatistics create(com.oracle.truffle.api.nodes.Node,java.lang.String[])
 supr java.lang.Object
+
+CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.SuppressPackageWarnings
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PACKAGE])
+intf java.lang.annotation.Annotation
+meth public abstract java.lang.String[] value()
 
 CLSS public abstract interface !annotation com.oracle.truffle.api.dsl.TypeCast
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
@@ -1250,84 +1703,103 @@ cons protected init(java.lang.String)
 cons protected init(java.lang.String,com.oracle.truffle.api.nodes.Node)
 cons protected init(java.lang.String,java.lang.Throwable,int,com.oracle.truffle.api.nodes.Node)
 fld public final static int UNLIMITED_STACK_TRACE = -1
-intf com.oracle.truffle.api.TruffleException
 intf com.oracle.truffle.api.interop.TruffleObject
-meth public final boolean isCancelled()
- anno 0 java.lang.Deprecated()
-meth public final boolean isExit()
- anno 0 java.lang.Deprecated()
-meth public final boolean isIncompleteSource()
- anno 0 java.lang.Deprecated()
-meth public final boolean isInternalError()
- anno 0 java.lang.Deprecated()
-meth public final boolean isSyntaxError()
- anno 0 java.lang.Deprecated()
 meth public final com.oracle.truffle.api.nodes.Node getLocation()
-meth public final com.oracle.truffle.api.source.SourceSection getSourceLocation()
- anno 0 java.lang.Deprecated()
-meth public final int getExitStatus()
- anno 0 java.lang.Deprecated()
 meth public final int getStackTraceElementLimit()
-meth public final java.lang.Object getExceptionObject()
- anno 0 java.lang.Deprecated()
 meth public final java.lang.Throwable fillInStackTrace()
 meth public final java.lang.Throwable getCause()
-meth public final java.lang.Throwable initCause(java.lang.Throwable)
- anno 0 java.lang.Deprecated()
 supr java.lang.RuntimeException
 hfds cause,lazyStackTrace,location,stackTraceElementLimit
 
 CLSS public abstract interface com.oracle.truffle.api.frame.Frame
-meth public abstract boolean getBoolean(com.oracle.truffle.api.frame.FrameSlot) throws com.oracle.truffle.api.frame.FrameSlotTypeException
-meth public abstract boolean isBoolean(com.oracle.truffle.api.frame.FrameSlot)
-meth public abstract boolean isByte(com.oracle.truffle.api.frame.FrameSlot)
-meth public abstract boolean isDouble(com.oracle.truffle.api.frame.FrameSlot)
-meth public abstract boolean isFloat(com.oracle.truffle.api.frame.FrameSlot)
-meth public abstract boolean isInt(com.oracle.truffle.api.frame.FrameSlot)
-meth public abstract boolean isLong(com.oracle.truffle.api.frame.FrameSlot)
-meth public abstract boolean isObject(com.oracle.truffle.api.frame.FrameSlot)
-meth public abstract byte getByte(com.oracle.truffle.api.frame.FrameSlot) throws com.oracle.truffle.api.frame.FrameSlotTypeException
 meth public abstract com.oracle.truffle.api.frame.FrameDescriptor getFrameDescriptor()
 meth public abstract com.oracle.truffle.api.frame.MaterializedFrame materialize()
-meth public abstract double getDouble(com.oracle.truffle.api.frame.FrameSlot) throws com.oracle.truffle.api.frame.FrameSlotTypeException
-meth public abstract float getFloat(com.oracle.truffle.api.frame.FrameSlot) throws com.oracle.truffle.api.frame.FrameSlotTypeException
-meth public abstract int getInt(com.oracle.truffle.api.frame.FrameSlot) throws com.oracle.truffle.api.frame.FrameSlotTypeException
-meth public abstract java.lang.Object getObject(com.oracle.truffle.api.frame.FrameSlot) throws com.oracle.truffle.api.frame.FrameSlotTypeException
-meth public abstract java.lang.Object getValue(com.oracle.truffle.api.frame.FrameSlot)
 meth public abstract java.lang.Object[] getArguments()
-meth public abstract long getLong(com.oracle.truffle.api.frame.FrameSlot) throws com.oracle.truffle.api.frame.FrameSlotTypeException
-meth public abstract void setBoolean(com.oracle.truffle.api.frame.FrameSlot,boolean)
-meth public abstract void setByte(com.oracle.truffle.api.frame.FrameSlot,byte)
-meth public abstract void setDouble(com.oracle.truffle.api.frame.FrameSlot,double)
-meth public abstract void setFloat(com.oracle.truffle.api.frame.FrameSlot,float)
-meth public abstract void setInt(com.oracle.truffle.api.frame.FrameSlot,int)
-meth public abstract void setLong(com.oracle.truffle.api.frame.FrameSlot,long)
-meth public abstract void setObject(com.oracle.truffle.api.frame.FrameSlot,java.lang.Object)
+meth public boolean getBoolean(int)
+meth public boolean getBooleanStatic(int)
+meth public boolean isBoolean(int)
+meth public boolean isByte(int)
+meth public boolean isDouble(int)
+meth public boolean isFloat(int)
+meth public boolean isInt(int)
+meth public boolean isLong(int)
+meth public boolean isObject(int)
+meth public boolean isStatic(int)
+meth public byte getByte(int)
+meth public byte getByteStatic(int)
+meth public byte getTag(int)
+meth public double getDouble(int)
+meth public double getDoubleStatic(int)
+meth public float getFloat(int)
+meth public float getFloatStatic(int)
+meth public int getInt(int)
+meth public int getIntStatic(int)
+meth public java.lang.Object getAuxiliarySlot(int)
+meth public java.lang.Object getObject(int)
+meth public java.lang.Object getObjectStatic(int)
+meth public java.lang.Object getValue(int)
+meth public long getLong(int)
+meth public long getLongStatic(int)
+meth public void clear(int)
+meth public void clearObjectStatic(int)
+meth public void clearPrimitiveStatic(int)
+meth public void clearStatic(int)
+meth public void copy(int,int)
+meth public void copyObjectStatic(int,int)
+meth public void copyPrimitiveStatic(int,int)
+meth public void copyStatic(int,int)
+meth public void setAuxiliarySlot(int,java.lang.Object)
+meth public void setBoolean(int,boolean)
+meth public void setBooleanStatic(int,boolean)
+meth public void setByte(int,byte)
+meth public void setByteStatic(int,byte)
+meth public void setDouble(int,double)
+meth public void setDoubleStatic(int,double)
+meth public void setFloat(int,float)
+meth public void setFloatStatic(int,float)
+meth public void setInt(int,int)
+meth public void setIntStatic(int,int)
+meth public void setLong(int,long)
+meth public void setLongStatic(int,long)
+meth public void setObject(int,java.lang.Object)
+meth public void setObjectStatic(int,java.lang.Object)
+meth public void swap(int,int)
+meth public void swapObjectStatic(int,int)
+meth public void swapPrimitiveStatic(int,int)
+meth public void swapStatic(int,int)
 
 CLSS public final com.oracle.truffle.api.frame.FrameDescriptor
 cons public init()
 cons public init(java.lang.Object)
+innr public final static Builder
 intf java.lang.Cloneable
-meth public com.oracle.truffle.api.Assumption getNotInFrameAssumption(java.lang.Object)
-meth public com.oracle.truffle.api.Assumption getVersion()
 meth public com.oracle.truffle.api.frame.FrameDescriptor copy()
-meth public com.oracle.truffle.api.frame.FrameSlot addFrameSlot(java.lang.Object)
-meth public com.oracle.truffle.api.frame.FrameSlot addFrameSlot(java.lang.Object,com.oracle.truffle.api.frame.FrameSlotKind)
-meth public com.oracle.truffle.api.frame.FrameSlot addFrameSlot(java.lang.Object,java.lang.Object,com.oracle.truffle.api.frame.FrameSlotKind)
-meth public com.oracle.truffle.api.frame.FrameSlot findFrameSlot(java.lang.Object)
-meth public com.oracle.truffle.api.frame.FrameSlot findOrAddFrameSlot(java.lang.Object)
-meth public com.oracle.truffle.api.frame.FrameSlot findOrAddFrameSlot(java.lang.Object,com.oracle.truffle.api.frame.FrameSlotKind)
-meth public com.oracle.truffle.api.frame.FrameSlot findOrAddFrameSlot(java.lang.Object,java.lang.Object,com.oracle.truffle.api.frame.FrameSlotKind)
-meth public com.oracle.truffle.api.frame.FrameSlotKind getFrameSlotKind(com.oracle.truffle.api.frame.FrameSlot)
-meth public int getSize()
+meth public com.oracle.truffle.api.frame.FrameSlotKind getSlotKind(int)
+meth public int findOrAddAuxiliarySlot(java.lang.Object)
+meth public int getNumberOfAuxiliarySlots()
+meth public int getNumberOfSlots()
 meth public java.lang.Object getDefaultValue()
+meth public java.lang.Object getInfo()
+meth public java.lang.Object getSlotInfo(int)
+meth public java.lang.Object getSlotName(int)
 meth public java.lang.String toString()
-meth public java.util.List<? extends com.oracle.truffle.api.frame.FrameSlot> getSlots()
-meth public java.util.Set<java.lang.Object> getIdentifiers()
-meth public void removeFrameSlot(java.lang.Object)
-meth public void setFrameSlotKind(com.oracle.truffle.api.frame.FrameSlot,com.oracle.truffle.api.frame.FrameSlotKind)
+meth public java.util.Map<java.lang.Object,java.lang.Integer> getAuxiliarySlots()
+meth public static com.oracle.truffle.api.frame.FrameDescriptor$Builder newBuilder()
+meth public static com.oracle.truffle.api.frame.FrameDescriptor$Builder newBuilder(int)
+meth public void disableAuxiliarySlot(java.lang.Object)
+meth public void setSlotKind(int,com.oracle.truffle.api.frame.FrameSlotKind)
 supr java.lang.Object
-hfds NEVER_PART_OF_COMPILATION_MESSAGE,defaultValue,identifierToNotInFrameAssumptionMap,identifierToSlotMap,lock,materializeCalled,size,slots,version
+hfds ALL_STATIC_MODE,EMPTY_BYTE_ARRAY,MIXED_STATIC_MODE,NEVER_PART_OF_COMPILATION_MESSAGE,NO_STATIC_MODE,activeAuxiliarySlotCount,auxiliarySlotCount,auxiliarySlotMap,defaultValue,descriptorInfo,disabledAuxiliarySlots,indexedSlotInfos,indexedSlotNames,indexedSlotTags,materializeCalled,staticMode
+
+CLSS public final static com.oracle.truffle.api.frame.FrameDescriptor$Builder
+ outer com.oracle.truffle.api.frame.FrameDescriptor
+meth public com.oracle.truffle.api.frame.FrameDescriptor build()
+meth public com.oracle.truffle.api.frame.FrameDescriptor$Builder defaultValue(java.lang.Object)
+meth public com.oracle.truffle.api.frame.FrameDescriptor$Builder info(java.lang.Object)
+meth public int addSlot(com.oracle.truffle.api.frame.FrameSlotKind,java.lang.Object,java.lang.Object)
+meth public int addSlots(int,com.oracle.truffle.api.frame.FrameSlotKind)
+supr java.lang.Object
+hfds DEFAULT_CAPACITY,defaultValue,descriptorInfo,infos,names,size,staticMode,tags
 
 CLSS public abstract interface com.oracle.truffle.api.frame.FrameInstance
 innr public final static !enum FrameAccess
@@ -1335,6 +1807,8 @@ meth public abstract boolean isVirtualFrame()
 meth public abstract com.oracle.truffle.api.CallTarget getCallTarget()
 meth public abstract com.oracle.truffle.api.frame.Frame getFrame(com.oracle.truffle.api.frame.FrameInstance$FrameAccess)
 meth public abstract com.oracle.truffle.api.nodes.Node getCallNode()
+meth public boolean isCompilationRoot()
+meth public int getCompilationTier()
 
 CLSS public final static !enum com.oracle.truffle.api.frame.FrameInstance$FrameAccess
  outer com.oracle.truffle.api.frame.FrameInstance
@@ -1348,20 +1822,6 @@ supr java.lang.Enum<com.oracle.truffle.api.frame.FrameInstance$FrameAccess>
 CLSS public abstract interface com.oracle.truffle.api.frame.FrameInstanceVisitor<%0 extends java.lang.Object>
 meth public abstract {com.oracle.truffle.api.frame.FrameInstanceVisitor%0} visitFrame(com.oracle.truffle.api.frame.FrameInstance)
 
-CLSS public final com.oracle.truffle.api.frame.FrameSlot
-intf java.lang.Cloneable
-meth public com.oracle.truffle.api.frame.FrameSlotKind getKind()
- anno 0 java.lang.Deprecated()
-meth public int getIndex()
- anno 0 java.lang.Deprecated()
-meth public java.lang.Object getIdentifier()
-meth public java.lang.Object getInfo()
-meth public java.lang.String toString()
-meth public void setKind(com.oracle.truffle.api.frame.FrameSlotKind)
- anno 0 java.lang.Deprecated()
-supr java.lang.Object
-hfds descriptor,identifier,index,info,kind
-
 CLSS public final !enum com.oracle.truffle.api.frame.FrameSlotKind
 fld public final byte tag
 fld public final static com.oracle.truffle.api.frame.FrameSlotKind Boolean
@@ -1372,24 +1832,17 @@ fld public final static com.oracle.truffle.api.frame.FrameSlotKind Illegal
 fld public final static com.oracle.truffle.api.frame.FrameSlotKind Int
 fld public final static com.oracle.truffle.api.frame.FrameSlotKind Long
 fld public final static com.oracle.truffle.api.frame.FrameSlotKind Object
+fld public final static com.oracle.truffle.api.frame.FrameSlotKind Static
+meth public static com.oracle.truffle.api.frame.FrameSlotKind fromTag(byte)
 meth public static com.oracle.truffle.api.frame.FrameSlotKind valueOf(java.lang.String)
 meth public static com.oracle.truffle.api.frame.FrameSlotKind[] values()
 supr java.lang.Enum<com.oracle.truffle.api.frame.FrameSlotKind>
+hfds VALUES
 
 CLSS public final com.oracle.truffle.api.frame.FrameSlotTypeException
 cons public init()
-supr com.oracle.truffle.api.nodes.SlowPathException
+supr java.lang.IllegalStateException
 hfds serialVersionUID
-
-CLSS public final com.oracle.truffle.api.frame.FrameUtil
-meth public static boolean getBooleanSafe(com.oracle.truffle.api.frame.Frame,com.oracle.truffle.api.frame.FrameSlot)
-meth public static byte getByteSafe(com.oracle.truffle.api.frame.Frame,com.oracle.truffle.api.frame.FrameSlot)
-meth public static double getDoubleSafe(com.oracle.truffle.api.frame.Frame,com.oracle.truffle.api.frame.FrameSlot)
-meth public static float getFloatSafe(com.oracle.truffle.api.frame.Frame,com.oracle.truffle.api.frame.FrameSlot)
-meth public static int getIntSafe(com.oracle.truffle.api.frame.Frame,com.oracle.truffle.api.frame.FrameSlot)
-meth public static java.lang.Object getObjectSafe(com.oracle.truffle.api.frame.Frame,com.oracle.truffle.api.frame.FrameSlot)
-meth public static long getLongSafe(com.oracle.truffle.api.frame.Frame,com.oracle.truffle.api.frame.FrameSlot)
-supr java.lang.Object
 
 CLSS public abstract interface com.oracle.truffle.api.frame.MaterializedFrame
 intf com.oracle.truffle.api.frame.VirtualFrame
@@ -1441,14 +1894,21 @@ meth public abstract void onLanguageContextDisposed(com.oracle.truffle.api.Truff
 meth public abstract void onLanguageContextFinalized(com.oracle.truffle.api.TruffleContext,com.oracle.truffle.api.nodes.LanguageInfo)
 meth public abstract void onLanguageContextInitialized(com.oracle.truffle.api.TruffleContext,com.oracle.truffle.api.nodes.LanguageInfo)
 meth public void onContextResetLimits(com.oracle.truffle.api.TruffleContext)
+meth public void onLanguageContextCreate(com.oracle.truffle.api.TruffleContext,com.oracle.truffle.api.nodes.LanguageInfo)
+meth public void onLanguageContextCreateFailed(com.oracle.truffle.api.TruffleContext,com.oracle.truffle.api.nodes.LanguageInfo)
+meth public void onLanguageContextInitialize(com.oracle.truffle.api.TruffleContext,com.oracle.truffle.api.nodes.LanguageInfo)
+meth public void onLanguageContextInitializeFailed(com.oracle.truffle.api.TruffleContext,com.oracle.truffle.api.nodes.LanguageInfo)
 
 CLSS public com.oracle.truffle.api.instrumentation.EventBinding<%0 extends java.lang.Object>
 meth public boolean isDisposed()
+meth public final boolean isAttached()
+meth public final boolean tryAttach()
+meth public final void attach()
 meth public void dispose()
 meth public {com.oracle.truffle.api.instrumentation.EventBinding%0} getElement()
 supr java.lang.Object
-hfds disposed,disposing,element,instrumenter
-hcls Allocation,Source
+hfds attached,attachedSemaphore,disposed,disposing,element,instrumenter
+hcls Allocation,Execution,LoadNearestSection,LoadSource,LoadedNotifier,NearestExecution,NearestSourceSection,Source,SourceExecuted,SourceLoaded,SourceSectionLoaded
 
 CLSS public final com.oracle.truffle.api.instrumentation.EventContext
 meth public boolean hasTag(java.lang.Class<? extends com.oracle.truffle.api.instrumentation.Tag>)
@@ -1458,6 +1918,7 @@ meth public com.oracle.truffle.api.nodes.Node getInstrumentedNode()
 meth public com.oracle.truffle.api.source.SourceSection getInstrumentedSourceSection()
 meth public java.lang.Object getNodeObject()
 meth public java.lang.RuntimeException createError(java.lang.RuntimeException)
+ anno 0 java.lang.Deprecated(null since="21.3")
 meth public java.lang.String toString()
 meth public java.lang.ThreadDeath createUnwind(java.lang.Object)
 meth public java.lang.ThreadDeath createUnwind(java.lang.Object,com.oracle.truffle.api.instrumentation.EventBinding<?>)
@@ -1479,7 +1940,9 @@ meth public abstract void onReturnExceptional(com.oracle.truffle.api.instrumenta
 meth public abstract void onReturnValue(com.oracle.truffle.api.instrumentation.EventContext,com.oracle.truffle.api.frame.VirtualFrame,java.lang.Object)
 meth public java.lang.Object onUnwind(com.oracle.truffle.api.instrumentation.EventContext,com.oracle.truffle.api.frame.VirtualFrame,java.lang.Object)
 meth public void onInputValue(com.oracle.truffle.api.instrumentation.EventContext,com.oracle.truffle.api.frame.VirtualFrame,com.oracle.truffle.api.instrumentation.EventContext,int,java.lang.Object)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="20.0")
+meth public void onResume(com.oracle.truffle.api.instrumentation.EventContext,com.oracle.truffle.api.frame.VirtualFrame)
+meth public void onYield(com.oracle.truffle.api.instrumentation.EventContext,com.oracle.truffle.api.frame.VirtualFrame,java.lang.Object)
 
 CLSS public abstract com.oracle.truffle.api.instrumentation.ExecutionEventNode
 cons protected init()
@@ -1491,8 +1954,10 @@ meth protected java.lang.Object onUnwind(com.oracle.truffle.api.frame.VirtualFra
 meth protected void onDispose(com.oracle.truffle.api.frame.VirtualFrame)
 meth protected void onEnter(com.oracle.truffle.api.frame.VirtualFrame)
 meth protected void onInputValue(com.oracle.truffle.api.frame.VirtualFrame,com.oracle.truffle.api.instrumentation.EventContext,int,java.lang.Object)
+meth protected void onResume(com.oracle.truffle.api.frame.VirtualFrame)
 meth protected void onReturnExceptional(com.oracle.truffle.api.frame.VirtualFrame,java.lang.Throwable)
 meth protected void onReturnValue(com.oracle.truffle.api.frame.VirtualFrame,java.lang.Object)
+meth protected void onYield(com.oracle.truffle.api.frame.VirtualFrame,java.lang.Object)
 supr com.oracle.truffle.api.nodes.Node
 
 CLSS public abstract interface com.oracle.truffle.api.instrumentation.ExecutionEventNodeFactory
@@ -1501,8 +1966,18 @@ meth public abstract com.oracle.truffle.api.instrumentation.ExecutionEventNode c
 CLSS public abstract interface !annotation com.oracle.truffle.api.instrumentation.GenerateWrapper
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+innr public abstract interface static !annotation Ignore
 innr public abstract interface static !annotation IncomingConverter
 innr public abstract interface static !annotation OutgoingConverter
+innr public abstract interface static YieldException
+intf java.lang.annotation.Annotation
+meth public abstract !hasdefault java.lang.Class<?>[] yieldExceptions()
+meth public abstract !hasdefault java.lang.String resumeMethodPrefix()
+
+CLSS public abstract interface static !annotation com.oracle.truffle.api.instrumentation.GenerateWrapper$Ignore
+ outer com.oracle.truffle.api.instrumentation.GenerateWrapper
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
 intf java.lang.annotation.Annotation
 
 CLSS public abstract interface static !annotation com.oracle.truffle.api.instrumentation.GenerateWrapper$IncomingConverter
@@ -1517,6 +1992,10 @@ CLSS public abstract interface static !annotation com.oracle.truffle.api.instrum
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
 intf java.lang.annotation.Annotation
 
+CLSS public abstract interface static com.oracle.truffle.api.instrumentation.GenerateWrapper$YieldException
+ outer com.oracle.truffle.api.instrumentation.GenerateWrapper
+meth public abstract java.lang.Object getYieldValue()
+
 CLSS public abstract interface com.oracle.truffle.api.instrumentation.InstrumentableNode
 innr public abstract interface static WrapperNode
 intf com.oracle.truffle.api.nodes.NodeInterface
@@ -1524,6 +2003,7 @@ meth public abstract boolean isInstrumentable()
 meth public abstract com.oracle.truffle.api.instrumentation.InstrumentableNode$WrapperNode createWrapper(com.oracle.truffle.api.instrumentation.ProbeNode)
 meth public boolean hasTag(java.lang.Class<? extends com.oracle.truffle.api.instrumentation.Tag>)
 meth public com.oracle.truffle.api.instrumentation.InstrumentableNode materializeInstrumentableNodes(java.util.Set<java.lang.Class<? extends com.oracle.truffle.api.instrumentation.Tag>>)
+meth public com.oracle.truffle.api.nodes.Node findNearestNodeAt(int,int,java.util.Set<java.lang.Class<? extends com.oracle.truffle.api.instrumentation.Tag>>)
 meth public com.oracle.truffle.api.nodes.Node findNearestNodeAt(int,java.util.Set<java.lang.Class<? extends com.oracle.truffle.api.instrumentation.Tag>>)
 meth public java.lang.Object getNodeObject()
 meth public static com.oracle.truffle.api.nodes.Node findInstrumentableParent(com.oracle.truffle.api.nodes.Node)
@@ -1538,13 +2018,19 @@ CLSS public abstract com.oracle.truffle.api.instrumentation.Instrumenter
 meth public abstract <%0 extends com.oracle.truffle.api.instrumentation.AllocationListener> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> attachAllocationListener(com.oracle.truffle.api.instrumentation.AllocationEventFilter,{%%0})
 meth public abstract <%0 extends com.oracle.truffle.api.instrumentation.ContextsListener> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> attachContextsListener({%%0},boolean)
 meth public abstract <%0 extends com.oracle.truffle.api.instrumentation.ExecuteSourceListener> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> attachExecuteSourceListener(com.oracle.truffle.api.instrumentation.SourceFilter,{%%0},boolean)
+meth public abstract <%0 extends com.oracle.truffle.api.instrumentation.ExecuteSourceListener> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> createExecuteSourceBinding(com.oracle.truffle.api.instrumentation.SourceFilter,{%%0},boolean)
 meth public abstract <%0 extends com.oracle.truffle.api.instrumentation.ExecutionEventListener> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> attachExecutionEventListener(com.oracle.truffle.api.instrumentation.SourceSectionFilter,com.oracle.truffle.api.instrumentation.SourceSectionFilter,{%%0})
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="20.0")
+meth public abstract <%0 extends com.oracle.truffle.api.instrumentation.ExecutionEventNodeFactory> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> attachExecutionEventFactory(com.oracle.truffle.api.instrumentation.NearestSectionFilter,com.oracle.truffle.api.instrumentation.SourceSectionFilter,{%%0})
 meth public abstract <%0 extends com.oracle.truffle.api.instrumentation.ExecutionEventNodeFactory> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> attachExecutionEventFactory(com.oracle.truffle.api.instrumentation.SourceSectionFilter,com.oracle.truffle.api.instrumentation.SourceSectionFilter,{%%0})
 meth public abstract <%0 extends com.oracle.truffle.api.instrumentation.LoadSourceListener> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> attachLoadSourceListener(com.oracle.truffle.api.instrumentation.SourceFilter,{%%0},boolean)
 meth public abstract <%0 extends com.oracle.truffle.api.instrumentation.LoadSourceListener> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> attachLoadSourceListener(com.oracle.truffle.api.instrumentation.SourceSectionFilter,{%%0},boolean)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="19.0")
+meth public abstract <%0 extends com.oracle.truffle.api.instrumentation.LoadSourceListener> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> createLoadSourceBinding(com.oracle.truffle.api.instrumentation.SourceFilter,{%%0},boolean)
+meth public abstract <%0 extends com.oracle.truffle.api.instrumentation.LoadSourceSectionListener> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> attachLoadSourceSectionListener(com.oracle.truffle.api.instrumentation.NearestSectionFilter,com.oracle.truffle.api.instrumentation.SourceSectionFilter,{%%0},boolean)
 meth public abstract <%0 extends com.oracle.truffle.api.instrumentation.LoadSourceSectionListener> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> attachLoadSourceSectionListener(com.oracle.truffle.api.instrumentation.SourceSectionFilter,{%%0},boolean)
+meth public abstract <%0 extends com.oracle.truffle.api.instrumentation.LoadSourceSectionListener> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> createLoadSourceSectionBinding(com.oracle.truffle.api.instrumentation.NearestSectionFilter,com.oracle.truffle.api.instrumentation.SourceSectionFilter,{%%0},boolean)
+meth public abstract <%0 extends com.oracle.truffle.api.instrumentation.LoadSourceSectionListener> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> createLoadSourceSectionBinding(com.oracle.truffle.api.instrumentation.SourceSectionFilter,{%%0},boolean)
 meth public abstract <%0 extends com.oracle.truffle.api.instrumentation.ThreadsListener> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> attachThreadsListener({%%0},boolean)
 meth public abstract <%0 extends java.io.OutputStream> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> attachErrConsumer({%%0})
 meth public abstract <%0 extends java.io.OutputStream> com.oracle.truffle.api.instrumentation.EventBinding<{%%0}> attachOutConsumer({%%0})
@@ -1574,15 +2060,32 @@ hfds node,sourceSection
 CLSS public abstract interface com.oracle.truffle.api.instrumentation.LoadSourceSectionListener
 meth public abstract void onLoad(com.oracle.truffle.api.instrumentation.LoadSourceSectionEvent)
 
+CLSS public final com.oracle.truffle.api.instrumentation.NearestSectionFilter
+innr public final static Builder
+meth public java.lang.String toString()
+meth public static com.oracle.truffle.api.instrumentation.NearestSectionFilter$Builder newBuilder(int,int)
+supr java.lang.Object
+hfds anchorStart,position,tagClasses,tags
+
+CLSS public final static com.oracle.truffle.api.instrumentation.NearestSectionFilter$Builder
+ outer com.oracle.truffle.api.instrumentation.NearestSectionFilter
+meth public !varargs com.oracle.truffle.api.instrumentation.NearestSectionFilter$Builder tagIs(java.lang.Class<?>[])
+meth public com.oracle.truffle.api.instrumentation.NearestSectionFilter build()
+meth public com.oracle.truffle.api.instrumentation.NearestSectionFilter$Builder anchorStart(boolean)
+supr java.lang.Object
+hfds anchorStart,column,line,theTags
+
 CLSS public final com.oracle.truffle.api.instrumentation.ProbeNode
 fld public final static java.lang.Object UNWIND_ACTION_REENTER
 meth public com.oracle.truffle.api.nodes.Node copy()
 meth public com.oracle.truffle.api.nodes.NodeCost getCost()
 meth public java.lang.Object onReturnExceptionalOrUnwind(com.oracle.truffle.api.frame.VirtualFrame,java.lang.Throwable,boolean)
 meth public void onEnter(com.oracle.truffle.api.frame.VirtualFrame)
+meth public void onResume(com.oracle.truffle.api.frame.VirtualFrame)
 meth public void onReturnValue(com.oracle.truffle.api.frame.VirtualFrame,java.lang.Object)
+meth public void onYield(com.oracle.truffle.api.frame.VirtualFrame,java.lang.Object)
 supr com.oracle.truffle.api.nodes.Node
-hfds SEEN_REENTER,SEEN_RETURN,SEEN_UNWIND,SEEN_UNWIND_NEXT,UNWIND_ACTION_IGNORED,chain,context,handler,retiredNodeReference,seen,version
+hfds ASSERT_ENTER_RETURN_PARITY,SEEN_REENTER,SEEN_RETURN,SEEN_UNWIND,SEEN_UNWIND_NEXT,UNWIND_ACTION_IGNORED,chain,context,handler,retiredNodeReference,seen,version
 hcls EventChainNode,EventFilterChainNode,EventProviderChainNode,EventProviderWithInputChainNode,InputChildContextLookup,InputChildIndexLookup,InputValueChainNode,InstrumentableChildVisitor,RetiredNodeReference
 
 CLSS public abstract interface !annotation com.oracle.truffle.api.instrumentation.ProvidedTags
@@ -1614,11 +2117,12 @@ innr public abstract interface static SourcePredicate
 innr public final Builder
 innr public final static IndexRange
 meth public boolean includes(com.oracle.truffle.api.nodes.Node)
+meth public boolean includes(com.oracle.truffle.api.nodes.RootNode,com.oracle.truffle.api.source.SourceSection,java.util.Set<java.lang.Class<?>>)
 meth public java.lang.String toString()
 meth public static com.oracle.truffle.api.instrumentation.SourceSectionFilter$Builder newBuilder()
 supr java.lang.Object
-hfds expressions
-hcls EventFilterExpression,Not
+hfds TAGGED_NODE_CACHE,expressions
+hcls EventFilterExpression,Not,TaggedNode
 
 CLSS public final com.oracle.truffle.api.instrumentation.SourceSectionFilter$Builder
  outer com.oracle.truffle.api.instrumentation.SourceSectionFilter
@@ -1735,25 +2239,35 @@ meth public abstract void onThreadInitialized(com.oracle.truffle.api.TruffleCont
 
 CLSS public abstract com.oracle.truffle.api.instrumentation.TruffleInstrument
 cons protected init()
+fld protected final com.oracle.truffle.api.instrumentation.TruffleInstrument$ContextLocalProvider locals
 innr protected abstract interface static ContextLocalFactory
 innr protected abstract interface static ContextThreadLocalFactory
+innr protected final static ContextLocalProvider
 innr public abstract interface static !annotation Registration
 innr public abstract interface static Provider
 innr public final static Env
 meth protected abstract void onCreate(com.oracle.truffle.api.instrumentation.TruffleInstrument$Env)
 meth protected final <%0 extends java.lang.Object> com.oracle.truffle.api.ContextLocal<{%%0}> createContextLocal(com.oracle.truffle.api.instrumentation.TruffleInstrument$ContextLocalFactory<{%%0}>)
+ anno 0 java.lang.Deprecated()
 meth protected final <%0 extends java.lang.Object> com.oracle.truffle.api.ContextThreadLocal<{%%0}> createContextThreadLocal(com.oracle.truffle.api.instrumentation.TruffleInstrument$ContextThreadLocalFactory<{%%0}>)
+ anno 0 java.lang.Deprecated()
 meth protected org.graalvm.options.OptionDescriptors getContextOptionDescriptors()
 meth protected org.graalvm.options.OptionDescriptors getOptionDescriptors()
 meth protected void onDispose(com.oracle.truffle.api.instrumentation.TruffleInstrument$Env)
 meth protected void onFinalize(com.oracle.truffle.api.instrumentation.TruffleInstrument$Env)
 supr java.lang.Object
-hfds contextLocals,contextThreadLocals
 
 CLSS protected abstract interface static com.oracle.truffle.api.instrumentation.TruffleInstrument$ContextLocalFactory<%0 extends java.lang.Object>
  outer com.oracle.truffle.api.instrumentation.TruffleInstrument
  anno 0 java.lang.FunctionalInterface()
 meth public abstract {com.oracle.truffle.api.instrumentation.TruffleInstrument$ContextLocalFactory%0} create(com.oracle.truffle.api.TruffleContext)
+
+CLSS protected final static com.oracle.truffle.api.instrumentation.TruffleInstrument$ContextLocalProvider
+ outer com.oracle.truffle.api.instrumentation.TruffleInstrument
+meth public <%0 extends java.lang.Object> com.oracle.truffle.api.ContextLocal<{%%0}> createContextLocal(com.oracle.truffle.api.instrumentation.TruffleInstrument$ContextLocalFactory<{%%0}>)
+meth public <%0 extends java.lang.Object> com.oracle.truffle.api.ContextThreadLocal<{%%0}> createContextThreadLocal(com.oracle.truffle.api.instrumentation.TruffleInstrument$ContextThreadLocalFactory<{%%0}>)
+supr java.lang.Object
+hfds contextLocals,contextThreadLocals
 
 CLSS protected abstract interface static com.oracle.truffle.api.instrumentation.TruffleInstrument$ContextThreadLocalFactory<%0 extends java.lang.Object>
  outer com.oracle.truffle.api.instrumentation.TruffleInstrument
@@ -1766,49 +2280,46 @@ meth public !varargs com.oracle.truffle.api.CallTarget parse(com.oracle.truffle.
 meth public <%0 extends java.lang.Object> {%%0} lookup(com.oracle.truffle.api.InstrumentInfo,java.lang.Class<{%%0}>)
 meth public <%0 extends java.lang.Object> {%%0} lookup(com.oracle.truffle.api.nodes.LanguageInfo,java.lang.Class<{%%0}>)
 meth public boolean isEngineRoot(com.oracle.truffle.api.nodes.RootNode)
+meth public boolean isSameFrame(com.oracle.truffle.api.nodes.RootNode,com.oracle.truffle.api.frame.Frame,com.oracle.truffle.api.frame.Frame)
 meth public com.oracle.truffle.api.TruffleContext getEnteredContext()
+meth public com.oracle.truffle.api.TruffleFile getInternalResource(java.lang.Class<? extends com.oracle.truffle.api.InternalResource>) throws java.io.IOException
+meth public com.oracle.truffle.api.TruffleFile getInternalResource(java.lang.String) throws java.io.IOException
+meth public com.oracle.truffle.api.TruffleFile getTruffleFile(com.oracle.truffle.api.TruffleContext,java.lang.String)
+meth public com.oracle.truffle.api.TruffleFile getTruffleFile(com.oracle.truffle.api.TruffleContext,java.net.URI)
 meth public com.oracle.truffle.api.TruffleFile getTruffleFile(java.lang.String)
+ anno 0 java.lang.Deprecated()
 meth public com.oracle.truffle.api.TruffleFile getTruffleFile(java.net.URI)
+ anno 0 java.lang.Deprecated()
 meth public com.oracle.truffle.api.TruffleLogger getLogger(java.lang.Class<?>)
 meth public com.oracle.truffle.api.TruffleLogger getLogger(java.lang.String)
 meth public com.oracle.truffle.api.instrumentation.Instrumenter getInstrumenter()
 meth public com.oracle.truffle.api.nodes.ExecutableNode parseInline(com.oracle.truffle.api.source.Source,com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.frame.MaterializedFrame)
-meth public com.oracle.truffle.api.nodes.LanguageInfo findLanguage(java.lang.Object)
- anno 0 java.lang.Deprecated()
 meth public com.oracle.truffle.api.nodes.LanguageInfo getLanguageInfo(java.lang.Class<? extends com.oracle.truffle.api.TruffleLanguage<?>>)
-meth public com.oracle.truffle.api.source.SourceSection findSourceLocation(com.oracle.truffle.api.nodes.LanguageInfo,java.lang.Object)
- anno 0 java.lang.Deprecated()
 meth public java.io.InputStream in()
 meth public java.io.OutputStream err()
 meth public java.io.OutputStream out()
-meth public java.lang.Iterable<com.oracle.truffle.api.Scope> findLocalScopes(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.frame.Frame)
- anno 0 java.lang.Deprecated()
-meth public java.lang.Iterable<com.oracle.truffle.api.Scope> findTopScopes(java.lang.String)
- anno 0 java.lang.Deprecated()
-meth public java.lang.Object findMetaObject(com.oracle.truffle.api.nodes.LanguageInfo,java.lang.Object)
- anno 0 java.lang.Deprecated()
 meth public java.lang.Object getLanguageView(com.oracle.truffle.api.nodes.LanguageInfo,java.lang.Object)
 meth public java.lang.Object getPolyglotBindings()
 meth public java.lang.Object getScope(com.oracle.truffle.api.nodes.LanguageInfo)
-meth public java.lang.Object getScopedView(com.oracle.truffle.api.nodes.LanguageInfo,com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.frame.Frame,java.lang.Object)
- anno 0 java.lang.Deprecated()
-meth public java.lang.String toString(com.oracle.truffle.api.nodes.LanguageInfo,java.lang.Object)
- anno 0 java.lang.Deprecated()
-meth public java.util.Map<java.lang.String,?> getExportedSymbols()
- anno 0 java.lang.Deprecated()
+meth public java.lang.Thread createSystemThread(java.lang.Runnable)
+meth public java.lang.Thread createSystemThread(java.lang.Runnable,java.lang.ThreadGroup)
 meth public java.util.Map<java.lang.String,com.oracle.truffle.api.InstrumentInfo> getInstruments()
 meth public java.util.Map<java.lang.String,com.oracle.truffle.api.nodes.LanguageInfo> getLanguages()
+meth public java.util.concurrent.Future<java.lang.Void> submitThreadLocal(com.oracle.truffle.api.TruffleContext,java.lang.Thread[],com.oracle.truffle.api.ThreadLocalAction)
+meth public long calculateContextHeapSize(com.oracle.truffle.api.TruffleContext,long,java.util.concurrent.atomic.AtomicBoolean)
 meth public org.graalvm.options.OptionValues getOptions()
 meth public org.graalvm.options.OptionValues getOptions(com.oracle.truffle.api.TruffleContext)
+meth public org.graalvm.polyglot.SandboxPolicy getSandboxPolicy()
 meth public org.graalvm.polyglot.io.MessageEndpoint startServer(java.net.URI,org.graalvm.polyglot.io.MessageEndpoint) throws java.io.IOException,org.graalvm.polyglot.io.MessageTransport$VetoException
 meth public void registerService(java.lang.Object)
 meth public void setAsynchronousStackDepth(int)
 supr java.lang.Object
-hfds INTEROP,err,in,instrumenter,messageTransport,options,out,polyglotInstrument,services
+hfds err,in,instrumenter,messageTransport,options,out,polyglotInstrument,services
 hcls GuardedExecutableNode,MessageTransportProxy
 
 CLSS public abstract interface static com.oracle.truffle.api.instrumentation.TruffleInstrument$Provider
  outer com.oracle.truffle.api.instrumentation.TruffleInstrument
+ anno 0 java.lang.Deprecated(null since="23.1")
 meth public abstract com.oracle.truffle.api.instrumentation.TruffleInstrument create()
 meth public abstract java.lang.String getInstrumentClassName()
 meth public abstract java.util.Collection<java.lang.String> getServicesClassNames()
@@ -1819,26 +2330,29 @@ CLSS public abstract interface static !annotation com.oracle.truffle.api.instrum
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault boolean internal()
+meth public abstract !hasdefault java.lang.Class<? extends com.oracle.truffle.api.InternalResource>[] internalResources()
 meth public abstract !hasdefault java.lang.Class<?>[] services()
 meth public abstract !hasdefault java.lang.String id()
 meth public abstract !hasdefault java.lang.String name()
 meth public abstract !hasdefault java.lang.String version()
+meth public abstract !hasdefault java.lang.String website()
+meth public abstract !hasdefault org.graalvm.polyglot.SandboxPolicy sandbox()
 
 CLSS public final com.oracle.truffle.api.interop.ArityException
 meth public int getActualArity()
-meth public int getExpectedArity()
+meth public int getExpectedMaxArity()
+meth public int getExpectedMinArity()
 meth public java.lang.String getMessage()
-meth public static com.oracle.truffle.api.interop.ArityException create(int,int)
-meth public static com.oracle.truffle.api.interop.ArityException create(int,int,java.lang.Throwable)
+meth public static com.oracle.truffle.api.interop.ArityException create(int,int,int)
+meth public static com.oracle.truffle.api.interop.ArityException create(int,int,int,java.lang.Throwable)
 supr com.oracle.truffle.api.interop.InteropException
-hfds actualArity,expectedArity,serialVersionUID
+hfds actualArity,expectedMaxArity,expectedMinArity,serialVersionUID
 
 CLSS public final !enum com.oracle.truffle.api.interop.ExceptionType
 fld public final static com.oracle.truffle.api.interop.ExceptionType EXIT
 fld public final static com.oracle.truffle.api.interop.ExceptionType INTERRUPT
 fld public final static com.oracle.truffle.api.interop.ExceptionType PARSE_ERROR
 fld public final static com.oracle.truffle.api.interop.ExceptionType RUNTIME_ERROR
-intf com.oracle.truffle.api.interop.TruffleObject
 meth public static com.oracle.truffle.api.interop.ExceptionType valueOf(java.lang.String)
 meth public static com.oracle.truffle.api.interop.ExceptionType[] values()
 supr java.lang.Enum<com.oracle.truffle.api.interop.ExceptionType>
@@ -1847,7 +2361,7 @@ CLSS public abstract com.oracle.truffle.api.interop.InteropException
 meth public final java.lang.Throwable fillInStackTrace()
 meth public final java.lang.Throwable getCause()
 meth public final java.lang.Throwable initCause(java.lang.Throwable)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="20.2")
 supr java.lang.Exception
 hfds serialVersionUID
 
@@ -1859,6 +2373,7 @@ meth public !varargs java.lang.Object execute(java.lang.Object,java.lang.Object[
 meth public !varargs java.lang.Object instantiate(java.lang.Object,java.lang.Object[]) throws com.oracle.truffle.api.interop.ArityException,com.oracle.truffle.api.interop.UnsupportedMessageException,com.oracle.truffle.api.interop.UnsupportedTypeException
 meth public !varargs java.lang.Object invokeMember(java.lang.Object,java.lang.String,java.lang.Object[]) throws com.oracle.truffle.api.interop.ArityException,com.oracle.truffle.api.interop.UnknownIdentifierException,com.oracle.truffle.api.interop.UnsupportedMessageException,com.oracle.truffle.api.interop.UnsupportedTypeException
 meth public boolean asBoolean(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public boolean fitsInBigInteger(java.lang.Object)
 meth public boolean fitsInByte(java.lang.Object)
 meth public boolean fitsInDouble(java.lang.Object)
 meth public boolean fitsInFloat(java.lang.Object)
@@ -1866,16 +2381,21 @@ meth public boolean fitsInInt(java.lang.Object)
 meth public boolean fitsInLong(java.lang.Object)
 meth public boolean fitsInShort(java.lang.Object)
 meth public boolean hasArrayElements(java.lang.Object)
+meth public boolean hasBufferElements(java.lang.Object)
 meth public boolean hasDeclaringMetaObject(java.lang.Object)
 meth public boolean hasExceptionCause(java.lang.Object)
 meth public boolean hasExceptionMessage(java.lang.Object)
 meth public boolean hasExceptionStackTrace(java.lang.Object)
 meth public boolean hasExecutableName(java.lang.Object)
+meth public boolean hasHashEntries(java.lang.Object)
+meth public boolean hasIterator(java.lang.Object)
+meth public boolean hasIteratorNextElement(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public boolean hasLanguage(java.lang.Object)
 meth public boolean hasMemberReadSideEffects(java.lang.Object,java.lang.String)
 meth public boolean hasMemberWriteSideEffects(java.lang.Object,java.lang.String)
 meth public boolean hasMembers(java.lang.Object)
 meth public boolean hasMetaObject(java.lang.Object)
+meth public boolean hasMetaParents(java.lang.Object)
 meth public boolean hasScopeParent(java.lang.Object)
 meth public boolean hasSourceLocation(java.lang.Object)
 meth public boolean isArrayElementInsertable(java.lang.Object,long)
@@ -1883,13 +2403,21 @@ meth public boolean isArrayElementModifiable(java.lang.Object,long)
 meth public boolean isArrayElementReadable(java.lang.Object,long)
 meth public boolean isArrayElementRemovable(java.lang.Object,long)
 meth public boolean isBoolean(java.lang.Object)
+meth public boolean isBufferWritable(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public boolean isDate(java.lang.Object)
 meth public boolean isDuration(java.lang.Object)
 meth public boolean isException(java.lang.Object)
 meth public boolean isExceptionIncompleteSource(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public boolean isExecutable(java.lang.Object)
+meth public boolean isHashEntryExisting(java.lang.Object,java.lang.Object)
+meth public boolean isHashEntryInsertable(java.lang.Object,java.lang.Object)
+meth public boolean isHashEntryModifiable(java.lang.Object,java.lang.Object)
+meth public boolean isHashEntryReadable(java.lang.Object,java.lang.Object)
+meth public boolean isHashEntryRemovable(java.lang.Object,java.lang.Object)
+meth public boolean isHashEntryWritable(java.lang.Object,java.lang.Object)
 meth public boolean isIdentical(java.lang.Object,java.lang.Object,com.oracle.truffle.api.interop.InteropLibrary)
 meth public boolean isInstantiable(java.lang.Object)
+meth public boolean isIterator(java.lang.Object)
 meth public boolean isMemberInsertable(java.lang.Object,java.lang.String)
 meth public boolean isMemberInternal(java.lang.Object,java.lang.String)
 meth public boolean isMemberInvocable(java.lang.Object,java.lang.String)
@@ -1906,9 +2434,12 @@ meth public boolean isString(java.lang.Object)
 meth public boolean isTime(java.lang.Object)
 meth public boolean isTimeZone(java.lang.Object)
 meth public byte asByte(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public byte readBufferByte(java.lang.Object,long) throws com.oracle.truffle.api.interop.InvalidBufferOffsetException,com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public com.oracle.truffle.api.interop.ExceptionType getExceptionType(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public com.oracle.truffle.api.source.SourceSection getSourceLocation(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public com.oracle.truffle.api.strings.TruffleString asTruffleString(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public double asDouble(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public double readBufferDouble(java.lang.Object,java.nio.ByteOrder,long) throws com.oracle.truffle.api.interop.InvalidBufferOffsetException,com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public final boolean hasIdentity(java.lang.Object)
 meth public final boolean isArrayElementExisting(java.lang.Object,long)
 meth public final boolean isArrayElementWritable(java.lang.Object,long)
@@ -1918,25 +2449,36 @@ meth public final boolean isMemberWritable(java.lang.Object,java.lang.String)
 meth public final java.lang.Object getMembers(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public final java.lang.Object toDisplayString(java.lang.Object)
 meth public float asFloat(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public float readBufferFloat(java.lang.Object,java.nio.ByteOrder,long) throws com.oracle.truffle.api.interop.InvalidBufferOffsetException,com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public int asInt(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public int getExceptionExitStatus(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public int identityHashCode(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public int readBufferInt(java.lang.Object,java.nio.ByteOrder,long) throws com.oracle.truffle.api.interop.InvalidBufferOffsetException,com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.Class<? extends com.oracle.truffle.api.TruffleLanguage<?>> getLanguage(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.Object getDeclaringMetaObject(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.Object getExceptionCause(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.Object getExceptionMessage(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.Object getExceptionStackTrace(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.Object getExecutableName(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public java.lang.Object getHashEntriesIterator(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public java.lang.Object getHashKeysIterator(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public java.lang.Object getHashValuesIterator(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public java.lang.Object getIterator(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public java.lang.Object getIteratorNextElement(java.lang.Object) throws com.oracle.truffle.api.interop.StopIterationException,com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.Object getMembers(java.lang.Object,boolean) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.Object getMetaObject(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public java.lang.Object getMetaParents(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.Object getMetaQualifiedName(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.Object getMetaSimpleName(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.Object getScopeParent(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.Object readArrayElement(java.lang.Object,long) throws com.oracle.truffle.api.interop.InvalidArrayIndexException,com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public java.lang.Object readHashValue(java.lang.Object,java.lang.Object) throws com.oracle.truffle.api.interop.UnknownKeyException,com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public java.lang.Object readHashValueOrDefault(java.lang.Object,java.lang.Object,java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.Object readMember(java.lang.Object,java.lang.String) throws com.oracle.truffle.api.interop.UnknownIdentifierException,com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.Object toDisplayString(java.lang.Object,boolean)
 meth public java.lang.RuntimeException throwException(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.String asString(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public java.math.BigInteger asBigInteger(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.time.Duration asDuration(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.time.Instant asInstant(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.time.LocalDate asDate(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
@@ -1945,14 +2487,29 @@ meth public java.time.ZoneId asTimeZone(java.lang.Object) throws com.oracle.truf
 meth public long asLong(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public long asPointer(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public long getArraySize(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public long getBufferSize(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public long getHashSize(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public long readBufferLong(java.lang.Object,java.nio.ByteOrder,long) throws com.oracle.truffle.api.interop.InvalidBufferOffsetException,com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public short asShort(java.lang.Object) throws com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public short readBufferShort(java.lang.Object,java.nio.ByteOrder,long) throws com.oracle.truffle.api.interop.InvalidBufferOffsetException,com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public static boolean isValidProtocolValue(java.lang.Object)
+meth public static boolean isValidValue(java.lang.Object)
 meth public static com.oracle.truffle.api.interop.InteropLibrary getUncached()
 meth public static com.oracle.truffle.api.interop.InteropLibrary getUncached(java.lang.Object)
 meth public static com.oracle.truffle.api.library.LibraryFactory<com.oracle.truffle.api.interop.InteropLibrary> getFactory()
+meth public void readBuffer(java.lang.Object,long,byte[],int,int) throws com.oracle.truffle.api.interop.InvalidBufferOffsetException,com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public void removeArrayElement(java.lang.Object,long) throws com.oracle.truffle.api.interop.InvalidArrayIndexException,com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public void removeHashEntry(java.lang.Object,java.lang.Object) throws com.oracle.truffle.api.interop.UnknownKeyException,com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public void removeMember(java.lang.Object,java.lang.String) throws com.oracle.truffle.api.interop.UnknownIdentifierException,com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public void toNative(java.lang.Object)
 meth public void writeArrayElement(java.lang.Object,long,java.lang.Object) throws com.oracle.truffle.api.interop.InvalidArrayIndexException,com.oracle.truffle.api.interop.UnsupportedMessageException,com.oracle.truffle.api.interop.UnsupportedTypeException
+meth public void writeBufferByte(java.lang.Object,long,byte) throws com.oracle.truffle.api.interop.InvalidBufferOffsetException,com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public void writeBufferDouble(java.lang.Object,java.nio.ByteOrder,long,double) throws com.oracle.truffle.api.interop.InvalidBufferOffsetException,com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public void writeBufferFloat(java.lang.Object,java.nio.ByteOrder,long,float) throws com.oracle.truffle.api.interop.InvalidBufferOffsetException,com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public void writeBufferInt(java.lang.Object,java.nio.ByteOrder,long,int) throws com.oracle.truffle.api.interop.InvalidBufferOffsetException,com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public void writeBufferLong(java.lang.Object,java.nio.ByteOrder,long,long) throws com.oracle.truffle.api.interop.InvalidBufferOffsetException,com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public void writeBufferShort(java.lang.Object,java.nio.ByteOrder,long,short) throws com.oracle.truffle.api.interop.InvalidBufferOffsetException,com.oracle.truffle.api.interop.UnsupportedMessageException
+meth public void writeHashEntry(java.lang.Object,java.lang.Object,java.lang.Object) throws com.oracle.truffle.api.interop.UnknownKeyException,com.oracle.truffle.api.interop.UnsupportedMessageException,com.oracle.truffle.api.interop.UnsupportedTypeException
 meth public void writeMember(java.lang.Object,java.lang.String,java.lang.Object) throws com.oracle.truffle.api.interop.UnknownIdentifierException,com.oracle.truffle.api.interop.UnsupportedMessageException,com.oracle.truffle.api.interop.UnsupportedTypeException
 supr com.oracle.truffle.api.library.Library
 hfds FACTORY,UNCACHED
@@ -1965,6 +2522,15 @@ meth public static com.oracle.truffle.api.interop.InvalidArrayIndexException cre
 meth public static com.oracle.truffle.api.interop.InvalidArrayIndexException create(long,java.lang.Throwable)
 supr com.oracle.truffle.api.interop.InteropException
 hfds invalidIndex,serialVersionUID
+
+CLSS public final com.oracle.truffle.api.interop.InvalidBufferOffsetException
+meth public java.lang.String getMessage()
+meth public long getByteOffset()
+meth public long getLength()
+meth public static com.oracle.truffle.api.interop.InvalidBufferOffsetException create(long,long)
+meth public static com.oracle.truffle.api.interop.InvalidBufferOffsetException create(long,long,java.lang.Throwable)
+supr com.oracle.truffle.api.interop.InteropException
+hfds byteOffset,length,serialVersionUID
 
 CLSS public abstract com.oracle.truffle.api.interop.NodeLibrary
 cons protected init()
@@ -1982,6 +2548,13 @@ supr com.oracle.truffle.api.library.Library
 hfds FACTORY
 hcls Asserts
 
+CLSS public final com.oracle.truffle.api.interop.StopIterationException
+meth public java.lang.String getMessage()
+meth public static com.oracle.truffle.api.interop.StopIterationException create()
+meth public static com.oracle.truffle.api.interop.StopIterationException create(java.lang.Throwable)
+supr com.oracle.truffle.api.interop.InteropException
+hfds INSTANCE,serialVersionUID
+
 CLSS public abstract interface com.oracle.truffle.api.interop.TruffleObject
 
 CLSS public final com.oracle.truffle.api.interop.UnknownIdentifierException
@@ -1991,6 +2564,14 @@ meth public static com.oracle.truffle.api.interop.UnknownIdentifierException cre
 meth public static com.oracle.truffle.api.interop.UnknownIdentifierException create(java.lang.String,java.lang.Throwable)
 supr com.oracle.truffle.api.interop.InteropException
 hfds serialVersionUID,unknownIdentifier
+
+CLSS public final com.oracle.truffle.api.interop.UnknownKeyException
+meth public java.lang.Object getUnknownKey()
+meth public java.lang.String getMessage()
+meth public static com.oracle.truffle.api.interop.UnknownKeyException create(java.lang.Object)
+meth public static com.oracle.truffle.api.interop.UnknownKeyException create(java.lang.Object,java.lang.Throwable)
+supr com.oracle.truffle.api.interop.InteropException
+hfds serialVersionUID,unknownKey
 
 CLSS public final com.oracle.truffle.api.interop.UnsupportedMessageException
 meth public java.lang.String getMessage()
@@ -2007,6 +2588,23 @@ meth public static com.oracle.truffle.api.interop.UnsupportedTypeException creat
 supr com.oracle.truffle.api.interop.InteropException
 hfds serialVersionUID,suppliedValues
 
+CLSS public final com.oracle.truffle.api.io.TruffleProcessBuilder
+meth public !varargs com.oracle.truffle.api.io.TruffleProcessBuilder command(java.lang.String[])
+meth public com.oracle.truffle.api.io.TruffleProcessBuilder clearEnvironment(boolean)
+meth public com.oracle.truffle.api.io.TruffleProcessBuilder command(java.util.List<java.lang.String>)
+meth public com.oracle.truffle.api.io.TruffleProcessBuilder directory(com.oracle.truffle.api.TruffleFile)
+meth public com.oracle.truffle.api.io.TruffleProcessBuilder environment(java.lang.String,java.lang.String)
+meth public com.oracle.truffle.api.io.TruffleProcessBuilder environment(java.util.Map<java.lang.String,java.lang.String>)
+meth public com.oracle.truffle.api.io.TruffleProcessBuilder inheritIO(boolean)
+meth public com.oracle.truffle.api.io.TruffleProcessBuilder redirectError(org.graalvm.polyglot.io.ProcessHandler$Redirect)
+meth public com.oracle.truffle.api.io.TruffleProcessBuilder redirectErrorStream(boolean)
+meth public com.oracle.truffle.api.io.TruffleProcessBuilder redirectInput(org.graalvm.polyglot.io.ProcessHandler$Redirect)
+meth public com.oracle.truffle.api.io.TruffleProcessBuilder redirectOutput(org.graalvm.polyglot.io.ProcessHandler$Redirect)
+meth public java.lang.Process start() throws java.io.IOException
+meth public org.graalvm.polyglot.io.ProcessHandler$Redirect createRedirectToStream(java.io.OutputStream)
+supr java.lang.Object
+hfds clearEnvironment,cmd,cwd,env,errorRedirect,fileSystem,inheritIO,inputRedirect,outputRedirect,polyglotLanguageContext,redirectErrorStream
+
 CLSS public abstract interface !annotation com.oracle.truffle.api.library.CachedLibrary
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=CLASS)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PARAMETER])
@@ -2015,10 +2613,8 @@ meth public abstract !hasdefault java.lang.String limit()
 meth public abstract !hasdefault java.lang.String value()
 
 CLSS public abstract interface com.oracle.truffle.api.library.DefaultExportProvider
-meth public abstract int getPriority()
-meth public abstract java.lang.Class<?> getDefaultExport()
-meth public abstract java.lang.Class<?> getReceiverClass()
-meth public abstract java.lang.String getLibraryClassName()
+ anno 0 java.lang.Deprecated(null since="23.1")
+intf com.oracle.truffle.api.library.provider.DefaultExportProvider
 
 CLSS public abstract com.oracle.truffle.api.library.DynamicDispatchLibrary
 cons protected init()
@@ -2028,13 +2624,19 @@ meth public static com.oracle.truffle.api.library.LibraryFactory<com.oracle.truf
 supr com.oracle.truffle.api.library.Library
 hfds FACTORY
 
+CLSS public abstract interface com.oracle.truffle.api.library.EagerExportProvider
+ anno 0 java.lang.Deprecated(null since="23.1")
+intf com.oracle.truffle.api.library.provider.EagerExportProvider
+
 CLSS public abstract interface !annotation com.oracle.truffle.api.library.ExportLibrary
  anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class com.oracle.truffle.api.library.ExportLibrary$Repeat)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 innr public abstract interface static !annotation Repeat
 intf java.lang.annotation.Annotation
+meth public abstract !hasdefault boolean useForAOT()
 meth public abstract !hasdefault int priority()
+meth public abstract !hasdefault int useForAOTPriority()
 meth public abstract !hasdefault java.lang.Class<?> receiverType()
 meth public abstract !hasdefault java.lang.String delegateTo()
 meth public abstract !hasdefault java.lang.String transitionLimit()
@@ -2089,6 +2691,7 @@ CLSS public abstract interface static !annotation com.oracle.truffle.api.library
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault java.lang.String[] ifExported()
+meth public abstract !hasdefault java.lang.String[] ifExportedAsWarning()
 
 CLSS public abstract interface static !annotation com.oracle.truffle.api.library.GenerateLibrary$DefaultExport
  outer com.oracle.truffle.api.library.GenerateLibrary
@@ -2113,15 +2716,17 @@ supr com.oracle.truffle.api.nodes.Node
 
 CLSS public abstract com.oracle.truffle.api.library.LibraryExport<%0 extends com.oracle.truffle.api.library.Library>
 cons protected init(java.lang.Class<? extends {com.oracle.truffle.api.library.LibraryExport%0}>,java.lang.Class<?>,boolean)
+cons protected init(java.lang.Class<? extends {com.oracle.truffle.api.library.LibraryExport%0}>,java.lang.Class<?>,boolean,boolean,int)
 innr protected abstract interface static DelegateExport
 meth protected !varargs static com.oracle.truffle.api.utilities.FinalBitSet createMessageBitSet(com.oracle.truffle.api.library.LibraryFactory<?>,java.lang.String[])
 meth protected abstract {com.oracle.truffle.api.library.LibraryExport%0} createCached(java.lang.Object)
 meth protected abstract {com.oracle.truffle.api.library.LibraryExport%0} createUncached(java.lang.Object)
 meth protected static <%0 extends com.oracle.truffle.api.library.Library> {%%0} createDelegate(com.oracle.truffle.api.library.LibraryFactory<{%%0}>,{%%0})
+meth protected static boolean assertAdopted(com.oracle.truffle.api.nodes.Node)
 meth public !varargs static <%0 extends com.oracle.truffle.api.library.Library> void register(java.lang.Class<?>,com.oracle.truffle.api.library.LibraryExport<?>[])
 meth public final java.lang.String toString()
 supr java.lang.Object
-hfds GENERATED_CLASS_SUFFIX,defaultExport,library,receiverClass,registerClass
+hfds GENERATED_CLASS_SUFFIX,aot,aotPriority,defaultExport,library,receiverClass,registerClass
 
 CLSS protected abstract interface static com.oracle.truffle.api.library.LibraryExport$DelegateExport
  outer com.oracle.truffle.api.library.LibraryExport
@@ -2137,12 +2742,17 @@ meth protected abstract java.lang.Object genericDispatch(com.oracle.truffle.api.
 meth protected abstract {com.oracle.truffle.api.library.LibraryFactory%0} createDispatchImpl(int)
 meth protected abstract {com.oracle.truffle.api.library.LibraryFactory%0} createProxy(com.oracle.truffle.api.library.ReflectionLibrary)
 meth protected abstract {com.oracle.truffle.api.library.LibraryFactory%0} createUncachedDispatch()
+meth protected final java.util.List<com.oracle.truffle.api.library.LibraryExport<{com.oracle.truffle.api.library.LibraryFactory%0}>> getAOTExports()
+meth protected final {com.oracle.truffle.api.library.LibraryFactory%0} createAOT(com.oracle.truffle.api.library.LibraryExport<{com.oracle.truffle.api.library.LibraryFactory%0}>)
+meth protected java.lang.invoke.MethodHandles$Lookup getLookup()
 meth protected static <%0 extends com.oracle.truffle.api.library.Library> void register(java.lang.Class<{%%0}>,com.oracle.truffle.api.library.LibraryFactory<{%%0}>)
 meth protected static <%0 extends com.oracle.truffle.api.library.Library> {%%0} getDelegateLibrary({%%0},java.lang.Object)
+meth protected static boolean assertAdopted(com.oracle.truffle.api.nodes.Node)
 meth protected static boolean isDelegated(com.oracle.truffle.api.library.Library,int)
 meth protected static java.lang.Object readDelegate(com.oracle.truffle.api.library.Library,java.lang.Object)
 meth protected {com.oracle.truffle.api.library.LibraryFactory%0} createAssertions({com.oracle.truffle.api.library.LibraryFactory%0})
 meth protected {com.oracle.truffle.api.library.LibraryFactory%0} createDelegate({com.oracle.truffle.api.library.LibraryFactory%0})
+meth public final java.util.List<com.oracle.truffle.api.library.Message> getMessages()
 meth public final {com.oracle.truffle.api.library.LibraryFactory%0} create(java.lang.Object)
 meth public final {com.oracle.truffle.api.library.LibraryFactory%0} createDispatched(int)
 meth public final {com.oracle.truffle.api.library.LibraryFactory%0} getUncached()
@@ -2150,17 +2760,21 @@ meth public final {com.oracle.truffle.api.library.LibraryFactory%0} getUncached(
 meth public java.lang.String toString()
 meth public static <%0 extends com.oracle.truffle.api.library.Library> com.oracle.truffle.api.library.LibraryFactory<{%%0}> resolve(java.lang.Class<{%%0}>)
 supr java.lang.Object
-hfds EMPTY_DEFAULT_EXPORT_ARRAY,LIBRARIES,UNSAFE,afterBuiltinDefaultExports,beforeBuiltinDefaultExports,cachedCache,dispatchLibrary,exportCache,externalDefaultProviders,libraryClass,messages,nameToMessages,proxyExports,uncachedCache,uncachedDispatch
-hcls ProxyExports,ResolvedDispatch
+hfds EMPTY_DEFAULT_EXPORT_ARRAY,LIBRARIES,afterBuiltinDefaultExports,aot,beforeBuiltinDefaultExports,cachedCache,dispatchLibrary,eagerExportProviders,exportCache,externalDefaultProviders,libraryClass,messages,nameToMessages,proxyExports,uncachedCache,uncachedDispatch
+hcls CachedAOTExports,ProxyExports,ResolvedDispatch
 
 CLSS public abstract com.oracle.truffle.api.library.Message
-cons protected !varargs init(java.lang.Class<? extends com.oracle.truffle.api.library.Library>,java.lang.String,java.lang.Class<?>,java.lang.Class<?>[])
+cons protected !varargs init(java.lang.Class<? extends com.oracle.truffle.api.library.Library>,java.lang.String,int,boolean,java.lang.Class<?>,java.lang.Class<?>[])
+cons protected !varargs init(java.lang.Class<? extends com.oracle.truffle.api.library.Library>,java.lang.String,int,java.lang.Class<?>,java.lang.Class<?>[])
 meth protected final java.lang.Object clone() throws java.lang.CloneNotSupportedException
 meth public final boolean equals(java.lang.Object)
+meth public final boolean isDeprecated()
 meth public final com.oracle.truffle.api.library.LibraryFactory<?> getFactory()
+meth public final int getId()
 meth public final int getParameterCount()
 meth public final int hashCode()
 meth public final java.lang.Class<? extends com.oracle.truffle.api.library.Library> getLibraryClass()
+meth public final java.lang.Class<?> getParameterType(int)
 meth public final java.lang.Class<?> getReceiverType()
 meth public final java.lang.Class<?> getReturnType()
 meth public final java.lang.String getLibraryName()
@@ -2171,14 +2785,89 @@ meth public final java.util.List<java.lang.Class<?>> getParameterTypes()
 meth public static com.oracle.truffle.api.library.Message resolve(java.lang.Class<? extends com.oracle.truffle.api.library.Library>,java.lang.String)
 meth public static com.oracle.truffle.api.library.Message resolve(java.lang.Class<? extends com.oracle.truffle.api.library.Library>,java.lang.String,boolean)
 supr java.lang.Object
-hfds hash,library,libraryClass,parameterCount,parameterTypes,qualifiedName,returnType,simpleName
+hfds deprecated,hash,id,library,libraryClass,parameterCount,parameterTypes,parameterTypesArray,qualifiedName,returnType,simpleName
 
 CLSS public abstract com.oracle.truffle.api.library.ReflectionLibrary
 cons protected init()
 meth public !varargs java.lang.Object send(java.lang.Object,com.oracle.truffle.api.library.Message,java.lang.Object[]) throws java.lang.Exception
 meth public static com.oracle.truffle.api.library.LibraryFactory<com.oracle.truffle.api.library.ReflectionLibrary> getFactory()
+meth public static com.oracle.truffle.api.library.ReflectionLibrary getUncached()
+meth public static com.oracle.truffle.api.library.ReflectionLibrary getUncached(java.lang.Object)
 supr com.oracle.truffle.api.library.Library
-hfds FACTORY
+hfds FACTORY,UNCACHED
+
+CLSS public abstract interface com.oracle.truffle.api.library.provider.DefaultExportProvider
+meth public abstract int getPriority()
+meth public abstract java.lang.Class<?> getDefaultExport()
+meth public abstract java.lang.Class<?> getReceiverClass()
+meth public abstract java.lang.String getLibraryClassName()
+
+CLSS public abstract interface com.oracle.truffle.api.library.provider.EagerExportProvider
+meth public abstract java.lang.String getLibraryClassName()
+meth public abstract void ensureRegistered()
+
+CLSS public abstract com.oracle.truffle.api.memory.ByteArraySupport
+meth public abstract byte compareAndExchangeByte(byte[],long,byte,byte)
+meth public abstract byte getAndAddByte(byte[],long,byte)
+meth public abstract byte getAndBitwiseAndByte(byte[],long,byte)
+meth public abstract byte getAndBitwiseOrByte(byte[],long,byte)
+meth public abstract byte getAndBitwiseXorByte(byte[],long,byte)
+meth public abstract byte getAndSetByte(byte[],long,byte)
+meth public abstract byte getByte(byte[],int)
+meth public abstract byte getByte(byte[],long)
+meth public abstract byte getByteVolatile(byte[],long)
+meth public abstract double getDouble(byte[],int)
+meth public abstract double getDouble(byte[],long)
+meth public abstract float getFloat(byte[],int)
+meth public abstract float getFloat(byte[],long)
+meth public abstract int compareAndExchangeInt(byte[],long,int,int)
+meth public abstract int getAndAddInt(byte[],long,int)
+meth public abstract int getAndBitwiseAndInt(byte[],long,int)
+meth public abstract int getAndBitwiseOrInt(byte[],long,int)
+meth public abstract int getAndBitwiseXorInt(byte[],long,int)
+meth public abstract int getAndSetInt(byte[],long,int)
+meth public abstract int getInt(byte[],int)
+meth public abstract int getInt(byte[],long)
+meth public abstract int getIntVolatile(byte[],long)
+meth public abstract long compareAndExchangeLong(byte[],long,long,long)
+meth public abstract long getAndAddLong(byte[],long,long)
+meth public abstract long getAndBitwiseAndLong(byte[],long,long)
+meth public abstract long getAndBitwiseOrLong(byte[],long,long)
+meth public abstract long getAndBitwiseXorLong(byte[],long,long)
+meth public abstract long getAndSetLong(byte[],long,long)
+meth public abstract long getLong(byte[],int)
+meth public abstract long getLong(byte[],long)
+meth public abstract long getLongVolatile(byte[],long)
+meth public abstract short compareAndExchangeShort(byte[],long,short,short)
+meth public abstract short getAndAddShort(byte[],long,short)
+meth public abstract short getAndBitwiseAndShort(byte[],long,short)
+meth public abstract short getAndBitwiseOrShort(byte[],long,short)
+meth public abstract short getAndBitwiseXorShort(byte[],long,short)
+meth public abstract short getAndSetShort(byte[],long,short)
+meth public abstract short getShort(byte[],int)
+meth public abstract short getShort(byte[],long)
+meth public abstract short getShortVolatile(byte[],long)
+meth public abstract void putByte(byte[],int,byte)
+meth public abstract void putByte(byte[],long,byte)
+meth public abstract void putByteVolatile(byte[],long,byte)
+meth public abstract void putDouble(byte[],int,double)
+meth public abstract void putDouble(byte[],long,double)
+meth public abstract void putFloat(byte[],int,float)
+meth public abstract void putFloat(byte[],long,float)
+meth public abstract void putInt(byte[],int,int)
+meth public abstract void putInt(byte[],long,int)
+meth public abstract void putIntVolatile(byte[],long,int)
+meth public abstract void putLong(byte[],int,long)
+meth public abstract void putLong(byte[],long,long)
+meth public abstract void putLongVolatile(byte[],long,long)
+meth public abstract void putShort(byte[],int,short)
+meth public abstract void putShort(byte[],long,short)
+meth public abstract void putShortVolatile(byte[],long,short)
+meth public final boolean inBounds(byte[],int,int)
+meth public final boolean inBounds(byte[],long,long)
+meth public static com.oracle.truffle.api.memory.ByteArraySupport bigEndian()
+meth public static com.oracle.truffle.api.memory.ByteArraySupport littleEndian()
+supr java.lang.Object
 
 CLSS public abstract com.oracle.truffle.api.nodes.BlockNode<%0 extends com.oracle.truffle.api.nodes.Node>
 cons protected init({com.oracle.truffle.api.nodes.BlockNode%0}[])
@@ -2213,11 +2902,31 @@ meth public java.lang.Object executeGeneric(com.oracle.truffle.api.frame.Virtual
 meth public long executeLong(com.oracle.truffle.api.frame.VirtualFrame,{com.oracle.truffle.api.nodes.BlockNode$ElementExecutor%0},int,int) throws com.oracle.truffle.api.nodes.UnexpectedResultException
 meth public short executeShort(com.oracle.truffle.api.frame.VirtualFrame,{com.oracle.truffle.api.nodes.BlockNode$ElementExecutor%0},int,int) throws com.oracle.truffle.api.nodes.UnexpectedResultException
 
+CLSS public abstract interface com.oracle.truffle.api.nodes.BytecodeOSRNode
+intf com.oracle.truffle.api.nodes.NodeInterface
+meth public abstract java.lang.Object executeOSR(com.oracle.truffle.api.frame.VirtualFrame,int,java.lang.Object)
+meth public abstract java.lang.Object getOSRMetadata()
+meth public abstract void setOSRMetadata(java.lang.Object)
+meth public com.oracle.truffle.api.frame.Frame restoreParentFrameFromArguments(java.lang.Object[])
+meth public java.lang.Object[] storeParentFrameInArguments(com.oracle.truffle.api.frame.VirtualFrame)
+meth public static boolean pollOSRBackEdge(com.oracle.truffle.api.nodes.BytecodeOSRNode)
+meth public static java.lang.Object tryOSR(com.oracle.truffle.api.nodes.BytecodeOSRNode,int,java.lang.Object,java.lang.Runnable,com.oracle.truffle.api.frame.VirtualFrame)
+meth public void copyIntoOSRFrame(com.oracle.truffle.api.frame.VirtualFrame,com.oracle.truffle.api.frame.VirtualFrame,int)
+ anno 0 java.lang.Deprecated(null since="22.2")
+meth public void copyIntoOSRFrame(com.oracle.truffle.api.frame.VirtualFrame,com.oracle.truffle.api.frame.VirtualFrame,int,java.lang.Object)
+meth public void prepareOSR(int)
+meth public void restoreParentFrame(com.oracle.truffle.api.frame.VirtualFrame,com.oracle.truffle.api.frame.VirtualFrame)
+
 CLSS public com.oracle.truffle.api.nodes.ControlFlowException
 cons public init()
 meth public final java.lang.Throwable fillInStackTrace()
 supr java.lang.RuntimeException
 hfds serialVersionUID
+
+CLSS public abstract interface !annotation com.oracle.truffle.api.nodes.DenyReplace
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+intf java.lang.annotation.Annotation
 
 CLSS public abstract com.oracle.truffle.api.nodes.DirectCallNode
 cons protected init(com.oracle.truffle.api.CallTarget)
@@ -2242,7 +2951,7 @@ meth public com.oracle.truffle.api.nodes.Node get()
 meth public com.oracle.truffle.api.nodes.Node set(com.oracle.truffle.api.nodes.Node)
 meth public static com.oracle.truffle.api.nodes.EncapsulatingNodeReference getCurrent()
 supr java.lang.Object
-hfds CURRENT,reference,thread
+hfds CURRENT,reference,seenNullContext,thread
 
 CLSS public abstract com.oracle.truffle.api.nodes.ExecutableNode
 cons protected init(com.oracle.truffle.api.TruffleLanguage<?>)
@@ -2250,8 +2959,7 @@ meth public abstract java.lang.Object execute(com.oracle.truffle.api.frame.Virtu
 meth public final <%0 extends com.oracle.truffle.api.TruffleLanguage> {%%0} getLanguage(java.lang.Class<{%%0}>)
 meth public final com.oracle.truffle.api.nodes.LanguageInfo getLanguageInfo()
 supr com.oracle.truffle.api.nodes.Node
-hfds GENERIC,engineRef,referenceCache
-hcls ReferenceCache
+hfds polyglotRef
 
 CLSS public final com.oracle.truffle.api.nodes.ExecutionSignature
 fld public final static com.oracle.truffle.api.nodes.ExecutionSignature GENERIC
@@ -2279,61 +2987,6 @@ meth public static com.oracle.truffle.api.nodes.ExplodeLoop$LoopExplosionKind va
 meth public static com.oracle.truffle.api.nodes.ExplodeLoop$LoopExplosionKind[] values()
 supr java.lang.Enum<com.oracle.truffle.api.nodes.ExplodeLoop$LoopExplosionKind>
 
-CLSS public com.oracle.truffle.api.nodes.GraphPrintVisitor
- anno 0 java.lang.Deprecated()
-cons public init()
-cons public init(java.io.OutputStream)
-fld public final static int GraphVisualizerPort = 4444
-fld public final static java.lang.String GraphVisualizerAddress = "127.0.0.1"
-innr public GraphPrintAdapter
-innr public abstract interface static !annotation CustomGraphPrintHandler
-innr public abstract interface static !annotation NullGraphPrintHandler
-innr public abstract interface static GraphPrintHandler
-intf java.io.Closeable
-meth public com.oracle.truffle.api.nodes.GraphPrintVisitor beginGraph(java.lang.String)
-meth public com.oracle.truffle.api.nodes.GraphPrintVisitor beginGroup(java.lang.String)
-meth public com.oracle.truffle.api.nodes.GraphPrintVisitor endGraph()
-meth public com.oracle.truffle.api.nodes.GraphPrintVisitor endGroup()
-meth public com.oracle.truffle.api.nodes.GraphPrintVisitor visit(java.lang.Object)
-meth public com.oracle.truffle.api.nodes.GraphPrintVisitor visit(java.lang.Object,com.oracle.truffle.api.nodes.GraphPrintVisitor$GraphPrintHandler)
-meth public java.lang.String toString()
-meth public void close()
-meth public void printToFile(java.io.File)
-meth public void printToNetwork(boolean)
-meth public void printToSysout()
-supr java.lang.Object
-hfds DEFAULT_GRAPH_NAME,currentGraphName,edgeList,id,nodeMap,openGraphCount,openGroupCount,outputStream,prevNodeMap,xmlstream
-hcls DefaultGraphPrintHandler,EdgeElement,Impl,NodeElement,XMLImpl
-
-CLSS public abstract interface static !annotation com.oracle.truffle.api.nodes.GraphPrintVisitor$CustomGraphPrintHandler
- outer com.oracle.truffle.api.nodes.GraphPrintVisitor
- anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
- anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
-intf java.lang.annotation.Annotation
-meth public abstract java.lang.Class<? extends com.oracle.truffle.api.nodes.GraphPrintVisitor$GraphPrintHandler> handler()
-
-CLSS public com.oracle.truffle.api.nodes.GraphPrintVisitor$GraphPrintAdapter
- outer com.oracle.truffle.api.nodes.GraphPrintVisitor
-cons public init(com.oracle.truffle.api.nodes.GraphPrintVisitor)
-meth public boolean visited(java.lang.Object)
-meth public void connectNodes(java.lang.Object,java.lang.Object)
-meth public void connectNodes(java.lang.Object,java.lang.Object,java.lang.String)
-meth public void createElementForNode(java.lang.Object)
-meth public void setNodeProperty(java.lang.Object,java.lang.String,java.lang.Object)
-meth public void visit(java.lang.Object)
-meth public void visit(java.lang.Object,com.oracle.truffle.api.nodes.GraphPrintVisitor$GraphPrintHandler)
-supr java.lang.Object
-
-CLSS public abstract interface static com.oracle.truffle.api.nodes.GraphPrintVisitor$GraphPrintHandler
- outer com.oracle.truffle.api.nodes.GraphPrintVisitor
-meth public abstract void visit(java.lang.Object,com.oracle.truffle.api.nodes.GraphPrintVisitor$GraphPrintAdapter)
-
-CLSS public abstract interface static !annotation com.oracle.truffle.api.nodes.GraphPrintVisitor$NullGraphPrintHandler
- outer com.oracle.truffle.api.nodes.GraphPrintVisitor
- anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
- anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
-intf java.lang.annotation.Annotation
-
 CLSS public abstract com.oracle.truffle.api.nodes.IndirectCallNode
 cons protected init()
 meth public abstract !varargs java.lang.Object call(com.oracle.truffle.api.CallTarget,java.lang.Object[])
@@ -2356,13 +3009,11 @@ meth public java.lang.String getName()
 meth public java.lang.String getVersion()
 meth public java.util.Set<java.lang.String> getMimeTypes()
 supr java.lang.Object
-hfds defaultMimeType,id,interactive,internal,mimeTypes,name,polyglotLanguage,version
+hfds defaultMimeType,id,interactive,internal,languageCache,mimeTypes,name,version
 
 CLSS public abstract com.oracle.truffle.api.nodes.LoopNode
 cons protected init()
 meth public abstract com.oracle.truffle.api.nodes.RepeatingNode getRepeatingNode()
-meth public abstract void executeLoop(com.oracle.truffle.api.frame.VirtualFrame)
- anno 0 java.lang.Deprecated()
 meth public java.lang.Object execute(com.oracle.truffle.api.frame.VirtualFrame)
 meth public static void reportLoopCount(com.oracle.truffle.api.nodes.Node,int)
 supr com.oracle.truffle.api.nodes.Node
@@ -2373,13 +3024,8 @@ innr public abstract interface static !annotation Child
 innr public abstract interface static !annotation Children
 intf com.oracle.truffle.api.nodes.NodeInterface
 intf java.lang.Cloneable
-meth protected final <%0 extends com.oracle.truffle.api.TruffleLanguage> com.oracle.truffle.api.TruffleLanguage$LanguageReference<{%%0}> lookupLanguageReference(java.lang.Class<{%%0}>)
-meth protected final <%0 extends com.oracle.truffle.api.nodes.Node> {%%0} insert({%%0})
-meth protected final <%0 extends com.oracle.truffle.api.nodes.Node> {%%0}[] insert({%%0}[])
-meth protected final <%0 extends java.lang.Object, %1 extends com.oracle.truffle.api.TruffleLanguage<{%%0}>> com.oracle.truffle.api.TruffleLanguage$ContextReference<{%%0}> lookupContextReference(java.lang.Class<{%%1}>)
 meth protected final java.util.concurrent.locks.Lock getLock()
 meth protected final void notifyInserted(com.oracle.truffle.api.nodes.Node)
-meth protected final void reportPolymorphicSpecialize()
 meth protected void onReplace(com.oracle.truffle.api.nodes.Node,java.lang.CharSequence)
 meth public boolean isAdoptable()
 meth public com.oracle.truffle.api.nodes.Node copy()
@@ -2387,8 +3033,10 @@ meth public com.oracle.truffle.api.nodes.Node deepCopy()
 meth public com.oracle.truffle.api.nodes.NodeCost getCost()
 meth public com.oracle.truffle.api.source.SourceSection getEncapsulatingSourceSection()
 meth public com.oracle.truffle.api.source.SourceSection getSourceSection()
+meth public final <%0 extends com.oracle.truffle.api.nodes.Node> {%%0} insert({%%0})
 meth public final <%0 extends com.oracle.truffle.api.nodes.Node> {%%0} replace({%%0})
 meth public final <%0 extends com.oracle.truffle.api.nodes.Node> {%%0} replace({%%0},java.lang.CharSequence)
+meth public final <%0 extends com.oracle.truffle.api.nodes.Node> {%%0}[] insert({%%0}[])
 meth public final <%0 extends java.lang.Object> {%%0} atomic(java.util.concurrent.Callable<{%%0}>)
 meth public final boolean isSafelyReplaceableBy(com.oracle.truffle.api.nodes.Node)
 meth public final com.oracle.truffle.api.nodes.Node getParent()
@@ -2397,11 +3045,12 @@ meth public final java.lang.Iterable<com.oracle.truffle.api.nodes.Node> getChild
 meth public final void accept(com.oracle.truffle.api.nodes.NodeVisitor)
 meth public final void adoptChildren()
 meth public final void atomic(java.lang.Runnable)
+meth public final void reportPolymorphicSpecialize()
 meth public java.lang.String getDescription()
 meth public java.lang.String toString()
 meth public java.util.Map<java.lang.String,java.lang.Object> getDebugProperties()
 supr java.lang.Object
-hfds GIL_LOCK,UNCACHED_CONTEXT_REFERENCES,UNCACHED_LANGUAGE_REFERENCES,parent
+hfds GIL_LOCK,PARENT_LIMIT,SAME_LANGUAGE_CHECK_VISITOR,parent
 
 CLSS public abstract interface static !annotation com.oracle.truffle.api.nodes.Node$Child
  outer com.oracle.truffle.api.nodes.Node
@@ -2420,27 +3069,14 @@ cons public init(java.lang.Class<? extends com.oracle.truffle.api.nodes.Node>)
 meth protected abstract boolean isChildField(java.lang.Object)
 meth protected abstract boolean isChildrenField(java.lang.Object)
 meth protected abstract boolean isCloneableField(java.lang.Object)
+meth protected abstract boolean isReplaceAllowed()
 meth protected abstract java.lang.Class<?> getFieldType(java.lang.Object)
-meth protected abstract java.lang.Iterable<?> getNodeFields()
- anno 0 java.lang.Deprecated()
 meth protected abstract java.lang.Object getFieldObject(java.lang.Object,com.oracle.truffle.api.nodes.Node)
 meth protected abstract java.lang.Object getFieldValue(java.lang.Object,com.oracle.truffle.api.nodes.Node)
 meth protected abstract java.lang.Object[] getNodeFieldArray()
 meth protected abstract java.lang.String getFieldName(java.lang.Object)
 meth protected abstract void putFieldObject(java.lang.Object,com.oracle.truffle.api.nodes.Node,java.lang.Object)
 meth public abstract java.lang.Class<? extends com.oracle.truffle.api.nodes.Node> getType()
-meth public com.oracle.truffle.api.nodes.NodeFieldAccessor getNodeClassField()
- anno 0 java.lang.Deprecated()
-meth public com.oracle.truffle.api.nodes.NodeFieldAccessor getParentField()
- anno 0 java.lang.Deprecated()
-meth public com.oracle.truffle.api.nodes.NodeFieldAccessor[] getChildFields()
- anno 0 java.lang.Deprecated()
-meth public com.oracle.truffle.api.nodes.NodeFieldAccessor[] getChildrenFields()
- anno 0 java.lang.Deprecated()
-meth public com.oracle.truffle.api.nodes.NodeFieldAccessor[] getCloneableFields()
- anno 0 java.lang.Deprecated()
-meth public com.oracle.truffle.api.nodes.NodeFieldAccessor[] getFields()
- anno 0 java.lang.Deprecated()
 meth public java.util.Iterator<com.oracle.truffle.api.nodes.Node> makeIterator(com.oracle.truffle.api.nodes.Node)
 meth public static com.oracle.truffle.api.nodes.NodeClass get(com.oracle.truffle.api.nodes.Node)
 meth public static com.oracle.truffle.api.nodes.NodeClass get(java.lang.Class<? extends com.oracle.truffle.api.nodes.Node>)
@@ -2465,54 +3101,6 @@ meth public static com.oracle.truffle.api.nodes.NodeCost valueOf(java.lang.Strin
 meth public static com.oracle.truffle.api.nodes.NodeCost[] values()
 supr java.lang.Enum<com.oracle.truffle.api.nodes.NodeCost>
 
-CLSS public abstract com.oracle.truffle.api.nodes.NodeFieldAccessor
- anno 0 java.lang.Deprecated()
-cons protected init(com.oracle.truffle.api.nodes.NodeFieldAccessor$NodeFieldKind,java.lang.Class<?>,java.lang.String,java.lang.Class<?>)
-fld protected final java.lang.Class<?> type
-innr public abstract static AbstractUnsafeNodeFieldAccessor
-innr public final static !enum NodeFieldKind
-meth protected static com.oracle.truffle.api.nodes.NodeFieldAccessor create(com.oracle.truffle.api.nodes.NodeFieldAccessor$NodeFieldKind,java.lang.reflect.Field)
-meth public abstract java.lang.Object getObject(com.oracle.truffle.api.nodes.Node)
- anno 0 java.lang.Deprecated()
-meth public abstract java.lang.Object loadValue(com.oracle.truffle.api.nodes.Node)
-meth public abstract void putObject(com.oracle.truffle.api.nodes.Node,java.lang.Object)
- anno 0 java.lang.Deprecated()
-meth public com.oracle.truffle.api.nodes.NodeFieldAccessor$NodeFieldKind getKind()
-meth public java.lang.Class<?> getDeclaringClass()
-meth public java.lang.Class<?> getType()
-meth public java.lang.String getName()
-meth public java.lang.String toString()
-supr java.lang.Object
-hfds USE_UNSAFE,declaringClass,kind,name
-hcls ReflectionNodeField,UnsafeNodeField
-
-CLSS public abstract static com.oracle.truffle.api.nodes.NodeFieldAccessor$AbstractUnsafeNodeFieldAccessor
- outer com.oracle.truffle.api.nodes.NodeFieldAccessor
- anno 0 java.lang.Deprecated()
-cons protected init(com.oracle.truffle.api.nodes.NodeFieldAccessor$NodeFieldKind,java.lang.Class<?>,java.lang.String,java.lang.Class<?>)
- anno 0 java.lang.Deprecated()
-meth public abstract long getOffset()
- anno 0 java.lang.Deprecated()
-meth public java.lang.Object getObject(com.oracle.truffle.api.nodes.Node)
- anno 0 java.lang.Deprecated()
-meth public java.lang.Object loadValue(com.oracle.truffle.api.nodes.Node)
- anno 0 java.lang.Deprecated()
-meth public void putObject(com.oracle.truffle.api.nodes.Node,java.lang.Object)
- anno 0 java.lang.Deprecated()
-supr com.oracle.truffle.api.nodes.NodeFieldAccessor
-hfds unsafe
-
-CLSS public final static !enum com.oracle.truffle.api.nodes.NodeFieldAccessor$NodeFieldKind
- outer com.oracle.truffle.api.nodes.NodeFieldAccessor
-fld public final static com.oracle.truffle.api.nodes.NodeFieldAccessor$NodeFieldKind CHILD
-fld public final static com.oracle.truffle.api.nodes.NodeFieldAccessor$NodeFieldKind CHILDREN
-fld public final static com.oracle.truffle.api.nodes.NodeFieldAccessor$NodeFieldKind DATA
-fld public final static com.oracle.truffle.api.nodes.NodeFieldAccessor$NodeFieldKind NODE_CLASS
-fld public final static com.oracle.truffle.api.nodes.NodeFieldAccessor$NodeFieldKind PARENT
-meth public static com.oracle.truffle.api.nodes.NodeFieldAccessor$NodeFieldKind valueOf(java.lang.String)
-meth public static com.oracle.truffle.api.nodes.NodeFieldAccessor$NodeFieldKind[] values()
-supr java.lang.Enum<com.oracle.truffle.api.nodes.NodeFieldAccessor$NodeFieldKind>
-
 CLSS public abstract interface !annotation com.oracle.truffle.api.nodes.NodeInfo
  anno 0 java.lang.annotation.Inherited()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
@@ -2535,35 +3123,32 @@ meth public static <%0 extends java.lang.Object> {%%0} findFirstNodeInstance(com
 meth public static <%0 extends java.lang.Object> {%%0} findParent(com.oracle.truffle.api.nodes.Node,java.lang.Class<{%%0}>)
 meth public static <%0 extends java.lang.Object> {%%0}[] concat({%%0}[],{%%0}[])
 meth public static <%0 extends java.lang.annotation.Annotation> {%%0} findAnnotation(java.lang.Class<?>,java.lang.Class<{%%0}>)
+meth public static boolean assertAdopted(com.oracle.truffle.api.nodes.Node)
+meth public static boolean assertRecursion(com.oracle.truffle.api.nodes.Node,int)
 meth public static boolean forEachChild(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.nodes.NodeVisitor)
 meth public static boolean isReplacementSafe(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.nodes.Node)
 meth public static boolean replaceChild(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.nodes.Node)
 meth public static boolean verify(com.oracle.truffle.api.nodes.Node)
-meth public static com.oracle.truffle.api.nodes.Node getCurrentEncapsulatingNode()
- anno 0 java.lang.Deprecated()
 meth public static com.oracle.truffle.api.nodes.Node getNthParent(com.oracle.truffle.api.nodes.Node,int)
-meth public static com.oracle.truffle.api.nodes.Node pushEncapsulatingNode(com.oracle.truffle.api.nodes.Node)
- anno 0 java.lang.Deprecated()
-meth public static com.oracle.truffle.api.nodes.NodeFieldAccessor findChildField(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.nodes.Node)
- anno 0 java.lang.Deprecated()
 meth public static int countNodes(com.oracle.truffle.api.nodes.Node)
 meth public static int countNodes(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.nodes.NodeUtil$NodeCountFilter)
+meth public static java.lang.String findChildFieldName(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.nodes.Node)
 meth public static java.lang.String printCompactTreeToString(com.oracle.truffle.api.nodes.Node)
 meth public static java.lang.String printSourceAttributionTree(com.oracle.truffle.api.nodes.Node)
 meth public static java.lang.String printSyntaxTags(java.lang.Object)
 meth public static java.lang.String printTreeToString(com.oracle.truffle.api.nodes.Node)
-meth public static java.util.Iterator<com.oracle.truffle.api.nodes.Node> makeRecursiveIterator(com.oracle.truffle.api.nodes.Node)
 meth public static java.util.List<com.oracle.truffle.api.nodes.Node> collectNodes(com.oracle.truffle.api.nodes.Node,com.oracle.truffle.api.nodes.Node)
 meth public static java.util.List<com.oracle.truffle.api.nodes.Node> findNodeChildren(com.oracle.truffle.api.nodes.Node)
-meth public static void popEncapsulatingNode(com.oracle.truffle.api.nodes.Node)
- anno 0 java.lang.Deprecated()
+meth public static java.util.List<java.lang.String> collectFieldNames(java.lang.Class<? extends com.oracle.truffle.api.nodes.Node>)
+meth public static java.util.Map<java.lang.String,com.oracle.truffle.api.nodes.Node> collectNodeChildren(com.oracle.truffle.api.nodes.Node)
+meth public static java.util.Map<java.lang.String,java.lang.Object> collectNodeProperties(com.oracle.truffle.api.nodes.Node)
 meth public static void printCompactTree(java.io.OutputStream,com.oracle.truffle.api.nodes.Node)
 meth public static void printSourceAttributionTree(java.io.OutputStream,com.oracle.truffle.api.nodes.Node)
 meth public static void printSourceAttributionTree(java.io.PrintWriter,com.oracle.truffle.api.nodes.Node)
 meth public static void printTree(java.io.OutputStream,com.oracle.truffle.api.nodes.Node)
 meth public static void printTree(java.io.PrintWriter,com.oracle.truffle.api.nodes.Node)
 supr java.lang.Object
-hcls NodeCounter,RecursiveNodeIterator
+hcls NodeCounter
 
 CLSS public abstract interface static com.oracle.truffle.api.nodes.NodeUtil$NodeCountFilter
  outer com.oracle.truffle.api.nodes.NodeUtil
@@ -2585,22 +3170,22 @@ meth public java.lang.Object initialLoopStatus()
 CLSS public abstract com.oracle.truffle.api.nodes.RootNode
 cons protected init(com.oracle.truffle.api.TruffleLanguage<?>)
 cons protected init(com.oracle.truffle.api.TruffleLanguage<?>,com.oracle.truffle.api.frame.FrameDescriptor)
+meth protected boolean countsTowardsStackTraceLimit()
 meth protected boolean isCloneUninitializedSupported()
 meth protected boolean isInstrumentable()
+meth protected boolean isSameFrame(com.oracle.truffle.api.frame.Frame,com.oracle.truffle.api.frame.Frame)
 meth protected boolean isTrivial()
+meth protected com.oracle.truffle.api.frame.FrameDescriptor getParentFrameDescriptor()
 meth protected com.oracle.truffle.api.nodes.ExecutionSignature prepareForAOT()
 meth protected com.oracle.truffle.api.nodes.RootNode cloneUninitialized()
-meth protected final void setCallTarget(com.oracle.truffle.api.RootCallTarget)
+meth protected int computeSize()
 meth protected java.lang.Object translateStackTraceElement(com.oracle.truffle.api.TruffleStackTraceElement)
 meth protected java.util.List<com.oracle.truffle.api.TruffleStackTraceElement> findAsynchronousFrames(com.oracle.truffle.api.frame.Frame)
 meth public abstract java.lang.Object execute(com.oracle.truffle.api.frame.VirtualFrame)
 meth public boolean isCaptureFramesForTrace()
 meth public boolean isCloningAllowed()
 meth public boolean isInternal()
-meth public com.oracle.truffle.api.CompilerOptions getCompilerOptions()
 meth public com.oracle.truffle.api.nodes.Node copy()
-meth public final <%0 extends java.lang.Object, %1 extends com.oracle.truffle.api.TruffleLanguage<{%%0}>> {%%0} getCurrentContext(java.lang.Class<{%%1}>)
- anno 0 java.lang.Deprecated()
 meth public final com.oracle.truffle.api.RootCallTarget getCallTarget()
 meth public final com.oracle.truffle.api.frame.FrameDescriptor getFrameDescriptor()
 meth public java.lang.String getName()
@@ -2616,7 +3201,7 @@ cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
 meth public final java.lang.Throwable fillInStackTrace()
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="19.0")
 supr java.lang.Exception
 hfds serialVersionUID
 
@@ -2627,61 +3212,41 @@ supr com.oracle.truffle.api.nodes.SlowPathException
 hfds result,serialVersionUID
 
 CLSS public abstract interface com.oracle.truffle.api.object.BooleanLocation
-intf com.oracle.truffle.api.object.TypedLocation
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract boolean getBoolean(com.oracle.truffle.api.object.DynamicObject,boolean)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract boolean getBoolean(com.oracle.truffle.api.object.DynamicObject,com.oracle.truffle.api.object.Shape)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract java.lang.Class<java.lang.Boolean> getType()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract void setBoolean(com.oracle.truffle.api.object.DynamicObject,boolean) throws com.oracle.truffle.api.object.FinalLocationException
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract void setBoolean(com.oracle.truffle.api.object.DynamicObject,boolean,com.oracle.truffle.api.object.Shape) throws com.oracle.truffle.api.object.FinalLocationException
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract void setBoolean(com.oracle.truffle.api.object.DynamicObject,boolean,com.oracle.truffle.api.object.Shape,com.oracle.truffle.api.object.Shape)
+ anno 0 java.lang.Deprecated(null since="22.2")
 
 CLSS public abstract interface com.oracle.truffle.api.object.DoubleLocation
-intf com.oracle.truffle.api.object.TypedLocation
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract double getDouble(com.oracle.truffle.api.object.DynamicObject,boolean)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract double getDouble(com.oracle.truffle.api.object.DynamicObject,com.oracle.truffle.api.object.Shape)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract java.lang.Class<java.lang.Double> getType()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract void setDouble(com.oracle.truffle.api.object.DynamicObject,double) throws com.oracle.truffle.api.object.FinalLocationException
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract void setDouble(com.oracle.truffle.api.object.DynamicObject,double,com.oracle.truffle.api.object.Shape) throws com.oracle.truffle.api.object.FinalLocationException
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract void setDouble(com.oracle.truffle.api.object.DynamicObject,double,com.oracle.truffle.api.object.Shape,com.oracle.truffle.api.object.Shape)
+ anno 0 java.lang.Deprecated(null since="22.2")
 
 CLSS public abstract com.oracle.truffle.api.object.DynamicObject
-cons protected init()
- anno 0 java.lang.Deprecated()
 cons protected init(com.oracle.truffle.api.object.Shape)
-cons protected init(com.oracle.truffle.api.object.Shape,com.oracle.truffle.api.object.Layout$Access)
- anno 0 java.lang.Deprecated()
 innr protected abstract interface static !annotation DynamicField
 intf com.oracle.truffle.api.interop.TruffleObject
 meth protected java.lang.Object clone() throws java.lang.CloneNotSupportedException
-meth public boolean containsKey(java.lang.Object)
- anno 0 java.lang.Deprecated()
-meth public boolean delete(java.lang.Object)
- anno 0 java.lang.Deprecated()
-meth public boolean isEmpty()
- anno 0 java.lang.Deprecated()
-meth public boolean set(java.lang.Object,java.lang.Object)
- anno 0 java.lang.Deprecated()
-meth public boolean updateShape()
- anno 0 java.lang.Deprecated()
-meth public com.oracle.truffle.api.object.DynamicObject copy(com.oracle.truffle.api.object.Shape)
- anno 0 java.lang.Deprecated()
 meth public final com.oracle.truffle.api.object.Shape getShape()
-meth public int size()
- anno 0 java.lang.Deprecated()
-meth public java.lang.Object get(java.lang.Object)
- anno 0 java.lang.Deprecated()
-meth public java.lang.Object get(java.lang.Object,java.lang.Object)
- anno 0 java.lang.Deprecated()
-meth public void define(java.lang.Object,java.lang.Object)
- anno 0 java.lang.Deprecated()
-meth public void define(java.lang.Object,java.lang.Object,int)
- anno 0 java.lang.Deprecated()
-meth public void define(java.lang.Object,java.lang.Object,int,com.oracle.truffle.api.object.LocationFactory)
- anno 0 java.lang.Deprecated()
-meth public void setShapeAndGrow(com.oracle.truffle.api.object.Shape,com.oracle.truffle.api.object.Shape)
- anno 0 java.lang.Deprecated()
-meth public void setShapeAndResize(com.oracle.truffle.api.object.Shape,com.oracle.truffle.api.object.Shape)
- anno 0 java.lang.Deprecated()
 supr java.lang.Object
 hfds SHAPE_OFFSET,UNSAFE,extRef,extVal,shape
 
@@ -2692,6 +3257,7 @@ CLSS protected abstract interface static !annotation com.oracle.truffle.api.obje
 intf java.lang.annotation.Annotation
 
 CLSS public abstract interface com.oracle.truffle.api.object.DynamicObjectFactory
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract !varargs com.oracle.truffle.api.object.DynamicObject newInstance(java.lang.Object[])
 meth public abstract com.oracle.truffle.api.object.Shape getShape()
 
@@ -2730,9 +3296,9 @@ supr com.oracle.truffle.api.library.Library
 hfds FACTORY,UNCACHED
 
 CLSS public final com.oracle.truffle.api.object.FinalLocationException
-cons public init()
+ anno 0 java.lang.Deprecated(null since="22.2")
 supr com.oracle.truffle.api.nodes.SlowPathException
-hfds serialVersionUID
+hfds INSTANCE,serialVersionUID
 
 CLSS public final com.oracle.truffle.api.object.HiddenKey
 cons public init(java.lang.String)
@@ -2745,41 +3311,39 @@ supr java.lang.Object
 hfds name
 
 CLSS public final com.oracle.truffle.api.object.IncompatibleLocationException
-cons public init()
+ anno 0 java.lang.Deprecated(null since="22.2")
 supr com.oracle.truffle.api.nodes.SlowPathException
-hfds serialVersionUID
+hfds INSTANCE,serialVersionUID
 
 CLSS public abstract interface com.oracle.truffle.api.object.IntLocation
-intf com.oracle.truffle.api.object.TypedLocation
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract int getInt(com.oracle.truffle.api.object.DynamicObject,boolean)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract int getInt(com.oracle.truffle.api.object.DynamicObject,com.oracle.truffle.api.object.Shape)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract java.lang.Class<java.lang.Integer> getType()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract void setInt(com.oracle.truffle.api.object.DynamicObject,int) throws com.oracle.truffle.api.object.FinalLocationException
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract void setInt(com.oracle.truffle.api.object.DynamicObject,int,com.oracle.truffle.api.object.Shape) throws com.oracle.truffle.api.object.FinalLocationException
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract void setInt(com.oracle.truffle.api.object.DynamicObject,int,com.oracle.truffle.api.object.Shape,com.oracle.truffle.api.object.Shape)
+ anno 0 java.lang.Deprecated(null since="22.2")
 
 CLSS public abstract com.oracle.truffle.api.object.Layout
+ anno 0 java.lang.Deprecated(null since="21.1")
 cons protected init()
 fld public final static java.lang.String OPTION_PREFIX = "truffle.object."
 innr protected abstract static Access
 innr public final static !enum ImplicitCast
 innr public final static Builder
 meth protected com.oracle.truffle.api.object.Shape buildShape(java.lang.Object,java.lang.Object,int,com.oracle.truffle.api.Assumption)
-meth protected static boolean getPolymorphicUnboxing(com.oracle.truffle.api.object.Layout$Builder)
 meth protected static com.oracle.truffle.api.object.LayoutFactory getFactory()
-meth protected static java.lang.Class<? extends com.oracle.truffle.api.object.DynamicObject> getType(com.oracle.truffle.api.object.Layout$Builder)
-meth protected static java.util.EnumSet<com.oracle.truffle.api.object.Layout$ImplicitCast> getAllowedImplicitCasts(com.oracle.truffle.api.object.Layout$Builder)
-meth public abstract com.oracle.truffle.api.object.DynamicObject newInstance(com.oracle.truffle.api.object.Shape)
- anno 0 java.lang.Deprecated()
-meth public abstract com.oracle.truffle.api.object.Shape createShape(com.oracle.truffle.api.object.ObjectType)
-meth public abstract com.oracle.truffle.api.object.Shape createShape(com.oracle.truffle.api.object.ObjectType,java.lang.Object)
-meth public abstract com.oracle.truffle.api.object.Shape createShape(com.oracle.truffle.api.object.ObjectType,java.lang.Object,int)
 meth public abstract com.oracle.truffle.api.object.Shape$Allocator createAllocator()
+ anno 0 java.lang.Deprecated(null since="21.1")
 meth public abstract java.lang.Class<? extends com.oracle.truffle.api.object.DynamicObject> getType()
-meth public static com.oracle.truffle.api.object.Layout createLayout()
-meth public static com.oracle.truffle.api.object.Layout$Builder newLayout()
 supr java.lang.Object
-hfds LAYOUT_FACTORY
+hfds INT_TO_DOUBLE_FLAG,INT_TO_LONG_FLAG,LAYOUT_FACTORY
 
 CLSS protected abstract static com.oracle.truffle.api.object.Layout$Access
  outer com.oracle.truffle.api.object.Layout
@@ -2796,17 +3360,17 @@ supr java.lang.Object
 
 CLSS public final static com.oracle.truffle.api.object.Layout$Builder
  outer com.oracle.truffle.api.object.Layout
+ anno 0 java.lang.Deprecated(null since="21.1")
 meth public com.oracle.truffle.api.object.Layout build()
 meth public com.oracle.truffle.api.object.Layout$Builder addAllowedImplicitCast(com.oracle.truffle.api.object.Layout$ImplicitCast)
 meth public com.oracle.truffle.api.object.Layout$Builder setAllowedImplicitCasts(java.util.EnumSet<com.oracle.truffle.api.object.Layout$ImplicitCast>)
-meth public com.oracle.truffle.api.object.Layout$Builder setPolymorphicUnboxing(boolean)
- anno 0 java.lang.Deprecated()
 meth public com.oracle.truffle.api.object.Layout$Builder type(java.lang.Class<? extends com.oracle.truffle.api.object.DynamicObject>)
 supr java.lang.Object
-hfds allowedImplicitCasts,dynamicObjectClass,polymorphicUnboxing
+hfds allowedImplicitCasts,dynamicObjectClass
 
 CLSS public final static !enum com.oracle.truffle.api.object.Layout$ImplicitCast
  outer com.oracle.truffle.api.object.Layout
+ anno 0 java.lang.Deprecated(null since="21.1")
 fld public final static com.oracle.truffle.api.object.Layout$ImplicitCast IntToDouble
 fld public final static com.oracle.truffle.api.object.Layout$ImplicitCast IntToLong
 meth public static com.oracle.truffle.api.object.Layout$ImplicitCast valueOf(java.lang.String)
@@ -2814,41 +3378,68 @@ meth public static com.oracle.truffle.api.object.Layout$ImplicitCast[] values()
 supr java.lang.Enum<com.oracle.truffle.api.object.Layout$ImplicitCast>
 
 CLSS public abstract interface com.oracle.truffle.api.object.LayoutFactory
-meth public abstract com.oracle.truffle.api.object.Layout createLayout(com.oracle.truffle.api.object.Layout$Builder)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract com.oracle.truffle.api.object.Property createProperty(java.lang.Object,com.oracle.truffle.api.object.Location)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract com.oracle.truffle.api.object.Property createProperty(java.lang.Object,com.oracle.truffle.api.object.Location,int)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract int getPriority()
+meth public com.oracle.truffle.api.object.Layout createLayout(com.oracle.truffle.api.object.Layout$Builder)
+ anno 0 java.lang.Deprecated(null since="22.2")
+meth public com.oracle.truffle.api.object.Shape createShape(java.lang.Object)
 
 CLSS public abstract com.oracle.truffle.api.object.Location
 cons protected init()
 meth protected abstract java.lang.Object getInternal(com.oracle.truffle.api.object.DynamicObject)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth protected abstract void setInternal(com.oracle.truffle.api.object.DynamicObject,java.lang.Object) throws com.oracle.truffle.api.object.IncompatibleLocationException
+ anno 0 java.lang.Deprecated(null since="22.2")
+meth protected double getDouble(com.oracle.truffle.api.object.DynamicObject,boolean) throws com.oracle.truffle.api.nodes.UnexpectedResultException
+meth protected int getInt(com.oracle.truffle.api.object.DynamicObject,boolean) throws com.oracle.truffle.api.nodes.UnexpectedResultException
+meth protected long getLong(com.oracle.truffle.api.object.DynamicObject,boolean) throws com.oracle.truffle.api.nodes.UnexpectedResultException
 meth protected static boolean checkShape(com.oracle.truffle.api.object.DynamicObject,com.oracle.truffle.api.object.Shape)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth protected static com.oracle.truffle.api.object.FinalLocationException finalLocation() throws com.oracle.truffle.api.object.FinalLocationException
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth protected static com.oracle.truffle.api.object.IncompatibleLocationException incompatibleLocation() throws com.oracle.truffle.api.object.IncompatibleLocationException
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract boolean equals(java.lang.Object)
 meth public abstract int hashCode()
 meth public boolean canSet(com.oracle.truffle.api.object.DynamicObject,java.lang.Object)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public boolean canSet(java.lang.Object)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public boolean canStore(java.lang.Object)
 meth public boolean isAssumedFinal()
 meth public boolean isConstant()
 meth public boolean isDeclared()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public boolean isFinal()
+meth public boolean isPrimitive()
 meth public boolean isValue()
 meth public com.oracle.truffle.api.Assumption getFinalAssumption()
 meth public final java.lang.Object get(com.oracle.truffle.api.object.DynamicObject)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public final java.lang.Object get(com.oracle.truffle.api.object.DynamicObject,com.oracle.truffle.api.object.Shape)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public final void set(com.oracle.truffle.api.object.DynamicObject,java.lang.Object) throws com.oracle.truffle.api.object.FinalLocationException,com.oracle.truffle.api.object.IncompatibleLocationException
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public java.lang.Object get(com.oracle.truffle.api.object.DynamicObject,boolean)
+ anno 0 java.lang.Deprecated(null since="22.2")
+meth public java.lang.Object getConstantValue()
 meth public void set(com.oracle.truffle.api.object.DynamicObject,java.lang.Object,com.oracle.truffle.api.object.Shape) throws com.oracle.truffle.api.object.FinalLocationException,com.oracle.truffle.api.object.IncompatibleLocationException
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public void set(com.oracle.truffle.api.object.DynamicObject,java.lang.Object,com.oracle.truffle.api.object.Shape,com.oracle.truffle.api.object.Shape) throws com.oracle.truffle.api.object.IncompatibleLocationException
+ anno 0 java.lang.Deprecated(null since="22.2")
 supr java.lang.Object
 
 CLSS public abstract interface com.oracle.truffle.api.object.LocationFactory
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract com.oracle.truffle.api.object.Location createLocation(com.oracle.truffle.api.object.Shape,java.lang.Object)
+ anno 0 java.lang.Deprecated(null since="22.2")
 
 CLSS public final !enum com.oracle.truffle.api.object.LocationModifier
+ anno 0 java.lang.Deprecated(null since="22.2")
 fld public final static com.oracle.truffle.api.object.LocationModifier Final
 fld public final static com.oracle.truffle.api.object.LocationModifier NonNull
 meth public static com.oracle.truffle.api.object.LocationModifier valueOf(java.lang.String)
@@ -2856,60 +3447,78 @@ meth public static com.oracle.truffle.api.object.LocationModifier[] values()
 supr java.lang.Enum<com.oracle.truffle.api.object.LocationModifier>
 
 CLSS public abstract interface com.oracle.truffle.api.object.LongLocation
-intf com.oracle.truffle.api.object.TypedLocation
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract java.lang.Class<java.lang.Long> getType()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract long getLong(com.oracle.truffle.api.object.DynamicObject,boolean)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract long getLong(com.oracle.truffle.api.object.DynamicObject,com.oracle.truffle.api.object.Shape)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract void setLong(com.oracle.truffle.api.object.DynamicObject,long) throws com.oracle.truffle.api.object.FinalLocationException
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract void setLong(com.oracle.truffle.api.object.DynamicObject,long,com.oracle.truffle.api.object.Shape) throws com.oracle.truffle.api.object.FinalLocationException
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract void setLong(com.oracle.truffle.api.object.DynamicObject,long,com.oracle.truffle.api.object.Shape,com.oracle.truffle.api.object.Shape)
+ anno 0 java.lang.Deprecated(null since="22.2")
 
 CLSS public abstract interface com.oracle.truffle.api.object.ObjectLocation
-intf com.oracle.truffle.api.object.TypedLocation
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract boolean isNonNull()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract java.lang.Class<?> getType()
+ anno 0 java.lang.Deprecated(null since="22.2")
 
 CLSS public com.oracle.truffle.api.object.ObjectType
+ anno 0 java.lang.Deprecated(null since="22.2")
 cons public init()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public boolean equals(com.oracle.truffle.api.object.DynamicObject,java.lang.Object)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public int hashCode(com.oracle.truffle.api.object.DynamicObject)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public java.lang.Class<?> dispatch()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public java.lang.String toString(com.oracle.truffle.api.object.DynamicObject)
+ anno 0 java.lang.Deprecated(null since="22.2")
 supr java.lang.Object
 hfds DEFAULT
 
 CLSS public abstract com.oracle.truffle.api.object.Property
 cons protected init()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract boolean isHidden()
-meth public abstract boolean isSame(com.oracle.truffle.api.object.Property)
- anno 0 java.lang.Deprecated()
 meth public abstract com.oracle.truffle.api.object.Location getLocation()
-meth public abstract com.oracle.truffle.api.object.Property copyWithFlags(int)
- anno 0 java.lang.Deprecated()
-meth public abstract com.oracle.truffle.api.object.Property copyWithRelocatable(boolean)
- anno 0 java.lang.Deprecated()
-meth public abstract com.oracle.truffle.api.object.Property relocate(com.oracle.truffle.api.object.Location)
- anno 0 java.lang.Deprecated()
 meth public abstract int getFlags()
 meth public abstract java.lang.Object get(com.oracle.truffle.api.object.DynamicObject,boolean)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract java.lang.Object get(com.oracle.truffle.api.object.DynamicObject,com.oracle.truffle.api.object.Shape)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract java.lang.Object getKey()
 meth public abstract void set(com.oracle.truffle.api.object.DynamicObject,java.lang.Object,com.oracle.truffle.api.object.Shape) throws com.oracle.truffle.api.object.FinalLocationException,com.oracle.truffle.api.object.IncompatibleLocationException
-meth public abstract void set(com.oracle.truffle.api.object.DynamicObject,java.lang.Object,com.oracle.truffle.api.object.Shape,com.oracle.truffle.api.object.Shape) throws com.oracle.truffle.api.object.IncompatibleLocationException
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract void setGeneric(com.oracle.truffle.api.object.DynamicObject,java.lang.Object,com.oracle.truffle.api.object.Shape)
-meth public abstract void setGeneric(com.oracle.truffle.api.object.DynamicObject,java.lang.Object,com.oracle.truffle.api.object.Shape,com.oracle.truffle.api.object.Shape)
- anno 0 java.lang.Deprecated()
-meth public abstract void setInternal(com.oracle.truffle.api.object.DynamicObject,java.lang.Object)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract void setSafe(com.oracle.truffle.api.object.DynamicObject,java.lang.Object,com.oracle.truffle.api.object.Shape)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract void setSafe(com.oracle.truffle.api.object.DynamicObject,java.lang.Object,com.oracle.truffle.api.object.Shape,com.oracle.truffle.api.object.Shape)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public static com.oracle.truffle.api.object.Property create(java.lang.Object,com.oracle.truffle.api.object.Location,int)
+ anno 0 java.lang.Deprecated(null since="22.2")
 supr java.lang.Object
+
+CLSS public final com.oracle.truffle.api.object.PropertyGetter
+meth public boolean accepts(com.oracle.truffle.api.object.DynamicObject)
+meth public double getDouble(com.oracle.truffle.api.object.DynamicObject) throws com.oracle.truffle.api.nodes.UnexpectedResultException
+meth public int getFlags()
+meth public int getInt(com.oracle.truffle.api.object.DynamicObject) throws com.oracle.truffle.api.nodes.UnexpectedResultException
+meth public java.lang.Object get(com.oracle.truffle.api.object.DynamicObject)
+meth public java.lang.Object getKey()
+meth public long getLong(com.oracle.truffle.api.object.DynamicObject) throws com.oracle.truffle.api.nodes.UnexpectedResultException
+supr java.lang.Object
+hfds expectedShape,location,property
 
 CLSS public abstract com.oracle.truffle.api.object.Shape
 cons protected init()
-innr public abstract interface static Pred
 innr public abstract static Allocator
 innr public final static Builder
 innr public final static DerivedBuilder
@@ -2918,60 +3527,54 @@ meth protected com.oracle.truffle.api.object.Shape setDynamicType(java.lang.Obje
 meth protected com.oracle.truffle.api.object.Shape setFlags(int)
 meth public abstract boolean check(com.oracle.truffle.api.object.DynamicObject)
 meth public abstract boolean hasProperty(java.lang.Object)
-meth public abstract boolean hasTransitionWithKey(java.lang.Object)
- anno 0 java.lang.Deprecated()
 meth public abstract boolean isLeaf()
-meth public abstract boolean isRelated(com.oracle.truffle.api.object.Shape)
- anno 0 java.lang.Deprecated()
 meth public abstract boolean isValid()
 meth public abstract com.oracle.truffle.api.Assumption getLeafAssumption()
 meth public abstract com.oracle.truffle.api.Assumption getValidAssumption()
 meth public abstract com.oracle.truffle.api.object.DynamicObject newInstance()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract com.oracle.truffle.api.object.DynamicObjectFactory createFactory()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract com.oracle.truffle.api.object.Layout getLayout()
+ anno 0 java.lang.Deprecated(null since="21.1")
 meth public abstract com.oracle.truffle.api.object.ObjectType getObjectType()
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="20.3")
 meth public abstract com.oracle.truffle.api.object.Property getLastProperty()
 meth public abstract com.oracle.truffle.api.object.Property getProperty(java.lang.Object)
 meth public abstract com.oracle.truffle.api.object.Shape addProperty(com.oracle.truffle.api.object.Property)
-meth public abstract com.oracle.truffle.api.object.Shape append(com.oracle.truffle.api.object.Property)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract com.oracle.truffle.api.object.Shape changeType(com.oracle.truffle.api.object.ObjectType)
-meth public abstract com.oracle.truffle.api.object.Shape createSeparateShape(java.lang.Object)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract com.oracle.truffle.api.object.Shape defineProperty(java.lang.Object,java.lang.Object,int)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract com.oracle.truffle.api.object.Shape defineProperty(java.lang.Object,java.lang.Object,int,com.oracle.truffle.api.object.LocationFactory)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="20.2")
 meth public abstract com.oracle.truffle.api.object.Shape getParent()
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="20.2")
 meth public abstract com.oracle.truffle.api.object.Shape getRoot()
 meth public abstract com.oracle.truffle.api.object.Shape removeProperty(com.oracle.truffle.api.object.Property)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="20.2")
 meth public abstract com.oracle.truffle.api.object.Shape replaceProperty(com.oracle.truffle.api.object.Property,com.oracle.truffle.api.object.Property)
- anno 0 java.lang.Deprecated()
-meth public abstract com.oracle.truffle.api.object.Shape reservePrimitiveExtensionArray()
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="20.2")
 meth public abstract com.oracle.truffle.api.object.Shape tryMerge(com.oracle.truffle.api.object.Shape)
 meth public abstract com.oracle.truffle.api.object.Shape$Allocator allocator()
-meth public abstract int getId()
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract int getPropertyCount()
 meth public abstract java.lang.Iterable<com.oracle.truffle.api.object.Property> getProperties()
 meth public abstract java.lang.Iterable<java.lang.Object> getKeys()
 meth public abstract java.lang.Object getMutex()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract java.lang.Object getSharedData()
 meth public abstract java.util.List<com.oracle.truffle.api.object.Property> getPropertyList()
-meth public abstract java.util.List<com.oracle.truffle.api.object.Property> getPropertyList(com.oracle.truffle.api.object.Shape$Pred<com.oracle.truffle.api.object.Property>)
- anno 0 java.lang.Deprecated()
 meth public abstract java.util.List<com.oracle.truffle.api.object.Property> getPropertyListInternal(boolean)
 meth public abstract java.util.List<java.lang.Object> getKeyList()
-meth public abstract java.util.List<java.lang.Object> getKeyList(com.oracle.truffle.api.object.Shape$Pred<com.oracle.truffle.api.object.Property>)
- anno 0 java.lang.Deprecated()
 meth public boolean allPropertiesMatch(java.util.function.Predicate<com.oracle.truffle.api.object.Property>)
 meth public boolean isShared()
 meth public com.oracle.truffle.api.Assumption getPropertyAssumption(java.lang.Object)
+meth public com.oracle.truffle.api.object.PropertyGetter makePropertyGetter(java.lang.Object)
 meth public com.oracle.truffle.api.object.Shape makeSharedShape()
 meth public int getFlags()
+meth public java.lang.Class<? extends com.oracle.truffle.api.object.DynamicObject> getLayoutClass()
 meth public java.lang.Object getDynamicType()
 meth public static com.oracle.truffle.api.object.Shape$Builder newBuilder()
 meth public static com.oracle.truffle.api.object.Shape$DerivedBuilder newBuilder(com.oracle.truffle.api.object.Shape)
@@ -2981,20 +3584,29 @@ hcls AbstractBuilder
 
 CLSS public abstract static com.oracle.truffle.api.object.Shape$Allocator
  outer com.oracle.truffle.api.object.Shape
+ anno 0 java.lang.Deprecated(null since="22.2")
 cons protected init()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth protected abstract com.oracle.truffle.api.object.Location locationForType(java.lang.Class<?>,boolean,boolean)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth protected abstract com.oracle.truffle.api.object.Location locationForValue(java.lang.Object,boolean,boolean)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="19.3")
 meth public abstract com.oracle.truffle.api.object.Location constantLocation(java.lang.Object)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract com.oracle.truffle.api.object.Location declaredLocation(java.lang.Object)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract com.oracle.truffle.api.object.Shape$Allocator addLocation(com.oracle.truffle.api.object.Location)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public abstract com.oracle.truffle.api.object.Shape$Allocator copy()
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public final com.oracle.truffle.api.object.Location locationForType(java.lang.Class<?>)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public final com.oracle.truffle.api.object.Location locationForType(java.lang.Class<?>,java.util.EnumSet<com.oracle.truffle.api.object.LocationModifier>)
+ anno 0 java.lang.Deprecated(null since="22.2")
 meth public final com.oracle.truffle.api.object.Location locationForValue(java.lang.Object)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="20.2")
 meth public final com.oracle.truffle.api.object.Location locationForValue(java.lang.Object,java.util.EnumSet<com.oracle.truffle.api.object.LocationModifier>)
- anno 0 java.lang.Deprecated()
+ anno 0 java.lang.Deprecated(null since="19.3")
 supr java.lang.Object
 
 CLSS public final static com.oracle.truffle.api.object.Shape$Builder
@@ -3011,7 +3623,7 @@ meth public com.oracle.truffle.api.object.Shape$Builder shared(boolean)
 meth public com.oracle.truffle.api.object.Shape$Builder sharedData(java.lang.Object)
 meth public com.oracle.truffle.api.object.Shape$Builder singleContextAssumption(com.oracle.truffle.api.Assumption)
 supr java.lang.Object<com.oracle.truffle.api.object.Shape$Builder>
-hfds allowedImplicitCasts,dynamicType,layoutClass,properties,propertyAssumptions,shapeFlags,shared,sharedData,singleContextAssumption
+hfds allowImplicitCastIntToDouble,allowImplicitCastIntToLong,dynamicType,layoutClass,properties,propertyAssumptions,shapeFlags,shared,sharedData,singleContextAssumption
 
 CLSS public final static com.oracle.truffle.api.object.Shape$DerivedBuilder
  outer com.oracle.truffle.api.object.Shape
@@ -3022,142 +3634,314 @@ meth public com.oracle.truffle.api.object.Shape$DerivedBuilder shapeFlags(int)
 supr java.lang.Object<com.oracle.truffle.api.object.Shape$DerivedBuilder>
 hfds baseShape,dynamicType,properties,shapeFlags
 
-CLSS public abstract interface static com.oracle.truffle.api.object.Shape$Pred<%0 extends java.lang.Object>
- outer com.oracle.truffle.api.object.Shape
- anno 0 java.lang.Deprecated()
-meth public abstract boolean test({com.oracle.truffle.api.object.Shape$Pred%0})
-
-CLSS public abstract interface com.oracle.truffle.api.object.ShapeListener
- anno 0 java.lang.Deprecated()
-meth public abstract void onPropertyTransition(java.lang.Object)
-
-CLSS public abstract interface com.oracle.truffle.api.object.TypedLocation
- anno 0 java.lang.Deprecated()
-meth public abstract java.lang.Class<?> getType()
-meth public abstract java.lang.Object get(com.oracle.truffle.api.object.DynamicObject,boolean)
-meth public abstract java.lang.Object get(com.oracle.truffle.api.object.DynamicObject,com.oracle.truffle.api.object.Shape)
-meth public abstract void set(com.oracle.truffle.api.object.DynamicObject,java.lang.Object) throws com.oracle.truffle.api.object.FinalLocationException,com.oracle.truffle.api.object.IncompatibleLocationException
-meth public abstract void set(com.oracle.truffle.api.object.DynamicObject,java.lang.Object,com.oracle.truffle.api.object.Shape) throws com.oracle.truffle.api.object.FinalLocationException,com.oracle.truffle.api.object.IncompatibleLocationException
-meth public abstract void set(com.oracle.truffle.api.object.DynamicObject,java.lang.Object,com.oracle.truffle.api.object.Shape,com.oracle.truffle.api.object.Shape) throws com.oracle.truffle.api.object.IncompatibleLocationException
-
-CLSS public abstract interface !annotation com.oracle.truffle.api.object.dsl.Layout
- anno 0 java.lang.Deprecated()
- anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=SOURCE)
- anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
-innr public final static DispatchDefaultValue
-intf java.lang.annotation.Annotation
-meth public abstract !hasdefault boolean implicitCastIntToDouble()
- anno 0 java.lang.Deprecated()
-meth public abstract !hasdefault boolean implicitCastIntToLong()
- anno 0 java.lang.Deprecated()
-meth public abstract !hasdefault java.lang.Class<? extends com.oracle.truffle.api.object.ObjectType> objectTypeSuperclass()
- anno 0 java.lang.Deprecated()
-meth public abstract !hasdefault java.lang.Class<?> dispatch()
- anno 0 java.lang.Deprecated()
-
-CLSS public final static com.oracle.truffle.api.object.dsl.Layout$DispatchDefaultValue
- outer com.oracle.truffle.api.object.dsl.Layout
- anno 0 java.lang.Deprecated()
-supr java.lang.Object
-
-CLSS public abstract interface !annotation com.oracle.truffle.api.object.dsl.Nullable
- anno 0 java.lang.Deprecated()
- anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=SOURCE)
- anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PARAMETER])
-intf java.lang.annotation.Annotation
-
-CLSS public abstract interface !annotation com.oracle.truffle.api.object.dsl.Volatile
- anno 0 java.lang.Deprecated()
- anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=SOURCE)
- anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PARAMETER])
-intf java.lang.annotation.Annotation
-
-CLSS public abstract com.oracle.truffle.api.profiles.BranchProfile
-meth public abstract void enter()
+CLSS public final com.oracle.truffle.api.profiles.BranchProfile
+meth public java.lang.String toString()
 meth public static com.oracle.truffle.api.profiles.BranchProfile create()
 meth public static com.oracle.truffle.api.profiles.BranchProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedBranchProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+meth public void disable()
+meth public void enter()
+meth public void reset()
 supr com.oracle.truffle.api.profiles.Profile
-hcls Disabled,Enabled
+hfds DISABLED,visited
 
-CLSS public abstract com.oracle.truffle.api.profiles.ByteValueProfile
-meth public abstract byte profile(byte)
+CLSS public final com.oracle.truffle.api.profiles.ByteValueProfile
+meth public byte profile(byte)
+meth public java.lang.String toString()
+meth public static com.oracle.truffle.api.profiles.ByteValueProfile create()
 meth public static com.oracle.truffle.api.profiles.ByteValueProfile createIdentityProfile()
 meth public static com.oracle.truffle.api.profiles.ByteValueProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedByteValueProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+meth public void disable()
+meth public void reset()
 supr com.oracle.truffle.api.profiles.Profile
-hcls Disabled,Enabled
+hfds DISABLED,GENERIC,SPECIALIZED,UNINITIALIZED,cachedValue,state
 
-CLSS public abstract com.oracle.truffle.api.profiles.ConditionProfile
-meth public abstract boolean profile(boolean)
+CLSS public com.oracle.truffle.api.profiles.ConditionProfile
+meth public boolean profile(boolean)
+meth public java.lang.String toString()
 meth public static com.oracle.truffle.api.profiles.ConditionProfile create()
 meth public static com.oracle.truffle.api.profiles.ConditionProfile createBinaryProfile()
+ anno 0 java.lang.Deprecated()
 meth public static com.oracle.truffle.api.profiles.ConditionProfile createCountingProfile()
+ anno 0 java.lang.Deprecated()
 meth public static com.oracle.truffle.api.profiles.ConditionProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedConditionProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+meth public void disable()
+meth public void reset()
 supr com.oracle.truffle.api.profiles.Profile
-hcls Binary,Counting,Disabled
+hfds DISABLED,wasFalse,wasTrue
+hcls Counting,Disabled
 
-CLSS public abstract com.oracle.truffle.api.profiles.DoubleValueProfile
-meth public abstract double profile(double)
+CLSS public final com.oracle.truffle.api.profiles.CountingConditionProfile
+meth public boolean profile(boolean)
+meth public java.lang.String toString()
+meth public static com.oracle.truffle.api.profiles.CountingConditionProfile create()
+meth public static com.oracle.truffle.api.profiles.CountingConditionProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedCountingConditionProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+meth public void disable()
+meth public void reset()
+supr com.oracle.truffle.api.profiles.Profile
+hfds DISABLED,MAX_VALUE,falseCount,trueCount
+
+CLSS public final com.oracle.truffle.api.profiles.DoubleValueProfile
+meth public double profile(double)
+meth public java.lang.String toString()
+meth public static com.oracle.truffle.api.profiles.DoubleValueProfile create()
 meth public static com.oracle.truffle.api.profiles.DoubleValueProfile createRawIdentityProfile()
 meth public static com.oracle.truffle.api.profiles.DoubleValueProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedDoubleValueProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+meth public void disable()
+meth public void reset()
 supr com.oracle.truffle.api.profiles.Profile
-hcls Disabled,Enabled
+hfds DISABLED,GENERIC,SPECIALIZED,UNINITIALIZED,cachedRawValue,cachedValue,state
 
-CLSS public abstract com.oracle.truffle.api.profiles.FloatValueProfile
-meth public abstract float profile(float)
+CLSS public final com.oracle.truffle.api.profiles.FloatValueProfile
+meth public float profile(float)
+meth public java.lang.String toString()
+meth public static com.oracle.truffle.api.profiles.FloatValueProfile create()
 meth public static com.oracle.truffle.api.profiles.FloatValueProfile createRawIdentityProfile()
 meth public static com.oracle.truffle.api.profiles.FloatValueProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedFloatValueProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+meth public void disable()
+meth public void reset()
 supr com.oracle.truffle.api.profiles.Profile
-hcls Disabled,Enabled
+hfds DISABLED,GENERIC,SPECIALIZED,UNINITIALIZED,cachedRawValue,cachedValue,state
 
-CLSS public abstract com.oracle.truffle.api.profiles.IntValueProfile
-meth public abstract int profile(int)
+CLSS public final com.oracle.truffle.api.profiles.InlinedBranchProfile
+meth public boolean wasEntered(com.oracle.truffle.api.nodes.Node)
+meth public java.lang.String toString(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.profiles.InlinedBranchProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedBranchProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+meth public void disable(com.oracle.truffle.api.nodes.Node)
+meth public void enter(com.oracle.truffle.api.nodes.Node)
+meth public void reset(com.oracle.truffle.api.nodes.Node)
+supr com.oracle.truffle.api.profiles.InlinedProfile
+hfds DISABLED,REQUIRED_STATE_BITS,state
+
+CLSS public final com.oracle.truffle.api.profiles.InlinedByteValueProfile
+fld protected final com.oracle.truffle.api.dsl.InlineSupport$StateField state
+fld protected final static int GENERIC = 2
+fld protected final static int REQUIRED_STATE_BITS = 2
+fld protected final static int SPECIALIZED = 1
+fld protected final static int UNINITIALIZED = 0
+meth public byte profile(com.oracle.truffle.api.nodes.Node,byte)
+meth public final void disable(com.oracle.truffle.api.nodes.Node)
+meth public final void reset(com.oracle.truffle.api.nodes.Node)
+meth public java.lang.String toString(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.profiles.InlinedByteValueProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedByteValueProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+supr com.oracle.truffle.api.profiles.InlinedProfile
+hfds DISABLED,cachedValue
+
+CLSS public final com.oracle.truffle.api.profiles.InlinedConditionProfile
+meth public boolean profile(com.oracle.truffle.api.nodes.Node,boolean)
+meth public boolean wasFalse(com.oracle.truffle.api.nodes.Node)
+meth public boolean wasTrue(com.oracle.truffle.api.nodes.Node)
+meth public java.lang.String toString(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.profiles.InlinedConditionProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedConditionProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+meth public void disable(com.oracle.truffle.api.nodes.Node)
+meth public void reset(com.oracle.truffle.api.nodes.Node)
+supr com.oracle.truffle.api.profiles.InlinedProfile
+hfds DISABLED,REQUIRED_STATE_BITS,state
+
+CLSS public final com.oracle.truffle.api.profiles.InlinedCountingConditionProfile
+meth public boolean profile(com.oracle.truffle.api.nodes.Node,boolean)
+meth public boolean wasFalse(com.oracle.truffle.api.nodes.Node)
+meth public boolean wasTrue(com.oracle.truffle.api.nodes.Node)
+meth public java.lang.String toString(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.profiles.InlinedCountingConditionProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedCountingConditionProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+meth public void disable(com.oracle.truffle.api.nodes.Node)
+meth public void reset(com.oracle.truffle.api.nodes.Node)
+supr com.oracle.truffle.api.profiles.InlinedProfile
+hfds DISABLED,MAX_VALUE,falseCount,trueCount
+
+CLSS public final com.oracle.truffle.api.profiles.InlinedDoubleValueProfile
+fld protected final com.oracle.truffle.api.dsl.InlineSupport$StateField state
+fld protected final static int GENERIC = 2
+fld protected final static int REQUIRED_STATE_BITS = 2
+fld protected final static int SPECIALIZED = 1
+fld protected final static int UNINITIALIZED = 0
+meth public double profile(com.oracle.truffle.api.nodes.Node,double)
+meth public final void disable(com.oracle.truffle.api.nodes.Node)
+meth public final void reset(com.oracle.truffle.api.nodes.Node)
+meth public java.lang.String toString(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.profiles.InlinedDoubleValueProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedDoubleValueProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+supr com.oracle.truffle.api.profiles.InlinedProfile
+hfds DISABLED,cachedValue0
+
+CLSS public final com.oracle.truffle.api.profiles.InlinedExactClassProfile
+fld protected final com.oracle.truffle.api.dsl.InlineSupport$StateField state
+fld protected final static int GENERIC = 2
+fld protected final static int REQUIRED_STATE_BITS = 2
+fld protected final static int SPECIALIZED = 1
+fld protected final static int UNINITIALIZED = 0
+meth public <%0 extends java.lang.Object> {%%0} profile(com.oracle.truffle.api.nodes.Node,{%%0})
+meth public final void disable(com.oracle.truffle.api.nodes.Node)
+meth public final void reset(com.oracle.truffle.api.nodes.Node)
+meth public java.lang.String toString(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.profiles.InlinedExactClassProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedExactClassProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+supr com.oracle.truffle.api.profiles.InlinedProfile
+hfds DISABLED,cachedValue
+
+CLSS public final com.oracle.truffle.api.profiles.InlinedFloatValueProfile
+fld protected final com.oracle.truffle.api.dsl.InlineSupport$StateField state
+fld protected final static int GENERIC = 2
+fld protected final static int REQUIRED_STATE_BITS = 2
+fld protected final static int SPECIALIZED = 1
+fld protected final static int UNINITIALIZED = 0
+meth public final void disable(com.oracle.truffle.api.nodes.Node)
+meth public final void reset(com.oracle.truffle.api.nodes.Node)
+meth public float profile(com.oracle.truffle.api.nodes.Node,float)
+meth public java.lang.String toString(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.profiles.InlinedFloatValueProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedFloatValueProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+supr com.oracle.truffle.api.profiles.InlinedProfile
+hfds DISABLED,cachedValue
+
+CLSS public final com.oracle.truffle.api.profiles.InlinedIntValueProfile
+fld protected final com.oracle.truffle.api.dsl.InlineSupport$StateField state
+fld protected final static int GENERIC = 2
+fld protected final static int REQUIRED_STATE_BITS = 2
+fld protected final static int SPECIALIZED = 1
+fld protected final static int UNINITIALIZED = 0
+meth public final void disable(com.oracle.truffle.api.nodes.Node)
+meth public final void reset(com.oracle.truffle.api.nodes.Node)
+meth public int profile(com.oracle.truffle.api.nodes.Node,int)
+meth public java.lang.String toString(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.profiles.InlinedIntValueProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedIntValueProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+supr com.oracle.truffle.api.profiles.InlinedProfile
+hfds DISABLED,cachedValue
+
+CLSS public final com.oracle.truffle.api.profiles.InlinedLongValueProfile
+fld protected final com.oracle.truffle.api.dsl.InlineSupport$StateField state
+fld protected final static int GENERIC = 2
+fld protected final static int REQUIRED_STATE_BITS = 2
+fld protected final static int SPECIALIZED = 1
+fld protected final static int UNINITIALIZED = 0
+meth public final void disable(com.oracle.truffle.api.nodes.Node)
+meth public final void reset(com.oracle.truffle.api.nodes.Node)
+meth public java.lang.String toString(com.oracle.truffle.api.nodes.Node)
+meth public long profile(com.oracle.truffle.api.nodes.Node,long)
+meth public static com.oracle.truffle.api.profiles.InlinedLongValueProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedLongValueProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+supr com.oracle.truffle.api.profiles.InlinedProfile
+hfds DISABLED,cachedValue
+
+CLSS public final com.oracle.truffle.api.profiles.InlinedLoopConditionProfile
+meth public boolean inject(com.oracle.truffle.api.nodes.Node,boolean)
+meth public boolean profile(com.oracle.truffle.api.nodes.Node,boolean)
+meth public boolean wasFalse(com.oracle.truffle.api.nodes.Node)
+meth public boolean wasTrue(com.oracle.truffle.api.nodes.Node)
+meth public java.lang.String toString(com.oracle.truffle.api.nodes.Node)
+meth public static com.oracle.truffle.api.profiles.InlinedLoopConditionProfile getUncached()
+meth public static com.oracle.truffle.api.profiles.InlinedLoopConditionProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+meth public void disable(com.oracle.truffle.api.nodes.Node)
+meth public void profileCounted(com.oracle.truffle.api.nodes.Node,long)
+meth public void reset(com.oracle.truffle.api.nodes.Node)
+supr com.oracle.truffle.api.profiles.InlinedProfile
+hfds DISABLED,MAX_VALUE,falseCount,trueCount
+
+CLSS public abstract com.oracle.truffle.api.profiles.InlinedProfile
+meth public abstract java.lang.String toString(com.oracle.truffle.api.nodes.Node)
+meth public abstract void disable(com.oracle.truffle.api.nodes.Node)
+meth public abstract void reset(com.oracle.truffle.api.nodes.Node)
+meth public final java.lang.String toString()
+supr java.lang.Object
+
+CLSS public final com.oracle.truffle.api.profiles.IntValueProfile
+meth public int profile(int)
+meth public java.lang.String toString()
+meth public static com.oracle.truffle.api.profiles.InlinedIntValueProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+meth public static com.oracle.truffle.api.profiles.IntValueProfile create()
 meth public static com.oracle.truffle.api.profiles.IntValueProfile createIdentityProfile()
 meth public static com.oracle.truffle.api.profiles.IntValueProfile getUncached()
+meth public void disable()
+meth public void reset()
 supr com.oracle.truffle.api.profiles.Profile
-hcls Disabled,Enabled
+hfds DISABLED,GENERIC,SPECIALIZED,UNINITIALIZED,cachedValue,state
 
-CLSS public abstract com.oracle.truffle.api.profiles.LongValueProfile
-meth public abstract long profile(long)
+CLSS public final com.oracle.truffle.api.profiles.LongValueProfile
+meth public java.lang.String toString()
+meth public long profile(long)
+meth public static com.oracle.truffle.api.profiles.InlinedLongValueProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+meth public static com.oracle.truffle.api.profiles.LongValueProfile create()
 meth public static com.oracle.truffle.api.profiles.LongValueProfile createIdentityProfile()
 meth public static com.oracle.truffle.api.profiles.LongValueProfile getUncached()
+meth public void disable()
+meth public void reset()
 supr com.oracle.truffle.api.profiles.Profile
-hcls Disabled,Enabled
+hfds DISABLED,GENERIC,SPECIALIZED,UNINITIALIZED,cachedValue,state
 
-CLSS public abstract com.oracle.truffle.api.profiles.LoopConditionProfile
-meth public abstract boolean inject(boolean)
-meth public abstract boolean profile(boolean)
-meth public abstract void profileCounted(long)
+CLSS public final com.oracle.truffle.api.profiles.LoopConditionProfile
+meth public boolean inject(boolean)
+meth public boolean profile(boolean)
+meth public java.lang.String toString()
+meth public static com.oracle.truffle.api.profiles.LoopConditionProfile create()
 meth public static com.oracle.truffle.api.profiles.LoopConditionProfile createCountingProfile()
+ anno 0 java.lang.Deprecated()
 meth public static com.oracle.truffle.api.profiles.LoopConditionProfile getUncached()
+meth public void disable()
+meth public void profileCounted(long)
+meth public void reset()
 supr com.oracle.truffle.api.profiles.ConditionProfile
-hcls Disabled,Enabled
+hfds DISABLED,falseCount,trueCount
 
-CLSS public abstract com.oracle.truffle.api.profiles.PrimitiveValueProfile
-meth public abstract <%0 extends java.lang.Object> {%%0} profile({%%0})
-meth public abstract boolean profile(boolean)
-meth public abstract byte profile(byte)
-meth public abstract char profile(char)
-meth public abstract double profile(double)
-meth public abstract float profile(float)
-meth public abstract int profile(int)
-meth public abstract long profile(long)
-meth public abstract short profile(short)
+CLSS public final com.oracle.truffle.api.profiles.PrimitiveValueProfile
+meth public <%0 extends java.lang.Object> {%%0} profile({%%0})
+meth public boolean profile(boolean)
+meth public byte profile(byte)
+meth public char profile(char)
+meth public double profile(double)
+meth public float profile(float)
+meth public int profile(int)
+meth public java.lang.String toString()
+meth public long profile(long)
+meth public short profile(short)
+meth public static com.oracle.truffle.api.profiles.PrimitiveValueProfile create()
 meth public static com.oracle.truffle.api.profiles.PrimitiveValueProfile createEqualityProfile()
 meth public static com.oracle.truffle.api.profiles.PrimitiveValueProfile getUncached()
+meth public void disable()
+meth public void reset()
 supr com.oracle.truffle.api.profiles.ValueProfile
-hcls Disabled,Enabled
+hfds DISABLED,GENERIC,UNINITIALIZED,cachedValue
 
 CLSS public abstract com.oracle.truffle.api.profiles.Profile
+meth public void disable()
+meth public void reset()
 supr com.oracle.truffle.api.nodes.NodeCloneable
 
 CLSS public abstract com.oracle.truffle.api.profiles.ValueProfile
 meth public abstract <%0 extends java.lang.Object> {%%0} profile({%%0})
+meth public static com.oracle.truffle.api.profiles.InlinedExactClassProfile inline(com.oracle.truffle.api.dsl.InlineSupport$InlineTarget)
+meth public static com.oracle.truffle.api.profiles.ValueProfile create()
 meth public static com.oracle.truffle.api.profiles.ValueProfile createClassProfile()
-meth public static com.oracle.truffle.api.profiles.ValueProfile createEqualityProfile()
 meth public static com.oracle.truffle.api.profiles.ValueProfile createIdentityProfile()
 meth public static com.oracle.truffle.api.profiles.ValueProfile getUncached()
 supr com.oracle.truffle.api.profiles.Profile
-hcls Disabled,Equality,ExactClass,Identity
+hcls Disabled,ExactClass,Identity
+
+CLSS public abstract com.oracle.truffle.api.provider.InternalResourceProvider
+cons public init()
+meth protected abstract java.lang.Object createInternalResource()
+meth protected abstract java.lang.String getComponentId()
+meth protected abstract java.lang.String getResourceId()
+supr java.lang.Object
+
+CLSS public abstract com.oracle.truffle.api.provider.TruffleLanguageProvider
+cons protected init()
+meth protected abstract java.lang.Object create()
+meth protected abstract java.lang.String getLanguageClassName()
+meth protected abstract java.util.Collection<java.lang.String> getServicesClassNames()
+meth protected abstract java.util.List<?> createFileTypeDetectors()
+meth protected java.lang.Object createInternalResource(java.lang.String)
+meth protected java.util.List<java.lang.String> getInternalResourceIds()
+supr java.lang.Object
 
 CLSS public abstract com.oracle.truffle.api.source.Source
 fld public final static java.lang.CharSequence CONTENT_NONE
@@ -3205,7 +3989,7 @@ meth public static java.lang.String findLanguage(java.net.URL) throws java.io.IO
 meth public static java.lang.String findMimeType(com.oracle.truffle.api.TruffleFile) throws java.io.IOException
 meth public static java.lang.String findMimeType(java.net.URL) throws java.io.IOException
 supr java.lang.Object
-hfds ALLOW_IO,BUFFER_SIZE,BYTE_SEQUENCE_CLASS,CONTENT_UNSET,EMPTY,MAX_BUFFER_SIZE,NO_FASTPATH_SUBSOURCE_CREATION_MESSAGE,SOURCES,URI_SCHEME,cachedPolyglotSource,computedURI,textMap
+hfds ALLOW_IO,BUFFER_SIZE,BYTE_SEQUENCE_CLASS,CONTENT_EMPTY,CONTENT_UNSET,EMPTY,MAX_BUFFER_SIZE,NO_FASTPATH_SUBSOURCE_CREATION_MESSAGE,SOURCES,URI_SCHEME,cachedPolyglotSource,computedURI,textMap
 
 CLSS public final com.oracle.truffle.api.source.Source$LiteralBuilder
  outer com.oracle.truffle.api.source.Source
@@ -3237,7 +4021,7 @@ meth public com.oracle.truffle.api.source.Source$SourceBuilder mimeType(java.lan
 meth public com.oracle.truffle.api.source.Source$SourceBuilder name(java.lang.String)
 meth public com.oracle.truffle.api.source.Source$SourceBuilder uri(java.net.URI)
 supr java.lang.Object
-hfds cached,canonicalizePath,content,fileEncoding,fileSystemContext,interactive,internal,language,mimeType,name,origin,path,uri,url
+hfds cached,canonicalizePath,content,embedderSource,fileEncoding,fileSystemContext,interactive,internal,language,mimeType,name,origin,path,uri,url
 
 CLSS public abstract com.oracle.truffle.api.source.SourceSection
 meth public abstract boolean equals(java.lang.Object)
@@ -3259,15 +4043,1199 @@ meth public final java.lang.String toString()
 supr java.lang.Object
 hfds source
 
-CLSS public final com.oracle.truffle.api.utilities.AlwaysValidAssumption
-fld public final static com.oracle.truffle.api.utilities.AlwaysValidAssumption INSTANCE
-intf com.oracle.truffle.api.Assumption
-meth public boolean isValid()
-meth public java.lang.String getName()
-meth public void check() throws com.oracle.truffle.api.nodes.InvalidAssumptionException
-meth public void invalidate()
-meth public void invalidate(java.lang.String)
+CLSS public abstract interface com.oracle.truffle.api.staticobject.DefaultStaticObjectFactory
+meth public abstract java.lang.Object create()
+
+CLSS public final com.oracle.truffle.api.staticobject.DefaultStaticProperty
+cons public init(java.lang.String)
+meth public java.lang.String getId()
+supr com.oracle.truffle.api.staticobject.StaticProperty
+hfds id
+
+CLSS public abstract com.oracle.truffle.api.staticobject.StaticProperty
+cons protected init()
+meth protected abstract java.lang.String getId()
+meth public final boolean compareAndExchangeBoolean(java.lang.Object,boolean,boolean)
+meth public final boolean compareAndSwapBoolean(java.lang.Object,boolean,boolean)
+meth public final boolean compareAndSwapByte(java.lang.Object,byte,byte)
+meth public final boolean compareAndSwapChar(java.lang.Object,char,char)
+meth public final boolean compareAndSwapDouble(java.lang.Object,double,double)
+meth public final boolean compareAndSwapFloat(java.lang.Object,float,float)
+meth public final boolean compareAndSwapInt(java.lang.Object,int,int)
+meth public final boolean compareAndSwapLong(java.lang.Object,long,long)
+meth public final boolean compareAndSwapObject(java.lang.Object,java.lang.Object,java.lang.Object)
+meth public final boolean compareAndSwapShort(java.lang.Object,short,short)
+meth public final boolean getBoolean(java.lang.Object)
+meth public final boolean getBooleanVolatile(java.lang.Object)
+meth public final byte compareAndExchangeByte(java.lang.Object,byte,byte)
+meth public final byte getByte(java.lang.Object)
+meth public final byte getByteVolatile(java.lang.Object)
+meth public final char compareAndExchangeChar(java.lang.Object,char,char)
+meth public final char getChar(java.lang.Object)
+meth public final char getCharVolatile(java.lang.Object)
+meth public final double compareAndExchangeDouble(java.lang.Object,double,double)
+meth public final double getDouble(java.lang.Object)
+meth public final double getDoubleVolatile(java.lang.Object)
+meth public final float compareAndExchangeFloat(java.lang.Object,float,float)
+meth public final float getFloat(java.lang.Object)
+meth public final float getFloatVolatile(java.lang.Object)
+meth public final int compareAndExchangeInt(java.lang.Object,int,int)
+meth public final int getAndAddInt(java.lang.Object,int)
+meth public final int getAndSetInt(java.lang.Object,int)
+meth public final int getInt(java.lang.Object)
+meth public final int getIntVolatile(java.lang.Object)
+meth public final java.lang.Object compareAndExchangeObject(java.lang.Object,java.lang.Object,java.lang.Object)
+meth public final java.lang.Object getAndSetObject(java.lang.Object,java.lang.Object)
+meth public final java.lang.Object getObject(java.lang.Object)
+meth public final java.lang.Object getObjectVolatile(java.lang.Object)
+meth public final long compareAndExchangeLong(java.lang.Object,long,long)
+meth public final long getAndAddLong(java.lang.Object,long)
+meth public final long getAndSetLong(java.lang.Object,long)
+meth public final long getLong(java.lang.Object)
+meth public final long getLongVolatile(java.lang.Object)
+meth public final short compareAndExchangeShort(java.lang.Object,short,short)
+meth public final short getShort(java.lang.Object)
+meth public final short getShortVolatile(java.lang.Object)
+meth public final void setBoolean(java.lang.Object,boolean)
+meth public final void setBooleanVolatile(java.lang.Object,boolean)
+meth public final void setByte(java.lang.Object,byte)
+meth public final void setByteVolatile(java.lang.Object,byte)
+meth public final void setChar(java.lang.Object,char)
+meth public final void setCharVolatile(java.lang.Object,char)
+meth public final void setDouble(java.lang.Object,double)
+meth public final void setDoubleVolatile(java.lang.Object,double)
+meth public final void setFloat(java.lang.Object,float)
+meth public final void setFloatVolatile(java.lang.Object,float)
+meth public final void setInt(java.lang.Object,int)
+meth public final void setIntVolatile(java.lang.Object,int)
+meth public final void setLong(java.lang.Object,long)
+meth public final void setLongVolatile(java.lang.Object,long)
+meth public final void setObject(java.lang.Object,java.lang.Object)
+meth public final void setObjectVolatile(java.lang.Object,java.lang.Object)
+meth public final void setShort(java.lang.Object,short)
+meth public final void setShortVolatile(java.lang.Object,short)
 supr java.lang.Object
+hfds UNSAFE,offset,shape,storeAsFinal,type
+hcls CASSupport
+
+CLSS public abstract com.oracle.truffle.api.staticobject.StaticShape<%0 extends java.lang.Object>
+innr public final static Builder
+meth public final {com.oracle.truffle.api.staticobject.StaticShape%0} getFactory()
+meth public static com.oracle.truffle.api.staticobject.StaticShape$Builder newBuilder(com.oracle.truffle.api.TruffleLanguage<?>)
+supr java.lang.Object
+hfds UNSAFE,factory,safetyChecks,storageClass
+hcls StorageStrategy
+
+CLSS public final static com.oracle.truffle.api.staticobject.StaticShape$Builder
+ outer com.oracle.truffle.api.staticobject.StaticShape
+meth public <%0 extends java.lang.Object> com.oracle.truffle.api.staticobject.StaticShape<{%%0}> build(com.oracle.truffle.api.staticobject.StaticShape<{%%0}>)
+meth public <%0 extends java.lang.Object> com.oracle.truffle.api.staticobject.StaticShape<{%%0}> build(java.lang.Class<?>,java.lang.Class<{%%0}>)
+meth public com.oracle.truffle.api.staticobject.StaticShape$Builder property(com.oracle.truffle.api.staticobject.StaticProperty,java.lang.Class<?>,boolean)
+meth public com.oracle.truffle.api.staticobject.StaticShape<com.oracle.truffle.api.staticobject.DefaultStaticObjectFactory> build()
+supr java.lang.Object
+hfds DELIMITER,MAX_NUMBER_OF_PROPERTIES,MAX_PROPERTY_ID_BYTE_LENGTH,counter,hasLongPropertyId,isActive,language,staticProperties,storageClassName
+
+CLSS public abstract com.oracle.truffle.api.strings.AbstractTruffleString
+meth public com.oracle.truffle.api.strings.TruffleString toValidStringUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final boolean codeRangeEqualsUncached(com.oracle.truffle.api.strings.TruffleString$CodeRange)
+meth public final boolean equals(java.lang.Object)
+meth public final boolean equalsUncached(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final boolean isCompatibleTo(com.oracle.truffle.api.strings.TruffleString$Encoding)
+ anno 0 java.lang.Deprecated(null since="23.0")
+meth public final boolean isCompatibleToUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final boolean isEmpty()
+meth public final boolean isImmutable()
+meth public final boolean isManaged()
+meth public final boolean isMutable()
+meth public final boolean isNative()
+meth public final boolean isValidUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final boolean regionEqualByteIndexUncached(int,com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final boolean regionEqualByteIndexUncached(int,com.oracle.truffle.api.strings.TruffleString$WithMask,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final boolean regionEqualsUncached(int,com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final byte[] copyToByteArrayUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final com.oracle.truffle.api.strings.InternalByteArray getInternalByteArrayUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final com.oracle.truffle.api.strings.MutableTruffleString asManagedMutableTruffleStringUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final com.oracle.truffle.api.strings.MutableTruffleString asMutableTruffleStringUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final com.oracle.truffle.api.strings.TruffleString asManagedTruffleStringUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final com.oracle.truffle.api.strings.TruffleString asManagedTruffleStringUncached(com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public final com.oracle.truffle.api.strings.TruffleString asTruffleStringUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final com.oracle.truffle.api.strings.TruffleString concatUncached(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public final com.oracle.truffle.api.strings.TruffleString forceEncodingUncached(com.oracle.truffle.api.strings.TruffleString$Encoding,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final com.oracle.truffle.api.strings.TruffleString repeatUncached(int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final com.oracle.truffle.api.strings.TruffleString substringByteIndexUncached(int,int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public final com.oracle.truffle.api.strings.TruffleString substringUncached(int,int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public final com.oracle.truffle.api.strings.TruffleString switchEncodingUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final com.oracle.truffle.api.strings.TruffleString switchEncodingUncached(com.oracle.truffle.api.strings.TruffleString$Encoding,com.oracle.truffle.api.strings.TranscodingErrorHandler)
+meth public final com.oracle.truffle.api.strings.TruffleString$CodeRange getByteCodeRangeUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final com.oracle.truffle.api.strings.TruffleString$CodeRange getCodeRangeImpreciseUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final com.oracle.truffle.api.strings.TruffleString$CodeRange getCodeRangeUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final com.oracle.truffle.api.strings.TruffleString$CompactionLevel getStringCompactionLevelUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final com.oracle.truffle.api.strings.TruffleStringIterator createBackwardCodePointIteratorUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final com.oracle.truffle.api.strings.TruffleStringIterator createCodePointIteratorUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final double parseDoubleUncached() throws com.oracle.truffle.api.strings.TruffleString$NumberFormatException
+meth public final int byteIndexOfAnyByteUncached(int,int,byte[],com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int byteIndexOfCodePointUncached(int,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int byteIndexOfStringUncached(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int byteIndexOfStringUncached(com.oracle.truffle.api.strings.TruffleString$WithMask,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int byteIndexToCodePointIndexUncached(int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int byteLength(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int byteLengthOfCodePointUncached(int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int byteLengthOfCodePointUncached(int,com.oracle.truffle.api.strings.TruffleString$Encoding,com.oracle.truffle.api.strings.TruffleString$ErrorHandling)
+meth public final int charIndexOfAnyCharUTF16Uncached(int,int,char[])
+meth public final int codePointAtByteIndexUncached(int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int codePointAtByteIndexUncached(int,com.oracle.truffle.api.strings.TruffleString$Encoding,com.oracle.truffle.api.strings.TruffleString$ErrorHandling)
+meth public final int codePointAtIndexUncached(int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int codePointAtIndexUncached(int,com.oracle.truffle.api.strings.TruffleString$Encoding,com.oracle.truffle.api.strings.TruffleString$ErrorHandling)
+meth public final int codePointIndexToByteIndexUncached(int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int codePointLengthUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int compareBytesUncached(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int compareCharsUTF16Uncached(com.oracle.truffle.api.strings.AbstractTruffleString)
+meth public final int compareIntsUTF32Uncached(com.oracle.truffle.api.strings.AbstractTruffleString)
+meth public final int hashCode()
+meth public final int hashCodeUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int indexOfCodePointUncached(int,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int indexOfStringUncached(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int intIndexOfAnyIntUTF32Uncached(int,int,int[])
+meth public final int lastByteIndexOfCodePointUncached(int,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int lastByteIndexOfStringUncached(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int lastByteIndexOfStringUncached(com.oracle.truffle.api.strings.TruffleString$WithMask,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int lastIndexOfCodePointUncached(int,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int lastIndexOfStringUncached(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int parseIntUncached() throws com.oracle.truffle.api.strings.TruffleString$NumberFormatException
+meth public final int parseIntUncached(int) throws com.oracle.truffle.api.strings.TruffleString$NumberFormatException
+meth public final int readByteUncached(int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int readCharUTF16Uncached(int)
+meth public final java.lang.Object getInternalNativePointerUncached(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final java.lang.String toJavaStringUncached()
+meth public final java.lang.String toString()
+meth public final java.lang.String toStringDebug()
+meth public final long parseLongUncached() throws com.oracle.truffle.api.strings.TruffleString$NumberFormatException
+meth public final long parseLongUncached(int) throws com.oracle.truffle.api.strings.TruffleString$NumberFormatException
+meth public final void copyToByteArrayNodeUncached(int,byte[],int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+ anno 0 java.lang.Deprecated(null since="22.3")
+meth public final void copyToByteArrayUncached(int,byte[],int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final void copyToNativeMemoryNodeUncached(int,java.lang.Object,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+ anno 0 java.lang.Deprecated(null since="22.3")
+meth public final void copyToNativeMemoryUncached(int,java.lang.Object,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public void materializeUncached(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+supr java.lang.Object
+hfds DEBUG_ALWAYS_CREATE_JAVA_STRING,DEBUG_NON_ZERO_OFFSET,DEBUG_STRICT_ENCODING_CHECKS,codePointLength,codeRange,data,encoding,flags,hashCode,length,offset,stride
+hcls LazyConcat,LazyLong,NativePointer
+
+CLSS public final com.oracle.truffle.api.strings.InternalByteArray
+meth public byte get(int)
+meth public byte[] getArray()
+meth public int getEnd()
+meth public int getLength()
+meth public int getOffset()
+supr java.lang.Object
+hfds EMPTY,array,length,offset
+
+CLSS public final com.oracle.truffle.api.strings.MutableTruffleString
+innr public abstract static AsManagedNode
+innr public abstract static AsMutableTruffleStringNode
+innr public abstract static ConcatNode
+innr public abstract static ForceEncodingNode
+innr public abstract static FromByteArrayNode
+innr public abstract static FromNativePointerNode
+innr public abstract static SubstringByteIndexNode
+innr public abstract static SubstringNode
+innr public abstract static SwitchEncodingNode
+innr public abstract static WriteByteNode
+meth public com.oracle.truffle.api.strings.MutableTruffleString concatUncached(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public com.oracle.truffle.api.strings.MutableTruffleString substringByteIndexUncached(int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public com.oracle.truffle.api.strings.MutableTruffleString substringUncached(int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.MutableTruffleString fromByteArrayUncached(byte[],int,int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public static com.oracle.truffle.api.strings.MutableTruffleString fromNativePointerUncached(java.lang.Object,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public void notifyExternalMutation()
+meth public void writeByteUncached(int,byte,com.oracle.truffle.api.strings.TruffleString$Encoding)
+supr com.oracle.truffle.api.strings.AbstractTruffleString
+hcls CalcLazyAttributesNode,DataClassProfile
+
+CLSS public abstract static com.oracle.truffle.api.strings.MutableTruffleString$AsManagedNode
+ outer com.oracle.truffle.api.strings.MutableTruffleString
+meth public abstract com.oracle.truffle.api.strings.MutableTruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$AsManagedNode create()
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$AsManagedNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.MutableTruffleString$AsMutableTruffleStringNode
+ outer com.oracle.truffle.api.strings.MutableTruffleString
+meth public abstract com.oracle.truffle.api.strings.MutableTruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$AsMutableTruffleStringNode create()
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$AsMutableTruffleStringNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.MutableTruffleString$ConcatNode
+ outer com.oracle.truffle.api.strings.MutableTruffleString
+meth public abstract com.oracle.truffle.api.strings.MutableTruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$ConcatNode create()
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$ConcatNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.MutableTruffleString$ForceEncodingNode
+ outer com.oracle.truffle.api.strings.MutableTruffleString
+meth public abstract com.oracle.truffle.api.strings.MutableTruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$ForceEncodingNode create()
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$ForceEncodingNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.MutableTruffleString$FromByteArrayNode
+ outer com.oracle.truffle.api.strings.MutableTruffleString
+meth public abstract com.oracle.truffle.api.strings.MutableTruffleString execute(byte[],int,int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$FromByteArrayNode create()
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$FromByteArrayNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.MutableTruffleString$FromNativePointerNode
+ outer com.oracle.truffle.api.strings.MutableTruffleString
+meth public abstract com.oracle.truffle.api.strings.MutableTruffleString execute(java.lang.Object,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$FromNativePointerNode create()
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$FromNativePointerNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.MutableTruffleString$SubstringByteIndexNode
+ outer com.oracle.truffle.api.strings.MutableTruffleString
+meth public abstract com.oracle.truffle.api.strings.MutableTruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$SubstringByteIndexNode create()
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$SubstringByteIndexNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.MutableTruffleString$SubstringNode
+ outer com.oracle.truffle.api.strings.MutableTruffleString
+meth public abstract com.oracle.truffle.api.strings.MutableTruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$SubstringNode create()
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$SubstringNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.MutableTruffleString$SwitchEncodingNode
+ outer com.oracle.truffle.api.strings.MutableTruffleString
+meth public abstract com.oracle.truffle.api.strings.MutableTruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding,com.oracle.truffle.api.strings.TranscodingErrorHandler)
+meth public final com.oracle.truffle.api.strings.MutableTruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$SwitchEncodingNode create()
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$SwitchEncodingNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.MutableTruffleString$WriteByteNode
+ outer com.oracle.truffle.api.strings.MutableTruffleString
+meth public abstract void execute(com.oracle.truffle.api.strings.MutableTruffleString,int,byte,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$WriteByteNode create()
+meth public static com.oracle.truffle.api.strings.MutableTruffleString$WriteByteNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public final com.oracle.truffle.api.strings.MutableTruffleStringFactory
+cons public init()
+supr java.lang.Object
+hcls AsManagedNodeGen,AsMutableTruffleStringNodeGen,CalcLazyAttributesNodeGen,ConcatNodeGen,DataClassProfileNodeGen,ForceEncodingNodeGen,FromByteArrayNodeGen,FromNativePointerNodeGen,SubstringByteIndexNodeGen,SubstringNodeGen,SwitchEncodingNodeGen,WriteByteNodeGen
+
+CLSS public abstract interface com.oracle.truffle.api.strings.NativeAllocator
+ anno 0 java.lang.FunctionalInterface()
+meth public abstract java.lang.Object allocate(int)
+
+CLSS public abstract interface com.oracle.truffle.api.strings.TranscodingErrorHandler
+ anno 0 java.lang.FunctionalInterface()
+fld public final static com.oracle.truffle.api.strings.TranscodingErrorHandler DEFAULT
+fld public final static com.oracle.truffle.api.strings.TranscodingErrorHandler DEFAULT_KEEP_SURROGATES_IN_UTF8
+innr public final static ReplacementString
+meth public abstract com.oracle.truffle.api.strings.TranscodingErrorHandler$ReplacementString apply(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding,com.oracle.truffle.api.strings.TruffleString$Encoding)
+
+CLSS public final static com.oracle.truffle.api.strings.TranscodingErrorHandler$ReplacementString
+ outer com.oracle.truffle.api.strings.TranscodingErrorHandler
+hfds byteLength,replacement
+
+CLSS public final com.oracle.truffle.api.strings.TruffleString
+innr public abstract static AsManagedNode
+innr public abstract static AsNativeNode
+innr public abstract static AsTruffleStringNode
+innr public abstract static ByteIndexOfAnyByteNode
+innr public abstract static ByteIndexOfCodePointNode
+innr public abstract static ByteIndexOfCodePointSetNode
+innr public abstract static ByteIndexOfStringNode
+innr public abstract static ByteIndexToCodePointIndexNode
+innr public abstract static ByteLengthOfCodePointNode
+innr public abstract static CharIndexOfAnyCharUTF16Node
+innr public abstract static CodePointAtByteIndexNode
+innr public abstract static CodePointAtIndexNode
+innr public abstract static CodePointIndexToByteIndexNode
+innr public abstract static CodePointLengthNode
+innr public abstract static CodeRangeEqualsNode
+innr public abstract static CompareBytesNode
+innr public abstract static CompareCharsUTF16Node
+innr public abstract static CompareIntsUTF32Node
+innr public abstract static ConcatNode
+innr public abstract static CopyToByteArrayNode
+innr public abstract static CopyToNativeMemoryNode
+innr public abstract static CreateBackwardCodePointIteratorNode
+innr public abstract static CreateCodePointIteratorNode
+innr public abstract static EqualNode
+innr public abstract static ForceEncodingNode
+innr public abstract static FromByteArrayNode
+innr public abstract static FromCharArrayUTF16Node
+innr public abstract static FromCodePointNode
+innr public abstract static FromIntArrayUTF32Node
+innr public abstract static FromJavaStringNode
+innr public abstract static FromLongNode
+innr public abstract static FromNativePointerNode
+innr public abstract static GetByteCodeRangeNode
+innr public abstract static GetCodeRangeImpreciseNode
+innr public abstract static GetCodeRangeNode
+innr public abstract static GetInternalByteArrayNode
+innr public abstract static GetInternalNativePointerNode
+innr public abstract static GetStringCompactionLevelNode
+innr public abstract static HashCodeNode
+innr public abstract static IndexOfCodePointNode
+innr public abstract static IndexOfStringNode
+innr public abstract static IntIndexOfAnyIntUTF32Node
+innr public abstract static IsValidNode
+innr public abstract static LastByteIndexOfCodePointNode
+innr public abstract static LastByteIndexOfStringNode
+innr public abstract static LastIndexOfCodePointNode
+innr public abstract static LastIndexOfStringNode
+innr public abstract static MaterializeNode
+innr public abstract static ParseDoubleNode
+innr public abstract static ParseIntNode
+innr public abstract static ParseLongNode
+innr public abstract static ReadByteNode
+innr public abstract static ReadCharUTF16Node
+innr public abstract static RegionEqualByteIndexNode
+innr public abstract static RegionEqualNode
+innr public abstract static RepeatNode
+innr public abstract static SubstringByteIndexNode
+innr public abstract static SubstringNode
+innr public abstract static SwitchEncodingNode
+innr public abstract static ToJavaStringNode
+innr public abstract static ToValidStringNode
+innr public final static !enum CodeRange
+innr public final static !enum CompactionLevel
+innr public final static !enum Encoding
+innr public final static !enum ErrorHandling
+innr public final static CodePointSet
+innr public final static IllegalByteArrayLengthException
+innr public final static NumberFormatException
+innr public final static WithMask
+meth public com.oracle.truffle.api.strings.TruffleString asNativeUncached(com.oracle.truffle.api.strings.NativeAllocator,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean,boolean)
+meth public static com.oracle.truffle.api.strings.TruffleString fromByteArrayUncached(byte[],com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString fromByteArrayUncached(byte[],com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public static com.oracle.truffle.api.strings.TruffleString fromByteArrayUncached(byte[],int,int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public static com.oracle.truffle.api.strings.TruffleString fromCharArrayUTF16Uncached(char[])
+meth public static com.oracle.truffle.api.strings.TruffleString fromCharArrayUTF16Uncached(char[],int,int)
+meth public static com.oracle.truffle.api.strings.TruffleString fromCodePointUncached(int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString fromCodePointUncached(int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public static com.oracle.truffle.api.strings.TruffleString fromConstant(java.lang.String,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString fromIntArrayUTF32Uncached(int[])
+meth public static com.oracle.truffle.api.strings.TruffleString fromIntArrayUTF32Uncached(int[],int,int)
+meth public static com.oracle.truffle.api.strings.TruffleString fromJavaStringUncached(java.lang.String,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString fromJavaStringUncached(java.lang.String,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public static com.oracle.truffle.api.strings.TruffleString fromLongUncached(long,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public static com.oracle.truffle.api.strings.TruffleString fromNativePointerUncached(java.lang.Object,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+supr com.oracle.truffle.api.strings.AbstractTruffleString
+hfds FLAG_CACHE_HEAD,NEXT_UPDATER,next
+hcls InternalAsTruffleStringNode,InternalCopyToByteArrayNode,InternalSwitchEncodingNode,ToIndexableNode
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$AsManagedNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public final com.oracle.truffle.api.strings.TruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$AsManagedNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$AsManagedNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$AsNativeNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(com.oracle.truffle.api.strings.TruffleString,com.oracle.truffle.api.strings.NativeAllocator,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean,boolean)
+meth public static com.oracle.truffle.api.strings.TruffleString$AsNativeNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$AsNativeNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+hfds NULL_TERMINATION_BYTES
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$AsTruffleStringNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$AsTruffleStringNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$AsTruffleStringNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$ByteIndexOfAnyByteNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,byte[],com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$ByteIndexOfAnyByteNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$ByteIndexOfAnyByteNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$ByteIndexOfCodePointNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$ByteIndexOfCodePointNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$ByteIndexOfCodePointNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$ByteIndexOfCodePointSetNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$CodePointSet)
+meth public static com.oracle.truffle.api.strings.TruffleString$ByteIndexOfCodePointSetNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$ByteIndexOfCodePointSetNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$ByteIndexOfStringNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public final int execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$WithMask,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$ByteIndexOfStringNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$ByteIndexOfStringNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$ByteIndexToCodePointIndexNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$ByteIndexToCodePointIndexNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$ByteIndexToCodePointIndexNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$ByteLengthOfCodePointNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,com.oracle.truffle.api.strings.TruffleString$Encoding,com.oracle.truffle.api.strings.TruffleString$ErrorHandling)
+meth public final int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$ByteLengthOfCodePointNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$ByteLengthOfCodePointNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$CharIndexOfAnyCharUTF16Node
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,char[])
+meth public static com.oracle.truffle.api.strings.TruffleString$CharIndexOfAnyCharUTF16Node create()
+meth public static com.oracle.truffle.api.strings.TruffleString$CharIndexOfAnyCharUTF16Node getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$CodePointAtByteIndexNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,com.oracle.truffle.api.strings.TruffleString$Encoding,com.oracle.truffle.api.strings.TruffleString$ErrorHandling)
+meth public final int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$CodePointAtByteIndexNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$CodePointAtByteIndexNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$CodePointAtIndexNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,com.oracle.truffle.api.strings.TruffleString$Encoding,com.oracle.truffle.api.strings.TruffleString$ErrorHandling)
+meth public final int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$CodePointAtIndexNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$CodePointAtIndexNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$CodePointIndexToByteIndexNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$CodePointIndexToByteIndexNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$CodePointIndexToByteIndexNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$CodePointLengthNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$CodePointLengthNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$CodePointLengthNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public final static com.oracle.truffle.api.strings.TruffleString$CodePointSet
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public boolean isIntrinsicCandidate(com.oracle.truffle.api.strings.TruffleString$CodeRange)
+meth public static com.oracle.truffle.api.strings.TruffleString$CodePointSet fromRanges(int[],com.oracle.truffle.api.strings.TruffleString$Encoding)
+supr java.lang.Object
+hfds encoding,indexOfNodes,ranges
+
+CLSS public final static !enum com.oracle.truffle.api.strings.TruffleString$CodeRange
+ outer com.oracle.truffle.api.strings.TruffleString
+fld public final static com.oracle.truffle.api.strings.TruffleString$CodeRange ASCII
+fld public final static com.oracle.truffle.api.strings.TruffleString$CodeRange BMP
+fld public final static com.oracle.truffle.api.strings.TruffleString$CodeRange BROKEN
+fld public final static com.oracle.truffle.api.strings.TruffleString$CodeRange LATIN_1
+fld public final static com.oracle.truffle.api.strings.TruffleString$CodeRange VALID
+meth public boolean isSubsetOf(com.oracle.truffle.api.strings.TruffleString$CodeRange)
+meth public boolean isSupersetOf(com.oracle.truffle.api.strings.TruffleString$CodeRange)
+meth public static com.oracle.truffle.api.strings.TruffleString$CodeRange valueOf(java.lang.String)
+meth public static com.oracle.truffle.api.strings.TruffleString$CodeRange[] values()
+supr java.lang.Enum<com.oracle.truffle.api.strings.TruffleString$CodeRange>
+hfds BYTE_CODE_RANGES
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$CodeRangeEqualsNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract boolean execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$CodeRange)
+meth public static com.oracle.truffle.api.strings.TruffleString$CodeRangeEqualsNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$CodeRangeEqualsNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public final static !enum com.oracle.truffle.api.strings.TruffleString$CompactionLevel
+ outer com.oracle.truffle.api.strings.TruffleString
+fld public final static com.oracle.truffle.api.strings.TruffleString$CompactionLevel S1
+fld public final static com.oracle.truffle.api.strings.TruffleString$CompactionLevel S2
+fld public final static com.oracle.truffle.api.strings.TruffleString$CompactionLevel S4
+meth public final int getBytes()
+meth public final int getLog2()
+meth public static com.oracle.truffle.api.strings.TruffleString$CompactionLevel valueOf(java.lang.String)
+meth public static com.oracle.truffle.api.strings.TruffleString$CompactionLevel[] values()
+supr java.lang.Enum<com.oracle.truffle.api.strings.TruffleString$CompactionLevel>
+hfds bytes,log2
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$CompareBytesNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$CompareBytesNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$CompareBytesNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$CompareCharsUTF16Node
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.AbstractTruffleString)
+meth public static com.oracle.truffle.api.strings.TruffleString$CompareCharsUTF16Node create()
+meth public static com.oracle.truffle.api.strings.TruffleString$CompareCharsUTF16Node getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$CompareIntsUTF32Node
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.AbstractTruffleString)
+meth public static com.oracle.truffle.api.strings.TruffleString$CompareIntsUTF32Node create()
+meth public static com.oracle.truffle.api.strings.TruffleString$CompareIntsUTF32Node getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$ConcatNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public static com.oracle.truffle.api.strings.TruffleString$ConcatNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$ConcatNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$CopyToByteArrayNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract void execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,byte[],int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final byte[] execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$CopyToByteArrayNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$CopyToByteArrayNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$CopyToNativeMemoryNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract void execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,java.lang.Object,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$CopyToNativeMemoryNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$CopyToNativeMemoryNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$CreateBackwardCodePointIteratorNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleStringIterator execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding,com.oracle.truffle.api.strings.TruffleString$ErrorHandling)
+meth public final com.oracle.truffle.api.strings.TruffleStringIterator execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$CreateBackwardCodePointIteratorNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$CreateBackwardCodePointIteratorNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$CreateCodePointIteratorNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleStringIterator execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding,com.oracle.truffle.api.strings.TruffleString$ErrorHandling)
+meth public final com.oracle.truffle.api.strings.TruffleStringIterator execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$CreateCodePointIteratorNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$CreateCodePointIteratorNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public final static !enum com.oracle.truffle.api.strings.TruffleString$Encoding
+ outer com.oracle.truffle.api.strings.TruffleString
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding BYTES
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Big5
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Big5_HKSCS
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Big5_UAO
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding CESU_8
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding CP50220
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding CP50221
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding CP51932
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding CP850
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding CP852
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding CP855
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding CP949
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding CP950
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding CP951
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding EUC_JIS_2004
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding EUC_JP
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding EUC_KR
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding EUC_TW
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Emacs_Mule
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding EucJP_ms
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding GB12345
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding GB18030
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding GB1988
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding GB2312
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding GBK
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM037
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM437
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM720
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM737
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM775
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM852
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM855
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM857
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM860
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM861
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM862
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM863
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM864
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM865
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM866
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding IBM869
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_2022_JP
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_2022_JP_2
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_2022_JP_KDDI
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_8859_1
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_8859_10
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_8859_11
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_8859_13
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_8859_14
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_8859_15
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_8859_16
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_8859_2
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_8859_3
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_8859_4
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_8859_5
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_8859_6
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_8859_7
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_8859_8
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding ISO_8859_9
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding KOI8_R
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding KOI8_U
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding MacCentEuro
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding MacCroatian
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding MacCyrillic
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding MacGreek
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding MacIceland
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding MacJapanese
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding MacRoman
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding MacRomania
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding MacThai
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding MacTurkish
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding MacUkraine
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding SJIS_DoCoMo
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding SJIS_KDDI
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding SJIS_SoftBank
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Shift_JIS
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Stateless_ISO_2022_JP
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Stateless_ISO_2022_JP_KDDI
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding TIS_620
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding US_ASCII
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding UTF8_DoCoMo
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding UTF8_KDDI
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding UTF8_MAC
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding UTF8_SoftBank
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding UTF_16
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding UTF_16BE
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding UTF_16LE
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding UTF_32
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding UTF_32BE
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding UTF_32LE
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding UTF_7
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding UTF_8
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Windows_1250
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Windows_1251
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Windows_1252
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Windows_1253
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Windows_1254
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Windows_1255
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Windows_1256
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Windows_1257
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Windows_1258
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Windows_31J
+fld public final static com.oracle.truffle.api.strings.TruffleString$Encoding Windows_874
+meth public com.oracle.truffle.api.strings.TruffleString getEmpty()
+meth public static com.oracle.truffle.api.strings.TruffleString$Encoding fromJCodingName(java.lang.String)
+meth public static com.oracle.truffle.api.strings.TruffleString$Encoding valueOf(java.lang.String)
+meth public static com.oracle.truffle.api.strings.TruffleString$Encoding[] values()
+supr java.lang.Enum<com.oracle.truffle.api.strings.TruffleString$Encoding>
+hfds EMPTY_STRINGS,ENCODINGS_TABLE,J_CODINGS_NAME_MAP,J_CODINGS_TABLE,MAX_COMPATIBLE_CODE_RANGE,fixedWidth,id,jCoding,maxCompatibleCodeRange,name,naturalStride
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$EqualNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract boolean execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$EqualNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$EqualNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public final static !enum com.oracle.truffle.api.strings.TruffleString$ErrorHandling
+ outer com.oracle.truffle.api.strings.TruffleString
+fld public final static com.oracle.truffle.api.strings.TruffleString$ErrorHandling BEST_EFFORT
+fld public final static com.oracle.truffle.api.strings.TruffleString$ErrorHandling RETURN_NEGATIVE
+meth public static com.oracle.truffle.api.strings.TruffleString$ErrorHandling valueOf(java.lang.String)
+meth public static com.oracle.truffle.api.strings.TruffleString$ErrorHandling[] values()
+supr java.lang.Enum<com.oracle.truffle.api.strings.TruffleString$ErrorHandling>
+hfds errorHandler
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$ForceEncodingNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$ForceEncodingNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$ForceEncodingNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$FromByteArrayNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(byte[],int,int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public final com.oracle.truffle.api.strings.TruffleString execute(byte[],com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final com.oracle.truffle.api.strings.TruffleString execute(byte[],com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public static com.oracle.truffle.api.strings.TruffleString$FromByteArrayNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$FromByteArrayNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$FromCharArrayUTF16Node
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(char[],int,int)
+meth public final com.oracle.truffle.api.strings.TruffleString execute(char[])
+meth public static com.oracle.truffle.api.strings.TruffleString$FromCharArrayUTF16Node create()
+meth public static com.oracle.truffle.api.strings.TruffleString$FromCharArrayUTF16Node getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$FromCodePointNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public final com.oracle.truffle.api.strings.TruffleString execute(int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$FromCodePointNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$FromCodePointNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$FromIntArrayUTF32Node
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(int[],int,int)
+meth public final com.oracle.truffle.api.strings.TruffleString execute(int[])
+meth public static com.oracle.truffle.api.strings.TruffleString$FromIntArrayUTF32Node create()
+meth public static com.oracle.truffle.api.strings.TruffleString$FromIntArrayUTF32Node getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$FromJavaStringNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(java.lang.String,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public final com.oracle.truffle.api.strings.TruffleString execute(java.lang.String,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$FromJavaStringNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$FromJavaStringNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$FromLongNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(long,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public static com.oracle.truffle.api.strings.TruffleString$FromLongNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$FromLongNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$FromNativePointerNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(java.lang.Object,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public static com.oracle.truffle.api.strings.TruffleString$FromNativePointerNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$FromNativePointerNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$GetByteCodeRangeNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString$CodeRange execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$GetByteCodeRangeNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$GetByteCodeRangeNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$GetCodeRangeImpreciseNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString$CodeRange execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$GetCodeRangeImpreciseNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$GetCodeRangeImpreciseNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$GetCodeRangeNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString$CodeRange execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$GetCodeRangeNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$GetCodeRangeNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$GetInternalByteArrayNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.InternalByteArray execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$GetInternalByteArrayNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$GetInternalByteArrayNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$GetInternalNativePointerNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract java.lang.Object execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$GetInternalNativePointerNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$GetInternalNativePointerNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$GetStringCompactionLevelNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString$CompactionLevel execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$GetStringCompactionLevelNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$GetStringCompactionLevelNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$HashCodeNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$HashCodeNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$HashCodeNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public final static com.oracle.truffle.api.strings.TruffleString$IllegalByteArrayLengthException
+ outer com.oracle.truffle.api.strings.TruffleString
+supr java.lang.IllegalArgumentException
+hfds serialVersionUID
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$IndexOfCodePointNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$IndexOfCodePointNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$IndexOfCodePointNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$IndexOfStringNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$IndexOfStringNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$IndexOfStringNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$IntIndexOfAnyIntUTF32Node
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,int[])
+meth public static com.oracle.truffle.api.strings.TruffleString$IntIndexOfAnyIntUTF32Node create()
+meth public static com.oracle.truffle.api.strings.TruffleString$IntIndexOfAnyIntUTF32Node getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$IsValidNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract boolean execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$IsValidNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$IsValidNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$LastByteIndexOfCodePointNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$LastByteIndexOfCodePointNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$LastByteIndexOfCodePointNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$LastByteIndexOfStringNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public final int execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final int execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$WithMask,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$LastByteIndexOfStringNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$LastByteIndexOfStringNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$LastIndexOfCodePointNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$LastIndexOfCodePointNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$LastIndexOfCodePointNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$LastIndexOfStringNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$LastIndexOfStringNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$LastIndexOfStringNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$MaterializeNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract void execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$MaterializeNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$MaterializeNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public final static com.oracle.truffle.api.strings.TruffleString$NumberFormatException
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public java.lang.String getMessage()
+meth public java.lang.Throwable fillInStackTrace()
+supr java.lang.Exception
+hfds reason,regionLength,regionOffset,serialVersionUID,string
+hcls Reason
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$ParseDoubleNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract double execute(com.oracle.truffle.api.strings.AbstractTruffleString) throws com.oracle.truffle.api.strings.TruffleString$NumberFormatException
+meth public static com.oracle.truffle.api.strings.TruffleString$ParseDoubleNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$ParseDoubleNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$ParseIntNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int) throws com.oracle.truffle.api.strings.TruffleString$NumberFormatException
+meth public static com.oracle.truffle.api.strings.TruffleString$ParseIntNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$ParseIntNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$ParseLongNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract long execute(com.oracle.truffle.api.strings.AbstractTruffleString,int) throws com.oracle.truffle.api.strings.TruffleString$NumberFormatException
+meth public static com.oracle.truffle.api.strings.TruffleString$ParseLongNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$ParseLongNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$ReadByteNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract int execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$ReadByteNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$ReadByteNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$ReadCharUTF16Node
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract char execute(com.oracle.truffle.api.strings.AbstractTruffleString,int)
+meth public static com.oracle.truffle.api.strings.TruffleString$ReadCharUTF16Node create()
+meth public static com.oracle.truffle.api.strings.TruffleString$ReadCharUTF16Node getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$RegionEqualByteIndexNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public final boolean execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public final boolean execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,com.oracle.truffle.api.strings.TruffleString$WithMask,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$RegionEqualByteIndexNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$RegionEqualByteIndexNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$RegionEqualNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract boolean execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$RegionEqualNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$RegionEqualNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$RepeatNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$RepeatNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$RepeatNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$SubstringByteIndexNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public static com.oracle.truffle.api.strings.TruffleString$SubstringByteIndexNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$SubstringByteIndexNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$SubstringNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,int,int,com.oracle.truffle.api.strings.TruffleString$Encoding,boolean)
+meth public static com.oracle.truffle.api.strings.TruffleString$SubstringNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$SubstringNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$SwitchEncodingNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding,com.oracle.truffle.api.strings.TranscodingErrorHandler)
+meth public final com.oracle.truffle.api.strings.TruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$SwitchEncodingNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$SwitchEncodingNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$ToJavaStringNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract java.lang.String execute(com.oracle.truffle.api.strings.AbstractTruffleString)
+meth public static com.oracle.truffle.api.strings.TruffleString$ToJavaStringNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$ToJavaStringNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$ToValidStringNode
+ outer com.oracle.truffle.api.strings.TruffleString
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(com.oracle.truffle.api.strings.AbstractTruffleString,com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$ToValidStringNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$ToValidStringNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public final static com.oracle.truffle.api.strings.TruffleString$WithMask
+ outer com.oracle.truffle.api.strings.TruffleString
+innr public abstract static CreateNode
+innr public abstract static CreateUTF16Node
+innr public abstract static CreateUTF32Node
+meth public static com.oracle.truffle.api.strings.TruffleString$WithMask createUTF16Uncached(com.oracle.truffle.api.strings.AbstractTruffleString,char[])
+meth public static com.oracle.truffle.api.strings.TruffleString$WithMask createUTF32Uncached(com.oracle.truffle.api.strings.AbstractTruffleString,int[])
+meth public static com.oracle.truffle.api.strings.TruffleString$WithMask createUncached(com.oracle.truffle.api.strings.AbstractTruffleString,byte[],com.oracle.truffle.api.strings.TruffleString$Encoding)
+supr java.lang.Object
+hfds mask,string
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$WithMask$CreateNode
+ outer com.oracle.truffle.api.strings.TruffleString$WithMask
+meth public abstract com.oracle.truffle.api.strings.TruffleString$WithMask execute(com.oracle.truffle.api.strings.AbstractTruffleString,byte[],com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleString$WithMask$CreateNode create()
+meth public static com.oracle.truffle.api.strings.TruffleString$WithMask$CreateNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$WithMask$CreateUTF16Node
+ outer com.oracle.truffle.api.strings.TruffleString$WithMask
+meth public abstract com.oracle.truffle.api.strings.TruffleString$WithMask execute(com.oracle.truffle.api.strings.AbstractTruffleString,char[])
+meth public static com.oracle.truffle.api.strings.TruffleString$WithMask$CreateUTF16Node create()
+meth public static com.oracle.truffle.api.strings.TruffleString$WithMask$CreateUTF16Node getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleString$WithMask$CreateUTF32Node
+ outer com.oracle.truffle.api.strings.TruffleString$WithMask
+meth public abstract com.oracle.truffle.api.strings.TruffleString$WithMask execute(com.oracle.truffle.api.strings.AbstractTruffleString,int[])
+meth public static com.oracle.truffle.api.strings.TruffleString$WithMask$CreateUTF32Node create()
+meth public static com.oracle.truffle.api.strings.TruffleString$WithMask$CreateUTF32Node getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract com.oracle.truffle.api.strings.TruffleStringBuilder
+innr public abstract static AppendByteNode
+innr public abstract static AppendCharUTF16Node
+innr public abstract static AppendCodePointNode
+innr public abstract static AppendIntNumberNode
+innr public abstract static AppendJavaStringUTF16Node
+innr public abstract static AppendLongNumberNode
+innr public abstract static AppendStringNode
+innr public abstract static AppendSubstringByteIndexNode
+innr public abstract static ToStringNode
+meth public final boolean isEmpty()
+meth public final com.oracle.truffle.api.strings.TruffleString toStringUncached()
+meth public final int byteLength()
+meth public final java.lang.String toString()
+meth public final void appendByteUncached(byte)
+meth public final void appendCharUTF16Uncached(char)
+meth public final void appendCodePointUncached(int)
+meth public final void appendCodePointUncached(int,int)
+meth public final void appendCodePointUncached(int,int,boolean)
+meth public final void appendIntNumberUncached(int)
+meth public final void appendJavaStringUTF16Uncached(java.lang.String)
+meth public final void appendJavaStringUTF16Uncached(java.lang.String,int,int)
+meth public final void appendLongNumberUncached(long)
+meth public final void appendStringUncached(com.oracle.truffle.api.strings.TruffleString)
+meth public final void appendSubstringByteIndexUncached(com.oracle.truffle.api.strings.TruffleString,int,int)
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder create(com.oracle.truffle.api.strings.TruffleString$Encoding)
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder create(com.oracle.truffle.api.strings.TruffleString$Encoding,int)
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilderUTF16 createUTF16()
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilderUTF16 createUTF16(int)
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilderUTF32 createUTF32()
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilderUTF32 createUTF32(int)
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilderUTF8 createUTF8()
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilderUTF8 createUTF8(int)
+supr java.lang.Object
+hfds DEFAULT_INITIAL_CAPACITY,buf,codePointLength,codeRange,encoding,length,stride
+hcls AppendCodePointIntlNode,AppendStringIntlNode,ToStringIntlNode
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendByteNode
+ outer com.oracle.truffle.api.strings.TruffleStringBuilder
+meth public abstract void execute(com.oracle.truffle.api.strings.TruffleStringBuilder,byte)
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendByteNode create()
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendByteNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendCharUTF16Node
+ outer com.oracle.truffle.api.strings.TruffleStringBuilder
+meth public abstract void execute(com.oracle.truffle.api.strings.TruffleStringBuilder,char)
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendCharUTF16Node create()
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendCharUTF16Node getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendCodePointNode
+ outer com.oracle.truffle.api.strings.TruffleStringBuilder
+meth public abstract void execute(com.oracle.truffle.api.strings.TruffleStringBuilder,int,int,boolean)
+meth public final void execute(com.oracle.truffle.api.strings.TruffleStringBuilder,int)
+meth public final void execute(com.oracle.truffle.api.strings.TruffleStringBuilder,int,int)
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendCodePointNode create()
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendCodePointNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendIntNumberNode
+ outer com.oracle.truffle.api.strings.TruffleStringBuilder
+meth public abstract void execute(com.oracle.truffle.api.strings.TruffleStringBuilder,int)
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendIntNumberNode create()
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendIntNumberNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendJavaStringUTF16Node
+ outer com.oracle.truffle.api.strings.TruffleStringBuilder
+meth public abstract void execute(com.oracle.truffle.api.strings.TruffleStringBuilder,java.lang.String,int,int)
+meth public final void execute(com.oracle.truffle.api.strings.TruffleStringBuilder,java.lang.String)
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendJavaStringUTF16Node create()
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendJavaStringUTF16Node getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendLongNumberNode
+ outer com.oracle.truffle.api.strings.TruffleStringBuilder
+meth public abstract void execute(com.oracle.truffle.api.strings.TruffleStringBuilder,long)
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendLongNumberNode create()
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendLongNumberNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendStringNode
+ outer com.oracle.truffle.api.strings.TruffleStringBuilder
+meth public abstract void execute(com.oracle.truffle.api.strings.TruffleStringBuilder,com.oracle.truffle.api.strings.AbstractTruffleString)
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendStringNode create()
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendStringNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendSubstringByteIndexNode
+ outer com.oracle.truffle.api.strings.TruffleStringBuilder
+meth public abstract void execute(com.oracle.truffle.api.strings.TruffleStringBuilder,com.oracle.truffle.api.strings.AbstractTruffleString,int,int)
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendSubstringByteIndexNode create()
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$AppendSubstringByteIndexNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleStringBuilder$ToStringNode
+ outer com.oracle.truffle.api.strings.TruffleStringBuilder
+meth public abstract com.oracle.truffle.api.strings.TruffleString execute(com.oracle.truffle.api.strings.TruffleStringBuilder,boolean)
+meth public final com.oracle.truffle.api.strings.TruffleString execute(com.oracle.truffle.api.strings.TruffleStringBuilder)
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$ToStringNode create()
+meth public static com.oracle.truffle.api.strings.TruffleStringBuilder$ToStringNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public final com.oracle.truffle.api.strings.TruffleStringBuilderFactory
+cons public init()
+supr java.lang.Object
+hcls AppendByteNodeGen,AppendCharUTF16NodeGen,AppendCodePointIntlNodeGen,AppendCodePointNodeGen,AppendIntNumberNodeGen,AppendJavaStringUTF16NodeGen,AppendLongNumberNodeGen,AppendStringIntlNodeGen,AppendStringNodeGen,AppendSubstringByteIndexNodeGen,ToStringIntlNodeGen,ToStringNodeGen
+
+CLSS public final com.oracle.truffle.api.strings.TruffleStringBuilderUTF16
+supr com.oracle.truffle.api.strings.TruffleStringBuilder
+
+CLSS public final com.oracle.truffle.api.strings.TruffleStringBuilderUTF32
+supr com.oracle.truffle.api.strings.TruffleStringBuilder
+
+CLSS public final com.oracle.truffle.api.strings.TruffleStringBuilderUTF8
+supr com.oracle.truffle.api.strings.TruffleStringBuilder
+
+CLSS public final com.oracle.truffle.api.strings.TruffleStringFactory
+cons public init()
+innr public final static WithMaskFactory
+supr java.lang.Object
+hcls AsManagedNodeGen,AsNativeNodeGen,AsTruffleStringNodeGen,ByteIndexOfAnyByteNodeGen,ByteIndexOfCodePointNodeGen,ByteIndexOfCodePointSetNodeGen,ByteIndexOfStringNodeGen,ByteIndexToCodePointIndexNodeGen,ByteLengthOfCodePointNodeGen,CharIndexOfAnyCharUTF16NodeGen,CodePointAtByteIndexNodeGen,CodePointAtIndexNodeGen,CodePointIndexToByteIndexNodeGen,CodePointLengthNodeGen,CodeRangeEqualsNodeGen,CompareBytesNodeGen,CompareCharsUTF16NodeGen,CompareIntsUTF32NodeGen,ConcatNodeGen,CopyToByteArrayNodeGen,CopyToNativeMemoryNodeGen,CreateBackwardCodePointIteratorNodeGen,CreateCodePointIteratorNodeGen,EqualNodeGen,ForceEncodingNodeGen,FromByteArrayNodeGen,FromCharArrayUTF16NodeGen,FromCodePointNodeGen,FromIntArrayUTF32NodeGen,FromJavaStringNodeGen,FromLongNodeGen,FromNativePointerNodeGen,GetByteCodeRangeNodeGen,GetCodeRangeImpreciseNodeGen,GetCodeRangeNodeGen,GetInternalByteArrayNodeGen,GetInternalNativePointerNodeGen,GetStringCompactionLevelNodeGen,HashCodeNodeGen,IndexOfCodePointNodeGen,IndexOfStringNodeGen,IntIndexOfAnyIntUTF32NodeGen,InternalAsTruffleStringNodeGen,InternalCopyToByteArrayNodeGen,InternalSwitchEncodingNodeGen,IsValidNodeGen,LastByteIndexOfCodePointNodeGen,LastByteIndexOfStringNodeGen,LastIndexOfCodePointNodeGen,LastIndexOfStringNodeGen,MaterializeNodeGen,ParseDoubleNodeGen,ParseIntNodeGen,ParseLongNodeGen,ReadByteNodeGen,ReadCharUTF16NodeGen,RegionEqualByteIndexNodeGen,RegionEqualNodeGen,RepeatNodeGen,SubstringByteIndexNodeGen,SubstringNodeGen,SwitchEncodingNodeGen,ToIndexableNodeGen,ToJavaStringNodeGen,ToValidStringNodeGen
+
+CLSS public final static com.oracle.truffle.api.strings.TruffleStringFactory$WithMaskFactory
+ outer com.oracle.truffle.api.strings.TruffleStringFactory
+cons public init()
+supr java.lang.Object
+hcls CreateNodeGen,CreateUTF16NodeGen,CreateUTF32NodeGen
+
+CLSS public final com.oracle.truffle.api.strings.TruffleStringIterator
+innr public abstract static NextNode
+innr public abstract static PreviousNode
+meth public boolean hasNext()
+meth public boolean hasPrevious()
+meth public int getByteIndex()
+meth public int nextUncached()
+meth public int previousUncached()
+supr java.lang.Object
+hfds a,arrayA,codeRangeA,encoding,errorHandling,rawIndex
+hcls InternalNextNode,InternalPreviousNode
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleStringIterator$NextNode
+ outer com.oracle.truffle.api.strings.TruffleStringIterator
+meth public abstract int execute(com.oracle.truffle.api.strings.TruffleStringIterator)
+meth public static com.oracle.truffle.api.strings.TruffleStringIterator$NextNode create()
+meth public static com.oracle.truffle.api.strings.TruffleStringIterator$NextNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public abstract static com.oracle.truffle.api.strings.TruffleStringIterator$PreviousNode
+ outer com.oracle.truffle.api.strings.TruffleStringIterator
+meth public abstract int execute(com.oracle.truffle.api.strings.TruffleStringIterator)
+meth public static com.oracle.truffle.api.strings.TruffleStringIterator$PreviousNode create()
+meth public static com.oracle.truffle.api.strings.TruffleStringIterator$PreviousNode getUncached()
+supr com.oracle.truffle.api.nodes.Node
+
+CLSS public final com.oracle.truffle.api.strings.TruffleStringIteratorFactory
+cons public init()
+supr java.lang.Object
+hcls InternalNextNodeGen,InternalPreviousNodeGen,NextNodeGen,PreviousNodeGen
 
 CLSS public com.oracle.truffle.api.utilities.AssumedValue<%0 extends java.lang.Object>
 cons public init(java.lang.String,{com.oracle.truffle.api.utilities.AssumedValue%0})
@@ -3338,16 +5306,6 @@ meth protected static void appendValue(java.lang.StringBuilder,java.lang.Object)
 meth public final java.lang.String toString()
 supr java.lang.Object
 
-CLSS public final com.oracle.truffle.api.utilities.NeverValidAssumption
-fld public final static com.oracle.truffle.api.utilities.NeverValidAssumption INSTANCE
-intf com.oracle.truffle.api.Assumption
-meth public boolean isValid()
-meth public java.lang.String getName()
-meth public void check() throws com.oracle.truffle.api.nodes.InvalidAssumptionException
-meth public void invalidate()
-meth public void invalidate(java.lang.String)
-supr java.lang.Object
-
 CLSS public final !enum com.oracle.truffle.api.utilities.TriState
 fld public final static com.oracle.truffle.api.utilities.TriState FALSE
 fld public final static com.oracle.truffle.api.utilities.TriState TRUE
@@ -3363,17 +5321,73 @@ cons public init({com.oracle.truffle.api.utilities.TruffleWeakReference%0})
 cons public init({com.oracle.truffle.api.utilities.TruffleWeakReference%0},java.lang.ref.ReferenceQueue<? super {com.oracle.truffle.api.utilities.TruffleWeakReference%0}>)
 supr java.lang.ref.WeakReference<{com.oracle.truffle.api.utilities.TruffleWeakReference%0}>
 
-CLSS public com.oracle.truffle.api.utilities.UnionAssumption
-cons public init(com.oracle.truffle.api.Assumption,com.oracle.truffle.api.Assumption)
-cons public init(java.lang.String,com.oracle.truffle.api.Assumption,com.oracle.truffle.api.Assumption)
-intf com.oracle.truffle.api.Assumption
-meth public boolean isValid()
-meth public java.lang.String getName()
-meth public void check() throws com.oracle.truffle.api.nodes.InvalidAssumptionException
-meth public void invalidate()
-meth public void invalidate(java.lang.String)
-supr java.lang.Object
-hfds first,name,second
+CLSS public final com.oracle.truffle.polyglot.PolyglotImpl
+cons public init()
+meth protected org.graalvm.options.OptionDescriptors createEngineOptionDescriptors()
+meth public !varargs boolean copyResources(java.nio.file.Path,java.lang.String[]) throws java.io.IOException
+meth public !varargs org.graalvm.options.OptionDescriptors createUnionOptionDescriptors(org.graalvm.options.OptionDescriptors[])
+meth public <%0 extends java.lang.Object, %1 extends java.lang.Object> java.lang.Object newTargetTypeMapping(java.lang.Class<{%%0}>,java.lang.Class<{%%1}>,java.util.function.Predicate<{%%0}>,java.util.function.Function<{%%0},{%%1}>,org.graalvm.polyglot.HostAccess$TargetMappingPrecedence)
+meth public boolean isDefaultProcessHandler(org.graalvm.polyglot.io.ProcessHandler)
+meth public boolean isHostFileSystem(org.graalvm.polyglot.io.FileSystem)
+meth public boolean isInCurrentEngineHostCallback(java.lang.Object)
+meth public boolean isInternalFileSystem(org.graalvm.polyglot.io.FileSystem)
+meth public com.oracle.truffle.api.TruffleLanguage<java.lang.Object> createHostLanguage(java.lang.Object)
+meth public int getPriority()
+meth public java.lang.Class<?> loadLanguageClass(java.lang.String)
+meth public java.lang.Object asValue(java.lang.Object)
+meth public java.lang.Object buildEngine(java.lang.String[],org.graalvm.polyglot.SandboxPolicy,java.io.OutputStream,java.io.OutputStream,java.io.InputStream,java.util.Map<java.lang.String,java.lang.String>,boolean,boolean,org.graalvm.polyglot.io.MessageTransport,java.lang.Object,java.lang.Object,boolean,boolean,java.lang.Object)
+meth public java.lang.Object buildLimits(long,java.util.function.Predicate<java.lang.Object>,java.util.function.Consumer<java.lang.Object>)
+meth public java.lang.Object buildSource(java.lang.String,java.lang.Object,java.net.URI,java.lang.String,java.lang.String,java.lang.Object,boolean,boolean,boolean,java.nio.charset.Charset,java.net.URL,java.lang.String) throws java.io.IOException
+meth public java.lang.Object getCurrentContext()
+meth public java.lang.Object initializeModuleToUnnamedAccess(java.lang.invoke.MethodHandles$Lookup,java.lang.Object,java.lang.Object,java.lang.Object,java.lang.Object)
+meth public java.lang.Object newIOAccess(java.lang.String,boolean,boolean,org.graalvm.polyglot.io.FileSystem)
+meth public java.lang.String findLanguage(java.io.File) throws java.io.IOException
+meth public java.lang.String findLanguage(java.lang.String)
+meth public java.lang.String findLanguage(java.net.URL) throws java.io.IOException
+meth public java.lang.String findMimeType(java.io.File) throws java.io.IOException
+meth public java.lang.String findMimeType(java.net.URL) throws java.io.IOException
+meth public java.lang.String getTruffleVersion()
+meth public org.graalvm.polyglot.impl.AbstractPolyglotImpl$AbstractHostAccess createHostAccess()
+meth public org.graalvm.polyglot.impl.AbstractPolyglotImpl$LogHandler newLogHandler(java.lang.Object)
+meth public org.graalvm.polyglot.impl.AbstractPolyglotImpl$ThreadScope createThreadScope()
+meth public org.graalvm.polyglot.io.ByteSequence asByteSequence(java.lang.Object)
+meth public org.graalvm.polyglot.io.FileSystem allowInternalResourceAccess(org.graalvm.polyglot.io.FileSystem)
+meth public org.graalvm.polyglot.io.FileSystem newDefaultFileSystem(java.lang.String)
+meth public org.graalvm.polyglot.io.FileSystem newFileSystem(org.graalvm.polyglot.io.FileSystem)
+meth public org.graalvm.polyglot.io.FileSystem newNIOFileSystem(java.nio.file.FileSystem)
+meth public org.graalvm.polyglot.io.FileSystem newReadOnlyFileSystem(org.graalvm.polyglot.io.FileSystem)
+meth public org.graalvm.polyglot.io.ProcessHandler newDefaultProcessHandler()
+meth public void initialize()
+meth public void preInitializeEngine()
+meth public void resetPreInitializedEngine()
+supr org.graalvm.polyglot.impl.AbstractPolyglotImpl
+hfds EMPTY_ARGS,SECRET,TRUFFLE_VERSION,contextDispatch,defaultFileSystemContext,disconnectedBigIntegerHostValue,disconnectedHostValue,engineDispatch,exceptionDispatch,executionEventDispatch,executionListenerDispatch,hostNull,instrumentDispatch,isolatePolyglot,languageDispatch,preInitializedEngineRef,primitiveValues,sourceDispatch,sourceSectionDispatch
+hcls EmbedderFileSystemContext,VMObject
+
+CLSS public com.oracle.truffle.polyglot.PolyglotMapEntryAndFunction<%0 extends java.lang.Object, %1 extends java.lang.Object>
+intf java.util.Map$Entry<{com.oracle.truffle.polyglot.PolyglotMapEntryAndFunction%0},{com.oracle.truffle.polyglot.PolyglotMapEntryAndFunction%1}>
+intf java.util.function.Function<java.lang.Object,java.lang.Object>
+meth public final boolean equals(java.lang.Object)
+meth public final int hashCode()
+meth public final java.lang.Object getContext()
+meth public final java.lang.Object getGuestObject()
+meth public final java.lang.Object getLanguageContext()
+meth public final java.lang.String toString()
+meth public final {com.oracle.truffle.polyglot.PolyglotMapEntryAndFunction%0} getKey()
+meth public final {com.oracle.truffle.polyglot.PolyglotMapEntryAndFunction%1} getValue()
+meth public final {com.oracle.truffle.polyglot.PolyglotMapEntryAndFunction%1} setValue({com.oracle.truffle.polyglot.PolyglotMapEntryAndFunction%1})
+meth public java.lang.Object apply(java.lang.Object)
+meth public static boolean equals(java.lang.Object,java.lang.Object,java.lang.Object)
+meth public static boolean equalsProxy(com.oracle.truffle.polyglot.PolyglotWrapper,java.lang.Object)
+meth public static boolean isHostProxy(java.lang.Object)
+meth public static boolean isInstance(java.lang.Object)
+meth public static int hashCode(java.lang.Object,java.lang.Object)
+meth public static java.lang.Object asInstance(java.lang.Object)
+meth public static java.lang.Object getHostProxy(java.lang.Object)
+meth public static java.lang.String toString(com.oracle.truffle.polyglot.PolyglotWrapper)
+meth public static java.lang.String toString(java.lang.Object,java.lang.Object)
+meth public static java.lang.String toStringImpl(java.lang.Object,java.lang.Object)
+supr java.lang.Object<{com.oracle.truffle.polyglot.PolyglotMapEntryAndFunction%0},{com.oracle.truffle.polyglot.PolyglotMapEntryAndFunction%1}>
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable
@@ -3424,6 +5438,25 @@ CLSS public abstract interface !annotation java.lang.FunctionalInterface
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
+
+CLSS public java.lang.IllegalArgumentException
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.RuntimeException
+
+CLSS public java.lang.IllegalStateException
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.RuntimeException
+
+CLSS public abstract interface java.lang.Iterable<%0 extends java.lang.Object>
+meth public abstract java.util.Iterator<{java.lang.Iterable%0}> iterator()
+meth public java.util.Spliterator<{java.lang.Iterable%0}> spliterator()
+meth public void forEach(java.util.function.Consumer<? super {java.lang.Iterable%0}>)
 
 CLSS public java.lang.Object
 cons public init()
@@ -3520,6 +5553,13 @@ cons public init({java.lang.ref.WeakReference%0})
 cons public init({java.lang.ref.WeakReference%0},java.lang.ref.ReferenceQueue<? super {java.lang.ref.WeakReference%0}>)
 supr java.lang.ref.Reference<{java.lang.ref.WeakReference%0}>
 
+CLSS public abstract interface java.util.function.Function<%0 extends java.lang.Object, %1 extends java.lang.Object>
+ anno 0 java.lang.FunctionalInterface()
+meth public <%0 extends java.lang.Object> java.util.function.Function<{%%0},{java.util.function.Function%1}> compose(java.util.function.Function<? super {%%0},? extends {java.util.function.Function%0}>)
+meth public <%0 extends java.lang.Object> java.util.function.Function<{java.util.function.Function%0},{%%0}> andThen(java.util.function.Function<? super {java.util.function.Function%1},? extends {%%0}>)
+meth public abstract {java.util.function.Function%1} apply({java.util.function.Function%0})
+meth public static <%0 extends java.lang.Object> java.util.function.Function<{%%0},{%%0}> identity()
+
 CLSS public abstract interface java.util.function.Predicate<%0 extends java.lang.Object>
  anno 0 java.lang.FunctionalInterface()
 meth public abstract boolean test({java.util.function.Predicate%0})
@@ -3527,4 +5567,373 @@ meth public java.util.function.Predicate<{java.util.function.Predicate%0}> and(j
 meth public java.util.function.Predicate<{java.util.function.Predicate%0}> negate()
 meth public java.util.function.Predicate<{java.util.function.Predicate%0}> or(java.util.function.Predicate<? super {java.util.function.Predicate%0}>)
 meth public static <%0 extends java.lang.Object> java.util.function.Predicate<{%%0}> isEqual(java.lang.Object)
+
+CLSS public abstract interface org.graalvm.options.OptionDescriptors
+fld public final static org.graalvm.options.OptionDescriptors EMPTY
+intf java.lang.Iterable<org.graalvm.options.OptionDescriptor>
+meth public !varargs static org.graalvm.options.OptionDescriptors createUnion(org.graalvm.options.OptionDescriptors[])
+meth public abstract java.util.Iterator<org.graalvm.options.OptionDescriptor> iterator()
+meth public abstract org.graalvm.options.OptionDescriptor get(java.lang.String)
+meth public static org.graalvm.options.OptionDescriptors create(java.util.List<org.graalvm.options.OptionDescriptor>)
+
+CLSS public abstract org.graalvm.polyglot.impl.AbstractPolyglotImpl
+cons protected init()
+innr public abstract static APIAccess
+innr public abstract static AbstractContextDispatch
+innr public abstract static AbstractDispatchClass
+innr public abstract static AbstractEngineDispatch
+innr public abstract static AbstractExceptionDispatch
+innr public abstract static AbstractExecutionEventDispatch
+innr public abstract static AbstractExecutionListenerDispatch
+innr public abstract static AbstractHostAccess
+innr public abstract static AbstractHostLanguageService
+innr public abstract static AbstractInstrumentDispatch
+innr public abstract static AbstractLanguageDispatch
+innr public abstract static AbstractPolyglotHostService
+innr public abstract static AbstractSourceDispatch
+innr public abstract static AbstractSourceSectionDispatch
+innr public abstract static AbstractStackFrameImpl
+innr public abstract static AbstractValueDispatch
+innr public abstract static IOAccessor
+innr public abstract static LogHandler
+innr public abstract static ManagementAccess
+innr public abstract static ThreadScope
+meth protected final org.graalvm.options.OptionDescriptors createAllEngineOptionDescriptors()
+meth protected org.graalvm.options.OptionDescriptors createEngineOptionDescriptors()
+meth public !varargs boolean copyResources(java.nio.file.Path,java.lang.String[]) throws java.io.IOException
+meth public !varargs org.graalvm.options.OptionDescriptors createUnionOptionDescriptors(org.graalvm.options.OptionDescriptors[])
+meth public <%0 extends java.lang.Object, %1 extends java.lang.Object> java.lang.Object newTargetTypeMapping(java.lang.Class<{%%0}>,java.lang.Class<{%%1}>,java.util.function.Predicate<{%%0}>,java.util.function.Function<{%%0},{%%1}>,org.graalvm.polyglot.HostAccess$TargetMappingPrecedence)
+meth public abstract int getPriority()
+meth public boolean isDefaultProcessHandler(org.graalvm.polyglot.io.ProcessHandler)
+meth public boolean isHostFileSystem(org.graalvm.polyglot.io.FileSystem)
+meth public boolean isInCurrentEngineHostCallback(java.lang.Object)
+meth public boolean isInternalFileSystem(org.graalvm.polyglot.io.FileSystem)
+meth public final org.graalvm.polyglot.impl.AbstractPolyglotImpl getNext()
+meth public final org.graalvm.polyglot.impl.AbstractPolyglotImpl getNextOrNull()
+meth public final org.graalvm.polyglot.impl.AbstractPolyglotImpl getRootImpl()
+meth public final org.graalvm.polyglot.impl.AbstractPolyglotImpl$APIAccess getAPIAccess()
+meth public final org.graalvm.polyglot.impl.AbstractPolyglotImpl$IOAccessor getIO()
+meth public final org.graalvm.polyglot.impl.AbstractPolyglotImpl$ManagementAccess getManagement()
+meth public final void setConstructors(org.graalvm.polyglot.impl.AbstractPolyglotImpl$APIAccess)
+meth public final void setIO(org.graalvm.polyglot.impl.AbstractPolyglotImpl$IOAccessor)
+meth public final void setMonitoring(org.graalvm.polyglot.impl.AbstractPolyglotImpl$ManagementAccess)
+meth public final void setNext(org.graalvm.polyglot.impl.AbstractPolyglotImpl)
+meth public java.lang.Class<?> loadLanguageClass(java.lang.String)
+meth public java.lang.Object asValue(java.lang.Object)
+meth public java.lang.Object buildEngine(java.lang.String[],org.graalvm.polyglot.SandboxPolicy,java.io.OutputStream,java.io.OutputStream,java.io.InputStream,java.util.Map<java.lang.String,java.lang.String>,boolean,boolean,org.graalvm.polyglot.io.MessageTransport,java.lang.Object,java.lang.Object,boolean,boolean,java.lang.Object)
+meth public java.lang.Object buildLimits(long,java.util.function.Predicate<java.lang.Object>,java.util.function.Consumer<java.lang.Object>)
+meth public java.lang.Object buildSource(java.lang.String,java.lang.Object,java.net.URI,java.lang.String,java.lang.String,java.lang.Object,boolean,boolean,boolean,java.nio.charset.Charset,java.net.URL,java.lang.String) throws java.io.IOException
+meth public java.lang.Object createHostAccess()
+meth public java.lang.Object createHostLanguage(java.lang.Object)
+meth public java.lang.Object getCurrentContext()
+meth public java.lang.Object initializeModuleToUnnamedAccess(java.lang.invoke.MethodHandles$Lookup,java.lang.Object,java.lang.Object,java.lang.Object,java.lang.Object)
+meth public java.lang.Object newFileSystem(org.graalvm.polyglot.io.FileSystem)
+meth public java.lang.Object newIOAccess(java.lang.String,boolean,boolean,org.graalvm.polyglot.io.FileSystem)
+meth public java.lang.Object newLogHandler(java.lang.Object)
+meth public java.lang.String findLanguage(java.io.File) throws java.io.IOException
+meth public java.lang.String findLanguage(java.lang.String)
+meth public java.lang.String findLanguage(java.net.URL) throws java.io.IOException
+meth public java.lang.String findMimeType(java.io.File) throws java.io.IOException
+meth public java.lang.String findMimeType(java.net.URL) throws java.io.IOException
+meth public java.lang.String getTruffleVersion()
+meth public org.graalvm.polyglot.impl.AbstractPolyglotImpl$ThreadScope createThreadScope()
+meth public org.graalvm.polyglot.io.ByteSequence asByteSequence(java.lang.Object)
+meth public org.graalvm.polyglot.io.FileSystem allowInternalResourceAccess(org.graalvm.polyglot.io.FileSystem)
+meth public org.graalvm.polyglot.io.FileSystem newDefaultFileSystem(java.lang.String)
+meth public org.graalvm.polyglot.io.FileSystem newNIOFileSystem(java.nio.file.FileSystem)
+meth public org.graalvm.polyglot.io.FileSystem newReadOnlyFileSystem(org.graalvm.polyglot.io.FileSystem)
+meth public org.graalvm.polyglot.io.ProcessHandler newDefaultProcessHandler()
+meth public void initialize()
+meth public void preInitializeEngine()
+meth public void resetPreInitializedEngine()
+supr java.lang.Object
+hfds api,io,management,next,prev
+
+CLSS public abstract interface org.graalvm.shadowed.org.jcodings.ApplyAllCaseFoldFunction
+meth public abstract void apply(int,int[],int,java.lang.Object)
+
+CLSS public abstract org.graalvm.shadowed.org.jcodings.CanBeTrailTableEncoding
+cons protected init(java.lang.String,int,int,int[],int[][],short[],boolean[])
+fld protected final boolean[] CanBeTrailTable
+meth public boolean isReverseMatchAllowed(byte[],int,int)
+meth public int leftAdjustCharHead(byte[],int,int,int)
+supr org.graalvm.shadowed.org.jcodings.MultiByteEncoding
+
+CLSS public final org.graalvm.shadowed.org.jcodings.CaseFoldCodeItem
+fld public final int byteLen
+fld public final int[] code
+fld public final static org.graalvm.shadowed.org.jcodings.CaseFoldCodeItem[] EMPTY_FOLD_CODES
+meth public static org.graalvm.shadowed.org.jcodings.CaseFoldCodeItem create(int,int)
+meth public static org.graalvm.shadowed.org.jcodings.CaseFoldCodeItem create(int,int,int)
+meth public static org.graalvm.shadowed.org.jcodings.CaseFoldCodeItem create(int,int,int,int)
+supr java.lang.Object
+
+CLSS public abstract org.graalvm.shadowed.org.jcodings.CaseFoldMapEncoding
+cons protected init(java.lang.String,short[],byte[],int[][])
+cons protected init(java.lang.String,short[],byte[],int[][],boolean)
+fld protected final boolean foldFlag
+fld protected final int[][] CaseFoldMap
+meth protected final int applyAllCaseFoldWithMap(int,int[][],boolean,int,org.graalvm.shadowed.org.jcodings.ApplyAllCaseFoldFunction,java.lang.Object)
+meth protected final org.graalvm.shadowed.org.jcodings.CaseFoldCodeItem[] getCaseFoldCodesByStringWithMap(int,int[][],boolean,int,byte[],int,int)
+meth public boolean isCodeCType(int,int)
+meth public org.graalvm.shadowed.org.jcodings.CaseFoldCodeItem[] caseFoldCodesByString(int,byte[],int,int)
+meth public void applyAllCaseFold(int,org.graalvm.shadowed.org.jcodings.ApplyAllCaseFoldFunction,java.lang.Object)
+supr org.graalvm.shadowed.org.jcodings.SingleByteEncoding
+hfds SS
+
+CLSS public final org.graalvm.shadowed.org.jcodings.CodeRange
+cons public init()
+meth public static boolean isInCodeRange(int[],int)
+meth public static boolean isInCodeRange(int[],int,int)
+supr java.lang.Object
+
+CLSS public abstract interface org.graalvm.shadowed.org.jcodings.Config
+fld public final static boolean USE_CRNL_AS_LINE_TERMINATOR = false
+fld public final static boolean USE_UNICODE_ALL_LINE_TERMINATORS = false
+fld public final static boolean USE_UNICODE_CASE_FOLD_TURKISH_AZERI = false
+fld public final static boolean USE_UNICODE_PROPERTIES = true
+fld public final static int CASE_ASCII_ONLY = 4194304
+fld public final static int CASE_DOWNCASE = 16384
+fld public final static int CASE_DOWN_SPECIAL = 131072
+fld public final static int CASE_FOLD = 524288
+fld public final static int CASE_FOLD_LITHUANIAN = 2097152
+fld public final static int CASE_FOLD_TURKISH_AZERI = 1048576
+fld public final static int CASE_IS_TITLECASE = 8388608
+fld public final static int CASE_MODIFIED = 262144
+fld public final static int CASE_SPECIALS = 8617984
+fld public final static int CASE_SPECIAL_OFFSET = 3
+fld public final static int CASE_TITLECASE = 32768
+fld public final static int CASE_UPCASE = 8192
+fld public final static int CASE_UP_SPECIAL = 65536
+fld public final static int CodePointMask = 7
+fld public final static int CodePointMaskWidth = 3
+fld public final static int ENC_CASE_FOLD_DEFAULT = 1073741824
+fld public final static int ENC_CASE_FOLD_MIN = 1073741824
+fld public final static int ENC_CODE_TO_MBC_MAXLEN = 7
+fld public final static int ENC_GET_CASE_FOLD_CODES_MAX_NUM = 13
+fld public final static int ENC_MAX_COMP_CASE_FOLD_CODE_LEN = 3
+fld public final static int ENC_MBC_CASE_FOLD_MAXLEN = 18
+fld public final static int INTERNAL_ENC_CASE_FOLD_MULTI_CHAR = 1073741824
+fld public final static int SpecialIndexMask = 8184
+fld public final static int SpecialIndexShift = 3
+fld public final static int SpecialIndexWidth = 10
+fld public final static int SpecialsLengthOffset = 25
+fld public final static int UNICODE_EMOJI_VERSION_MAJOR = 13
+fld public final static int UNICODE_EMOJI_VERSION_MINOR = 1
+fld public final static int UNICODE_VERSION_MAJOR = 13
+fld public final static int UNICODE_VERSION_MINOR = 0
+fld public final static int UNICODE_VERSION_TEENY = 0
+fld public final static java.lang.String UNICODE_EMOJI_VERSION_STRING = "13.1"
+fld public final static java.lang.String UNICODE_VERSION_STRING = "13.0.0"
+
+CLSS public abstract org.graalvm.shadowed.org.jcodings.Encoding
+cons protected init(java.lang.String,int,int)
+fld protected boolean isUTF8
+fld protected boolean isUnicode
+fld protected final int maxLength
+fld protected final int minLength
+fld public final static byte NEW_LINE = 10
+fld public final static int CHAR_INVALID = -1
+intf java.lang.Cloneable
+meth protected final void setDummy()
+meth protected final void setName(byte[])
+meth protected final void setName(java.lang.String)
+meth public abstract boolean isCodeCType(int,int)
+meth public abstract boolean isNewLine(byte[],int,int)
+meth public abstract boolean isReverseMatchAllowed(byte[],int,int)
+meth public abstract int caseMap(org.graalvm.shadowed.org.jcodings.IntHolder,byte[],org.graalvm.shadowed.org.jcodings.IntHolder,int,byte[],int,int)
+meth public abstract int codeToMbc(int,byte[],int)
+meth public abstract int codeToMbcLength(int)
+meth public abstract int leftAdjustCharHead(byte[],int,int,int)
+meth public abstract int length(byte)
+meth public abstract int length(byte[],int,int)
+meth public abstract int mbcCaseFold(int,byte[],org.graalvm.shadowed.org.jcodings.IntHolder,int,byte[])
+meth public abstract int mbcToCode(byte[],int,int)
+meth public abstract int propertyNameToCType(byte[],int,int)
+meth public abstract int strCodeAt(byte[],int,int,int)
+meth public abstract int strLength(byte[],int,int)
+meth public abstract int[] ctypeCodeRange(int,org.graalvm.shadowed.org.jcodings.IntHolder)
+meth public abstract org.graalvm.shadowed.org.jcodings.CaseFoldCodeItem[] caseFoldCodesByString(int,byte[],int,int)
+meth public abstract void applyAllCaseFold(int,org.graalvm.shadowed.org.jcodings.ApplyAllCaseFoldFunction,java.lang.Object)
+meth public boolean isMbcCrnl(byte[],int,int)
+meth public byte[] toLowerCaseTable()
+meth public final boolean equals(java.lang.Object)
+meth public final boolean isAlnum(int)
+meth public final boolean isAlpha(int)
+meth public final boolean isAsciiCompatible()
+meth public final boolean isBlank(int)
+meth public final boolean isCntrl(int)
+meth public final boolean isDigit(int)
+meth public final boolean isDummy()
+meth public final boolean isFixedWidth()
+meth public final boolean isGraph(int)
+meth public final boolean isLower(int)
+meth public final boolean isMbcHead(byte[],int,int)
+meth public final boolean isMbcWord(byte[],int,int)
+meth public final boolean isNewLine(int)
+meth public final boolean isPrint(int)
+meth public final boolean isPunct(int)
+meth public final boolean isSbWord(int)
+meth public final boolean isSingleByte()
+meth public final boolean isSpace(int)
+meth public final boolean isUTF8()
+meth public final boolean isUnicode()
+meth public final boolean isUpper(int)
+meth public final boolean isWord(int)
+meth public final boolean isXDigit(int)
+meth public final byte[] getName()
+meth public final int getIndex()
+meth public final int hashCode()
+meth public final int maxLength()
+meth public final int maxLengthDistance()
+ anno 0 java.lang.Deprecated()
+meth public final int mbcodeStartPosition()
+ anno 0 java.lang.Deprecated()
+meth public final int minLength()
+meth public final int prevCharHead(byte[],int,int,int)
+meth public final int rightAdjustCharHead(byte[],int,int,int)
+meth public final int rightAdjustCharHeadWithPrev(byte[],int,int,int,org.graalvm.shadowed.org.jcodings.IntHolder)
+meth public final int step(byte[],int,int,int)
+meth public final int stepBack(byte[],int,int,int,int)
+meth public final int strByteLengthNull(byte[],int,int)
+meth public final int strLengthNull(byte[],int,int)
+meth public final int strNCmp(byte[],int,int,byte[],int,int)
+meth public final int xdigitVal(int)
+meth public final java.lang.String toString()
+meth public java.lang.String getCharsetName()
+meth public java.nio.charset.Charset getCharset()
+meth public static boolean isAscii(byte)
+meth public static boolean isAscii(int)
+meth public static boolean isMbcAscii(byte)
+meth public static boolean isWordGraphPrint(int)
+meth public static byte asciiToLower(int)
+meth public static byte asciiToUpper(int)
+meth public static int digitVal(int)
+meth public static int odigitVal(int)
+meth public static org.graalvm.shadowed.org.jcodings.Encoding load(java.lang.String)
+supr java.lang.Object
+hfds charset,count,hashCode,index,isAsciiCompatible,isDummy,isFixedWidth,isSingleByte,name,stringName
+
+CLSS public final org.graalvm.shadowed.org.jcodings.EncodingDB
+cons public init()
+innr public final static Entry
+meth public final static org.graalvm.shadowed.org.jcodings.util.CaseInsensitiveBytesHash<org.graalvm.shadowed.org.jcodings.EncodingDB$Entry> getAliases()
+meth public final static org.graalvm.shadowed.org.jcodings.util.CaseInsensitiveBytesHash<org.graalvm.shadowed.org.jcodings.EncodingDB$Entry> getEncodings()
+meth public static org.graalvm.shadowed.org.jcodings.EncodingDB$Entry dummy(byte[])
+meth public static void alias(java.lang.String,java.lang.String)
+meth public static void declare(java.lang.String,java.lang.String)
+meth public static void dummy(java.lang.String)
+meth public static void dummy_unicode(java.lang.String)
+meth public static void replicate(java.lang.String,java.lang.String)
+meth public static void set_base(java.lang.String,java.lang.String)
+supr java.lang.Object
+hfds aliases,ascii,encodings
+
+CLSS public final static org.graalvm.shadowed.org.jcodings.EncodingDB$Entry
+ outer org.graalvm.shadowed.org.jcodings.EncodingDB
+meth public boolean isDummy()
+meth public int getIndex()
+meth public int hashCode()
+meth public java.lang.String getEncodingClass()
+meth public org.graalvm.shadowed.org.jcodings.Encoding getEncoding()
+meth public org.graalvm.shadowed.org.jcodings.EncodingDB$Entry getBase()
+supr java.lang.Object
+hfds base,count,encoding,encodingClass,index,isDummy,name
+
+CLSS public abstract org.graalvm.shadowed.org.jcodings.EucEncoding
+cons protected init(java.lang.String,int,int,int[],int[][],short[])
+meth protected abstract boolean isLead(int)
+meth public int leftAdjustCharHead(byte[],int,int,int)
+supr org.graalvm.shadowed.org.jcodings.MultiByteEncoding
+
+CLSS public abstract org.graalvm.shadowed.org.jcodings.ISOEncoding
+cons protected init(java.lang.String,short[],byte[],int[][])
+cons protected init(java.lang.String,short[],byte[],int[][],boolean)
+fld public static int SHARP_s
+meth public boolean isCodeCType(int,int)
+meth public int mbcCaseFold(int,byte[],org.graalvm.shadowed.org.jcodings.IntHolder,int,byte[])
+meth public java.lang.String getCharsetName()
+supr org.graalvm.shadowed.org.jcodings.CaseFoldMapEncoding
+
+CLSS public org.graalvm.shadowed.org.jcodings.IntHolder
+cons public init()
+fld public int value
+supr java.lang.Object
+
+CLSS public abstract org.graalvm.shadowed.org.jcodings.MultiByteEncoding
+cons protected init(java.lang.String,int,int,int[],int[][],short[])
+fld protected final int[] EncLen
+fld protected final int[] TransZero
+fld protected final int[][] Trans
+fld protected final static int A = -1
+fld protected final static int F = -2
+meth protected final boolean isCodeCTypeInternal(int,int)
+meth protected final boolean mb2IsCodeCType(int,int)
+meth protected final boolean mb4IsCodeCType(int,int)
+meth protected final int asciiMbcCaseFold(int,byte[],org.graalvm.shadowed.org.jcodings.IntHolder,int,byte[])
+meth protected final int lengthForTwoUptoFour(byte[],int,int,int,int)
+meth protected final int mb2CodeToMbc(int,byte[],int)
+meth protected final int mb2CodeToMbcLength(int)
+meth protected final int mb4CodeToMbc(int,byte[],int)
+meth protected final int mb4CodeToMbcLength(int)
+meth protected final int mbnMbcCaseFold(int,byte[],org.graalvm.shadowed.org.jcodings.IntHolder,int,byte[])
+meth protected final int mbnMbcToCode(byte[],int,int)
+meth protected final int missing(int)
+meth protected final int missing(int,int)
+meth protected final int safeLengthForUptoFour(byte[],int,int)
+meth protected final int safeLengthForUptoThree(byte[],int,int)
+meth protected final int safeLengthForUptoTwo(byte[],int,int)
+meth protected final org.graalvm.shadowed.org.jcodings.CaseFoldCodeItem[] asciiCaseFoldCodesByString(int,byte[],int,int)
+meth protected final void asciiApplyAllCaseFold(int,org.graalvm.shadowed.org.jcodings.ApplyAllCaseFoldFunction,java.lang.Object)
+meth public boolean isNewLine(byte[],int,int)
+meth public int caseMap(org.graalvm.shadowed.org.jcodings.IntHolder,byte[],org.graalvm.shadowed.org.jcodings.IntHolder,int,byte[],int,int)
+meth public int length(byte)
+meth public int mbcCaseFold(int,byte[],org.graalvm.shadowed.org.jcodings.IntHolder,int,byte[])
+meth public int propertyNameToCType(byte[],int,int)
+meth public int strCodeAt(byte[],int,int,int)
+meth public int strLength(byte[],int,int)
+meth public org.graalvm.shadowed.org.jcodings.CaseFoldCodeItem[] caseFoldCodesByString(int,byte[],int,int)
+meth public static boolean isInRange(int,int,int)
+meth public void applyAllCaseFold(int,org.graalvm.shadowed.org.jcodings.ApplyAllCaseFoldFunction,java.lang.Object)
+supr org.graalvm.shadowed.org.jcodings.Encoding
+
+CLSS public final org.graalvm.shadowed.org.jcodings.ObjPtr<%0 extends java.lang.Object>
+cons public init()
+cons public init({org.graalvm.shadowed.org.jcodings.ObjPtr%0})
+fld public {org.graalvm.shadowed.org.jcodings.ObjPtr%0} p
+supr java.lang.Object
+hfds NULL
+
+CLSS public final org.graalvm.shadowed.org.jcodings.Ptr
+cons public init()
+cons public init(int)
+fld public final static org.graalvm.shadowed.org.jcodings.Ptr NULL
+fld public int p
+supr java.lang.Object
+
+CLSS public abstract org.graalvm.shadowed.org.jcodings.SingleByteEncoding
+cons protected init(java.lang.String,short[],byte[])
+fld protected final byte[] LowerCaseTable
+fld public final static int MAX_BYTE = 255
+meth protected final boolean isCodeCTypeInternal(int,int)
+meth protected final int asciiMbcCaseFold(int,byte[],org.graalvm.shadowed.org.jcodings.IntHolder,int,byte[])
+meth protected final org.graalvm.shadowed.org.jcodings.CaseFoldCodeItem[] asciiCaseFoldCodesByString(int,byte[],int,int)
+meth protected final void asciiApplyAllCaseFold(int,org.graalvm.shadowed.org.jcodings.ApplyAllCaseFoldFunction,java.lang.Object)
+meth public boolean isNewLine(byte[],int,int)
+meth public final boolean isReverseMatchAllowed(byte[],int,int)
+meth public final int codeToMbc(int,byte[],int)
+meth public final int leftAdjustCharHead(byte[],int,int,int)
+meth public final int strLength(byte[],int,int)
+meth public final int[] ctypeCodeRange(int,org.graalvm.shadowed.org.jcodings.IntHolder)
+meth public int caseMap(org.graalvm.shadowed.org.jcodings.IntHolder,byte[],org.graalvm.shadowed.org.jcodings.IntHolder,int,byte[],int,int)
+meth public int codeToMbcLength(int)
+meth public int length(byte)
+meth public int length(byte[],int,int)
+meth public int mbcCaseFold(int,byte[],org.graalvm.shadowed.org.jcodings.IntHolder,int,byte[])
+meth public int mbcToCode(byte[],int,int)
+meth public int propertyNameToCType(byte[],int,int)
+meth public int strCodeAt(byte[],int,int,int)
+meth public org.graalvm.shadowed.org.jcodings.CaseFoldCodeItem[] caseFoldCodesByString(int,byte[],int,int)
+meth public void applyAllCaseFold(int,org.graalvm.shadowed.org.jcodings.ApplyAllCaseFoldFunction,java.lang.Object)
+supr org.graalvm.shadowed.org.jcodings.Encoding
 

--- a/ide/libs.truffleapi/nbproject/project.properties
+++ b/ide/libs.truffleapi/nbproject/project.properties
@@ -19,4 +19,10 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 
-release.external/truffle-api-20.3.0.jar=modules/ext/truffle-api-20.3.0.jar
+release.external/truffle-api-24.0.0.jar=modules/ext/truffle-api-24.0.0.jar
+release.external/truffle-compiler-24.0.0.jar=modules/ext/truffle-compiler-24.0.0.jar
+release.external/truffle-runtime-24.0.0.jar=modules/ext/truffle-runtime-24.0.0.jar
+
+# gen-sigtest fails because it thinks methods on the allocators change their
+# return types - it is unclear why that happens, disassembled methods look sane
+sigtest.gen.fail.on.error=false

--- a/ide/libs.truffleapi/nbproject/project.xml
+++ b/ide/libs.truffleapi/nbproject/project.xml
@@ -30,7 +30,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.11</specification-version>
+                        <specification-version>1.25</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>
@@ -42,17 +42,32 @@
                 <package>com.oracle.truffle.api.frame</package>
                 <package>com.oracle.truffle.api.instrumentation</package>
                 <package>com.oracle.truffle.api.interop</package>
+                <package>com.oracle.truffle.api.io</package>
                 <package>com.oracle.truffle.api.library</package>
+                <package>com.oracle.truffle.api.memory</package>
                 <package>com.oracle.truffle.api.nodes</package>
                 <package>com.oracle.truffle.api.object</package>
                 <package>com.oracle.truffle.api.object.dsl</package>
                 <package>com.oracle.truffle.api.profiles</package>
+                <package>com.oracle.truffle.api.provider</package>
                 <package>com.oracle.truffle.api.source</package>
+                <package>com.oracle.truffle.api.staticobject</package>
+                <package>com.oracle.truffle.api.strings</package>
                 <package>com.oracle.truffle.api.utilities</package>
+                <package>com.oracle.truffle.polyglot</package>
+                <package>org.graalvm.shadowed.org.jcodings</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/truffle-api-20.3.0.jar</runtime-relative-path>
-                <binary-origin>external/truffle-api-20.3.0.jar</binary-origin>
+                <runtime-relative-path>ext/truffle-api-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/truffle-api-24.0.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/truffle-compiler-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/truffle-compiler-24.0.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/truffle-runtime-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/truffle-runtime-24.0.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/nashorn.execution/test/unit/src/org/netbeans/modules/nashorn/execution/JSExecutorTest.java
+++ b/java/nashorn.execution/test/unit/src/org/netbeans/modules/nashorn/execution/JSExecutorTest.java
@@ -46,7 +46,7 @@ public class JSExecutorTest extends NbTestCase {
         find.setAccessible(true);
         final ClassPath cp = (ClassPath) find.invoke(null);
         final FileObject[] roots = cp.getRoots();
-        assertEquals("Seven roots", 7, roots.length);
+        assertEquals("Fifteen roots", 15, roots.length);
         for (FileObject fo : roots) {
             assertTrue("valid: " + fo, fo.isValid());
             assertTrue("folder: " + fo, fo.isFolder());

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -115,3 +115,11 @@ ide/servletapi/external/jakarta.servlet-api-4.0.4.jar enterprise/websvc.restlib/
 # The library is used for compilation, but is not distributed, as graalsdk.system relies on JDK-provided packages at runtime
 ide/libs.graalsdk/external/graal-sdk-20.3.0.jar ide/libs.graalsdk.system/external/graal-sdk-20.3.0.jar
 ide/libs.graalsdk/external/launcher-common-20.3.0.jar ide/libs.graalsdk.system/external/launcher-common-20.3.0.jar
+ide/libs.graalsdk/external/collections-24.0.0.jar ide/libs.graalsdk.system/external/collections-24.0.0.jar
+ide/libs.graalsdk/external/jline-24.0.0.jar ide/libs.graalsdk.system/external/jline-24.0.0.jar
+ide/libs.graalsdk/external/jniutils-24.0.0.jar ide/libs.graalsdk.system/external/jniutils-24.0.0.jar
+ide/libs.graalsdk/external/launcher-common-24.0.0.jar ide/libs.graalsdk.system/external/launcher-common-24.0.0.jar
+ide/libs.graalsdk/external/nativeimage-24.0.0.jar ide/libs.graalsdk.system/external/nativeimage-24.0.0.jar
+ide/libs.graalsdk/external/polyglot-24.0.0.jar ide/libs.graalsdk.system/external/polyglot-24.0.0.jar
+ide/libs.graalsdk/external/word-24.0.0.jar ide/libs.graalsdk.system/external/word-24.0.0.jar
+

--- a/nbbuild/licenses/BSD-jline3
+++ b/nbbuild/licenses/BSD-jline3
@@ -1,0 +1,34 @@
+Copyright (c) 2002-2023, the original author or authors.
+All rights reserved.
+
+https://opensource.org/licenses/BSD-3-Clause
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the following
+conditions are met:
+
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with
+the distribution.
+
+Neither the name of JLine nor the names of its contributors
+may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/nbbuild/licenses/MIT-icu4j-74
+++ b/nbbuild/licenses/MIT-icu4j-74
@@ -1,0 +1,512 @@
+UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 2016-2023 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.
+
+----------------------------------------------------------------------
+
+Third-Party Software Licenses
+
+This section contains third-party software notices and/or additional
+terms for licensed third-party software components included within ICU
+libraries.
+
+----------------------------------------------------------------------
+
+ICU License - ICU 1.8.1 to ICU 57.1
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1995-2016 International Business Machines Corporation and others
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, and/or sell copies of the Software, and to permit persons
+to whom the Software is furnished to do so, provided that the above
+copyright notice(s) and this permission notice appear in all copies of
+the Software and that both the above copyright notice(s) and this
+permission notice appear in supporting documentation.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
+SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale, use
+or other dealings in this Software without prior written authorization
+of the copyright holder.
+
+All trademarks and registered trademarks mentioned herein are the
+property of their respective owners.
+
+----------------------------------------------------------------------
+
+Chinese/Japanese Word Break Dictionary Data (cjdict.txt)
+
+ #     The Google Chrome software developed by Google is licensed under
+ # the BSD license. Other software included in this distribution is
+ # provided under other licenses, as set forth below.
+ #
+ #  The BSD License
+ #  http://opensource.org/licenses/bsd-license.php
+ #  Copyright (C) 2006-2008, Google Inc.
+ #
+ #  All rights reserved.
+ #
+ #  Redistribution and use in source and binary forms, with or without
+ # modification, are permitted provided that the following conditions are met:
+ #
+ #  Redistributions of source code must retain the above copyright notice,
+ # this list of conditions and the following disclaimer.
+ #  Redistributions in binary form must reproduce the above
+ # copyright notice, this list of conditions and the following
+ # disclaimer in the documentation and/or other materials provided with
+ # the distribution.
+ #  Neither the name of  Google Inc. nor the names of its
+ # contributors may be used to endorse or promote products derived from
+ # this software without specific prior written permission.
+ #
+ #
+ #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ # CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ # DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ # LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ # CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ # BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #
+ #
+ #  The word list in cjdict.txt are generated by combining three word lists
+ # listed below with further processing for compound word breaking. The
+ # frequency is generated with an iterative training against Google web
+ # corpora.
+ #
+ #  * Libtabe (Chinese)
+ #    - https://sourceforge.net/project/?group_id=1519
+ #    - Its license terms and conditions are shown below.
+ #
+ #  * IPADIC (Japanese)
+ #    - http://chasen.aist-nara.ac.jp/chasen/distribution.html
+ #    - Its license terms and conditions are shown below.
+ #
+ #  ---------COPYING.libtabe ---- BEGIN--------------------
+ #
+ #  /*
+ #   * Copyright (c) 1999 TaBE Project.
+ #   * Copyright (c) 1999 Pai-Hsiang Hsiao.
+ #   * All rights reserved.
+ #   *
+ #   * Redistribution and use in source and binary forms, with or without
+ #   * modification, are permitted provided that the following conditions
+ #   * are met:
+ #   *
+ #   * . Redistributions of source code must retain the above copyright
+ #   *   notice, this list of conditions and the following disclaimer.
+ #   * . Redistributions in binary form must reproduce the above copyright
+ #   *   notice, this list of conditions and the following disclaimer in
+ #   *   the documentation and/or other materials provided with the
+ #   *   distribution.
+ #   * . Neither the name of the TaBE Project nor the names of its
+ #   *   contributors may be used to endorse or promote products derived
+ #   *   from this software without specific prior written permission.
+ #   *
+ #   * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ #   * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ #   * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ #   * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ #   * REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ #   * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ #   * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ #   * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ #   * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ #   * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ #   * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ #   * OF THE POSSIBILITY OF SUCH DAMAGE.
+ #   */
+ #
+ #  /*
+ #   * Copyright (c) 1999 Computer Systems and Communication Lab,
+ #   *                    Institute of Information Science, Academia
+ #       *                    Sinica. All rights reserved.
+ #   *
+ #   * Redistribution and use in source and binary forms, with or without
+ #   * modification, are permitted provided that the following conditions
+ #   * are met:
+ #   *
+ #   * . Redistributions of source code must retain the above copyright
+ #   *   notice, this list of conditions and the following disclaimer.
+ #   * . Redistributions in binary form must reproduce the above copyright
+ #   *   notice, this list of conditions and the following disclaimer in
+ #   *   the documentation and/or other materials provided with the
+ #   *   distribution.
+ #   * . Neither the name of the Computer Systems and Communication Lab
+ #   *   nor the names of its contributors may be used to endorse or
+ #   *   promote products derived from this software without specific
+ #   *   prior written permission.
+ #   *
+ #   * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ #   * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ #   * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ #   * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ #   * REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ #   * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ #   * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ #   * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ #   * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ #   * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ #   * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ #   * OF THE POSSIBILITY OF SUCH DAMAGE.
+ #   */
+ #
+ #  Copyright 1996 Chih-Hao Tsai @ Beckman Institute,
+ #      University of Illinois
+ #  c-tsai4@uiuc.edu  http://casper.beckman.uiuc.edu/~c-tsai4
+ #
+ #  ---------------COPYING.libtabe-----END--------------------------------
+ #
+ #
+ #  ---------------COPYING.ipadic-----BEGIN-------------------------------
+ #
+ #  Copyright 2000, 2001, 2002, 2003 Nara Institute of Science
+ #  and Technology.  All Rights Reserved.
+ #
+ #  Use, reproduction, and distribution of this software is permitted.
+ #  Any copy of this software, whether in its original form or modified,
+ #  must include both the above copyright notice and the following
+ #  paragraphs.
+ #
+ #  Nara Institute of Science and Technology (NAIST),
+ #  the copyright holders, disclaims all warranties with regard to this
+ #  software, including all implied warranties of merchantability and
+ #  fitness, in no event shall NAIST be liable for
+ #  any special, indirect or consequential damages or any damages
+ #  whatsoever resulting from loss of use, data or profits, whether in an
+ #  action of contract, negligence or other tortuous action, arising out
+ #  of or in connection with the use or performance of this software.
+ #
+ #  A large portion of the dictionary entries
+ #  originate from ICOT Free Software.  The following conditions for ICOT
+ #  Free Software applies to the current dictionary as well.
+ #
+ #  Each User may also freely distribute the Program, whether in its
+ #  original form or modified, to any third party or parties, PROVIDED
+ #  that the provisions of Section 3 ("NO WARRANTY") will ALWAYS appear
+ #  on, or be attached to, the Program, which is distributed substantially
+ #  in the same form as set out herein and that such intended
+ #  distribution, if actually made, will neither violate or otherwise
+ #  contravene any of the laws and regulations of the countries having
+ #  jurisdiction over the User or the intended distribution itself.
+ #
+ #  NO WARRANTY
+ #
+ #  The program was produced on an experimental basis in the course of the
+ #  research and development conducted during the project and is provided
+ #  to users as so produced on an experimental basis.  Accordingly, the
+ #  program is provided without any warranty whatsoever, whether express,
+ #  implied, statutory or otherwise.  The term "warranty" used herein
+ #  includes, but is not limited to, any warranty of the quality,
+ #  performance, merchantability and fitness for a particular purpose of
+ #  the program and the nonexistence of any infringement or violation of
+ #  any right of any third party.
+ #
+ #  Each user of the program will agree and understand, and be deemed to
+ #  have agreed and understood, that there is no warranty whatsoever for
+ #  the program and, accordingly, the entire risk arising from or
+ #  otherwise connected with the program is assumed by the user.
+ #
+ #  Therefore, neither ICOT, the copyright holder, or any other
+ #  organization that participated in or was otherwise related to the
+ #  development of the program and their respective officials, directors,
+ #  officers and other employees shall be held liable for any and all
+ #  damages, including, without limitation, general, special, incidental
+ #  and consequential damages, arising out of or otherwise in connection
+ #  with the use or inability to use the program or any product, material
+ #  or result produced or otherwise obtained by using the program,
+ #  regardless of whether they have been advised of, or otherwise had
+ #  knowledge of, the possibility of such damages at any time during the
+ #  project or thereafter.  Each user will be deemed to have agreed to the
+ #  foregoing by his or her commencement of use of the program.  The term
+ #  "use" as used herein includes, but is not limited to, the use,
+ #  modification, copying and distribution of the program and the
+ #  production of secondary products from the program.
+ #
+ #  In the case where the program, whether in its original form or
+ #  modified, was distributed or delivered to or received by a user from
+ #  any person, organization or entity other than ICOT, unless it makes or
+ #  grants independently of ICOT any specific warranty to the user in
+ #  writing, such person, organization or entity, will also be exempted
+ #  from and not be held liable to the user for any such damages as noted
+ #  above as far as the program is concerned.
+ #
+ #  ---------------COPYING.ipadic-----END----------------------------------
+
+----------------------------------------------------------------------
+
+Lao Word Break Dictionary Data (laodict.txt)
+
+ # Copyright (C) 2016 and later: Unicode, Inc. and others.
+ # License & terms of use: http://www.unicode.org/copyright.html
+ # Copyright (c) 2015 International Business Machines Corporation
+ # and others. All Rights Reserved.
+ #
+ # Project: https://github.com/rober42539/lao-dictionary
+ # Dictionary: https://github.com/rober42539/lao-dictionary/laodict.txt
+ # License: https://github.com/rober42539/lao-dictionary/LICENSE.txt
+ #          (copied below)
+ #
+ #	This file is derived from the above dictionary version of Nov 22, 2020
+ #  ----------------------------------------------------------------------
+ #  Copyright (C) 2013 Brian Eugene Wilson, Robert Martin Campbell.
+ #  All rights reserved.
+ #
+ #  Redistribution and use in source and binary forms, with or without
+ #  modification, are permitted provided that the following conditions are met:
+ #
+ #  Redistributions of source code must retain the above copyright notice, this
+ #  list of conditions and the following disclaimer. Redistributions in binary
+ #  form must reproduce the above copyright notice, this list of conditions and
+ #  the following disclaimer in the documentation and/or other materials
+ #  provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ # FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ # INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ # (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ # SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ # OF THE POSSIBILITY OF SUCH DAMAGE.
+ #  --------------------------------------------------------------------------
+
+----------------------------------------------------------------------
+
+Burmese Word Break Dictionary Data (burmesedict.txt)
+
+ #  Copyright (c) 2014 International Business Machines Corporation
+ #  and others. All Rights Reserved.
+ #
+ #  This list is part of a project hosted at:
+ #    github.com/kanyawtech/myanmar-karen-word-lists
+ #
+ #  --------------------------------------------------------------------------
+ #  Copyright (c) 2013, LeRoy Benjamin Sharon
+ #  All rights reserved.
+ #
+ #  Redistribution and use in source and binary forms, with or without
+ #  modification, are permitted provided that the following conditions
+ #  are met: Redistributions of source code must retain the above
+ #  copyright notice, this list of conditions and the following
+ #  disclaimer.  Redistributions in binary form must reproduce the
+ #  above copyright notice, this list of conditions and the following
+ #  disclaimer in the documentation and/or other materials provided
+ #  with the distribution.
+ #
+ #    Neither the name Myanmar Karen Word Lists, nor the names of its
+ #    contributors may be used to endorse or promote products derived
+ #    from this software without specific prior written permission.
+ #
+ #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ #  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ #  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ #  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ #  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+ #  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ #  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ #  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ #  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ #  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ #  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ #  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ #  SUCH DAMAGE.
+ #  --------------------------------------------------------------------------
+
+----------------------------------------------------------------------
+
+Time Zone Database
+
+  ICU uses the public domain data and code derived from Time Zone
+Database for its time zone support. The ownership of the TZ database
+is explained in BCP 175: Procedure for Maintaining the Time Zone
+Database section 7.
+
+ # 7.  Database Ownership
+ #
+ #    The TZ database itself is not an IETF Contribution or an IETF
+ #    document.  Rather it is a pre-existing and regularly updated work
+ #    that is in the public domain, and is intended to remain in the
+ #    public domain.  Therefore, BCPs 78 [RFC5378] and 79 [RFC3979] do
+ #    not apply to the TZ Database or contributions that individuals make
+ #    to it.  Should any claims be made and substantiated against the TZ
+ #    Database, the organization that is providing the IANA
+ #    Considerations defined in this RFC, under the memorandum of
+ #    understanding with the IETF, currently ICANN, may act in accordance
+ #    with all competent court orders.  No ownership claims will be made
+ #    by ICANN or the IETF Trust on the database or the code.  Any person
+ #    making a contribution to the database or code waives all rights to
+ #    future claims in that contribution or in the TZ Database.
+
+----------------------------------------------------------------------
+
+Google double-conversion
+
+Copyright 2006-2011, the V8 project authors. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----------------------------------------------------------------------
+
+File: aclocal.m4 (only for ICU4C)
+Section: pkg.m4 - Macros to locate and utilise pkg-config.
+
+
+Copyright © 2004 Scott James Remnant <scott@netsplit.com>.
+Copyright © 2012-2015 Dan Nicholson <dbn.lists@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+02111-1307, USA.
+
+As a special exception to the GNU General Public License, if you
+distribute this file as part of a program that contains a
+configuration script generated by Autoconf, you may include it under
+the same distribution terms that you use for the rest of that
+program.
+
+
+(The condition for the exception is fulfilled because
+ICU4C includes a configuration script generated by Autoconf,
+namely the `configure` script.)
+
+----------------------------------------------------------------------
+
+File: config.guess (only for ICU4C)
+
+
+This file is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+As a special exception to the GNU General Public License, if you
+distribute this file as part of a program that contains a
+configuration script generated by Autoconf, you may include it under
+the same distribution terms that you use for the rest of that
+program.  This Exception is an additional permission under section 7
+of the GNU General Public License, version 3 ("GPLv3").
+
+
+(The condition for the exception is fulfilled because
+ICU4C includes a configuration script generated by Autoconf,
+namely the `configure` script.)
+
+----------------------------------------------------------------------
+
+File: install-sh (only for ICU4C)
+
+
+Copyright 1991 by the Massachusetts Institute of Technology
+
+Permission to use, copy, modify, distribute, and sell this software and its
+documentation for any purpose is hereby granted without fee, provided that
+the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation, and that the name of M.I.T. not be used in advertising or
+publicity pertaining to distribution of the software without specific,
+written prior permission.  M.I.T. makes no representations about the
+suitability of this software for any purpose.  It is provided "as is"
+without express or implied warranty.

--- a/nbbuild/licenses/UPL-MIT-jcodings
+++ b/nbbuild/licenses/UPL-MIT-jcodings
@@ -1,0 +1,41 @@
+GraalVM Community Edition - UPL
+
+Copyright (c) __YEARS__, __NAMES__
+
+The Universal Permissive License (UPL), Version 1.0
+
+Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software, associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
+
+(a) the Software, and
+
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software each a "Larger Work" to which the Software is contributed by such licensors),
+
+without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
+
+This license is subject to the following condition:
+
+The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+jcodings - MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/platform/core.network/nbproject/project.xml
+++ b/platform/core.network/nbproject/project.xml
@@ -149,7 +149,11 @@
                     <test-dependency>
                         <code-name-base>org.netbeans.core.startup</code-name-base>
                         <compile-dependency/>
-                        <test/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.graaljs</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.libs.junit4</code-name-base>
@@ -179,12 +183,12 @@
                         <test/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.openide.util.ui</code-name-base>
-                        <compile-dependency/>
+                        <code-name-base>org.openide.util.lookup</code-name-base>
                         <test/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.openide.util.lookup</code-name-base>
+                        <code-name-base>org.openide.util.ui</code-name-base>
+                        <compile-dependency/>
                         <test/>
                     </test-dependency>
                 </test-type>

--- a/platform/core.network/test/unit/src/org/netbeans/core/network/proxy/ProxyAutoConfigDirectTest.java
+++ b/platform/core.network/test/unit/src/org/netbeans/core/network/proxy/ProxyAutoConfigDirectTest.java
@@ -25,6 +25,7 @@ import java.net.URISyntaxException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
+import org.netbeans.junit.NbModuleSuite;
 import org.netbeans.junit.NbTestCase;
 
 public class ProxyAutoConfigDirectTest extends NbTestCase {
@@ -33,6 +34,15 @@ public class ProxyAutoConfigDirectTest extends NbTestCase {
     }
     public ProxyAutoConfigDirectTest(String name) {
         super(name);
+    }
+    
+    public static final junit.framework.Test suite() {
+        NbModuleSuite.Configuration cfg = NbModuleSuite.emptyConfiguration().
+                honorAutoloadEager(true).
+                enableClasspathModules(false).
+                gui(false);
+        
+        return cfg.clusters("platform|webcommon|ide").addTest(ProxyAutoConfigDirectTest.class).suite();
     }
 
     public void testGetProxyAutoConfigWithLocalPAC() throws URISyntaxException {

--- a/platform/core.network/test/unit/src/org/netbeans/core/network/proxy/pac/PacEngineTest.java
+++ b/platform/core.network/test/unit/src/org/netbeans/core/network/proxy/pac/PacEngineTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.netbeans.core.network.proxy.pac.impl.NbPacScriptEvaluatorFactory;
+import org.netbeans.junit.NbModuleSuite;
 import org.netbeans.junit.NbTestCase;
 
 /**
@@ -56,6 +57,14 @@ public class PacEngineTest extends NbTestCase {
     }
 
    
+    public static final junit.framework.Test suite() {
+        NbModuleSuite.Configuration cfg = NbModuleSuite.emptyConfiguration().
+                honorAutoloadEager(true).
+                enableClasspathModules(false).
+                gui(false);
+        
+        return cfg.clusters("platform|webcommon|ide").addTest(PacEngineTest.class).suite();
+    }
    
 
     /**

--- a/platform/core.network/test/unit/src/org/netbeans/core/network/proxy/pac/impl/NbPacScriptEvaluatorTest.java
+++ b/platform/core.network/test/unit/src/org/netbeans/core/network/proxy/pac/impl/NbPacScriptEvaluatorTest.java
@@ -20,14 +20,25 @@ package org.netbeans.core.network.proxy.pac.impl;
 
 import javax.script.ScriptEngine;
 import org.junit.Assert;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import org.junit.Test;
+import org.netbeans.junit.NbModuleSuite;
+import org.netbeans.junit.NbTestCase;
 
-public class NbPacScriptEvaluatorTest {
+public class NbPacScriptEvaluatorTest extends NbTestCase {
 
-    @Test
-    public void findsAnEngineByDefault() {
+    public NbPacScriptEvaluatorTest(String name) {
+        super(name);
+    }
+
+    public static final junit.framework.Test suite() {
+        NbModuleSuite.Configuration cfg = NbModuleSuite.emptyConfiguration().
+                honorAutoloadEager(true).
+                enableClasspathModules(false).
+                gui(false);
+        
+        return cfg.clusters("platform|webcommon|ide").addTest(NbPacScriptEvaluatorTest.class).suite();
+    }
+
+    public void testFindsAnEngineByDefault() {
         StringBuilder err = new StringBuilder();
         ScriptEngine eng = findDefaultEngineInTheSystem(err);
         assertNotNull(err.toString(), eng);
@@ -37,8 +48,7 @@ public class NbPacScriptEvaluatorTest {
         return NbPacScriptEvaluator.newAllowedPacEngine(null, err);
     }
 
-    @Test
-    public void reportsAnErrorForNonExistingEngine() {
+    public void testReportsAnErrorForNonExistingEngine() {
         StringBuilder err = new StringBuilder();
         ScriptEngine eng = NbPacScriptEvaluator.newAllowedPacEngine("NonExisting", err);
         assertNull("No engine should be found: " + err.toString(), eng);

--- a/webcommon/libs.graaljs/external/binaries-list
+++ b/webcommon/libs.graaljs/external/binaries-list
@@ -14,7 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-BCB6EB7175DEABD6A1D6351E0A68AED43D713A5F org.graalvm.js:js:20.3.0
-2E29DA5B00AB9FDDD3154C2DB975220A4709F2AE org.graalvm.js:js-launcher:20.3.0
-6D6049F8743F2F2FBAA51393EA6833CD28FED04D org.graalvm.regex:regex:20.3.0
-2E159807158095566726600534034030DDDAB6D0 com.ibm.icu:icu4j:67.1
+C82C42FC2154836A7DB7B0A23B96E031B1C069A9 org.graalvm.js:js-scriptengine:24.0.0
+9A93F546EA83144A7A57E6D80F3991ED83F6D7BD org.graalvm.js:js-language:24.0.0
+218D40861169B063B3193B06C0489A128B172B4E org.graalvm.js:js-launcher:24.0.0
+67571B504B06CF10C909A364936C318CF6373D74 org.graalvm.regex:regex:24.0.0
+2D75AB0726628F9A0A88270EA57CF9C997DB26F4 org.graalvm.shadowed:icu4j:24.0.0

--- a/webcommon/libs.graaljs/external/icu4j-24.0.0-license.txt
+++ b/webcommon/libs.graaljs/external/icu4j-24.0.0-license.txt
@@ -1,45 +1,51 @@
 Name: icu4j
 Description: icu4j license
-License: MIT-icu4j-58
+License: MIT-icu4j-74
 Origin: http://site.icu-project.org/
-Version: 67.1
-Files: icu4j-67.1.jar
+Version: 24.0.0
+Files: icu4j-24.0.0.jar
 
-COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)
+UNICODE LICENSE V3
 
-Copyright © 1991-2020 Unicode, Inc. All rights reserved.
-Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+COPYRIGHT AND PERMISSION NOTICE
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of the Unicode data files and any associated documentation
-(the "Data Files") or Unicode software and any associated documentation
-(the "Software") to deal in the Data Files or Software
-without restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, and/or sell copies of
-the Data Files or Software, and to permit persons to whom the Data Files
-or Software are furnished to do so, provided that either
-(a) this copyright and permission notice appear with all copies
-of the Data Files or Software, or
-(b) this copyright and permission notice appear in associated
-Documentation.
+Copyright © 2016-2023 Unicode, Inc.
 
-THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT OF THIRD PARTY RIGHTS.
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
-NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
-DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
-DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
 
-Except as contained in this notice, the name of a copyright holder
-shall not be used in advertising or otherwise to promote the sale,
-use or other dealings in these Data Files or Software without prior
-written authorization of the copyright holder.
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
 
----------------------
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.
+
+----------------------------------------------------------------------
 
 Third-Party Software Licenses
 
@@ -47,7 +53,9 @@ This section contains third-party software notices and/or additional
 terms for licensed third-party software components included within ICU
 libraries.
 
-1. ICU License - ICU 1.8.1 to ICU 57.1
+----------------------------------------------------------------------
+
+ICU License - ICU 1.8.1 to ICU 57.1
 
 COPYRIGHT AND PERMISSION NOTICE
 
@@ -82,7 +90,9 @@ of the copyright holder.
 All trademarks and registered trademarks mentioned herein are the
 property of their respective owners.
 
-2. Chinese/Japanese Word Break Dictionary Data (cjdict.txt)
+----------------------------------------------------------------------
+
+Chinese/Japanese Word Break Dictionary Data (cjdict.txt)
 
  #     The Google Chrome software developed by Google is licensed under
  # the BSD license. Other software included in this distribution is
@@ -286,33 +296,33 @@ property of their respective owners.
  #
  #  ---------------COPYING.ipadic-----END----------------------------------
 
-3. Lao Word Break Dictionary Data (laodict.txt)
+----------------------------------------------------------------------
 
- #  Copyright (c) 2013 International Business Machines Corporation
- #  and others. All Rights Reserved.
+Lao Word Break Dictionary Data (laodict.txt)
+
+ # Copyright (C) 2016 and later: Unicode, Inc. and others.
+ # License & terms of use: http://www.unicode.org/copyright.html
+ # Copyright (c) 2015 International Business Machines Corporation
+ # and others. All Rights Reserved.
  #
- # Project: http://code.google.com/p/lao-dictionary/
- # Dictionary: http://lao-dictionary.googlecode.com/git/Lao-Dictionary.txt
- # License: http://lao-dictionary.googlecode.com/git/Lao-Dictionary-LICENSE.txt
- #              (copied below)
+ # Project: https://github.com/rober42539/lao-dictionary
+ # Dictionary: https://github.com/rober42539/lao-dictionary/laodict.txt
+ # License: https://github.com/rober42539/lao-dictionary/LICENSE.txt
+ #          (copied below)
  #
- #  This file is derived from the above dictionary, with slight
- #  modifications.
+ #	This file is derived from the above dictionary version of Nov 22, 2020
  #  ----------------------------------------------------------------------
  #  Copyright (C) 2013 Brian Eugene Wilson, Robert Martin Campbell.
  #  All rights reserved.
  #
  #  Redistribution and use in source and binary forms, with or without
- #  modification,
- #  are permitted provided that the following conditions are met:
+ #  modification, are permitted provided that the following conditions are met:
  #
- #
- # Redistributions of source code must retain the above copyright notice, this
- #  list of conditions and the following disclaimer. Redistributions in
- #  binary form must reproduce the above copyright notice, this list of
- #  conditions and the following disclaimer in the documentation and/or
- #  other materials provided with the distribution.
- #
+ #  Redistributions of source code must retain the above copyright notice, this
+ #  list of conditions and the following disclaimer. Redistributions in binary
+ #  form must reproduce the above copyright notice, this list of conditions and
+ #  the following disclaimer in the documentation and/or other materials
+ #  provided with the distribution.
  #
  # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -328,7 +338,9 @@ property of their respective owners.
  # OF THE POSSIBILITY OF SUCH DAMAGE.
  #  --------------------------------------------------------------------------
 
-4. Burmese Word Break Dictionary Data (burmesedict.txt)
+----------------------------------------------------------------------
+
+Burmese Word Break Dictionary Data (burmesedict.txt)
 
  #  Copyright (c) 2014 International Business Machines Corporation
  #  and others. All Rights Reserved.
@@ -368,7 +380,9 @@ property of their respective owners.
  #  SUCH DAMAGE.
  #  --------------------------------------------------------------------------
 
-5. Time Zone Database
+----------------------------------------------------------------------
+
+Time Zone Database
 
   ICU uses the public domain data and code derived from Time Zone
 Database for its time zone support. The ownership of the TZ database
@@ -391,7 +405,9 @@ Database section 7.
  #    making a contribution to the database or code waives all rights to
  #    future claims in that contribution or in the TZ Database.
 
-6. Google double-conversion
+----------------------------------------------------------------------
+
+Google double-conversion
 
 Copyright 2006-2011, the V8 project authors. All rights reserved.
 Redistribution and use in source and binary forms, with or without
@@ -419,3 +435,85 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----------------------------------------------------------------------
+
+File: aclocal.m4 (only for ICU4C)
+Section: pkg.m4 - Macros to locate and utilise pkg-config.
+
+
+Copyright © 2004 Scott James Remnant <scott@netsplit.com>.
+Copyright © 2012-2015 Dan Nicholson <dbn.lists@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+02111-1307, USA.
+
+As a special exception to the GNU General Public License, if you
+distribute this file as part of a program that contains a
+configuration script generated by Autoconf, you may include it under
+the same distribution terms that you use for the rest of that
+program.
+
+
+(The condition for the exception is fulfilled because
+ICU4C includes a configuration script generated by Autoconf,
+namely the `configure` script.)
+
+----------------------------------------------------------------------
+
+File: config.guess (only for ICU4C)
+
+
+This file is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+As a special exception to the GNU General Public License, if you
+distribute this file as part of a program that contains a
+configuration script generated by Autoconf, you may include it under
+the same distribution terms that you use for the rest of that
+program.  This Exception is an additional permission under section 7
+of the GNU General Public License, version 3 ("GPLv3").
+
+
+(The condition for the exception is fulfilled because
+ICU4C includes a configuration script generated by Autoconf,
+namely the `configure` script.)
+
+----------------------------------------------------------------------
+
+File: install-sh (only for ICU4C)
+
+
+Copyright 1991 by the Massachusetts Institute of Technology
+
+Permission to use, copy, modify, distribute, and sell this software and its
+documentation for any purpose is hereby granted without fee, provided that
+the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation, and that the name of M.I.T. not be used in advertising or
+publicity pertaining to distribution of the software without specific,
+written prior permission.  M.I.T. makes no representations about the
+suitability of this software for any purpose.  It is provided "as is"
+without express or implied warranty.

--- a/webcommon/libs.graaljs/external/js-24.0.0-license.txt
+++ b/webcommon/libs.graaljs/external/js-24.0.0-license.txt
@@ -2,8 +2,8 @@ Name: Graal SDK and Truffle API
 Description: Graal SDK and Truffle API
 License: UPL
 Origin: https://github.com/oracle/graal
-Version: 20.3.0
-Files: js-20.3.0.jar js-launcher-20.3.0.jar regex-20.3.0.jar
+Version: 24.0.0
+Files: js-language-24.0.0.jar js-scriptengine-24.0.0.jar regex-24.0.0.jar js-launcher-24.0.0.jar
 
 Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
 

--- a/webcommon/libs.graaljs/manifest.mf
+++ b/webcommon/libs.graaljs/manifest.mf
@@ -3,7 +3,8 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.libs.graaljs/2
 OpenIDE-Module-Layer: org/netbeans/libs/graaljs/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/graaljs/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.24
+OpenIDE-Module-Specification-Version: 1.25
 OpenIDE-Module-Provides: javax.script.ScriptEngine.js,org.netbeans.libs.graaljs
+OpenIDE-Module-Java-Dependencies: Java > 17
 OpenIDE-Module-Hide-Classpath-Packages: com.oracle.truffle.js.scriptengine.**, 
     com.oracle.js.parser.**, com.oracle.truffle.js.**

--- a/webcommon/libs.graaljs/nbproject/project.properties
+++ b/webcommon/libs.graaljs/nbproject/project.properties
@@ -19,7 +19,12 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 
-release.external/js-20.3.0.jar=modules/ext/js-20.3.0.jar
-release.external/js-launcher-20.3.0.jar=modules/ext/js-launcher-20.3.0.jar
-release.external/regex-20.3.0.jar=modules/ext/regex-20.3.0.jar
-release.external/icu4j-67.1.jar=modules/ext/icu4j-67.1.jar
+release.external/js-language-24.0.0.jar=modules/ext/js-language-24.0.0.jar
+release.external/js-scriptengine-24.0.0.jar=modules/ext/js-scriptengine-24.0.0.jar
+release.external/regex-24.0.0.jar=modules/ext/regex-24.0.0.jar
+release.external/icu4j-24.0.0.jar=modules/ext/icu4j-24.0.0.jar
+release.external/js-launcher-24.0.0.jar=modules/ext/js-launcher-24.0.0.jar
+
+# gen-sigtest finds hidden classes - we can't change the API, so we have to
+# accept that shortcoming
+sigtest.gen.fail.on.error=false

--- a/webcommon/libs.graaljs/nbproject/project.xml
+++ b/webcommon/libs.graaljs/nbproject/project.xml
@@ -30,7 +30,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.11</specification-version>
+                        <specification-version>1.25</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -38,7 +38,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.11</specification-version>
+                        <specification-version>1.25</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>
@@ -73,22 +73,27 @@
             <public-packages>
                 <package>com.oracle.js.parser</package>
                 <package>com.oracle.js.parser.ir</package>
+                <package>com.oracle.truffle.js.lang</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/js-20.3.0.jar</runtime-relative-path>
-                <binary-origin>external/js-20.3.0.jar</binary-origin>
+                <runtime-relative-path>ext/js-language-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/js-language-24.0.0.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/js-launcher-20.3.0.jar</runtime-relative-path>
-                <binary-origin>external/js-launcher-20.3.0.jar</binary-origin>
+                <runtime-relative-path>ext/js-launcher-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/js-launcher-24.0.0.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/regex-20.3.0.jar</runtime-relative-path>
-                <binary-origin>external/regex-20.3.0.jar</binary-origin>
+                <runtime-relative-path>ext/js-scriptengine-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/js-scriptengine-24.0.0.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/icu4j-67.1.jar</runtime-relative-path>
-                <binary-origin>external/icu4j-67.1.jar</binary-origin>
+                <runtime-relative-path>ext/regex-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/regex-24.0.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/icu4j-24.0.0.jar</runtime-relative-path>
+                <binary-origin>external/icu4j-24.0.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/webcommon/libs.graaljs/src/org/netbeans/libs/graaljs/graaljs.xml
+++ b/webcommon/libs.graaljs/src/org/netbeans/libs/graaljs/graaljs.xml
@@ -25,15 +25,22 @@
     <localizing-bundle>org.netbeans.libs.graaljs.Bundle</localizing-bundle>
     <volume>
         <type>classpath</type>
-        <resource>jar:nbinst://org.netbeans.libs.graaljs/modules/ext/js-20.3.0.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.libs.graaljs/modules/ext/js-launcher-20.3.0.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.libs.graaljs/modules/ext/regex-20.3.0.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.libs.graaljs/modules/ext/icu4j-67.1.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.graaljs/modules/ext/js-launcher-24.0.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.graaljs/modules/ext/js-language-24.0.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.graaljs/modules/ext/js-scriptengine-24.0.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.graaljs/modules/ext/regex-24.0.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.graaljs/modules/ext/icu4j-24.0.0.jar!/</resource>
 
-        <resource>jar:nbinst://org.netbeans.libs.graalsdk/modules/ext/graal-sdk-20.3.0.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.libs.graalsdk/modules/ext/launcher-common-20.3.0.jar!/</resource>
-
-        <resource>jar:nbinst://org.netbeans.libs.truffleapi/modules/ext/truffle-api-20.3.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.graalsdk/modules/ext/collections-24.0.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.graalsdk/modules/ext/jline-24.0.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.graalsdk/modules/ext/jniutils-24.0.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.graalsdk/modules/ext/launcher-common-24.0.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.graalsdk/modules/ext/nativeimage-24.0.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.graalsdk/modules/ext/polyglot-24.0.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.graalsdk/modules/ext/word-24.0.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.truffleapi/modules/ext/truffle-api-24.0.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.truffleapi/modules/ext/truffle-compiler-24.0.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.truffleapi/modules/ext/truffle-runtime-24.0.0.jar!/</resource>
     </volume>
     <volume>
         <type>src</type>
@@ -45,8 +52,9 @@
         <property>
             <name>maven-dependencies</name>
             <value>
-                org.graalvm.js:js:20.3.0:jar
-                org.graalvm.js:js-launcher:20.3.0:jar
+                org.graalvm.polyglot:polyglot:24.0.0:jar
+                org.graalvm.polyglot:js:24.0.0:pom
+                org.graalvm.js:js-scriptengine:24.0.0:jar
             </value>
         </property>
     </properties>


### PR DESCRIPTION
This is an alternative approach to #7248, trying just to upgrade the libraries + necessary fixes for tests to pass. I started from a clean `master`, upgraded libs and applied relevant fixes found during development of #7248, but without dropping `libs.graalsdk.system` and restructuring the libraries.

So far I tested in locally on
- Oracle JDK 17.0.8
- Oracle JDK 22+36-2370
- Oracle JDK 21+35-2513
- Oracle GraalVM 17.0.10+11.1  - with JS installed and without 
- Oracle GraalVM 21.0.2+13.1
- GraalVM CE 21+35.1
- GraalVM CE JDK17, release 22.3.3  - with JS installed and without 

tests seem to pass. I would appreciate a review against #7248 so that all issues addressed there were correctly picked.


