### PR TITLE
Update nb-javac to jdk-22.0.1

### DIFF
--- a/java/libs.javacapi/external/binaries-list
+++ b/java/libs.javacapi/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-8F51DAC670C68C5F54EA1F6C114CCDB39A59CF50 com.dukescript.nbjavac:nb-javac:jdk-22+33:api
-BEBF599062B88260B9F75C0EE3DD33D2870B39E3 com.dukescript.nbjavac:nb-javac:jdk-22+33
+07266A99C001F11616B36F5128EB78D2242F3096 com.dukescript.nbjavac:nb-javac:jdk-22.0.1+8:api
+D8B9FE09D677A6D589BA3C1E5AD636AF7F47AEE2 com.dukescript.nbjavac:nb-javac:jdk-22.0.1+8

--- a/java/libs.javacapi/external/nb-javac-jdk-22.0.1+8-license.txt
+++ b/java/libs.javacapi/external/nb-javac-jdk-22.0.1+8-license.txt
@@ -1,10 +1,10 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Version: jdk-22+33
-Files: nb-javac-jdk-22+33-api.jar nb-javac-jdk-22+33.jar
+Version: jdk-22.0.1+8
+Files: nb-javac-jdk-22.0.1+8-api.jar nb-javac-jdk-22.0.1+8.jar
 License: GPL-2-CP
-Origin: OpenJDK (https://github.com/openjdk/jdk22)
-Source: https://github.com/openjdk/jdk22
+Origin: OpenJDK (https://github.com/openjdk/jdk22u)
+Source: https://github.com/openjdk/jdk22u
 Type: optional,reviewed
 Comment: The binary has been reviewed to be under the Classpath Exception as a whole. Optional at runtime, but used by default.
 

--- a/java/libs.javacapi/nbproject/project.properties
+++ b/java/libs.javacapi/nbproject/project.properties
@@ -18,7 +18,6 @@ build.compiler.debug=false
 build.compiler.deprecation=false
 is.autoload=true
 javadoc.title=Javac API
-nbm.homepage=http://jackpot.netbeans.org/
 nbm.module.author=Petr Hrebejk
 spec.version.base=8.48.0
 javadoc.arch=${basedir}/arch.xml

--- a/java/libs.javacapi/nbproject/project.xml
+++ b/java/libs.javacapi/nbproject/project.xml
@@ -40,11 +40,11 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-jdk-22+33-api.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-22.0.1+8-api.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-jdk-22+33.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-22.0.1+8.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/libs.nbjavacapi/external/binaries-list
+++ b/java/libs.nbjavacapi/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-8F51DAC670C68C5F54EA1F6C114CCDB39A59CF50 com.dukescript.nbjavac:nb-javac:jdk-22+33:api
-BEBF599062B88260B9F75C0EE3DD33D2870B39E3 com.dukescript.nbjavac:nb-javac:jdk-22+33
+07266A99C001F11616B36F5128EB78D2242F3096 com.dukescript.nbjavac:nb-javac:jdk-22.0.1+8:api
+D8B9FE09D677A6D589BA3C1E5AD636AF7F47AEE2 com.dukescript.nbjavac:nb-javac:jdk-22.0.1+8

--- a/java/libs.nbjavacapi/external/nb-javac-jdk-22.0.1+8-license.txt
+++ b/java/libs.nbjavacapi/external/nb-javac-jdk-22.0.1+8-license.txt
@@ -1,10 +1,10 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Version: jdk-22+33
-Files: nb-javac-jdk-22+33-api.jar nb-javac-jdk-22+33.jar
+Version: jdk-22.0.1+8
+Files: nb-javac-jdk-22.0.1+8-api.jar nb-javac-jdk-22.0.1+8.jar
 License: GPL-2-CP
-Origin: OpenJDK (https://github.com/openjdk/jdk22)
-Source: https://github.com/openjdk/jdk22
+Origin: OpenJDK (https://github.com/openjdk/jdk22u)
+Source: https://github.com/openjdk/jdk22u
 Type: optional,reviewed
 Comment: The binary has been reviewed to be under the Classpath Exception as a whole. Optional at runtime, but used by default.
 

--- a/java/libs.nbjavacapi/nbproject/project.properties
+++ b/java/libs.nbjavacapi/nbproject/project.properties
@@ -18,8 +18,8 @@
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 license.file.override=${nb_all}/nbbuild/licenses/GPL-2-CP
-release.external/nb-javac-jdk-22+33-api.jar=modules/ext/nb-javac-jdk-22-33-api.jar
-release.external/nb-javac-jdk-22+33.jar=modules/ext/nb-javac-jdk-22-33.jar
+release.external/nb-javac-jdk-22.0.1+8-api.jar=modules/ext/nb-javac-jdk-22u1-8-api.jar
+release.external/nb-javac-jdk-22.0.1+8.jar=modules/ext/nb-javac-jdk-22u1-8.jar
 
 # for tests
 requires.nb.javac=true

--- a/java/libs.nbjavacapi/nbproject/project.xml
+++ b/java/libs.nbjavacapi/nbproject/project.xml
@@ -45,12 +45,12 @@
             </test-dependencies>
             <public-packages/>
             <class-path-extension>
-                <runtime-relative-path>ext/nb-javac-jdk-22-33-api.jar</runtime-relative-path>
-                <binary-origin>external/nb-javac-jdk-22+33-api.jar</binary-origin>
+                <runtime-relative-path>ext/nb-javac-jdk-22u1-8-api.jar</runtime-relative-path>
+                <binary-origin>external/nb-javac-jdk-22.0.1+8-api.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/nb-javac-jdk-22-33.jar</runtime-relative-path>
-                <binary-origin>external/nb-javac-jdk-22+33.jar</binary-origin>
+                <runtime-relative-path>ext/nb-javac-jdk-22u1-8.jar</runtime-relative-path>
+                <binary-origin>external/nb-javac-jdk-22.0.1+8.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -96,8 +96,8 @@ nb/ide.launcher/external/launcher-external-binaries-1-94a19f0.zip platform/o.n.b
 nb/ide.launcher/external/launcher-external-binaries-1-94a19f0.zip harness/apisupport.harness/external/launcher-external-binaries-1-94a19f0.zip
 
 # only one is part of the product:
-java/libs.javacapi/external/nb-javac-jdk-22+33-api.jar java/libs.nbjavacapi/external/nb-javac-jdk-22+33-api.jar
-java/libs.javacapi/external/nb-javac-jdk-22+33.jar java/libs.nbjavacapi/external/nb-javac-jdk-22+33.jar
+java/libs.javacapi/external/nb-javac-jdk-22.0.1+8-api.jar java/libs.nbjavacapi/external/nb-javac-jdk-22.0.1+8-api.jar
+java/libs.javacapi/external/nb-javac-jdk-22.0.1+8.jar java/libs.nbjavacapi/external/nb-javac-jdk-22.0.1+8.jar
 
 # Used only in unittests for mysql db specific tests
 ide/db.metadata.model/external/mysql-connector-j-8.0.31.jar ide/db.mysql/external/mysql-connector-j-8.0.31.jar


### PR DESCRIPTION
upgrades nb-javac from jdk-22+33 to jdk-22.0.1+8

~currently uses a staged build~

fixes #6826 due to https://bugs.openjdk.org/browse/JDK-8322159