### PR TITLE
Fix TreeUtilities.pathFor for synthetic 'value=' in annotations also for start position

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -358,12 +358,14 @@ public final class TreeUtilities {
             
             public Void scan(Tree tree, Void p) {
                 if (tree != null) {
+                    long startPos = sourcePositions.getStartPosition(getCurrentPath().getCompilationUnit(), tree);
                     long endPos = sourcePositions.getEndPosition(getCurrentPath().getCompilationUnit(), tree);
                     if (endPos == (-1)) {
                         switch (tree.getKind()) {
                             case ASSIGNMENT:
                                 if (getCurrentPath().getLeaf().getKind() == Kind.ANNOTATION) {
                                     ExpressionTree value = ((AssignmentTree) tree).getExpression();
+                                    startPos = sourcePositions.getStartPosition(getCurrentPath().getCompilationUnit(), value);
                                     endPos = sourcePositions.getEndPosition(getCurrentPath().getCompilationUnit(), value);
                                 }
                                 break;
@@ -376,7 +378,7 @@ public final class TreeUtilities {
                                 break;
                         }
                     }
-                    if (sourcePositions.getStartPosition(getCurrentPath().getCompilationUnit(), tree) < pos && endPos >= pos) {
+                    if (startPos < pos && endPos >= pos) {
                         if (tree.getKind() == Tree.Kind.ERRONEOUS) {
                             tree.accept(this, p);
                             throw new Result(getCurrentPath());

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TreeUtilitiesTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TreeUtilitiesTest.java
@@ -420,6 +420,15 @@ public class TreeUtilitiesTest extends NbTestCase {
         assertEquals(Kind.MEMBER_SELECT, tp.getLeaf().getKind());
         assertEquals("Test.VALUE", tp.getLeaf().toString());
     }
+
+    public void testAnnotationSyntheticValue4() throws Exception {
+        prepareTest("Test", "package test; @Meta(String.class) public class Test { } @interface Meta { public Class value(); }");
+
+        TreePath tp = info.getTreeUtilities().pathFor(24);
+
+        assertEquals(Kind.IDENTIFIER, tp.getLeaf().getKind());
+        assertEquals("String", tp.getLeaf().toString());
+    }
     
     public void testAutoMapComments1() throws Exception {
         prepareTest("Test", "package test;\n" +


### PR DESCRIPTION
Closes: #4186