### PR TITLE
Fix Exception template to extend from Exception

### DIFF
--- a/java/java.project.ui/src/org/netbeans/modules/java/project/ui/resources/Exception.java.template
+++ b/java/java.project.ui/src/org/netbeans/modules/java/project/ui/resources/Exception.java.template
@@ -33,7 +33,7 @@ import ${interface};
     </#list>
     <#assign implementation = "${implementation}"?remove_ending(", ")>
 </#if>
-public class ${name}<#if extension?? && extension != ""> extends ${extension}</#if><#if implementation?? && implementation != ""> implements ${implementation}</#if> {
+public class ${name}<#if extension?? && extension != ""> extends ${extension}<#else> extends Exception</#if><#if implementation?? && implementation != ""> implements ${implementation}</#if> {
 
     /**
      * Creates a new instance of <code>${name}</code> without detail message.


### PR DESCRIPTION
Fix Exception template to extend from Exception when no superclass specified in wizard.  It's a minor annoyance but odd to have a built-in template create uncompilable code by default.

Theoretically this is a regression, although it seems to have been there since this was last updated for NB 12.3 in #2275 !
