### PR TITLE
Re-add org.netbeans.libs.nbjavac as recommends for java.source.base.

### DIFF
--- a/java/java.source.base/manifest.mf
+++ b/java/java.source.base/manifest.mf
@@ -3,3 +3,4 @@ OpenIDE-Module: org.netbeans.modules.java.source.base
 OpenIDE-Module-Implementation-Version: 6
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/java/source/base/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/java/source/base/layer.xml
+OpenIDE-Module-Recommends: org.netbeans.libs.nbjavac


### PR DESCRIPTION
Potential quick fix for #7091 caused by regression in #6743 .  More detail at https://github.com/apache/netbeans/issues/7091#issuecomment-2077554343

Do not merge if there's a better suggestion from @lahodaj or others on how to handle this issue.