### PR TITLE
Import local schema to avoid DNS lookup in build

### DIFF
--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/jakartaee_11.xsd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/jakartaee_11.xsd
@@ -52,7 +52,7 @@
 
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="https://www.w3.org/2001/xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:include schemaLocation="jakartaee_web_services_client_2_0.xsd"/>
 


### PR DESCRIPTION
Please review this one-line change to the file `jakartaee_11.xsd`, which is a new file for NetBeans 22. This change in the Jakarta EE 11 file is the same as the previous changes for Jakarta EE 10 in 2023 and Jakarta EE 9 in 2022:

* #5372 (Jan 26, 2023)
* #4933 (Nov 6, 2022)

The original issue is:

* #4920 (Nov 4, 2022)

Without this fix, building NetBeans on Launchpad fails with the exception:

```
/build/snapcraft-strictly-netbeans-79a4131177e2fda97a9ea091531b589f/parts/...
    netbeans/build/build-release-temp/enterprise/j2ee.dd/build.xml:219:
    Failed to parse document at 'https://www.w3.org/2001/xml.xsd'.
java.net.UnknownHostException: www.w3.org
    at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:567)
    at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
    at java.base/java.net.Socket.connect(Socket.java:633)
```

With this fix, there are no DNS lookups during the build, and the NetBeans build on Launchpad is successful.
