### PR TITLE
HCL: fix possible NPE-s, in List.of() and asString()

### DIFF
--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLArithmeticOperation.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLArithmeticOperation.java
@@ -19,6 +19,8 @@
 package org.netbeans.modules.languages.hcl.ast;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
  *
@@ -64,24 +66,26 @@ public sealed interface HCLArithmeticOperation extends HCLExpression {
     public record Binary(Operator op, HCLExpression left, HCLExpression right) implements HCLArithmeticOperation {
         @Override
         public String asString() {
-            return left.toString() + op.toString() + right.toString();
+            return HCLExpression.asString(left) + op.toString() + HCLExpression.asString(right);
         }
 
         @Override
         public List<? extends HCLExpression> elements() {
-            return List.of(left, right);
+            return Stream.of(left, right)
+                    .filter(Objects::nonNull)
+                    .toList();
         }
     } 
 
     public record Unary(Operator op, HCLExpression operand) implements HCLArithmeticOperation {
         @Override
         public String asString() {
-            return op.toString() + operand.toString();
+            return op.toString() + HCLExpression.asString(operand);
         }
 
         @Override
         public List<? extends HCLExpression> elements() {
-            return List.of(operand);
+            return operand != null ? List.of(operand) : List.of();
         }
     } 
 }

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLAttribute.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLAttribute.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.languages.hcl.ast;
 
 import java.util.List;
+import java.util.Objects;
 
 
 /**
@@ -26,6 +27,10 @@ import java.util.List;
  * @author Laszlo Kishalmi
  */
 public record HCLAttribute(HCLIdentifier name, HCLExpression value) implements HCLElement {
+
+    public HCLAttribute {
+        Objects.requireNonNull(name, "name cannot be null");
+    }
 
     public String id() {
         return name.id();

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLBlock.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLBlock.java
@@ -34,6 +34,10 @@ public final class HCLBlock extends HCLContainer  {
 
     public HCLBlock(List<HCLIdentifier> declaration, List<HCLElement> elements) {
         super(elements);
+        Objects.requireNonNull(declaration, "declaration cannot be null");
+        if (declaration.isEmpty()) {
+            throw new IllegalArgumentException("declaration cannot be empty");
+        }
         this.declaration = List.copyOf(declaration);
         this.id = declaration.stream().map(d -> d.id()).collect(Collectors.joining("."));
     }

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLCollection.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLCollection.java
@@ -19,7 +19,9 @@
 package org.netbeans.modules.languages.hcl.ast;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.stream.Stream;
 
 /**
  *
@@ -37,7 +39,7 @@ public sealed interface HCLCollection<T> extends HCLExpression {
         public String asString() {
             StringJoiner sj = new StringJoiner(",", "[", "]");
             for (HCLExpression element : elements) {
-                sj.add(element.asString());
+                sj.add(HCLExpression.asString(element));
             }
             return sj.toString();
         }
@@ -47,12 +49,14 @@ public sealed interface HCLCollection<T> extends HCLExpression {
     public record ObjectElement(HCLExpression key, HCLExpression value) implements HCLExpression {
         @Override
         public String asString() {
-            return key.asString() + "=" + value.asString();
+            return HCLExpression.asString(key) + "=" + HCLExpression.asString(value);
         }
 
         @Override
         public List<? extends HCLExpression> elements() {
-            return List.of(key, value);
+            return Stream.of(key, value)
+                    .filter(Objects::nonNull)
+                    .toList();
         }
     }
     
@@ -66,7 +70,7 @@ public sealed interface HCLCollection<T> extends HCLExpression {
         public String asString() {
             StringJoiner sj = new StringJoiner(",", "{", "}");
             for (ObjectElement element : elements) {
-                sj.add(element.toString());
+                sj.add(HCLExpression.asString(element));
             }
             return sj.toString();
         }        

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLConditionalOperation.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLConditionalOperation.java
@@ -18,8 +18,9 @@
  */
 package org.netbeans.modules.languages.hcl.ast;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
  *
@@ -29,12 +30,14 @@ public record HCLConditionalOperation(HCLExpression condition, HCLExpression tru
 
     @Override
     public String asString() {
-        return condition.toString() + "?" + trueValue.toString() + ":" + falseValue.toString();
+        return HCLExpression.asString(condition) + "?" + HCLExpression.asString(trueValue) + ":" + HCLExpression.asString(falseValue);
     }
 
     @Override
     public List<? extends HCLExpression> elements() {
-        return Arrays.asList(condition, trueValue, falseValue);
+        return Stream.of(condition, trueValue, falseValue)
+                .filter(Objects::nonNull)
+                .toList();
     }
         
     

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLContainer.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLContainer.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.languages.hcl.ast;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  *
@@ -31,6 +32,7 @@ public sealed abstract class HCLContainer implements HCLElement permits HCLBlock
     private final List<HCLAttribute> attributes;
 
     protected HCLContainer(List<HCLElement> elements) {
+        Objects.requireNonNull(elements, "elements can be empty, but cannot be null");
         this.elements = List.copyOf(elements);
         this.blocks = elements.stream().filter(HCLBlock.class::isInstance).map(HCLBlock.class::cast).toList();
         this.attributes = elements.stream().filter(HCLAttribute.class::isInstance).map(HCLAttribute.class::cast).toList();

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLExpressionFactory.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLExpressionFactory.java
@@ -18,16 +18,14 @@
  */
 package org.netbeans.modules.languages.hcl.ast;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import org.antlr.v4.runtime.NoViableAltException;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTree;
-import org.antlr.v4.runtime.tree.TerminalNode;
 import org.netbeans.modules.languages.hcl.grammar.HCLLexer;
 import static org.netbeans.modules.languages.hcl.grammar.HCLLexer.*;
 import org.netbeans.modules.languages.hcl.grammar.HCLParser;
@@ -150,7 +148,10 @@ public final class HCLExpressionFactory extends HCLElementFactory {
             HCLParser.TupleContext tuple = ctx.tuple();
             List<HCLExpression> elements = new LinkedList<>();
             for (HCLParser.ExpressionContext ec : tuple.expression()) {
-                elements.add(expr(ec));
+                HCLExpression e = expr(ec);
+                if (e != null) {
+                    elements.add(created(e, ec));
+                }
             }
             return new HCLCollection.Tuple(elements);
         }
@@ -184,6 +185,7 @@ public final class HCLExpressionFactory extends HCLElementFactory {
         if (ctx.arguments() != null) {
             args =  ctx.arguments().expression().stream()
                     .map(this::expr)
+                    .filter(Objects::nonNull)
                     .toList();
             expand = ctx.arguments().ELLIPSIS() != null;
         }

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLForExpression.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLForExpression.java
@@ -19,6 +19,8 @@
 package org.netbeans.modules.languages.hcl.ast;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
  *
@@ -39,10 +41,10 @@ public sealed interface HCLForExpression extends HCLExpression {
             StringBuilder sb = new StringBuilder();
             sb.append("[for ");
             if (keyVar != null) {
-                sb.append(keyVar).append(',');
+                sb.append(keyVar.asString()).append(',');
             }
-            sb.append(valueVar).append(" in ").append(iterable.asString()).append(':');
-            sb.append(result.asString());
+            sb.append(HCLExpression.asString(valueVar)).append(" in ").append(HCLExpression.asString(iterable)).append(':');
+            sb.append(HCLExpression.asString(result));
             if (condition != null) { 
                 sb.append(" if ").append(condition.asString());
             }
@@ -52,7 +54,9 @@ public sealed interface HCLForExpression extends HCLExpression {
         
         @Override
         public List<? extends HCLExpression> elements() {
-            return List.of(iterable, result, condition);
+            return Stream.of(iterable, result, condition)
+                    .filter(Objects::nonNull)
+                    .toList();
         }
     }
     
@@ -62,10 +66,10 @@ public sealed interface HCLForExpression extends HCLExpression {
             StringBuilder sb = new StringBuilder();
             sb.append("{for ");
             if (keyVar != null) {
-                sb.append(keyVar).append(',');
+                sb.append(keyVar.asString()).append(',');
             }
-            sb.append(valueVar).append(" in ").append(iterable.asString()).append(':');
-            sb.append(resultKey.asString()).append("=>").append(resultValue.asString());
+            sb.append(HCLExpression.asString(valueVar)).append(" in ").append(HCLExpression.asString(iterable)).append(':');
+            sb.append(HCLExpression.asString(resultKey)).append("=>").append(HCLExpression.asString(resultValue));
             if (grouping) {
                 sb.append("...");
             }
@@ -78,7 +82,9 @@ public sealed interface HCLForExpression extends HCLExpression {
 
         @Override
         public List<? extends HCLExpression> elements() {
-            return List.of(iterable, resultKey, resultValue, condition);
+            return Stream.of(iterable, resultKey, resultValue, condition)
+                    .filter(Objects::nonNull)
+                    .toList();
         }
         
     }

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLFunction.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLFunction.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.languages.hcl.ast;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.StringJoiner;
 
 /**
@@ -28,14 +29,16 @@ import java.util.StringJoiner;
 public record HCLFunction(HCLIdentifier name, List<HCLExpression> args, boolean expand) implements HCLExpression {
 
     public HCLFunction {
+        Objects.requireNonNull(name, "name cannot be null");
+        Objects.requireNonNull(args, "args can be empty, but cannot be null");
         args = List.copyOf(args);
     }
 
     @Override
     public String asString() {
         StringJoiner sargs = new StringJoiner(",", "(", expand ? "...)" : ")");
-        args.forEach((arg) -> sargs.add(arg.toString()));
-        return name + sargs.toString();
+        args.forEach((arg) -> sargs.add(arg.asString()));
+        return name.asString() + sargs.toString();
     }
 
     @Override

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLIdentifier.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLIdentifier.java
@@ -24,18 +24,36 @@ import java.util.List;
  *
  * @author Laszlo Kishalmi
  */
-public sealed interface HCLIdentifier extends HCLElement {
+public sealed interface HCLIdentifier extends HCLExpression {
 
     String id();
     
     @Override
-    default List<? extends HCLElement> elements() {
+    default List<? extends HCLExpression> elements() {
         return List.of();
     }
     
-    public record SimpleId(String id) implements HCLIdentifier {}
+    public record SimpleId(String id) implements HCLIdentifier {
 
-    public record StringId(String id) implements HCLIdentifier {}
+        @Override
+        public String asString() {
+            return id;
+        }
+    }
 
-    public record ScopedId(HCLIdentifier parent, String id) implements HCLIdentifier {}
+    public record StringId(String id) implements HCLIdentifier {
+
+        @Override
+        public String asString() {
+            return id;
+        }
+    }
+
+    public record ScopedId(HCLIdentifier parent, String id) implements HCLIdentifier {
+
+        @Override
+        public String asString() {
+            return HCLExpression.asString(parent) + "::" + id;
+        }
+    }
 }

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLResolveOperation.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLResolveOperation.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.languages.hcl.ast;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  *
@@ -26,25 +27,37 @@ import java.util.List;
  */
 public sealed interface HCLResolveOperation extends HCLExpression {
 
-
     HCLExpression base();
+
     default List<? extends HCLExpression> elements() {
             return List.of(base());
     }
 
     public record Attribute(HCLExpression base, HCLIdentifier attr) implements HCLResolveOperation {
+
+        public Attribute {
+            Objects.requireNonNull(base, "base cannot be null");
+        }
+
         @Override
         public String asString() {
-            return base.asString() + "." + attr;
+            return base.asString() + "." + HCLExpression.asString(attr);
         }
 
     }
 
     public record Index(HCLExpression base, HCLExpression index, boolean legacy) implements HCLResolveOperation {
+
+        public Index {
+            Objects.requireNonNull(base, "base cannot be null");
+            Objects.requireNonNull(index, "index cannot be null");
+        }
+
         @Override
         public String asString() {
-            return base.asString() + (legacy ? "." + index : "[" + index + "]");
+            return base.asString() + (legacy ? "." + index.asString() : "[" + index.asString() + "]");
         }
+
         @Override
         public List<? extends HCLExpression> elements() {
             return List.of(base, index);
@@ -52,6 +65,11 @@ public sealed interface HCLResolveOperation extends HCLExpression {
     }
     
     public record AttrSplat(HCLExpression base) implements HCLResolveOperation {
+
+        public AttrSplat {
+            Objects.requireNonNull(base, "base cannot be null");
+        }
+
         @Override
         public String asString() {
             return base.asString() + ".*";
@@ -59,6 +77,11 @@ public sealed interface HCLResolveOperation extends HCLExpression {
     }
 
     public record FullSplat(HCLExpression base) implements HCLResolveOperation {
+
+        public FullSplat {
+            Objects.requireNonNull(base, "base cannot be null");
+        }
+
         @Override
         public String asString() {
             return base.asString() + "[*]";

--- a/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLVariable.java
+++ b/ide/languages.hcl/src/org/netbeans/modules/languages/hcl/ast/HCLVariable.java
@@ -26,6 +26,6 @@ public record HCLVariable(HCLIdentifier name) implements HCLExpression {
 
     @Override
     public String asString() {
-        return name.id();
+        return HCLExpression.asString(name);
     }
 }

--- a/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/ast/HCLCollectionTest.java
+++ b/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/ast/HCLCollectionTest.java
@@ -18,12 +18,26 @@
  */
 package org.netbeans.modules.languages.hcl.ast;
 
-import java.util.List;
+import static org.netbeans.modules.languages.hcl.ast.HCLExpressionTestSupport.*;
+import org.junit.Test;
 
 /**
  *
- * @author Laszlo Kishalmi
+ * @author lkishalmi
  */
-public sealed interface HCLElement permits HCLExpression, HCLContainer, HCLAttribute {
-    List<? extends HCLElement> elements();
+public class HCLCollectionTest {
+
+    @Test
+    public void testTupleSelf() {
+        assertExpr("[]");
+        assertExpr("[a]");
+        assertExpr("[a,b]");
+    }
+
+    @Test
+    public void testObjectSelf() {
+        assertExpr("{}");
+        assertExpr("{a=b}");
+        assertExpr("{a=b,b=c}");
+    }
 }

--- a/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/ast/HCLExpressionTestSupport.java
+++ b/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/ast/HCLExpressionTestSupport.java
@@ -18,10 +18,10 @@
  */
 package org.netbeans.modules.languages.hcl.ast;
 
-import java.util.Collections;
-import java.util.List;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import org.netbeans.modules.languages.hcl.grammar.HCLLexer;
 import org.netbeans.modules.languages.hcl.grammar.HCLParser;
 
@@ -29,29 +29,21 @@ import org.netbeans.modules.languages.hcl.grammar.HCLParser;
  *
  * @author lkishalmi
  */
-public sealed interface HCLExpression extends HCLElement permits
-        HCLArithmeticOperation,
-        HCLCollection,
-        HCLCollection.ObjectElement,
-        HCLConditionalOperation,
-        HCLForExpression,
-        HCLFunction,
-        HCLIdentifier,
-        HCLLiteral,
-        HCLResolveOperation,
-        HCLTemplate,
-        HCLVariable {
-
-
-    public static String asString(HCLExpression expr) {
-        return expr != null ? expr.asString() : "";
+public class HCLExpressionTestSupport {
+    private HCLExpressionTestSupport() {}
+    
+    public static HCLExpression parse(String expr) {
+        HCLLexer lexer = new HCLLexer(CharStreams.fromString(expr));
+        HCLParser parser = new HCLParser(new CommonTokenStream(lexer));
+        return new HCLExpressionFactory().process(parser.expression());
     }
 
-    @Override
-    default List<? extends HCLExpression> elements() {
-        return Collections.emptyList();
+    public static void assertExpr(String expected, HCLExpression expr) {
+        assertNotNull(expr);
+        assertEquals(expected, expr.asString());
     }
 
-    public abstract String asString();
-
+    public static void assertExpr(String expected) {
+        assertExpr(expected, parse(expected));
+    }
 }

--- a/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/ast/HCLForExpressionTest.java
+++ b/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/ast/HCLForExpressionTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.languages.hcl.ast;
+
+import static org.junit.Assert.*;
+import static org.netbeans.modules.languages.hcl.ast.HCLExpressionTestSupport.*;
+import org.junit.Test;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class HCLForExpressionTest {
+
+    @Test
+    public void testForTuple() {
+        HCLExpression expr = parse("[for i in local.t : i]");
+        if (expr instanceof HCLForExpression.Tuple t) {
+            assertNull(t.keyVar());
+            assertNull(t.condition());
+        } else {
+            fail();
+        }
+    }
+
+    @Test
+    public void testForTupleSelf() {
+        assertExpr("[for i in l:i]");
+        assertExpr("[for i,j in l:i]");
+        assertExpr("[for i in l:i if i>0]");
+    }
+
+    @Test
+    public void testForObjectSelf() {
+        assertExpr("{for k,v in l:k=>v}");
+        assertExpr("{for k,v in l:k=>v if v!=null}");
+        assertExpr("{for k,v in l:k=>v... if v!=null}");
+    }
+
+    @Test
+    public void testForObject() {
+        HCLExpression expr = parse("{for k, v in local.m : k => v}");
+        if (expr instanceof HCLForExpression.Object o) {
+            assertEquals("k", HCLExpression.asString(o.keyVar()));
+            assertNull(o.condition());
+        } else {
+            fail();
+        }
+    }
+
+    @Test
+    public void testForObjectCondition() {
+        HCLExpression expr = parse("{for k, v in local.m : k => v if v > 0}");
+        if (expr instanceof HCLForExpression.Object o) {
+            assertExpr("k", o.keyVar());
+            assertExpr("v>0", o.condition());
+        } else {
+            fail();
+        }
+    }
+
+}

--- a/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/ast/HCLFunctionTest.java
+++ b/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/ast/HCLFunctionTest.java
@@ -18,12 +18,19 @@
  */
 package org.netbeans.modules.languages.hcl.ast;
 
-import java.util.List;
+import static org.netbeans.modules.languages.hcl.ast.HCLExpressionTestSupport.*;
+import org.junit.Test;
 
 /**
  *
- * @author Laszlo Kishalmi
+ * @author lkishalmi
  */
-public sealed interface HCLElement permits HCLExpression, HCLContainer, HCLAttribute {
-    List<? extends HCLElement> elements();
+public class HCLFunctionTest {
+
+    @Test
+    public void testFunctionSelf() {
+        assertExpr("min()");
+        assertExpr("min([1,b]...)");
+        assertExpr("local::min()");
+    }
 }

--- a/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/ast/HCLLiteralsTest.java
+++ b/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/ast/HCLLiteralsTest.java
@@ -21,7 +21,7 @@ package org.netbeans.modules.languages.hcl.ast;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
-import static org.netbeans.modules.languages.hcl.ast.HCLExpression.parse;
+import static org.netbeans.modules.languages.hcl.ast.HCLExpressionTestSupport.*;
 
 /**
  *

--- a/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/ast/HCLOperationsTest.java
+++ b/ide/languages.hcl/test/unit/src/org/netbeans/modules/languages/hcl/ast/HCLOperationsTest.java
@@ -21,7 +21,7 @@ package org.netbeans.modules.languages.hcl.ast;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
-import static org.netbeans.modules.languages.hcl.ast.HCLExpression.parse;
+import static org.netbeans.modules.languages.hcl.ast.HCLExpressionTestSupport.*;
 
 /**
  *
@@ -35,6 +35,16 @@ public class HCLOperationsTest {
         assertTrue(exp instanceof HCLResolveOperation.Attribute);
         HCLResolveOperation.Attribute  resolve = (HCLResolveOperation.Attribute) exp;
         assertEquals("key", resolve.attr().id());
+        assertTrue(resolve.base() instanceof HCLVariable);
+        assertEquals("var", ((HCLVariable)resolve.base()).name().id());
+    }
+
+    @Test
+    public void testResolveIncomplete() throws Exception {
+        HCLExpression exp = parse("var.");
+        assertTrue(exp instanceof HCLResolveOperation.Attribute);
+        HCLResolveOperation.Attribute  resolve = (HCLResolveOperation.Attribute) exp;
+        assertNull(resolve.attr());
         assertTrue(resolve.base() instanceof HCLVariable);
         assertEquals("var", ((HCLVariable)resolve.base()).name().id());
     }
@@ -70,7 +80,36 @@ public class HCLOperationsTest {
         assertTrue(cond.condition() instanceof HCLArithmeticOperation.Binary);
         assertTrue(cond.trueValue() instanceof HCLLiteral.NumericLit);
         assertTrue(cond.falseValue() instanceof HCLVariable);
-        
-        
+    }
+
+    @Test
+    public void testConditionalSelf() throws Exception {
+        assertExpr("a?b:c");
+        assertExpr("a>b?1:0");
+    }
+
+    @Test
+    public void testBinaryOperationSelf() throws Exception {
+        assertExpr("a+b");
+        assertExpr("a-b");
+        assertExpr("a*b");
+        assertExpr("a/b");
+        assertExpr("a%b");
+
+        assertExpr("a||b");
+        assertExpr("a&&b");
+
+        assertExpr("a<b");
+        assertExpr("a>b");
+        assertExpr("a<=b");
+        assertExpr("a>=b");
+        assertExpr("a==b");
+        assertExpr("a!=b");
+    }
+
+    @Test
+    public void testUnaryOperationSelf() throws Exception {
+        assertExpr("!a");
+        assertExpr("-a");
     }
 }


### PR DESCRIPTION
Well, it seems NPE-s can happen if `List.of()` has a `null` argument, and sometimes incomplete language elements can evaluate to `null`.

Also fixed `asString()` methods as that was relying too much on `toString()` methods which is not auto-generated with records.

Added a bunch of simple unit-tests as well.