### PR TITLE
ComputeImports: fix package computation.

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/java/editor/imports/ComputeImports.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/imports/ComputeImports.java
@@ -596,9 +596,20 @@ public final class ComputeImports {
                         }
                     }
 
-                    if (type != null && type.getKind() == TypeKind.PACKAGE) {
+                    if (type.getKind() == TypeKind.PACKAGE) {
+                        TreePath parent = getCurrentPath().getParentPath();
+                        Element fullPackage = el;
+                        while (parent != null) {
+                            Element parentElement = info.getTrees().getElement(parent);
+                            if (parentElement != null && parentElement.getKind() == ElementKind.PACKAGE) {
+                                fullPackage = parentElement;
+                                parent = parent.getParentPath();
+                            } else {
+                                break;
+                            }
+                        }
                         //does the package really exists?
-                        String s = ((PackageElement) el).getQualifiedName().toString();
+                        String s = ((PackageElement) fullPackage).getQualifiedName().toString();
                         Element thisPack = info.getTrees().getElement(new TreePath(info.getCompilationUnit()));
                         ModuleElement module = thisPack != null ? info.getElements().getModuleOf(thisPack) : null;
                         PackageElement pack = module != null ? info.getElements().getPackageElement(module, s) : info.getElements().getPackageElement(s);

--- a/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/imports/ComputeImportsTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/imports/ComputeImportsTest.java
@@ -27,7 +27,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.io.PrintStream;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -35,7 +34,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -303,6 +301,26 @@ public class ComputeImportsTest extends NbTestCase {
                                 "package mytest.test;\n"
                                 + "public record MyRecord() {\n"
                                 + "}\n")
+                ),
+                "",
+                "");
+    }
+
+    // https://github.com/apache/netbeans/issues/7073
+    public void testDontImportRootPackageMatchingMember() throws Exception {
+        doTest("test/Test",
+                "11",
+                Arrays.asList(
+                        new FileData("test/Test.java",
+                                "package test;\n" +
+                                "import java.util.List;\n" +
+                                "public class Test {\n" +
+                                "    public static class SomeClass {\n" +
+                                "        public static Object java(java.util.Map<String, String> value) {\n" +
+                                "            return value;\n" +
+                                "        }\n" +
+                                "    }\n" +
+                                "}")
                 ),
                 "",
                 "");


### PR DESCRIPTION
attempt to fix #7073, #5537 and #6902

 - `getPackageElement()` requires the full package String or it returns null (e.g `javax` is not sufficient)
 - this caused a bug where the fix-imports-action imported members which matched root packages of random fully qualified declarations (e.g imports)
 
 
```java
 // hit ctrl+shift+i, it shouldn't import anything
import java.util.List;
public class FixImports {
    public static class SomeClass2 {
        public static String java(String value) {
            return value;
        }
    }
}
```