### PR TITLE
In VSCode provide quickfix relevant to the position of the cursor

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -1022,6 +1022,11 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                         if (err.getEndPosition().getOffset() < lineStartOffset || err.getStartPosition().getOffset() > lineEndOffset) {
                             continue;
                         }
+			int lineStart = NbDocument.findLineNumber(doc, startOffset);
+                        int errStartLine = NbDocument.findLineNumber(doc, err.getStartPosition().getOffset());
+                        if(errStartLine != lineStart){
+                            continue;
+                        }
                     }
                     Optional<Diagnostic> diag = diagnostics.stream().filter(d -> entry.getKey().equals(d.getCode().getLeft())).findFirst();
                     org.netbeans.api.lsp.Diagnostic.LazyCodeActions actions = err.getActions();


### PR DESCRIPTION
Currently, all the quickfix calculated appears in the VS code which may not be related to the current cursor position as well.
So, if we add a condition that it should provide quick fixes for the current line only then it would provide quickfixes with better context.

**Examples:** 

**Example-1:**
As seen in the below image before this fix all the hints are shown irrespective of the line context after this only relevant to the current line hints are provided

Before this fix:
<img width="528" alt="Screenshot 2024-05-03 at 2 24 24 PM" src="https://github.com/apache/netbeans/assets/55803675/0f217c26-078f-4452-ad70-5afe4c374d49">

After this fix:
<img width="419" alt="Screenshot 2024-05-03 at 2 26 41 PM" src="https://github.com/apache/netbeans/assets/55803675/4e253907-bdc3-4c04-aad1-5e97116dc98c">

**Example-2**
In this example, a false hint appears since context of the line is not provided, the hint of `test()` method is shown in `test1()` method.

Before this fix:
<img width="357" alt="Screenshot 2024-05-03 at 2 25 41 PM" src="https://github.com/apache/netbeans/assets/55803675/bdafa0b4-5e37-4b7b-aaed-222d5f6e6810">

After this fix:
<img width="357" alt="Screenshot 2024-05-03 at 2 26 22 PM" src="https://github.com/apache/netbeans/assets/55803675/704eb86f-a586-4637-aedc-7da3c4e8fa74">

For more info:
https://github.com/oracle/javavscode/issues/59
