### PR TITLE
Include api.dashboard in Javadoc.

### DIFF
--- a/nbbuild/build.properties
+++ b/nbbuild/build.properties
@@ -173,7 +173,8 @@ config.javadoc.forwarded.devel=\
     editor,\
     lib.uihandler,\
     uihandler,\
-    spi.editor.hints
+    spi.editor.hints,\
+    api.dashboard
 
 # List of javadocs under development
 config.javadoc.devel=\

--- a/nbbuild/javadoctools/links.xml
+++ b/nbbuild/javadoctools/links.xml
@@ -243,3 +243,4 @@
 <link href="${javadoc.docs.org-netbeans-api-lsp}" offline="true" packagelistloc="${netbeans.javadoc.dir}/org-netbeans-api-lsp"/>
 <link href="${javadoc.docs.org-netbeans-modules-java-j2seplatform}" offline="true" packagelistloc="${netbeans.javadoc.dir}/org-netbeans-modules-java-j2seplatform"/>
 <link href="${javadoc.docs.org-netbeans-modules-xml-wsdl-model}" offline="true" packagelistloc="${netbeans.javadoc.dir}/org-netbeans-modules-xml-wsdl-model"/>
+<link href="${javadoc.docs.org-netbeans-api-dashboard}" offline="true" packagelistloc="${netbeans.javadoc.dir}/org-netbeans-api-dashboard"/>

--- a/nbbuild/javadoctools/properties.xml
+++ b/nbbuild/javadoctools/properties.xml
@@ -240,3 +240,4 @@
 <property name="javadoc.docs.org-netbeans-api-lsp" value="${javadoc.web.root}/org-netbeans-api-lsp"/>
 <property name="javadoc.docs.org-netbeans-modules-java-j2seplatform" value="${javadoc.web.root}/org-netbeans-modules-java-j2seplatform"/>
 <property name="javadoc.docs.org-netbeans-modules-xml-wsdl-model" value="${javadoc.web.root}/org-netbeans-modules-xml-wsdl-model"/>
+<property name="javadoc.docs.org-netbeans-api-dashboard" value="${javadoc.web.root}/org-netbeans-api-dashboard"/>

--- a/nbbuild/javadoctools/replaces.xml
+++ b/nbbuild/javadoctools/replaces.xml
@@ -238,6 +238,7 @@
 <replacefilter token="@org-netbeans-api-lsp@" value="${javadoc.docs.org-netbeans-api-lsp}"/>
 <replacefilter token="@org-netbeans-modules-java-j2seplatform@" value="${javadoc.docs.org-netbeans-modules-java-j2seplatform}"/>
 <replacefilter token="@org-netbeans-modules-xml-wsdl-model@" value="${javadoc.docs.org-netbeans-modules-xml-wsdl-model}"/>
+<replacefilter token="@org-netbeans-api-dashboard@" value="${javadoc.docs.org-netbeans-api-dashboard}"/>
 <!-- deprecated -->
 <replacefilter token="@org-openidex-util@" value="${javadoc.docs.org-openidex-util}"/>
 <!-- deprecated not linked-->


### PR DESCRIPTION
Make sure the Dashboard API module added in #7239 is included in the Javadocs.

Changes as discussed with @ebarboni on Slack.