### PR TITLE
Configure commons-logging to log using java.util.logging

### DIFF
--- a/platform/o.apache.commons.logging/build.xml
+++ b/platform/o.apache.commons.logging/build.xml
@@ -21,13 +21,31 @@
 -->
 <project name="platform/o.apache.commons.logging" default="build" basedir=".">
     <import file="../../nbbuild/templates/projectized.xml"/>
-    <target name="jar" depends="-define-FileCRC32Calculator">
+    <!--
+        The NetBeans module org.apache.commons.logging is just a repackaging
+        of the original bundle, the bulk of the module is a verbatim copy of
+        the original commons-logging.
+    -->
+    <target name="jar" depends="-prepare-mandatory-files-for-module,projectized-common.jar,-define-FileCRC32Calculator">
         <FileCRC32Calculator file="external/commons-logging-1.3.1.jar" property="o.apache.commons.logging.crc32" />
         <jar jarfile="${cluster}/${module.jar}">
             <zipfileset src="external/commons-logging-1.3.1.jar"/>
+            <!--
+                The module source code consists only of a bundle activator, that
+                configures commons-logging to log using java.util.logging. The
+                built classes must be included in the rebuild jar.
+            -->
+            <fileset dir="build/classes" 
+                     includes="**/*"
+                     excludes="META-INF/LICENSE META-INF/NOTICE"
+            >
+            </fileset>
             <manifest>
                 <attribute name="Bundle-SymbolicName" value="org.apache.commons.logging"/>
                 <attribute name="Bundle-Version" value="1.3.1"/>
+                <!-- register the BundleActivator, so that commons-logging is propertly configured -->
+                <attribute name="Bundle-Activator" value="org.netbeans.modules.commonslogging.CommonsLoggingBundleActivator"/>
+                <attribute name="Import-Package" value="org.osgi.framework"/>
                 <attribute name="Export-Package" value="org.apache.commons.logging;version=&quot;1.3.1&quot;,org.apache.commons.logging.impl;version=&quot;1.3.1&quot;"/>
                 <attribute name="NB-Original-CRC" value="${o.apache.commons.logging.crc32}"/>
             </manifest>

--- a/platform/o.apache.commons.logging/nbproject/project.xml
+++ b/platform/o.apache.commons.logging/nbproject/project.xml
@@ -30,6 +30,10 @@
                 <runtime-relative-path>org-apache-commons-logging.jar</runtime-relative-path>
                 <binary-origin>external/commons-logging-1.3.1.jar</binary-origin>
             </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path></runtime-relative-path>
+                <binary-origin>../libs.osgi/external/osgi.core-8.0.0.jar</binary-origin>
+            </class-path-extension>
         </data>
     </configuration>
 </project>

--- a/platform/o.apache.commons.logging/src/org/netbeans/modules/commonslogging/CommonsLoggingBundleActivator.java
+++ b/platform/o.apache.commons.logging/src/org/netbeans/modules/commonslogging/CommonsLoggingBundleActivator.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.commonslogging;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+
+public class CommonsLoggingBundleActivator implements BundleActivator {
+
+    @Override
+    public void start(BundleContext bc) throws Exception {
+        // Configure commons-logging to log using java.util.logging unless
+        // overridden by the user
+        if((! System.getProperties().containsKey("org.apache.commons.logging.Log"))
+                && (! System.getProperties().containsKey("org.apache.commons.logging.LogFactory"))) {
+            System.setProperty("org.apache.commons.logging.Log", "org.apache.commons.logging.impl.Jdk14Logger");
+            System.setProperty("org.apache.commons.logging.LogFactory", "org.apache.commons.logging.impl.LogFactoryImpl");
+        }
+    }
+
+    @Override
+    public void stop(BundleContext bc) throws Exception {
+    }
+
+}


### PR DESCRIPTION
It was observed that maven classpath display failed. The stack trace:

     [exec] SEVERE [org.openide.util.RequestProcessor]: Error in RequestProcessor org.netbeans.modules.maven.repository.ui.ArtifactMultiViewFactory$1
     [exec] java.lang.ClassNotFoundException: org.slf4j.MarkerFactory cannot be found by org.apache.commons.logging_1.3.1
     [exec]     at org.eclipse.osgi.internal.loader.BundleLoader.findClassInternal(BundleLoader.java:501)
     [exec]     at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:421)
     [exec]     at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:412)
     [exec]     at org.eclipse.osgi.internal.baseadaptor.DefaultClassLoader.loadClass(DefaultClassLoader.java:107)
     [exec]     at org.netbeans.modules.netbinox.NetbinoxLoader.loadClass(NetbinoxLoader.java:55)
     [exec]     at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
     [exec] Caused: java.lang.NoClassDefFoundError: org/slf4j/MarkerFactory
     [exec]     at org.apache.commons.logging.impl.Slf4jLogFactory.<clinit>(Slf4jLogFactory.java:255)
     [exec]     at java.base/java.lang.Class.forName0(Native Method)
     [exec]     at java.base/java.lang.Class.forName(Class.java:421)
     [exec]     at java.base/java.lang.Class.forName(Class.java:412)
     [exec]     at org.apache.commons.logging.LogFactory.createFactory(LogFactory.java:419)
     [exec]     at org.apache.commons.logging.LogFactory.lambda$newFactory$3(LogFactory.java:1432)
     [exec]     at java.base/java.security.AccessController.doPrivileged(AccessController.java:319)
     [exec]     at org.apache.commons.logging.LogFactory.newFactory(LogFactory.java:1431)
     [exec]     at org.apache.commons.logging.LogFactory.getFactory(LogFactory.java:934)
     [exec]     at org.apache.commons.logging.LogFactory.getLog(LogFactory.java:987)
     [exec]     at org.apache.http.conn.ssl.AbstractVerifier.<init>(AbstractVerifier.java:61)
     [exec]     at org.apache.http.conn.ssl.AllowAllHostnameVerifier.<init>(AllowAllHostnameVerifier.java:44)
     [exec]     at org.apache.http.conn.ssl.AllowAllHostnameVerifier.<clinit>(AllowAllHostnameVerifier.java:46)
     [exec]     at org.apache.http.conn.ssl.SSLConnectionSocketFactory.<clinit>(SSLConnectionSocketFactory.java:151)
     [exec]     at org.eclipse.aether.transport.http.GlobalState.newConnectionManager(GlobalState.java:169)
     [exec]     at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
     [exec]     at org.eclipse.aether.transport.http.GlobalState.getConnectionManager(GlobalState.java:145)
     [exec]     at org.eclipse.aether.transport.http.LocalState.<init>(LocalState.java:62)
     [exec]     at org.eclipse.aether.transport.http.HttpTransporter.<init>(HttpTransporter.java:197)
     [exec]     at org.eclipse.aether.transport.http.HttpTransporterFactory.newInstance(HttpTransporterFactory.java:95)
     [exec]     at org.eclipse.aether.internal.impl.DefaultTransporterProvider.newTransporter(DefaultTransporterProvider.java:

indicates, that commons-logging tries to load slf4j to handle logging, but fails. Running with
"-J-Dorg.apache.commons.logging.diagnostics.dest=STDERR" supports that conclusion:

```
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] [ENV] Extension directories (java.ext.dir): null
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] [ENV] Application classpath (java.class.path): /home/matthias/src/netbeans/nbbuild/netbeans/platform/lib/boot.jar:/home/matthias/src/netbeans/nbbuild/netbeans/platform/lib/org-openide-modules.jar:/home/matthias/src/netbeans/nbbuild/netbeans/platform/lib/org-openide-util.jar:/home/matthias/src/netbeans/nbbuild/netbeans/platform/lib/org-openide-util-lookup.jar:/home/matthias/src/netbeans/nbbuild/netbeans/platform/lib/org-openide-util-ui.jar
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] [ENV] Class org.apache.commons.logging.LogFactory was loaded via class loader org.netbeans.modules.netbinox.NetbinoxLoader@244303269
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] [ENV] Ancestry of class loader which loaded org.apache.commons.logging.LogFactory is org.netbeans.modules.netbinox.NetbinoxLoader@244303269 == 'NetbinoxLoader delegating to org.apache.commons.logging_1.3.1'
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] [ENV] Ancestry of class loader which loaded org.apache.commons.logging.LogFactory is ClassLoader tree:org.netbeans.modules.netbinox.NetbinoxLoader@244303269 --> jdk.internal.loader.ClassLoaders$PlatformClassLoader@1922830567 --> BOOT
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] BOOTSTRAP COMPLETED                                                                                                                                                        
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] [LOOKUP] LogFactory implementation requested for the first time for context class loader org.codehaus.plexus.classworlds.realm.ClassRealm@1303991949
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] [LOOKUP] org.codehaus.plexus.classworlds.realm.ClassRealm@1303991949 == 'ClassRealm[project>org.knowm.xchart:xchart:3.8.7, parent: ClassRealm[maven.api, parent: null]]'
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] [LOOKUP] ClassLoader tree:org.codehaus.plexus.classworlds.realm.ClassRealm@1303991949 --> BOOT
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] [LOOKUP] No properties file of name 'commons-logging.properties' found.
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] [LOOKUP] Looking for system property [org.apache.commons.logging.LogFactory] to define the LogFactory subclass to use...
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] [LOOKUP] No system property [org.apache.commons.logging.LogFactory] defined.
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] [LOOKUP] Using ServiceLoader  to define the LogFactory subclass to use...
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] [LOOKUP] No properties file available to determine LogFactory subclass from..
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] Checking if class 'org.apache.logging.log4j.Logger' is available in class loader org.netbeans.modules.netbinox.NetbinoxLoader@244303269
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] Failed to load class 'org.apache.logging.log4j.Logger' from class loader org.netbeans.modules.netbinox.NetbinoxLoader@244303269: org.apache.logging.log4j.Logger
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] Checking if class 'org.slf4j.Logger' is available in class loader org.netbeans.modules.netbinox.NetbinoxLoader@244303269
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] [LOOKUP] SLF4J detected. Loading the SLF4J LogFactory implementation 'org.apache.commons.logging.impl.Slf4jLogFactory'.
    [LogFactory from org.netbeans.modules.netbinox.NetbinoxLoader@244303269] Unable to load factory class via class loader org.codehaus.plexus.classworlds.realm.ClassRealm@1303991949 - trying the class loader associated with this LogFactory.
    SEVERE [org.openide.util.RequestProcessor]: Error in RequestProcessor org.netbeans.modules.maven.repository.ui.ArtifactMultiViewFactory$1
```
