### PR TITLE
Support for relative paths in the source file launcher's paths; automatic expanding of modular paths.

### DIFF
--- a/java/api.java/apichanges.xml
+++ b/java/api.java/apichanges.xml
@@ -52,6 +52,21 @@
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
 <changes>
+        <change id="ParseLineArgFile">
+            <api name="queries"/>
+            <summary>Result.parseLine permits parsing of argfiles based on current working directory.</summary>
+            <version major="1" minor="92"/>
+            <date day="4" month="6" year="2024"/>
+            <author login="jlahoda"/>
+            <compatibility semantic="compatible" source="compatible" binary="compatible"/>
+            <description>
+                <p>
+                    CompilerOptionsQueryImplementation.Result.parseLine is enhanced with the ability to parse
+                    argfiles, based on a specified current working directory
+                </p>
+            </description>
+            <class package="org.netbeans.spi.java.queries" name="CompilerOptionsQueryImplementation"/>
+        </change>
         <change id="SourceAttacher.Definer2">
             <api name="queries"/>
             <summary>Allows <code>SourceJavadocAttacherImplementation.Definer</code> to reject a binary root.</summary>

--- a/java/api.java/manifest.mf
+++ b/java/api.java/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.api.java/1
-OpenIDE-Module-Specification-Version: 1.91
+OpenIDE-Module-Specification-Version: 1.92
 OpenIDE-Module-Localizing-Bundle: org/netbeans/api/java/queries/Bundle.properties
 AutoUpdate-Show-In-Client: false
 

--- a/java/api.java/test/unit/src/org/netbeans/spi/java/queries/CompilerOptionsQueryImplementationTest.java
+++ b/java/api.java/test/unit/src/org/netbeans/spi/java/queries/CompilerOptionsQueryImplementationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.spi.java.queries;
+
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.junit.Test;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.spi.java.queries.CompilerOptionsQueryImplementation.Result;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class CompilerOptionsQueryImplementationTest extends NbTestCase {
+
+    public CompilerOptionsQueryImplementationTest(String name) {
+        super(name);
+    }
+
+    @Test
+    public void testArgumentFiles() throws Exception {
+        FileObject wd = FileUtil.toFileObject(getWorkDir());
+        FileObject argfile = FileUtil.createData(wd, "argfile");
+        try (OutputStream out = argfile.getOutputStream()) {
+            out.write("test \t\t \"quoted1\"   'quoted2'\n   \t\n   @argfile\n".getBytes(StandardCharsets.UTF_8));
+        }
+
+        assertEquals(Arrays.asList("test", "quoted1", "quoted2", "@argfile"),
+                     Result.doParseLine("@argfile", wd.toURI()));
+        assertEquals(Arrays.asList("@argfile"),
+                     Result.doParseLine("@argfile", null));
+        assertEquals(Arrays.asList("prefix@argfile"),
+                     Result.doParseLine("prefix@argfile", wd.toURI()));
+        assertEquals(Arrays.asList("@@"),
+                     Result.doParseLine("@@", wd.toURI()));
+        assertEquals(Arrays.asList("@"),
+                     Result.doParseLine("@", wd.toURI()));
+        assertEquals(Arrays.asList("test", "quoted1", "quoted2", "@argfile"),
+                     Result.doParseLine("@" + FileUtil.toFile(argfile).getAbsolutePath(), wd.toURI()));
+        assertEquals(Arrays.asList("@nonexistent"),
+                     Result.doParseLine("@nonexistent", wd.toURI()));
+    }
+
+}

--- a/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/AttributeBasedSingleFileOptions.java
+++ b/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/AttributeBasedSingleFileOptions.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.java.file.launcher;
 
+import java.net.URI;
 import javax.swing.event.ChangeListener;
 import org.netbeans.modules.java.file.launcher.queries.MultiSourceRootProvider;
 import org.netbeans.modules.java.file.launcher.spi.SingleFileOptionsQueryImplementation;
@@ -92,6 +93,11 @@ public class AttributeBasedSingleFileOptions implements SingleFileOptionsQueryIm
             vmOptionsObj = root != null ? root.getAttribute(SingleSourceFileUtil.FILE_VM_OPTIONS) : null;
 
             return vmOptionsObj != null ? (String) vmOptionsObj : "";
+        }
+
+        @Override
+        public URI getWorkDirectory() {
+            return root != null ? root.toURI() : source.getParent().toURI();
         }
 
         @Override

--- a/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/actions/LaunchProcess.java
+++ b/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/actions/LaunchProcess.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.java.file.launcher.actions;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -31,6 +32,7 @@ import org.netbeans.modules.java.file.launcher.SingleSourceFileUtil;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.BaseUtilities;
+import org.openide.util.Utilities;
 
 final class LaunchProcess implements Callable<Process> {
 
@@ -69,12 +71,14 @@ final class LaunchProcess implements Callable<Process> {
             FileObject java = JavaPlatformManager.getDefault().getDefaultPlatform().findTool("java"); //NOI18N
             File javaFile = FileUtil.toFile(java);
             String javaPath = javaFile.getAbsolutePath();
+            URI cwd = SingleSourceFileUtil.getOptionsFor(fileObject).getWorkDirectory();
+            File workDir = Utilities.toFile(cwd);
 
             ExplicitProcessParameters paramsFromAttributes =
                     ExplicitProcessParameters.builder()
                                              .args(readArgumentsFromAttribute(fileObject, SingleSourceFileUtil.FILE_ARGUMENTS))
                                              .launcherArgs(readArgumentsFromAttribute(fileObject, SingleSourceFileUtil.FILE_VM_OPTIONS))
-                                             .workingDirectory(FileUtil.toFile(fileObject.getParent()))
+                                             .workingDirectory(workDir)
                                              .build();
 
             ExplicitProcessParameters realParameters =
@@ -97,7 +101,7 @@ final class LaunchProcess implements Callable<Process> {
                 commandsList.add(FileUtil.toFile(fileObject.getParent()).toString());
                 commandsList.add(fileObject.getName());
             } else {
-                commandsList.add(fileObject.getNameExt());
+                commandsList.add(FileUtil.toFile(fileObject).getAbsolutePath());
             }
 
             if (realParameters.getArguments() != null) {

--- a/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/api/SourceLauncher.java
+++ b/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/api/SourceLauncher.java
@@ -59,7 +59,7 @@ public final class SourceLauncher {
         Map<String, String> joinedOptions = new HashMap<>();
 
         for (String value : inputLines) {
-            List<String> args = SingleSourceFileUtil.parseLine(value);
+            List<String> args = SingleSourceFileUtil.parseLine(value, null);
 
             for (int i = 0; i < args.size(); i++) {
                 switch (args.get(i)) {

--- a/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/queries/LauncherSourceLevelQueryImpl.java
+++ b/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/queries/LauncherSourceLevelQueryImpl.java
@@ -24,7 +24,7 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.java.platform.JavaPlatformManager;
 import org.netbeans.modules.java.file.launcher.SingleSourceFileUtil;
-import org.netbeans.modules.java.file.launcher.spi.SingleFileOptionsQueryImplementation;
+import org.netbeans.modules.java.file.launcher.SingleSourceFileUtil.ParsedFileOptions;
 import org.netbeans.spi.java.queries.SourceLevelQueryImplementation2;
 import org.openide.filesystems.FileObject;
 import org.openide.util.ChangeSupport;
@@ -39,7 +39,7 @@ public class LauncherSourceLevelQueryImpl implements SourceLevelQueryImplementat
 
     @Override
     public Result getSourceLevel(FileObject javaFile) {
-        SingleFileOptionsQueryImplementation.Result delegate = SingleSourceFileUtil.getOptionsFor(javaFile);
+        ParsedFileOptions delegate = SingleSourceFileUtil.getOptionsFor(javaFile);
 
         if (delegate != null) {
             return new ResultImpl(delegate);
@@ -54,17 +54,17 @@ public class LauncherSourceLevelQueryImpl implements SourceLevelQueryImplementat
                 JavaPlatformManager.getDefault().getDefaultPlatform().getSpecification().getVersion().toString();
 
         private final ChangeSupport cs = new ChangeSupport(this);
-        private final SingleFileOptionsQueryImplementation.Result delegate;
+        private final ParsedFileOptions delegate;
         private String sourceLevel;
 
-        public ResultImpl(SingleFileOptionsQueryImplementation.Result delegate) {
+        public ResultImpl(ParsedFileOptions delegate) {
             this.delegate = delegate;
             this.delegate.addChangeListener(this);
             updateDelegate();
         }
 
         private void updateDelegate() {
-            List<String> parsed = SingleSourceFileUtil.parseLine(delegate.getOptions());
+            List<? extends String> parsed = delegate.getArguments();
             String sourceLevel = DEFAULT_SOURCE_LEVEL;
 
             for (int i = 0; i < parsed.size(); i++) {

--- a/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/queries/MultiSourceRootProvider.java
+++ b/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/queries/MultiSourceRootProvider.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.java.file.launcher.queries;
 
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -47,7 +48,7 @@ import org.netbeans.api.lexer.TokenSequence;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.queries.FileEncodingQuery;
 import org.netbeans.modules.java.file.launcher.SingleSourceFileUtil;
-import org.netbeans.modules.java.file.launcher.spi.SingleFileOptionsQueryImplementation;
+import org.netbeans.modules.java.file.launcher.SingleSourceFileUtil.ParsedFileOptions;
 import org.netbeans.spi.java.classpath.ClassPathFactory;
 import org.netbeans.spi.java.classpath.ClassPathImplementation;
 
@@ -57,10 +58,16 @@ import org.netbeans.spi.java.classpath.ClassPathProvider;
 import org.netbeans.spi.java.classpath.FilteringPathResourceImplementation;
 import org.netbeans.spi.java.classpath.PathResourceImplementation;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileChangeAdapter;
+import org.openide.filesystems.FileEvent;
 import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileRenameEvent;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
 import org.openide.util.NbBundle.Messages;
+import org.openide.util.RequestProcessor;
+import org.openide.util.RequestProcessor.Task;
+import org.openide.util.Utilities;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
 
@@ -70,9 +77,15 @@ import org.openide.util.lookup.ServiceProviders;
 })
 public class MultiSourceRootProvider implements ClassPathProvider {
 
+    private static final RequestProcessor WORKER = new RequestProcessor(MultiSourceRootProvider.class.getName(), 1, false, false);
     private static final Logger LOG = Logger.getLogger(MultiSourceRootProvider.class.getName());
 
     public static boolean DISABLE_MULTI_SOURCE_ROOT = Boolean.getBoolean("java.disable.multi.source.root");
+    public static boolean SYNCHRONOUS_UPDATES = false;
+
+    private static final Set<String> MODULAR_DIRECTORY_OPTIONS = new HashSet<>(Arrays.asList(
+        "--module-path", "-p"
+    ));
 
     //TODO: the cache will probably be never cleared, as the ClassPath/value refers to the key(?)
     private Map<FileObject, ClassPath> file2SourceCP = new WeakHashMap<>();
@@ -234,7 +247,7 @@ public class MultiSourceRootProvider implements ClassPathProvider {
 
         synchronized (this) {
         return file2ClassPath.computeIfAbsent(file, f -> {
-            SingleFileOptionsQueryImplementation.Result delegate = SingleSourceFileUtil.getOptionsFor(f);
+            ParsedFileOptions delegate = SingleSourceFileUtil.getOptionsFor(f);
 
             if (delegate == null) {
                 return null;
@@ -253,14 +266,16 @@ public class MultiSourceRootProvider implements ClassPathProvider {
         return "true".equals(Bundle.SETTING_AutoRegisterAsRoot());
     }
 
-    private static final class AttributeBasedClassPathImplementation implements ChangeListener, ClassPathImplementation {
+    private static final class AttributeBasedClassPathImplementation extends FileChangeAdapter implements ChangeListener, ClassPathImplementation {
         private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
-        private final SingleFileOptionsQueryImplementation.Result delegate;
+        private final Task updateDelegatesTask = WORKER.create(this::doUpdateDelegates);
+        private final Set<String> directoriesWithListener = new HashSet<>();
+        private final ParsedFileOptions delegate;
         private final Set<String> optionKeys;
         private Set<URL> currentURLs;
         private List<? extends PathResourceImplementation> delegates = Collections.emptyList();
 
-        public AttributeBasedClassPathImplementation(SingleFileOptionsQueryImplementation.Result delegate, String... optionKeys) {
+        public AttributeBasedClassPathImplementation(ParsedFileOptions delegate, String... optionKeys) {
             this.delegate = delegate;
             this.optionKeys = new HashSet<>(Arrays.asList(optionKeys));
             delegate.addChangeListener(this);
@@ -273,21 +288,74 @@ public class MultiSourceRootProvider implements ClassPathProvider {
         }
 
         private void updateDelegates() {
+            if (SYNCHRONOUS_UPDATES) {
+                doUpdateDelegates();
+            } else {
+                updateDelegatesTask.schedule(0);
+            }
+        }
+
+        private void doUpdateDelegates() {
             Set<URL> newURLs = new HashSet<>();
             List<PathResourceImplementation> newDelegates = new ArrayList<>();
-            List<String> parsed = SingleSourceFileUtil.parseLine(delegate.getOptions());
+            List<? extends String> parsed = delegate.getArguments();
+            File workDirectory = Utilities.toFile(delegate.getWorkDirectory());
+            Set<String> toRemoveFSListeners = new HashSet<>();
+            Set<String> addedFSListeners = new HashSet<>();
 
-            for (int i = 0; i < parsed.size(); i++) {
-                if (optionKeys.contains(parsed.get(i)) && i + 1 < parsed.size()) {
-                    ClassPathSupport.createClassPath(parsed.get(i + 1))
-                        .entries()
-                        .stream()
-                        .map(e -> e.getURL())
-                        .forEach(u -> {
+            synchronized (this) {
+                toRemoveFSListeners.addAll(directoriesWithListener);
+            }
+
+            for (int i = 0; i < parsed.size() - 1; i++) {
+                String currentOption = parsed.get(i);
+
+                if (optionKeys.contains(currentOption)) {
+                    for (String piece : parsed.get(i + 1).split(File.pathSeparator)) {
+                        File pieceFile = new File(piece);
+
+                        if (!pieceFile.isAbsolute()) {
+                            pieceFile = new File(workDirectory, piece);
+                        }
+
+                        File f = FileUtil.normalizeFile(pieceFile);
+                        Iterable<File> expandedPaths;
+
+                        if (MODULAR_DIRECTORY_OPTIONS.contains(currentOption)) {
+                            if (!toRemoveFSListeners.remove(f.getAbsolutePath()) &&
+                                addedFSListeners.add(f.getAbsolutePath())) {
+                                FileUtil.addFileChangeListener(this, f);
+                            }
+                        }
+
+                        if (MODULAR_DIRECTORY_OPTIONS.contains(currentOption) &&
+                            f.isDirectory() &&
+                            !new File(f, "module-info.class").exists()) {
+                            File[] children = f.listFiles();
+
+                            if (children != null) {
+                                expandedPaths = Arrays.asList(children);
+                            } else {
+                                expandedPaths = Collections.emptyList();
+                            }
+                        } else {
+                            expandedPaths = Arrays.asList(f);
+                        }
+
+                        for (File expanded : expandedPaths) {
+                            URL u = FileUtil.urlForArchiveOrDir(expanded);
+                            if (u == null) {
+                                throw new IllegalArgumentException("Path entry looks to be invalid: " + piece); // NOI18N
+                            }
                             newURLs.add(u);
                             newDelegates.add(ClassPathSupport.createResource(u));
-                        });
+                        }
+                    }
                 }
+            }
+
+            for (String removeFSListener : toRemoveFSListeners) {
+                FileUtil.removeFileChangeListener(this, new File(removeFSListener));
             }
 
             synchronized (this) {
@@ -296,6 +364,8 @@ public class MultiSourceRootProvider implements ClassPathProvider {
                 }
                 this.currentURLs = newURLs;
                 this.delegates = newDelegates;
+                this.directoriesWithListener.removeAll(toRemoveFSListeners);
+                this.directoriesWithListener.addAll(addedFSListeners);
             }
 
             pcs.firePropertyChange(PROP_RESOURCES, null, null);
@@ -314,6 +384,26 @@ public class MultiSourceRootProvider implements ClassPathProvider {
         @Override
         public void removePropertyChangeListener(PropertyChangeListener listener) {
             pcs.removePropertyChangeListener(listener);
+        }
+
+        @Override
+        public void fileDataCreated(FileEvent fe) {
+            updateDelegates();
+        }
+
+        @Override
+        public void fileDeleted(FileEvent fe) {
+            updateDelegates();
+        }
+
+        @Override
+        public void fileFolderCreated(FileEvent fe) {
+            updateDelegates();
+        }
+
+        @Override
+        public void fileRenamed(FileRenameEvent fe) {
+            updateDelegates();
         }
 
     }

--- a/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/queries/SingleSourceCompilerOptQueryImpl.java
+++ b/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/queries/SingleSourceCompilerOptQueryImpl.java
@@ -18,14 +18,9 @@
  */
 package org.netbeans.modules.java.file.launcher.queries;
 
-import java.util.List;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 import org.netbeans.modules.java.file.launcher.SingleSourceFileUtil;
-import org.netbeans.modules.java.file.launcher.spi.SingleFileOptionsQueryImplementation;
 import org.netbeans.spi.java.queries.CompilerOptionsQueryImplementation;
 import org.openide.filesystems.FileObject;
-import org.openide.util.ChangeSupport;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -35,46 +30,11 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = CompilerOptionsQueryImplementation.class, position = 100)
 public class SingleSourceCompilerOptQueryImpl implements CompilerOptionsQueryImplementation {
 
+    public static final SingleSourceCompilerOptQueryImpl INSTANCE = new SingleSourceCompilerOptQueryImpl();
+
     @Override
     public CompilerOptionsQueryImplementation.Result getOptions(FileObject file) {
-        SingleFileOptionsQueryImplementation.Result delegate = SingleSourceFileUtil.getOptionsFor(file);
-
-        if (delegate != null) {
-            return new ResultImpl(delegate);
-        } else {
-            return null;
-        }
+        return SingleSourceFileUtil.getOptionsFor(file);
     }
 
-    private static final class ResultImpl extends CompilerOptionsQueryImplementation.Result implements ChangeListener {
-
-        private final ChangeSupport cs;
-        private final SingleFileOptionsQueryImplementation.Result delegate;
-
-        ResultImpl(SingleFileOptionsQueryImplementation.Result delegate) {
-            this.cs = new ChangeSupport(this);
-            this.delegate = delegate;
-            this.delegate.addChangeListener(this);
-        }
-
-        @Override
-        public List<? extends String> getArguments() {
-            return parseLine(delegate.getOptions());
-        }
-
-        @Override
-        public void addChangeListener(ChangeListener listener) {
-            cs.addChangeListener(listener);
-        }
-
-        @Override
-        public void removeChangeListener(ChangeListener listener) {
-            cs.removeChangeListener(listener);
-        }
-
-        @Override
-        public void stateChanged(ChangeEvent ce) {
-            cs.fireChange();
-        }
-    }
 }

--- a/java/java.file.launcher/test/unit/src/org/netbeans/modules/java/file/launcher/queries/MultiSourceRootProviderTest.java
+++ b/java/java.file.launcher/test/unit/src/org/netbeans/modules/java/file/launcher/queries/MultiSourceRootProviderTest.java
@@ -18,17 +18,32 @@
  */
 package org.netbeans.modules.java.file.launcher.queries;
 
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.event.ChangeListener;
 import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.api.java.classpath.JavaClassPathConstants;
 import org.netbeans.api.java.source.TestUtilities;
 import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.java.file.launcher.spi.SingleFileOptionsQueryImplementation;
+import org.netbeans.modules.java.file.launcher.spi.SingleFileOptionsQueryImplementation.Result;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
+import org.openide.util.ChangeSupport;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.lookup.ProxyLookup;
 
 /**
  *
  * @author lahvac
  */
 public class MultiSourceRootProviderTest extends NbTestCase {
+
+    private final TestResultImpl testResult = new TestResultImpl();
 
     public MultiSourceRootProviderTest(String name) {
         super(name);
@@ -40,8 +55,6 @@ public class MultiSourceRootProviderTest extends NbTestCase {
     }
 
     public void testSourcePathFiltering() throws Exception {
-        clearWorkDir();
-
         FileObject wd = FileUtil.toFileObject(getWorkDir());
         FileObject validTest = FileUtil.createData(wd, "valid/pack/Test1.java");
         FileObject invalidTest1 = FileUtil.createData(wd, "valid/pack/Test2.java");
@@ -60,5 +73,244 @@ public class MultiSourceRootProviderTest extends NbTestCase {
 
         assertNull(provider.findClassPath(invalidTest1, ClassPath.SOURCE));
         assertNull(provider.findClassPath(invalidTest2, ClassPath.SOURCE));
+    }
+
+    public void testRelativePaths() throws Exception {
+        FileObject wd = FileUtil.toFileObject(getWorkDir());
+        FileObject test = FileUtil.createData(wd, "src/pack/Test1.java");
+        FileObject libJar = FileUtil.createData(wd, "libs/lib.jar");
+        FileObject other = FileUtil.createFolder(wd, "other");
+        FileObject otherLibJar = FileUtil.createData(other, "libs/lib.jar");
+        FileObject otherLib2Jar = FileUtil.createData(other, "libs/lib2.jar");
+
+        TestUtilities.copyStringToFile(test, "package pack;");
+
+        testResult.setOptions("--class-path libs/lib.jar");
+        testResult.setWorkDirectory(wd.toURI());
+
+        MultiSourceRootProvider provider = new MultiSourceRootProvider();
+        ClassPath compileCP = provider.findClassPath(test, ClassPath.COMPILE);
+        AtomicInteger changeCount = new AtomicInteger();
+
+        compileCP.addPropertyChangeListener(evt -> {
+            if (ClassPath.PROP_ENTRIES.equals(evt.getPropertyName())) {
+                changeCount.incrementAndGet();
+            }
+        });
+        assertEquals(FileUtil.toFile(libJar).getAbsolutePath(), compileCP.toString());
+
+        testResult.setWorkDirectory(other.toURI());
+
+        assertEquals(1, changeCount.get());
+
+        assertEquals(FileUtil.toFile(otherLibJar).getAbsolutePath(), compileCP.toString());
+
+        testResult.setOptions("--class-path libs/lib2.jar");
+
+        assertEquals(2, changeCount.get());
+
+        assertEquals(FileUtil.toFile(otherLib2Jar).getAbsolutePath(), compileCP.toString());
+    }
+
+    public void testExpandModularDir() throws Exception {
+        FileObject wd = FileUtil.toFileObject(getWorkDir());
+        FileObject test = FileUtil.createData(wd, "src/pack/Test1.java");
+        FileObject libsDir = FileUtil.createFolder(wd, "libs");
+        FileObject lib1Jar = FileUtil.createData(libsDir, "lib1.jar");
+        FileObject lib2Jar = FileUtil.createData(libsDir, "lib2.jar");
+        FileObject lib3Dir = FileUtil.createFolder(libsDir, "lib3");
+
+        FileUtil.createData(lib3Dir, "module-info.class");
+
+        TestUtilities.copyStringToFile(test, "package pack;");
+
+        testResult.setOptions("--module-path " + FileUtil.toFile(libsDir).getAbsolutePath());
+        testResult.setWorkDirectory(FileUtil.toFileObject(getWorkDir()).toURI());
+
+        MultiSourceRootProvider provider = new MultiSourceRootProvider();
+        ClassPath moduleCP = provider.findClassPath(test, JavaClassPathConstants.MODULE_COMPILE_PATH);
+        ClassPath compileCP = provider.findClassPath(test, ClassPath.COMPILE);
+
+        assertEquals(new HashSet<>(Arrays.asList(FileUtil.getArchiveRoot(lib1Jar),
+                                                 FileUtil.getArchiveRoot(lib2Jar),
+                                                 lib3Dir)),
+                     new HashSet<>(Arrays.asList(moduleCP.getRoots())));
+
+        assertEquals(new HashSet<>(Arrays.asList(FileUtil.getArchiveRoot(lib1Jar),
+                                                 FileUtil.getArchiveRoot(lib2Jar),
+                                                 lib3Dir)),
+                     new HashSet<>(Arrays.asList(compileCP.getRoots())));
+
+        FileObject lib4Jar = FileUtil.createData(libsDir, "lib4.jar");
+
+        assertEquals(new HashSet<>(Arrays.asList(FileUtil.getArchiveRoot(lib1Jar),
+                                                 FileUtil.getArchiveRoot(lib2Jar),
+                                                 lib3Dir,
+                                                 FileUtil.getArchiveRoot(lib4Jar))),
+                     new HashSet<>(Arrays.asList(moduleCP.getRoots())));
+
+        assertEquals(new HashSet<>(Arrays.asList(FileUtil.getArchiveRoot(lib1Jar),
+                                                 FileUtil.getArchiveRoot(lib2Jar),
+                                                 lib3Dir,
+                                                 FileUtil.getArchiveRoot(lib4Jar))),
+                     new HashSet<>(Arrays.asList(compileCP.getRoots())));
+
+        testResult.setOptions("--module-path " + FileUtil.toFile(lib1Jar).getAbsolutePath());
+
+        assertEquals(new HashSet<>(Arrays.asList(FileUtil.getArchiveRoot(lib1Jar))),
+                     new HashSet<>(Arrays.asList(moduleCP.getRoots())));
+        assertEquals(new HashSet<>(Arrays.asList(FileUtil.getArchiveRoot(lib1Jar))),
+                     new HashSet<>(Arrays.asList(compileCP.getRoots())));
+
+        testResult.setOptions("--module-path " + FileUtil.toFile(lib3Dir).getAbsolutePath());
+
+        assertEquals(new HashSet<>(Arrays.asList(lib3Dir)),
+                     new HashSet<>(Arrays.asList(moduleCP.getRoots())));
+        assertEquals(new HashSet<>(Arrays.asList(lib3Dir)),
+                     new HashSet<>(Arrays.asList(compileCP.getRoots())));
+
+        testResult.setOptions("--module-path " + FileUtil.toFile(libsDir).getAbsolutePath());
+
+        assertEquals(new HashSet<>(Arrays.asList(FileUtil.getArchiveRoot(lib1Jar),
+                                                 FileUtil.getArchiveRoot(lib2Jar),
+                                                 lib3Dir,
+                                                 FileUtil.getArchiveRoot(lib4Jar))),
+                     new HashSet<>(Arrays.asList(moduleCP.getRoots())));
+
+        assertEquals(new HashSet<>(Arrays.asList(FileUtil.getArchiveRoot(lib1Jar),
+                                                 FileUtil.getArchiveRoot(lib2Jar),
+                                                 lib3Dir,
+                                                 FileUtil.getArchiveRoot(lib4Jar))),
+                     new HashSet<>(Arrays.asList(compileCP.getRoots())));
+
+        FileObject lib5Dir = FileUtil.createFolder(libsDir, "lib5Dir");
+
+        assertEquals(new HashSet<>(Arrays.asList(FileUtil.getArchiveRoot(lib1Jar),
+                                                 FileUtil.getArchiveRoot(lib2Jar),
+                                                 lib3Dir,
+                                                 FileUtil.getArchiveRoot(lib4Jar),
+                                                 lib5Dir)),
+                     new HashSet<>(Arrays.asList(moduleCP.getRoots())));
+
+        assertEquals(new HashSet<>(Arrays.asList(FileUtil.getArchiveRoot(lib1Jar),
+                                                 FileUtil.getArchiveRoot(lib2Jar),
+                                                 lib3Dir,
+                                                 FileUtil.getArchiveRoot(lib4Jar),
+                                                 lib5Dir)),
+                     new HashSet<>(Arrays.asList(compileCP.getRoots())));
+
+        lib5Dir.delete();
+
+        assertEquals(new HashSet<>(Arrays.asList(FileUtil.getArchiveRoot(lib1Jar),
+                                                 FileUtil.getArchiveRoot(lib2Jar),
+                                                 lib3Dir,
+                                                 FileUtil.getArchiveRoot(lib4Jar))),
+                     new HashSet<>(Arrays.asList(moduleCP.getRoots())));
+
+        assertEquals(new HashSet<>(Arrays.asList(FileUtil.getArchiveRoot(lib1Jar),
+                                                 FileUtil.getArchiveRoot(lib2Jar),
+                                                 lib3Dir,
+                                                 FileUtil.getArchiveRoot(lib4Jar))),
+                     new HashSet<>(Arrays.asList(compileCP.getRoots())));
+
+        lib4Jar.delete();
+
+        assertEquals(new HashSet<>(Arrays.asList(FileUtil.getArchiveRoot(lib1Jar),
+                                                 FileUtil.getArchiveRoot(lib2Jar),
+                                                 lib3Dir)),
+                     new HashSet<>(Arrays.asList(moduleCP.getRoots())));
+
+        assertEquals(new HashSet<>(Arrays.asList(FileUtil.getArchiveRoot(lib1Jar),
+                                                 FileUtil.getArchiveRoot(lib2Jar),
+                                                 lib3Dir)),
+                     new HashSet<>(Arrays.asList(compileCP.getRoots())));
+
+        FileUtil.createData(libsDir, "module-info.class");
+
+        assertEquals(new HashSet<>(Arrays.asList(libsDir)),
+                     new HashSet<>(Arrays.asList(moduleCP.getRoots())));
+        assertEquals(new HashSet<>(Arrays.asList(libsDir)),
+                     new HashSet<>(Arrays.asList(compileCP.getRoots())));
+    }
+
+    public void testBrokenOptions() throws Exception {
+        FileObject wd = FileUtil.toFileObject(getWorkDir());
+        FileObject test = FileUtil.createData(wd, "src/pack/Test1.java");
+
+        testResult.setOptions("--module-path");
+        testResult.setWorkDirectory(FileUtil.toFileObject(getWorkDir()).toURI());
+
+        MultiSourceRootProvider provider = new MultiSourceRootProvider();
+
+        provider.findClassPath(test, JavaClassPathConstants.MODULE_COMPILE_PATH);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        clearWorkDir();
+    }
+
+    @Override
+    protected void runTest() throws Throwable {
+        SingleFileOptionsQueryImplementation queryImpl = file -> testResult;
+        ProxyLookup newQueryLookup = new ProxyLookup(Lookups.fixed(queryImpl),
+                                                     Lookups.exclude(Lookup.getDefault(),
+                                                                     SingleFileOptionsQueryImplementation.class));
+        Lookups.executeWith(newQueryLookup, () -> {
+            try {
+                super.runTest();
+            } catch (Error err) {
+                throw err;
+            } catch (RuntimeException ex) {
+                throw ex;
+            } catch (Throwable ex) {
+                throw new IllegalStateException(ex);
+            }
+        });
+    }
+
+    private static class TestResultImpl implements Result {
+
+        private final ChangeSupport cs = new ChangeSupport(this);
+        private final AtomicReference<String> options = new AtomicReference<>();
+        private final AtomicReference<URI> workdir = new AtomicReference<>();
+
+        public TestResultImpl() {
+        }
+
+        @Override
+        public String getOptions() {
+            return options.get();
+        }
+
+        public void setOptions(String options) {
+            this.options.set(options);
+            cs.fireChange();
+        }
+
+        @Override
+        public URI getWorkDirectory() {
+            return workdir.get();
+        }
+
+        public void setWorkDirectory(URI workdir) {
+            this.workdir.set(workdir);
+            cs.fireChange();
+        }
+
+        @Override
+        public void addChangeListener(ChangeListener l) {
+            cs.addChangeListener(l);
+        }
+
+        @Override
+        public void removeChangeListener(ChangeListener l) {
+            cs.removeChangeListener(l);
+        }
+    }
+
+    static {
+        MultiSourceRootProvider.SYNCHRONOUS_UPDATES = true;
     }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -1108,6 +1108,7 @@ public final class Server {
             sessionServices.add(new WorkspaceUIContext(client));
             sessionServices.add(treeService.getNodeRegistry());
             sessionServices.add(inputService.getRegistry());
+            sessionServices.add(workspaceService.getWorkspace());
             ((LanguageClientAware) getTextDocumentService()).connect(client);
             ((LanguageClientAware) getWorkspaceService()).connect(client);
             ((LanguageClientAware) treeService).connect(client);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Workspace.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Workspace.java
@@ -16,23 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.netbeans.modules.java.file.launcher.spi;
+package org.netbeans.modules.java.lsp.server.protocol;
 
-import java.net.URI;
-import javax.swing.event.ChangeListener;
-import org.netbeans.api.annotations.common.NonNull;
+import java.util.List;
 import org.openide.filesystems.FileObject;
 
-public interface SingleFileOptionsQueryImplementation {
-
-    public Result optionsFor(FileObject file);
-
-    public interface Result {
-        public String getOptions();
-        public default @NonNull URI getWorkDirectory() {
-            throw new UnsupportedOperationException();
-        }
-        public void addChangeListener(ChangeListener l);
-        public void removeChangeListener(ChangeListener l);
-    }
+/**
+ * One workspace opened in the UI.
+ */
+public interface Workspace {
+    public List<FileObject> getClientWorkspaceFolders();
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/singlesourcefile/SingleFileOptionsQueryImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/singlesourcefile/SingleFileOptionsQueryImpl.java
@@ -18,113 +18,190 @@
  */
 package org.netbeans.modules.java.lsp.server.singlesourcefile;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.io.File;
+import java.net.URI;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.WeakHashMap;
+import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.java.file.launcher.api.SourceLauncher;
 import org.netbeans.modules.java.file.launcher.spi.SingleFileOptionsQueryImplementation;
-import org.netbeans.modules.java.lsp.server.protocol.NbCodeLanguageClient;
+import org.netbeans.modules.java.lsp.server.protocol.Workspace;
+import org.openide.filesystems.FileChangeAdapter;
+import org.openide.filesystems.FileEvent;
 import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
 import org.openide.util.ChangeSupport;
 import org.openide.util.Lookup;
+import org.openide.util.Parameters;
 
 public abstract class SingleFileOptionsQueryImpl implements SingleFileOptionsQueryImplementation {
 
-    private final Map<NbCodeLanguageClient, ResultImpl> client2Options = new WeakHashMap<>();
-    private final GlobalResultImpl globalOptions = new GlobalResultImpl();
+    private final Map<Workspace, WorkspaceSettings> workspace2Settings = new WeakHashMap<>();
+    private final Map<Workspace, Map<FileObject, ResultImpl>> workspace2Folder2Options = new WeakHashMap<>();
 
     @Override
     public Result optionsFor(FileObject file) {
         if (isSingleSourceFile(file)) {
-            NbCodeLanguageClient client = Lookup.getDefault().lookup(NbCodeLanguageClient.class);
+            Workspace workspace = Lookup.getDefault().lookup(Workspace.class);
+            FileObject workspaceFolder = workspace != null ? findWorkspaceFolder(workspace, file) : null;
 
-            if (client != null) {
-                return getResult(client);
+            if (workspaceFolder != null) {
+                return getResult(workspace, workspaceFolder);
             } else {
-                return globalOptions;
+                Set<Workspace> workspaces;
+
+                synchronized (this) {
+                    workspaces = workspace2Settings.keySet();
+                }
+
+                for (Workspace w : workspaces) {
+                    FileObject folder = findWorkspaceFolder(w, file);
+                    if (folder != null) {
+                        return getResult(w, folder);
+                    }
+                }
+
+                return null;
             }
         }
         return null;
     }
 
-    private static final class ResultImpl implements Result {
+    private synchronized Result getResult(Workspace workspace, FileObject workspaceFolder) {
+        Map<FileObject, ResultImpl> folder2Result =
+                workspace2Folder2Options.computeIfAbsent(workspace, w -> new HashMap<>());
+        return folder2Result.computeIfAbsent(workspaceFolder, f -> new ResultImpl(folder2Result,
+                workspaceFolder,
+                getWorkspaceSettings(workspace)));
+    }
+
+    static FileObject findWorkspaceFolder(Workspace workspace, FileObject file) {
+        for (FileObject workspaceFolder : workspace.getClientWorkspaceFolders()) {
+            if (FileUtil.isParentOf(workspaceFolder, file) || workspaceFolder == file) {
+                return workspaceFolder;
+            }
+        }
+
+        //in case file is a source root, and the workspace folder is nested inside the root:
+        for (FileObject workspaceFolder : workspace.getClientWorkspaceFolders()) {
+            if (FileUtil.isParentOf(file, workspaceFolder)) {
+                return workspaceFolder;
+            }
+        }
+
+        return null;
+    }
+
+    private static final class ResultImpl extends FileChangeAdapter implements Result, ChangeListener {
 
         private final ChangeSupport cs = new ChangeSupport(this);
-        private String options = "";
+        private final Map<FileObject, ResultImpl> workspaceFolders2Results;
+        private final FileObject workspaceFolder;
+        private final WorkspaceSettings workspaceSettings;
+
+        public ResultImpl(Map<FileObject, ResultImpl> workspaceFolders2Results,
+                          FileObject workspaceFolder,
+                          WorkspaceSettings workspaceSettings) {
+            this.workspaceFolders2Results = workspaceFolders2Results;
+            this.workspaceFolder = workspaceFolder;
+            this.workspaceSettings = workspaceSettings;
+
+            workspaceSettings.addChangeListener(this);
+            workspaceFolder.addFileChangeListener(this);
+        }
 
         @Override
+        public String getOptions() {
+            return workspaceSettings.getOptions();
+        }
+
+        @Override
+        public URI getWorkDirectory() {
+            String cwd = workspaceSettings.getWorkDirectory();
+            FileObject workDir = cwd != null ? FileUtil.toFileObject(new File(cwd))
+                                             : workspaceFolder;
+            return workDir.toURI();
+        }
+
+        @Override
+        public void addChangeListener(ChangeListener l) {
+            cs.addChangeListener(l);
+        }
+
+        @Override
+        public void removeChangeListener(ChangeListener l) {
+            cs.removeChangeListener(l);
+        }
+
+        @Override
+        public void stateChanged(ChangeEvent ce) {
+            cs.fireChange();
+        }
+
+        @Override
+        public void fileDeleted(FileEvent fe) {
+            workspaceFolders2Results.remove(workspaceFolder);
+        }
+
+    }
+
+    private final class WorkspaceSettings {
+
+        private final ChangeSupport cs = new ChangeSupport(this);
+
+        private String options;
+        private String workdirDirectory;
+
         public synchronized String getOptions() {
             return options;
         }
 
-        public boolean setOptions(String options) {
+        public synchronized String getWorkDirectory() {
+            return workdirDirectory;
+        }
+
+        public boolean setOptions(String options, String workingDirectory) {
+            boolean modified = false;
             synchronized (this) {
-                if (Objects.equals(this.options, options)) {
-                    return false;
+                if (!Objects.equals(this.options, options)) {
+                    this.options = options;
+                    modified = true;
                 }
-                this.options = options;
+                if (!Objects.equals(this.workdirDirectory, workingDirectory)) {
+                    this.workdirDirectory = workingDirectory;
+                    modified = true;
+                }
             }
-            cs.fireChange();
-            return true;
+            if (modified) {
+                cs.fireChange();
+            }
+            return modified;
         }
 
-        @Override
         public void addChangeListener(ChangeListener l) {
             cs.addChangeListener(l);
         }
 
-        @Override
         public void removeChangeListener(ChangeListener l) {
             cs.removeChangeListener(l);
         }
 
     }
 
-    private final class GlobalResultImpl implements Result {
-
-        private final ChangeSupport cs = new ChangeSupport(this);
-
-        @Override
-        public String getOptions() {
-            List<String> options = new ArrayList<>();
-
-            synchronized (SingleFileOptionsQueryImpl.this) {
-                for (ResultImpl r : client2Options.values()) {
-                    options.add(r.getOptions());
-                }
-            }
-
-            return SourceLauncher.joinCommandLines(options);
-        }
-
-        @Override
-        public void addChangeListener(ChangeListener l) {
-            cs.addChangeListener(l);
-        }
-
-        @Override
-        public void removeChangeListener(ChangeListener l) {
-            cs.removeChangeListener(l);
-        }
-
+    public boolean setConfiguration(Workspace workspace, String vmOptions, String workDirectory) {
+        return getWorkspaceSettings(workspace).setOptions(vmOptions, workDirectory);
     }
 
-    public boolean setConfiguration(NbCodeLanguageClient client, String vmOptions) {
-        if (getResult(client).setOptions(vmOptions)) {
-            globalOptions.cs.fireChange();
-            return true;
-        }
-        return false;
-    }
-
-    private synchronized ResultImpl getResult(NbCodeLanguageClient client) {
-        return client2Options.computeIfAbsent(client, cl -> {
-            return new ResultImpl();
+    private synchronized WorkspaceSettings getWorkspaceSettings(Workspace workspace) {
+        Parameters.notNull("workspace", workspace);
+        return workspace2Settings.computeIfAbsent(workspace, w -> {
+            return new WorkspaceSettings();
         });
     }
 

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/singlesourcefile/SingleFileOptionsQueryImplTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/singlesourcefile/SingleFileOptionsQueryImplTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.singlesourcefile;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.java.lsp.server.protocol.Workspace;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.lookup.ProxyLookup;
+
+public class SingleFileOptionsQueryImplTest extends NbTestCase {
+
+    public SingleFileOptionsQueryImplTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        clearWorkDir();
+    }
+
+    public void testFindWorkspaceFolder() throws Exception {
+        FileObject wd = FileUtil.toFileObject(getWorkDir());
+        FileObject workspace1 = FileUtil.createFolder(wd, "workspace1");
+        FileObject source1 = FileUtil.createData(workspace1, "test/Test.java");
+        FileObject prjRoot = FileUtil.createFolder(wd, "prjRoot");
+        FileObject workspace2 = FileUtil.createFolder(prjRoot, "test2");
+        FileObject source2 = FileUtil.createData(workspace2, "Test.java");
+
+        Workspace workspace = new WorkspaceImpl(Arrays.asList(workspace1, workspace2));
+
+        assertEquals(workspace1, SingleFileOptionsQueryImpl.findWorkspaceFolder(workspace, source1));
+        assertEquals(workspace1, SingleFileOptionsQueryImpl.findWorkspaceFolder(workspace, source1.getParent()));
+        assertEquals(workspace1, SingleFileOptionsQueryImpl.findWorkspaceFolder(workspace, workspace1));
+        assertEquals(workspace2, SingleFileOptionsQueryImpl.findWorkspaceFolder(workspace, source2));
+        assertEquals(workspace2, SingleFileOptionsQueryImpl.findWorkspaceFolder(workspace, source2.getParent()));
+        assertEquals(workspace2, SingleFileOptionsQueryImpl.findWorkspaceFolder(workspace, source2.getParent().getParent()));
+    }
+
+    public void testWorkspaceOptions() throws Exception {
+        FileObject wd = FileUtil.toFileObject(getWorkDir());
+        FileObject workspace1 = FileUtil.createFolder(wd, "workspace1");
+        FileObject source1 = FileUtil.createData(workspace1, "test1/Test.java");
+        FileObject workspace2 = FileUtil.createFolder(wd, "workspace2");
+        FileObject source2 = FileUtil.createData(workspace2, "test2/Test.java");
+        FileObject source3 = FileUtil.createData(wd, "test3/Test.java");
+
+        SingleFileOptionsQueryImpl query = new SingleFileOptionsQueryImpl() {};
+        Workspace workspace = new WorkspaceImpl(Arrays.asList(workspace1, workspace2));
+
+        query.setConfiguration(workspace, "-Dtest=test", null);
+
+        Lookups.executeWith(new ProxyLookup(Lookups.fixed(workspace), Lookup.getDefault()), () -> {
+            assertEquals("-Dtest=test", query.optionsFor(source1).getOptions());
+            assertEquals(workspace1.toURI(), query.optionsFor(source1).getWorkDirectory());
+            assertEquals("-Dtest=test", query.optionsFor(source1.getParent()).getOptions());
+            assertEquals(workspace1.toURI(), query.optionsFor(source1.getParent()).getWorkDirectory());
+
+            assertEquals("-Dtest=test", query.optionsFor(source2).getOptions());
+            assertEquals(workspace2.toURI(), query.optionsFor(source2).getWorkDirectory());
+            assertEquals("-Dtest=test", query.optionsFor(source2.getParent()).getOptions());
+            assertEquals(workspace2.toURI(), query.optionsFor(source2.getParent()).getWorkDirectory());
+
+            AtomicInteger changeCount = new AtomicInteger();
+
+            query.optionsFor(source1).addChangeListener(evt -> changeCount.incrementAndGet());
+
+            query.setConfiguration(workspace, "-Dtest=test", null);
+
+            assertEquals(0, changeCount.get());
+
+            FileObject newWD = source1.getParent();
+
+            query.setConfiguration(workspace, "-Dtest=test", FileUtil.toFile(newWD).getAbsolutePath());
+
+            assertEquals(1, changeCount.get());
+
+            assertEquals("-Dtest=test", query.optionsFor(source1).getOptions());
+            assertEquals(newWD.toURI(), query.optionsFor(source1).getWorkDirectory());
+            assertEquals("-Dtest=test", query.optionsFor(source1.getParent()).getOptions());
+            assertEquals(newWD.toURI(), query.optionsFor(source1.getParent()).getWorkDirectory());
+
+            assertEquals("-Dtest=test", query.optionsFor(source2).getOptions());
+            assertEquals(newWD.toURI(), query.optionsFor(source2).getWorkDirectory());
+            assertEquals("-Dtest=test", query.optionsFor(source2.getParent()).getOptions());
+            assertEquals(newWD.toURI(), query.optionsFor(source2.getParent()).getWorkDirectory());
+
+            query.setConfiguration(workspace, "-Dtest=test2", FileUtil.toFile(newWD).getAbsolutePath());
+
+            assertEquals(2, changeCount.get());
+
+            assertEquals("-Dtest=test2", query.optionsFor(source1).getOptions());
+            assertEquals(newWD.toURI(), query.optionsFor(source1).getWorkDirectory());
+            assertEquals("-Dtest=test2", query.optionsFor(source1.getParent()).getOptions());
+            assertEquals(newWD.toURI(), query.optionsFor(source1.getParent()).getWorkDirectory());
+
+            assertEquals("-Dtest=test2", query.optionsFor(source2).getOptions());
+            assertEquals(newWD.toURI(), query.optionsFor(source2).getWorkDirectory());
+            assertEquals("-Dtest=test2", query.optionsFor(source2.getParent()).getOptions());
+            assertEquals(newWD.toURI(), query.optionsFor(source2.getParent()).getWorkDirectory());
+
+            query.setConfiguration(workspace, "-Dtest=test2", null);
+
+            assertEquals(3, changeCount.get());
+
+            assertEquals("-Dtest=test2", query.optionsFor(source1).getOptions());
+            assertEquals(workspace1.toURI(), query.optionsFor(source1).getWorkDirectory());
+            assertEquals("-Dtest=test2", query.optionsFor(source1.getParent()).getOptions());
+            assertEquals(workspace1.toURI(), query.optionsFor(source1.getParent()).getWorkDirectory());
+
+            assertEquals("-Dtest=test2", query.optionsFor(source2).getOptions());
+            assertEquals(workspace2.toURI(), query.optionsFor(source2).getWorkDirectory());
+            assertEquals("-Dtest=test2", query.optionsFor(source2.getParent()).getOptions());
+            assertEquals(workspace2.toURI(), query.optionsFor(source2.getParent()).getWorkDirectory());
+        });
+
+
+        //with no workspace context:
+        assertEquals("-Dtest=test2", query.optionsFor(source1).getOptions());
+        assertEquals(workspace1.toURI(), query.optionsFor(source1).getWorkDirectory());
+        assertEquals("-Dtest=test2", query.optionsFor(source1.getParent()).getOptions());
+        assertEquals(workspace1.toURI(), query.optionsFor(source1.getParent()).getWorkDirectory());
+
+        assertEquals("-Dtest=test2", query.optionsFor(source2).getOptions());
+        assertEquals(workspace2.toURI(), query.optionsFor(source2).getWorkDirectory());
+        assertEquals("-Dtest=test2", query.optionsFor(source2.getParent()).getOptions());
+        assertEquals(workspace2.toURI(), query.optionsFor(source2.getParent()).getWorkDirectory());
+
+        assertNull(query.optionsFor(source3));
+        assertNull(query.optionsFor(source3.getParent()));
+    }
+
+    private static final class WorkspaceImpl implements Workspace {
+        private final List<FileObject> workspaceFolders;
+
+        public WorkspaceImpl(List<FileObject> workspaceFolders) {
+            this.workspaceFolders = workspaceFolders;
+        }
+
+        @Override
+        public List<FileObject> getClientWorkspaceFolders() {
+            return workspaceFolders;
+        }
+
+    }
+}

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -1071,7 +1071,8 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
                 'netbeans.hints',
                 'netbeans.format',
                 'netbeans.java.imports',
-                'java+.runConfig.vmOptions'
+                'java+.runConfig.vmOptions',
+                'java+.runConfig.cwd'
             ],
             fileEvents: [
                 workspace.createFileSystemWatcher('**/*.java')

--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/APTUtils.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/APTUtils.java
@@ -135,9 +135,6 @@ public class APTUtils implements ChangeListener, PropertyChangeListener {
         this.root = root;
         bootPath = ClassPath.getClassPath(root, ClassPath.BOOT);
         compilePath = ClassPath.getClassPath(root, ClassPath.COMPILE);
-        if (compilePath != null) {
-            compilePath.addPropertyChangeListener(this);
-        }
         processorPath = new AtomicReference<>(ClassPath.getClassPath(root, JavaClassPathConstants.PROCESSOR_PATH));
         processorModulePath = new AtomicReference<>(ClassPath.getClassPath(root, JavaClassPathConstants.MODULE_PROCESSOR_PATH));
         aptOptions = AnnotationProcessingQuery.getAnnotationProcessingOptions(root);
@@ -150,6 +147,9 @@ public class APTUtils implements ChangeListener, PropertyChangeListener {
                     false);
         });
         usedRoots = new UsedRoots(root.toURL());
+        if (compilePath != null) {
+            compilePath.addPropertyChangeListener(this);
+        }
     }
 
     @CheckForNull


### PR DESCRIPTION
The VS Code extension supports the (multi-)source file launcher using the RUN CONFIGURATION explorer tab. One can specify the command line options, which are then used when starting a file in the workspace.

There are a few problems with that:
- options like `-classpath` could contain relative paths, but NB will not resolve them
- the default working directory is weird - it is the directory in which the file-to-run resides. That made sense for single-source launcher, but not anymore. And while runtime will resolve relative paths, it will resolve them to this weird working directory
- for `--module-path`, the elements specified may be modules, or a directory, which contains the modules. But NB will only see module path which contains modules, and will not resolve modules inside the specified directory

This patch:
- when needed, computes "relevant" default working directory for files - it is a) the workspace folder that encloses the given file (which should be the common case), or, if that fails to find a workspace folder b) the workspace folder that is enclosed by the file's source root (for the case where the user opens just a part of the source root)
- this relevant default working directory is then used as the working directory, unless overridden by the user
- the working directory (either computed as above, or explicit) is used the base to resolve relative paths
- when a module path contains a directory which does not contain `module-info.class`, it is interpreted as a directory consisting of a collection of modules, and will expand the module path to include these modules. This includes listening on the directory content, and updates to the module path when the content changes
