### PR TITLE
Renaming classes in Maven projects without project properties fails

### DIFF
--- a/java/maven.refactoring/src/org/netbeans/modules/maven/refactoring/MavenRefactoringPlugin.java
+++ b/java/maven.refactoring/src/org/netbeans/modules/maven/refactoring/MavenRefactoringPlugin.java
@@ -71,7 +71,7 @@ class MavenRefactoringPlugin implements RefactoringPlugin {
         if (query != null && !query.getBooleanValue(WhereUsedQuery.FIND_REFERENCES)) {
             return null;
         }
-        final AtomicReference<String> fqn = new AtomicReference<String>();
+        final AtomicReference<String> fqn = new AtomicReference<>();
         CancellableTask<CompilationController> info = new CancellableTask<CompilationController>() {
             @Override public void run(CompilationController info) throws Exception {
                 info.toPhase(JavaSource.Phase.RESOLVED);
@@ -98,7 +98,7 @@ class MavenRefactoringPlugin implements RefactoringPlugin {
             ModelOperation<POMModel> renameMainClassProp = (final POMModel model) -> {
                 Properties pr = model.getProject().getProperties();
                 ElementHandle e = handle.getElementHandle();
-                if (e != null) {
+                if (pr != null && e != null) {
                     String oldName = e.getBinaryName();
                     String newName = refactoring.getNewName();
 
@@ -131,7 +131,13 @@ class MavenRefactoringPlugin implements RefactoringPlugin {
             return null;
         }
 
-        JavaSource source = JavaSource.forFileObject(handle.getFileObject());
+        FileObject fo = handle.getFileObject();
+        JavaSource source;
+        if (fo != null) {
+            source = JavaSource.forFileObject(fo);
+        } else {
+            source = null;
+        }
         if (source != null) {
             try {
                 source.runUserActionTask(info, true);


### PR DESCRIPTION
The MavenRefactoringPlugin provides a rename refactoring for classes. If a class is renamed, it is checked whether that class is referenced from the project exec.mainClass property. The properties are not required and can be null, this case must be checked.