### PR TITLE
Restructured node_modules license and package.json Validation Logic

### DIFF
--- a/nbbuild/misc/prepare-bundles/src/main/java/org/netbeans/prepare/bundles/PrepareBundles.java
+++ b/nbbuild/misc/prepare-bundles/src/main/java/org/netbeans/prepare/bundles/PrepareBundles.java
@@ -107,18 +107,16 @@ public class PrepareBundles {
                 if ("@types".equals(module.getFileName().toString())) continue;
                 if ("@esbuild".equals(module.getFileName().toString())) continue;
                 if ("@microsoft".equals(module.getFileName().toString())) continue;
-                if ("@vscode".equals(module.getFileName().toString())) {
-                    try (DirectoryStream<Path> sds = Files.newDirectoryStream(module)) {
-                        for (Path sModule : sds) {
-                            checkModule(sModule, sb, tokens2Projects, project2License, bundlesDir, targetDir, externalDir, binariesList);
-                        }
+                Path packageJson = module.resolve("package.json");
+                if (Files.isReadable(packageJson)) {
+                    checkModule(module, sb, tokens2Projects, project2License, bundlesDir, targetDir, externalDir, binariesList);
+                    continue;    
+                }
+                try (DirectoryStream<Path> sds = Files.newDirectoryStream(module)) {
+                    for (Path sModule : sds) {
+                        checkModule(sModule, sb, tokens2Projects, project2License, bundlesDir, targetDir, externalDir, binariesList);
                     }
-                    continue;
                 }
-                if ("@ungap".equals(module.getFileName().toString())) {
-                    module = module.resolve("promise-all-settled");
-                }
-                checkModule(module, sb, tokens2Projects, project2License, bundlesDir, targetDir, externalDir, binariesList);
             }
         }
         if (sb.length() > 0) {


### PR DESCRIPTION
This pull request addresses issues encountered with the `prepareModules` class's validation of licenses and `package.json` files. Presently, the function only scans the top-level directory, leading to occasional false error reports. Additionally, whenever a new dependency is introduced, it necessitates separate handling due to the potential presence of subdirectories containing relevant `package.json` and license information.

To enhance generalization and streamline the process of adding new dependencies, the code has been refactored accordingly.