### PR TITLE
Fixing 'nbls.project.resolveProjectProblems' command name.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/JavaErrorProvider.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/JavaErrorProvider.java
@@ -206,7 +206,7 @@ public class JavaErrorProvider implements ErrorProvider {
         for (Fix f : fixes) {
             if (f instanceof IncompleteClassPath.ResolveFix) {
                 // We know that this is a project problem and that the problems reported by ProjectProblemsProvider should be resolved
-                CodeAction action = new CodeAction(f.getText(), new Command(f.getText(), "nbls.java.project.resolveProjectProblems"));
+                CodeAction action = new CodeAction(f.getText(), new Command(f.getText(), "nbls.project.resolveProjectProblems"));
                 result.add(action);
             }
             if (f instanceof org.netbeans.modules.java.hints.errors.EnablePreview.ResolveFix) {

--- a/java/maven/src/org/netbeans/modules/maven/problems/MavenModelProblemsProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/problems/MavenModelProblemsProvider.java
@@ -74,6 +74,7 @@ import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.lookup.Lookups;
 import org.netbeans.modules.maven.InternalActionDelegate;
+import org.netbeans.modules.maven.problems.SanityBuildAction.SanityBuildNeededChecker;
 import org.openide.util.Pair;
 
 /**
@@ -85,9 +86,10 @@ import org.openide.util.Pair;
 @ProjectServiceProvider(service = { 
         ProjectProblemsProvider.class, 
         InternalActionDelegate.class,
+        SanityBuildNeededChecker.class,
     }, projectType = "org-netbeans-modules-maven"
 )
-public class MavenModelProblemsProvider implements ProjectProblemsProvider, InternalActionDelegate {
+public class MavenModelProblemsProvider implements ProjectProblemsProvider, InternalActionDelegate, SanityBuildNeededChecker {
     static final RequestProcessor RP  = new RequestProcessor(MavenModelProblemsProvider.class);
     private static final Logger LOG = Logger.getLogger(MavenModelProblemsProvider.class.getName());
     

--- a/java/maven/src/org/netbeans/modules/maven/problems/SanityBuildAction.java
+++ b/java/maven/src/org/netbeans/modules/maven/problems/SanityBuildAction.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -31,14 +32,17 @@ import org.netbeans.api.project.Project;
 import org.netbeans.modules.maven.NbMavenProjectImpl;
 import org.netbeans.modules.maven.TestChecker;
 import org.netbeans.modules.maven.api.NbMavenProject;
+import org.netbeans.modules.maven.api.execute.ExecutionContext;
+import org.netbeans.modules.maven.api.execute.ExecutionResultChecker;
+import org.netbeans.modules.maven.api.execute.RunConfig;
 import org.netbeans.modules.maven.api.execute.RunConfig.ReactorStyle;
 import org.netbeans.modules.maven.api.execute.RunUtils;
 import org.netbeans.modules.maven.execute.BeanRunConfig;
 import org.netbeans.modules.maven.execute.MavenProxySupport;
 import org.netbeans.modules.maven.execute.MavenProxySupport.ProxyResult;
-import org.netbeans.modules.maven.modelcache.MavenProjectCache;
 import org.netbeans.modules.maven.options.MavenSettings;
 import static org.netbeans.modules.maven.problems.Bundle.*;
+import org.netbeans.spi.project.ProjectServiceProvider;
 import org.netbeans.spi.project.ui.ProjectProblemResolver;
 import org.netbeans.spi.project.ui.ProjectProblemsProvider;
 import org.openide.execution.ExecutorTask;
@@ -54,7 +58,8 @@ import org.openide.util.NbPreferences;
  * to believe that there really is a problem with their project, not NetBeans.
  */
 @Messages({"ACT_validate=Priming Build",
-            "ACT_PrimingComplete=Priming build was completed",
+            "ACT_PrimingComplete=Priming build was completed.",
+            "ACT_PrimingFailed=Priming build failed. Please check project build output and resolve problems manually.",
             "ACT_start_validate=Priming build was started."})
 public class SanityBuildAction implements ProjectProblemResolver {
     private static final Logger LOG = Logger.getLogger(SanityBuildAction.class.getName());
@@ -116,6 +121,7 @@ public class SanityBuildAction implements ProjectProblemResolver {
                 }
                 try {
                     LOG.log(Level.FINE, "Configuring sanity build");
+                    AtomicInteger result = new AtomicInteger();
                     BeanRunConfig config = new BeanRunConfig();
                     if (context != null) {
                         config.setActionContext(context);
@@ -138,6 +144,7 @@ public class SanityBuildAction implements ProjectProblemResolver {
                     String label = build_label(nbproject.getProjectDirectory().getNameExt());
                     config.setExecutionName(label);
                     config.setTaskDisplayName(label);
+                    config.setInternalProperty(SanityBuildAction.class.getName(), result);
                     
                     MavenProxySupport mps = nbproject.getLookup().lookup(MavenProxySupport.class);
                     if (mps != null) {
@@ -164,7 +171,15 @@ public class SanityBuildAction implements ProjectProblemResolver {
                     ExecutorTask et = RunUtils.run(config);
                     if (et != null) {
                         et.waitFinished();
-                        ProjectProblemsProvider.Result r = ProjectProblemsProvider.Result.create(ProjectProblemsProvider.Status.RESOLVED, ACT_start_validate());
+                        ProjectProblemsProvider.Result r;
+                        if (result.get() == 0 ||
+                            // if the build failed, the problem may be in user's sources, rather than in
+                            // missing artifacts. Check if sanity build is still needed:
+                            !nbproject.getLookup().lookup(SanityBuildNeededChecker.class).isSanityBuildNeeded()) {
+                            r = ProjectProblemsProvider.Result.create(ProjectProblemsProvider.Status.RESOLVED, ACT_PrimingComplete());
+                        } else {
+                            r = ProjectProblemsProvider.Result.create(ProjectProblemsProvider.Status.UNRESOLVED, ACT_PrimingFailed());
+                        }
                         LOG.log(Level.FINE, "Sanity build of {0} finished, took {1} ms.", new Object[] { nbproject, System.currentTimeMillis() - t});
                         publicResult.complete(r);
                     }
@@ -210,5 +225,22 @@ public class SanityBuildAction implements ProjectProblemResolver {
         return true;
     }
 
-    
+
+    @ProjectServiceProvider(service=ExecutionResultChecker.class, projectType="org-netbeans-modules-maven")
+    public static class ResultChecker implements ExecutionResultChecker {
+
+        @Override
+        public void executionResult(RunConfig config, ExecutionContext res, int resultCode) {
+            Object resultObj = config.getInternalProperties().get(SanityBuildAction.class.getName());
+            if (!(resultObj instanceof AtomicInteger)) {
+                return ;
+            }
+            AtomicInteger result = (AtomicInteger) resultObj;
+            result.set(resultCode);
+        }
+    }
+
+    public interface SanityBuildNeededChecker {
+        public boolean isSanityBuildNeeded();
+    }
 }


### PR DESCRIPTION
The server defines `nbls.project.resolveProjectProblems` command to resolve project problems. The name makes sense to me, as it can resolve problems for any projects, I believe, not only Java-related projects.

But, `JavaErrorProvider` tries to use `nbls.java.project.resolveProjectProblems`, which obviously fails, as that command does not exist.

The proposed fix is to simply use the correct name in `JavaErrorProvider`.