### PR TITLE
Allow focus events to propagate before running glyph gutter actions - GH4155

### DIFF
--- a/ide/editor.lib/src/org/netbeans/editor/GlyphGutter.java
+++ b/ide/editor.lib/src/org/netbeans/editor/GlyphGutter.java
@@ -25,6 +25,7 @@ import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.awt.Graphics;
 import java.awt.Color;
+import java.awt.EventQueue;
 import java.awt.Font;
 import java.awt.Image;
 import java.awt.Toolkit;
@@ -858,11 +859,26 @@ public class GlyphGutter extends JComponent implements Annotations.AnnotationsLi
         /** end line of the dragging. */
         private int dragEndOffset;
 
-        public @Override void mouseClicked(MouseEvent e) {
+        @Override
+        public void mouseClicked(MouseEvent e) {
+            EditorUI eui = editorUI;
+            if (eui == null) {
+                return;
+            }
+            JTextComponent cmp = eui.getComponent();
+            if (cmp.hasFocus()) {
+                handleMouseClicked(e);
+            } else {
+                cmp.requestFocusInWindow();
+                // allow focus events to propagate
+                EventQueue.invokeLater(() -> handleMouseClicked(e));
+            }
+        }
+
+        private void handleMouseClicked(MouseEvent e) {
             EditorUI eui = editorUI;
             if (eui==null)
                 return;
-            eui.getComponent().requestFocus();
             // cycling button was clicked by left mouse button
             if (e.getModifiers() == InputEvent.BUTTON1_MASK) {
                 if (isMouseOverCycleButton(e)) {


### PR DESCRIPTION
As reported in #4155 breakpoints are added at the wrong point when clicking on the glyph gutter of an unfocused editor split.  The glyph gutter mouse listener attempts to focus the editor component, but the focus change events are queued causing `EditorContextDispatcher` to report the wrong focused component.

Attempt to fix by checking if the component has the focus, and if not queuing up the event handling to run after the focus events. 