### PR TITLE
Remove keyboard shortcut from terminal close action

### DIFF
--- a/ide/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/CloseAction.java
+++ b/ide/terminal.nb/src/org/netbeans/modules/terminal/nb/actions/CloseAction.java
@@ -34,7 +34,6 @@ import org.openide.util.Lookup;
 @ActionRegistration(displayName = "#CTL_Close", lazy = true) //NOI18N
 @ActionReferences({
     @ActionReference(path = ActionFactory.ACTIONS_PATH, name = "CloseAction"), //NOI18N
-    @ActionReference(path = "Shortcuts", name = "CS-W")
 })
 public final class CloseAction extends TerminalAction {
 


### PR DESCRIPTION
Remove keyboard shortcut from terminal close action due to multiple conflicts.

While testing the dashboard on macOS I noticed that the terminal close action shortcut clashes with the new dashboard action, which sometimes causes issues.  The terminal action uses a non-portable registration, and I was going to look at whether this should change.  However, while testing I noticed that the binding on Linux and Windows also clashes with the close all documents action.

As this shortcut seems to only work sporadically, often does nothing, and sometimes inadvertently closes all your open documents instead, it seems a good idea to remove it (for now).

Anyone desperate for keyboard control can always remap, or type `exit`! :smile: