### PR TITLE
Micronaut: Method parameters should be resolvable in expression language

### DIFF
--- a/enterprise/micronaut/nbproject/project.xml
+++ b/enterprise/micronaut/nbproject/project.xml
@@ -273,7 +273,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>2.49</specification-version>
+                        <specification-version>2.68</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/MicronautConfigUtilities.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/MicronautConfigUtilities.java
@@ -69,7 +69,7 @@ import org.springframework.boot.configurationmetadata.ConfigurationMetadataSourc
  */
 public class MicronautConfigUtilities {
 
-    private static final Pattern REGEXP = Pattern.compile("^(application|bootstrap)(-\\w*)*\\.(yml|properties)$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern REGEXP = Pattern.compile("^(application|bootstrap)(-\\w*)*\\.(yml|yaml|properties)$", Pattern.CASE_INSENSITIVE);
 
     public static final String YAML_MIME = "text/x-yaml";
     public static final String PROPERTIES_MIME = "text/x-properties";

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautDataCompletionCollector.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautDataCompletionCollector.java
@@ -309,6 +309,14 @@ public class MicronautDataCompletionCollector implements CompletionCollector {
                 }
                 Builder builder = CompletionCollector.newBuilder(simpleName);
                 switch (element.getKind()) {
+                    case PARAMETER:
+                        builder.kind(Completion.Kind.Variable).sortText(String.format("%04d%s", 90, simpleName))
+                                .labelDescription(Utils.getTypeName(info, element.asType(), false, false).toString());
+                        break;
+                    case RECORD_COMPONENT:
+                        builder.kind(Completion.Kind.Field).sortText(String.format("%04d%s", 90, simpleName))
+                                .labelDescription(Utils.getTypeName(info, element.asType(), false, false).toString());
+                        break;
                     case ENUM:
                         builder.kind(Completion.Kind.Enum).sortText(String.format("%04d%s", 300, simpleName));
                         break;

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautDataCompletionProvider.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/completion/MicronautDataCompletionProvider.java
@@ -107,12 +107,16 @@ public final class MicronautDataCompletionProvider implements CompletionProvider
         private static final String RECORD_ICON = "org/netbeans/modules/editor/resources/completion/record.png";
         private static final String METHOD_PUBLIC = "org/netbeans/modules/editor/resources/completion/method_16.png"; //NOI18N
         private static final String METHOD_ST_PUBLIC = "org/netbeans/modules/editor/resources/completion/method_static_16.png";
+        private static final String FIELD_PUBLIC = "org/netbeans/modules/editor/resources/completion/field_16.png"; //NOI18N
+        private static final String LOCAL_VARIABLE = "org/netbeans/modules/editor/resources/completion/localVariable.gif"; //NOI18N
         private static final String ATTRIBUTE_VALUE = "org/netbeans/modules/java/editor/resources/attribute_value_16.png"; // NOI18N
         private static final String PROPERTY = "org/netbeans/modules/beans/resources/propertyRO.gif";
         private static final String KEYWORD_COLOR = getHTMLColor(64, 64, 217);
         private static final String PACKAGE_COLOR = getHTMLColor(64, 150, 64);
         private static final String CLASS_COLOR = getHTMLColor(150, 64, 64);
         private static final String INTERFACE_COLOR = getHTMLColor(128, 128, 128);
+        private static final String FIELD_COLOR = getHTMLColor(64, 198, 88);
+        private static final String PARAMETER_COLOR = getHTMLColor(64, 64, 188);
         private static final String PARAMETERS_COLOR = getHTMLColor(192, 192, 192);
         private static final String PARAMETER_NAME_COLOR = getHTMLColor(224, 160, 65);
         private static final String ATTRIBUTE_VALUE_COLOR = getHTMLColor(128, 128, 128);
@@ -496,6 +500,14 @@ public final class MicronautDataCompletionProvider implements CompletionProvider
                     }
                     CompletionUtilities.CompletionItemBuilder builder = CompletionUtilities.newCompletionItemBuilder(simpleName).startOffset(offset);
                     switch (element.getKind()) {
+                        case PARAMETER:
+                            builder.iconResource(LOCAL_VARIABLE).leftHtmlText(PARAMETER_COLOR + simpleName + COLOR_END).sortPriority(90)
+                                    .rightHtmlText(Utils.getTypeName(info, element.asType(), false, false).toString());
+                            break;
+                        case RECORD_COMPONENT:
+                            builder.iconResource(FIELD_PUBLIC).leftHtmlText(FIELD_COLOR + simpleName + COLOR_END).sortPriority(90)
+                                    .rightHtmlText(Utils.getTypeName(info, element.asType(), false, false).toString());
+                            break;
                         case ENUM:
                             builder.iconResource(ENUM_ICON).leftHtmlText(CLASS_COLOR + simpleName + COLOR_END).sortPriority(300);
                             break;

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/expression/EvaluationContext.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/expression/EvaluationContext.java
@@ -107,15 +107,19 @@ public final class EvaluationContext {
         return scope;
     }
 
-    public List<ExecutableElement> getContextMethods() {
+    public List<? extends Element> getContextElements() {
         if (contextClasses == null) {
             initializeContextClasses();
         }
-        List<ExecutableElement> methods = new ArrayList<>();
+        List<Element> elements = new ArrayList<>();
         for (TypeElement contextClass : contextClasses) {
-            methods.addAll(ElementFilter.methodsIn(contextClass.getEnclosedElements()));
+            elements.addAll(ElementFilter.methodsIn(contextClass.getEnclosedElements()));
         }
-        return methods;
+        ExecutableElement enclosingMethod = scope.getEnclosingMethod();
+        if (enclosingMethod != null && !enclosingMethod.getParameters().isEmpty()) {
+            elements.addAll(enclosingMethod.getParameters());
+        }
+        return elements;
     }
 
     private void initializeContextClasses() {

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -1036,7 +1036,7 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
     const conf = workspace.getConfiguration();
     let documentSelectors : DocumentSelector = [
             { language: 'java' },
-            { language: 'yaml', pattern: '**/{application,bootstrap}*.yml' },
+            { language: 'yaml', pattern: '**/{application,bootstrap}*.{yml,yaml}' },
             { language: 'properties', pattern: '**/{application,bootstrap}*.properties' },
             { language: 'jackpot-hint' },
             { language: 'xml', pattern: '**/pom.xml' },

--- a/java/java.source.base/nbproject/project.properties
+++ b/java/java.source.base/nbproject/project.properties
@@ -23,7 +23,7 @@ javadoc.name=Java Source Base
 javadoc.title=Java Source Base
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
-spec.version.base=2.67.0
+spec.version.base=2.68.0
 test.qa-functional.cp.extra=${refactoring.java.dir}/modules/ext/nb-javac-api.jar
 test.unit.run.cp.extra=${o.n.core.dir}/core/core.jar:\
     ${o.n.core.dir}/lib/boot.jar:\

--- a/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
+++ b/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
@@ -551,6 +551,11 @@ public final class ElementOpen {
 
                     v.scan(cu, null);
                     Tree elTree = v.declTree;
+
+                    if (elTree == null) {
+                        elTree = info.getTrees().getTree(el);
+                    }
+
                     if (elTree != null) {
                         result[1] = (int)info.getTrees().getSourcePositions().getStartPosition(cu, elTree);
                         result[2] = (int)info.getTrees().getSourcePositions().getEndPosition(cu, elTree);


### PR DESCRIPTION
 Code completion for Micronaut Expression Language should be able to resolve parameters of the annotated method. For example `param` in the following snippet:
 ```
@XYZ("#{param.toUpperCase()}")
void test(String param);
```