### PR TITLE
Filtering TextDocumentService.codeAction results based on the provided kinds.

### DIFF
--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/db/MicronautDataEndpointGenerator.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/db/MicronautDataEndpointGenerator.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -93,6 +94,7 @@ import org.openide.util.lookup.ServiceProvider;
 public class MicronautDataEndpointGenerator implements CodeActionProvider, CommandProvider {
 
     private static final String SOURCE = "source";
+    private static final Set<String> SUPPORTED_CODE_ACTION_KINDS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(SOURCE)));
     private static final String CONTROLLER_ANNOTATION_NAME = "io.micronaut.http.annotation.Controller";
     private static final String GENERATE_DATA_ENDPOINT = "nbls.micronaut.generate.data.endpoint";
     private static final String URI =  "uri";
@@ -106,6 +108,11 @@ public class MicronautDataEndpointGenerator implements CodeActionProvider, Comma
         String description = json.getAsJsonObject().get("description").getAsString();;
         return new NotifyDescriptor.QuickPick.Item(label, description);
     }).create();
+
+    @Override
+    public Set<String> getSupportedCodeActionKinds() {
+        return SUPPORTED_CODE_ACTION_KINDS;
+    }
 
     @Override
     @NbBundle.Messages({

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/db/MicronautEndpointTestGenerator.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/db/MicronautEndpointTestGenerator.java
@@ -117,6 +117,7 @@ import org.openide.util.lookup.ServiceProvider;
 public class MicronautEndpointTestGenerator implements CodeActionProvider, CommandProvider {
 
     private static final String SOURCE = "source";
+    private static final Set<String> SUPPORTED_CODE_ACTION_KINDS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(SOURCE)));
     private static final String GENERATE_MICRONAUT_ENDPOINT_TEST = "nbls.micronaut.generate.endpoint.test";
     private static final String CONTROLLER_ANNOTATION_NAME = "io.micronaut.http.annotation.Controller";
     private static final String MICRONAUT_TEST_ANNOTATION_NAME = "io.micronaut.test.extensions.junit5.annotation.MicronautTest";
@@ -147,6 +148,11 @@ public class MicronautEndpointTestGenerator implements CodeActionProvider, Comma
         String description = json.getAsJsonObject().get("description").getAsString();
         return new NotifyDescriptor.QuickPick.Item(label, description);
     }).create();
+
+    @Override
+    public Set<String> getSupportedCodeActionKinds() {
+        return SUPPORTED_CODE_ACTION_KINDS;
+    }
 
     @Override
     @NbBundle.Messages({

--- a/ide/api.lsp/apichanges.xml
+++ b/ide/api.lsp/apichanges.xml
@@ -51,6 +51,19 @@
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
 <changes>
+    <change id="CodeActionProvider.getSupportedCodeActionKinds">
+        <api name="LSP_API"/>
+        <summary>Adding CodeActionProvider.getSupportedCodeActionKinds method</summary>
+        <version major="1" minor="27"/>
+        <date day="8" month="5" year="2024"/>
+        <author login="jlahoda"/>
+        <compatibility binary="compatible" source="compatible" addition="yes" deletion="no" />
+        <description>
+            A <code>CodeActionProvider.getSupportedCodeActionKinds</code> method is
+            introduced that allows to specify supported kinds of code actions.
+        </description>
+        <class package="org.netbeans.spi.lsp" name="CodeActionProvider"/>
+    </change>
     <change id="ErrorProvider.Context.getHintsConfigFile">
         <api name="LSP_API"/>
         <summary>Adding ErrorProvider.Context.getHintsConfigFile() method</summary>

--- a/ide/api.lsp/manifest.mf
+++ b/ide/api.lsp/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.api.lsp/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/api/lsp/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.26
+OpenIDE-Module-Specification-Version: 1.27
 AutoUpdate-Show-In-Client: false

--- a/ide/api.lsp/src/org/netbeans/spi/lsp/CodeActionProvider.java
+++ b/ide/api.lsp/src/org/netbeans/spi/lsp/CodeActionProvider.java
@@ -19,7 +19,9 @@
 package org.netbeans.spi.lsp;
 
 import java.util.List;
+import java.util.Set;
 import javax.swing.text.Document;
+import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.lsp.CodeAction;
 import org.netbeans.api.lsp.Range;
@@ -42,4 +44,15 @@ public interface CodeActionProvider {
      * @since 1.23
      */
     public List<CodeAction> getCodeActions(@NonNull Document doc, @NonNull Range range, @NonNull Lookup context);
+
+    /**
+     * Return the set of code action kinds produced by this provider. May return null
+     * if unknown/all kinds may be produced.
+     *
+     * @return the set of supported code action kinds, or {@code null}
+     * @since 1.27
+     */
+    public default @CheckForNull Set<String> getSupportedCodeActionKinds() {
+        return null;
+    }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
@@ -33,6 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -570,5 +571,11 @@ public class Utils {
             }
         }
         return new WorkspaceEdit(documentChanges);
+    }
+
+    public static Predicate<String> codeActionKindFilter(List<String> only) {
+        return k -> only == null ||
+                    only.stream()
+                        .anyMatch(o -> k.equals(o) || k.startsWith(o + "."));
     }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/CodeActionsProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/CodeActionsProvider.java
@@ -37,6 +37,7 @@ import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.xtext.xbase.lib.Pure;
+import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.java.source.ElementHandle;
 import org.netbeans.modules.java.lsp.server.Utils;
@@ -53,6 +54,10 @@ public abstract class CodeActionsProvider {
     public static final String CODE_ACTIONS_PROVIDER_CLASS = "providerClass";
     public static final String DATA = "data";
     protected static final String ERROR = "<error>"; //NOI18N
+
+    public @CheckForNull Set<String> getSupportedCodeActionKinds() {
+        return null;
+    }
 
     public abstract List<CodeAction> getCodeActions(NbCodeLanguageClient client, ResultIterator resultIterator, CodeActionParams params) throws Exception;
 

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/IntroduceCodeActions.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/IntroduceCodeActions.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.swing.text.StyledDocument;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.ResourceOperation;
+import org.eclipse.lsp4j.TextDocumentEdit;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.netbeans.api.java.source.CompilationController;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.ModificationResult;
+import org.netbeans.modules.java.editor.codegen.GeneratorUtils;
+import org.netbeans.modules.java.hints.introduce.IntroduceFixBase;
+import org.netbeans.modules.java.hints.introduce.IntroduceHint;
+import org.netbeans.modules.java.hints.introduce.IntroduceKind;
+import org.netbeans.modules.java.lsp.server.Utils;
+import org.netbeans.modules.parsing.api.ResultIterator;
+import org.netbeans.spi.editor.hints.ErrorDescription;
+import org.netbeans.spi.editor.hints.Fix;
+import org.openide.filesystems.FileObject;
+import org.openide.util.lookup.ServiceProvider;
+
+@ServiceProvider(service = CodeActionsProvider.class)
+public final class IntroduceCodeActions extends CodeActionsProvider {
+
+    private static final Set<String> SUPPORTED_CODE_ACTION_KINDS =
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(CodeActionKind.RefactorExtract)));
+
+    public IntroduceCodeActions() {
+    }
+
+    @Override
+    public Set<String> getSupportedCodeActionKinds() {
+        return SUPPORTED_CODE_ACTION_KINDS;
+    }
+
+    @Override
+    public List<CodeAction> getCodeActions(NbCodeLanguageClient client, ResultIterator resultIterator, CodeActionParams params) throws Exception {
+        Range range = params.getRange();
+        List<CodeAction> result = new ArrayList<>();
+
+        if (client.getNbCodeCapabilities().wantsJavaSupport() && !range.getStart().equals(range.getEnd())) {
+            CompilationController cc = resultIterator.getParserResult() != null ? CompilationController.get(resultIterator.getParserResult()) : null;
+
+            if (cc != null) {
+                cc.toPhase(JavaSource.Phase.RESOLVED);
+
+                StyledDocument doc = (StyledDocument) cc.getDocument();
+                int startOffset = Utils.getOffset(doc, range.getStart());
+                int endOffset = Utils.getOffset(doc, range.getEnd());
+
+                for (ErrorDescription err : IntroduceHint.computeError(cc, startOffset, endOffset, new EnumMap<IntroduceKind, Fix>(IntroduceKind.class), new EnumMap<IntroduceKind, String>(IntroduceKind.class), new AtomicBoolean())) {
+                    for (Fix fix : err.getFixes().getFixes()) {
+                        if (fix instanceof IntroduceFixBase) {
+                            try {
+                                ModificationResult changes = ((IntroduceFixBase) fix).getModificationResult();
+                                if (changes != null) {
+                                    List<Either<TextDocumentEdit, ResourceOperation>> documentChanges = new ArrayList<>();
+                                    Set<? extends FileObject> fos = changes.getModifiedFileObjects();
+                                    if (fos.size() == 1) {
+                                        FileObject fileObject = fos.iterator().next();
+                                        List<? extends ModificationResult.Difference> diffs = changes.getDifferences(fileObject);
+                                        if (diffs != null) {
+                                            List<TextEdit> edits = new ArrayList<>();
+                                            for (ModificationResult.Difference diff : diffs) {
+                                                String newText = diff.getNewText();
+                                                edits.add(new TextEdit(new Range(Utils.createPosition(fileObject, diff.getStartPosition().getOffset()),
+                                                        Utils.createPosition(fileObject, diff.getEndPosition().getOffset())),
+                                                        newText != null ? newText : ""));
+                                            }
+                                            documentChanges.add(Either.forLeft(new TextDocumentEdit(new VersionedTextDocumentIdentifier(Utils.toUri(fileObject), -1), edits)));
+                                        }
+                                        CodeAction codeAction = new CodeAction(fix.getText());
+                                        codeAction.setKind(CodeActionKind.RefactorExtract);
+                                        codeAction.setEdit(new WorkspaceEdit(documentChanges));
+                                        int renameOffset = ((IntroduceFixBase) fix).getNameOffset(changes);
+                                        if (renameOffset >= 0) {
+                                            codeAction.setCommand(new Command("Rename", client.getNbCodeCapabilities().getCommandPrefix() + ".rename.element.at", Collections.singletonList(renameOffset)));
+                                        }
+                                        result.add(codeAction);
+                                    }
+                                }
+                            } catch (GeneratorUtils.DuplicateMemberException dme) {
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+}


### PR DESCRIPTION
When the `TextDocumentServiceImpl` produces code actions, it will ignore the requested code action kinds for code actions associated with errors, which may lead to warnings like this in the log:
```
2024-05-08 19:50:36.988 [warning] asf.apache-netbeans-java - Code actions of kind 'source 'requested but returned code action is of kind 'quickfix'. Code action will be dropped. Please check 'CodeActionContext.only' to only return requested code actions.
```

The ability to specify which kinds should be returned is probably meant to avoid unnecessary computation.

As I was investigating this, I also looked at the `CodeActionsProvider` and `CodeActionProvider`. While most of these perform the filtering internally, I am not sure if that's an approach that scales too well. E.g. the `SurroundWithHint` provider does not seem to perform the filtering. This patch proposes to enhance the providers with an ability to return which kinds they process, and avoid calling providers that don't even provide any useful results. Plus, there's an automatic filtering of the results.

Also, the introduce hint is hardcoded in `TextDocumentServiceImpl`, and feels problematic in the current situation, so I tried to take that out into a separate provider.

Please let me know what you think.

Thanks!
