### PR TITLE
Fix usage of ToggleBookmarkAction in split windows scenario

### DIFF
--- a/ide/editor.bookmarks/src/org/netbeans/lib/editor/bookmarks/actions/ToggleBookmarkAction.java
+++ b/ide/editor.bookmarks/src/org/netbeans/lib/editor/bookmarks/actions/ToggleBookmarkAction.java
@@ -19,38 +19,18 @@
 
 package org.netbeans.lib.editor.bookmarks.actions;
 
-import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-import java.lang.ref.Reference;
-import java.lang.ref.WeakReference;
-import javax.swing.AbstractAction;
-import javax.swing.AbstractButton;
-import javax.swing.Action;
-import javax.swing.ButtonModel;
-import javax.swing.JButton;
-import javax.swing.JToggleButton;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-import javax.swing.text.BadLocationException;
 import javax.swing.text.Caret;
-import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 import org.netbeans.api.editor.EditorRegistry;
-import org.netbeans.editor.BaseDocument;
-import org.netbeans.lib.editor.bookmarks.api.Bookmark;
+import org.netbeans.editor.BaseAction;
 import org.netbeans.lib.editor.bookmarks.api.BookmarkList;
 import org.openide.awt.Actions;
 import org.openide.cookies.EditorCookie;
 import org.openide.text.NbDocument;
-import org.openide.util.ContextAwareAction;
-import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
-import org.openide.util.Utilities;
-import org.openide.util.WeakListeners;
-import org.openide.util.actions.Presenter;
 
 
 /**
@@ -58,91 +38,30 @@ import org.openide.util.actions.Presenter;
  *
  * @author Vita Stejskal
  */
-public final class ToggleBookmarkAction extends AbstractAction implements ContextAwareAction, Presenter.Toolbar {
+public final class ToggleBookmarkAction extends BaseAction {
 
     private static final String ACTION_NAME = "bookmark-toggle"; // NOI18N
     private static final String ACTION_ICON = "org/netbeans/modules/editor/bookmarks/resources/toggle_bookmark.png"; // NOI18N
-        
-    private final JTextComponent component;
-    
-    public ToggleBookmarkAction() {
-        this(null);
-    }
 
-    public ToggleBookmarkAction(JTextComponent component) {
-        super(
-            NbBundle.getMessage(ToggleBookmarkAction.class, ACTION_NAME),ImageUtilities.loadImageIcon(ACTION_ICON, false));
+    public ToggleBookmarkAction() {
+        super(NbBundle.getMessage(ToggleBookmarkAction.class, ACTION_NAME));
+        putValue(ICON_RESOURCE_PROPERTY, ACTION_ICON);
         putValue(SHORT_DESCRIPTION, Actions.cutAmpersand((String) getValue(NAME)));
         putValue("noIconInMenu", Boolean.TRUE); // NOI18N
-        
-        this.component = component;
+
         updateEnabled();
-        PropertyChangeListener editorRegistryListener = new EditorRegistryListener(this);
-        EditorRegistry.addPropertyChangeListener(editorRegistryListener);
+        EditorRegistry.addPropertyChangeListener((PropertyChangeEvent evt) -> {
+            updateEnabled();
+        });
+
     }
 
     private void updateEnabled() {
-        setEnabled(isEnabled());
+        setEnabled(EditorRegistry.lastFocusedComponent() != null);
     }
 
     @Override
-    public Action createContextAwareInstance(Lookup actionContext) {
-        JTextComponent jtc = findComponent(actionContext);
-        ToggleBookmarkAction toggleBookmarkAction = new ToggleBookmarkAction(jtc);
-        toggleBookmarkAction.putValue(ACCELERATOR_KEY, this.getValue(ACCELERATOR_KEY));
-        return toggleBookmarkAction;
-    }
-
-    @Override
-    public void actionPerformed(ActionEvent arg0) {
-        if (component != null) {
-            // cloned action with context
-            actionPerformed(component);
-        } else {
-            // global action, will have to find the current component
-            JTextComponent jtc = findComponent(Utilities.actionsGlobalContext());
-            if (jtc != null) {
-                actionPerformed(jtc);
-            }
-        }
-    }
-
-    @Override
-    public boolean isEnabled() {
-        if (component != null) {
-            return true;
-        } else {
-            if (EditorRegistry.lastFocusedComponent() == null) {
-                return false;
-            } else {
-                return true;
-            }
-        }
-    }
-
-    @Override
-    public Component getToolbarPresenter() {
-        AbstractButton b;
-        
-        if (component != null) {
-            b = new MyGaGaButton();
-            b.setModel(new BookmarkButtonModel(component));
-        } else {
-            b = new JButton();
-        }
-        
-        b.putClientProperty("hideActionText", Boolean.TRUE); //NOI18N
-        b.setAction(this);
-        
-        return b;
-    }
-
-    public static JTextComponent findComponent(Lookup lookup) {
-        EditorCookie ec = lookup.lookup(EditorCookie.class);
-        return ec == null ? null : NbDocument.findRecentEditorPane(ec);
-    }
-    
-    private static void actionPerformed(JTextComponent target) {
+    public void actionPerformed(ActionEvent arg0, JTextComponent target) {
         if (target != null) {
             if (org.netbeans.editor.Utilities.getEditorUI(target).isGlyphGutterVisible()) {
                 Caret caret = target.getCaret();
@@ -154,170 +73,10 @@ public final class ToggleBookmarkAction extends AbstractAction implements Contex
             }
         }
     }
-    
-    private static final class BookmarkButtonModel extends JToggleButton.ToggleButtonModel implements PropertyChangeListener, ChangeListener {
-        
-        private final JTextComponent component;
-        private Caret caret;
-        private BookmarkList bookmarks;
-        private int lastCurrentLineStartOffset = -1;
-        
-        private PropertyChangeListener bookmarksListener = null;
-        private ChangeListener caretListener = null;
-        
-        @SuppressWarnings("LeakingThisInConstructor")
-        public BookmarkButtonModel(JTextComponent component) {
-            this.component = component;
-            this.component.addPropertyChangeListener(WeakListeners.propertyChange(this, this.component));
-            rebuild();
-        }
 
-        @Override
-        public void propertyChange(PropertyChangeEvent evt) {
-            if (evt.getPropertyName() == null || 
-                "document".equals(evt.getPropertyName()) || //NOI18N
-                "caret".equals(evt.getPropertyName()) //NOI18N
-            ) {
-                rebuild();
-            } else if ("bookmarks".equals(evt.getPropertyName())) { //NOI18N
-                lastCurrentLineStartOffset = -1;
-                updateState();
-            }
-        }
-
-        @Override
-        public void stateChanged(ChangeEvent evt) {
-            updateState();
-        }
-
-        private static boolean isBookmarkOnTheLine(BookmarkList bookmarks, int lineStartOffset) {
-            Bookmark bm = bookmarks.getNextBookmark(lineStartOffset - 1, false);
-//            System.out.println("offset: " + lineStartOffset + " -> " + bm + (bm == null ? "" : "; bm.getOffset() = " + bm.getOffset()));
-            return bm == null ? false : lineStartOffset == bm.getOffset();
-        }
-        
-        private void rebuild() {
-            // Hookup the bookmark list
-            BookmarkList newBookmarks = BookmarkList.get(component.getDocument());
-            if (newBookmarks != bookmarks) {
-                if (bookmarksListener != null) {
-                    bookmarks.removePropertyChangeListener (bookmarksListener);
-                    bookmarksListener = null;
-                }
-
-                bookmarks = newBookmarks;
-
-                if (bookmarks != null) {
-                    bookmarksListener = WeakListeners.propertyChange(this, bookmarks);
-                    bookmarks.addPropertyChangeListener (bookmarksListener);
-                }
-            }
-            
-            // Hookup the caret
-            Caret newCaret = component.getCaret();
-            if (newCaret != caret) {
-                if (caretListener != null) {
-                    caret.removeChangeListener(caretListener);
-                    caretListener = null;
-                }
-
-                caret = newCaret;
-
-                if (caret != null) {
-                    caretListener = WeakListeners.change(this, caret);
-                    caret.addChangeListener(caretListener);
-                }
-            }
-            
-            lastCurrentLineStartOffset = -1;
-            updateState();
-        }
-        
-        private void updateState() {
-            Document doc = component.getDocument();
-            if (caret != null && bookmarks != null && doc instanceof BaseDocument) {
-                try {
-                    int currentLineStartOffset = org.netbeans.editor.Utilities.getRowStart((BaseDocument) doc, caret.getDot());
-                    if (currentLineStartOffset != lastCurrentLineStartOffset) {
-                        lastCurrentLineStartOffset = currentLineStartOffset;
-                        boolean selected = isBookmarkOnTheLine(bookmarks, currentLineStartOffset);
-                        
-//                        System.out.println("updateState: offset=" + currentLineStartOffset + ", hasBookmark=" + selected);
-                        
-                        setSelected(selected);
-                    }
-                } catch (BadLocationException e) {
-                    // ignore
-                    lastCurrentLineStartOffset = -1;
-                }
-            }
-        }
-    } // End of BookmarkButtonModel class
-    
-    private static final class MyGaGaButton extends JToggleButton implements ChangeListener {
-
-        public MyGaGaButton() {
-
-        }
-
-        @Override
-        public void setModel(ButtonModel model) {
-            ButtonModel oldModel = getModel();
-            if (oldModel != null) {
-                oldModel.removeChangeListener(this);
-            }
-
-            super.setModel(model);
-
-            ButtonModel newModel = getModel();
-            if (newModel != null) {
-                newModel.addChangeListener(this);
-            }
-
-            stateChanged(null);
-        }
-
-        @Override
-        public void stateChanged(ChangeEvent evt) {
-            boolean selected = isSelected();
-            super.setContentAreaFilled(selected);
-            super.setBorderPainted(selected);
-        }
-
-        @Override
-        public void setBorderPainted(boolean arg0) {
-            if (!isSelected()) {
-                super.setBorderPainted(arg0);
-            }
-        }
-
-        @Override
-        public void setContentAreaFilled(boolean arg0) {
-            if (!isSelected()) {
-                super.setContentAreaFilled(arg0);
-            }
-        }
-    } // End of MyGaGaButton class
-
-    private static final class EditorRegistryListener implements PropertyChangeListener {
-        
-        private final Reference<ToggleBookmarkAction> actionRef;
-        
-        EditorRegistryListener(ToggleBookmarkAction action) {
-            actionRef = new WeakReference<ToggleBookmarkAction>(action);
-        }
-        
-        @Override
-        public void propertyChange(PropertyChangeEvent evt) {
-            ToggleBookmarkAction action = actionRef.get();
-            if (action != null) {
-                action.updateEnabled();
-            } else {
-                EditorRegistry.removePropertyChangeListener(this); // EditorRegistry fires frequently so remove this way
-            }
-        }
-
+    public static JTextComponent findComponent(Lookup lookup) {
+        EditorCookie ec = lookup.lookup(EditorCookie.class);
+        return ec == null ? null : NbDocument.findRecentEditorPane(ec);
     }
 
 }
-


### PR DESCRIPTION
It was observed, that the "Goto Bookmark" actions cause the goto action in the correct window (the focused one or the one the toolbar is located in), while the "Toogle Bookmark" action invokes the action for the first editor window.

The implementation of the ToggleBookmarkAction implies that the button should reflect whether or not there s a bookmark on the current line (rendering the button active/pressed when there is a bookmark). It was observered, that this does not work.

So instead of fixing the complex implementation, the implementation for ToggleBookmarkAction was aligned with the "GotoBookmarkAction", inheriting the "find the right text component" behavior from BaseAction.

Closes: #4155