### PR TITLE
PHP: Improved validation of rename refactoring

### DIFF
--- a/php/php.refactoring/src/org/netbeans/modules/refactoring/php/rename/RenamePanel.java
+++ b/php/php.refactoring/src/org/netbeans/modules/refactoring/php/rename/RenamePanel.java
@@ -67,6 +67,8 @@ public class RenamePanel extends JPanel implements CustomRefactoringPanel {
                 RenamePanel.this.parent.stateChanged(null);
             }
         });
+
+        RenamePanel.this.parent.stateChanged(null);
     }
 
     @Override


### PR DESCRIPTION
In rename refactoring, element name validation occurs only when the name is changed, which can lead to a situation like in #6531.

This PR adds element name validation when opening the rename refactoring window.

Before:

https://github.com/apache/netbeans/assets/9607501/174422c7-a31f-4754-98c9-43029c6271c5


After:

https://github.com/apache/netbeans/assets/9607501/393e7fa0-ac5e-4a51-976a-11a5b32bb983

