### PR TITLE
Stack trace parser fixes

### DIFF
--- a/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyser.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyser.java
@@ -53,14 +53,14 @@ class StackLineAnalyser {
     private static final RequestProcessor RP = new RequestProcessor(StackLineAnalyser.class);
 
     private static final String IDENTIFIER =
-        "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*";    // NOI18N
+        "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*";
     private static final Pattern LINE_PATTERN = Pattern.compile(
-        "at\\s+" +                                       //  initial at // NOI18N
-        "("+IDENTIFIER+"(?:\\."+IDENTIFIER+")*/)?" + // optional module name // NOI18N
-        "(("+IDENTIFIER+"(\\."+IDENTIFIER+")*)\\.)?("+IDENTIFIER+")" + // class name // NOI18N
-        "\\.("+IDENTIFIER+"|\\<init\\>|\\<clinit\\>)\\s*"+ // method name
-        "\\((?:"+IDENTIFIER+"(?:\\."+IDENTIFIER+")*/)?"+IDENTIFIER+"(\\.(?:\\p{javaJavaIdentifierPart}+))?"+ // '(File.java' // NOI18N
-        "\\:([0-9]*)\\)");                              // ':123)' // NOI18N
+        "at\\s+" +                                                      // initial 'at'
+        "("+IDENTIFIER+"\\S*/)?" +                                      // optional module name like 'java.base/' or 'Mavenproject1@0.1-SNAPSHOT/'
+        "(("+IDENTIFIER+"(\\."+IDENTIFIER+")*)\\.)?("+IDENTIFIER+")" +  // class name
+        "\\.("+IDENTIFIER+"|\\<init\\>|\\<clinit\\>)\\s*"+              // method name
+        "\\((?:"+IDENTIFIER+"(?:\\."+IDENTIFIER+")*/)?"+IDENTIFIER+"(\\.(?:\\p{javaJavaIdentifierPart}+))?"+ // '(File.java'
+        "\\:([0-9]*)\\)");                                              // ':123)'
 
     static boolean matches(String line) {
         Matcher matcher = LINE_PATTERN.matcher(line);

--- a/java/java.navigation/test/unit/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyserTest.java
+++ b/java/java.navigation/test/unit/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyserTest.java
@@ -48,6 +48,10 @@ public class StackLineAnalyserTest extends NbTestCase {
         assertTrue(StackLineAnalyser.matches("             [exec]     at org.openide.filesystems.FileUtil.normalizeFileOnMac(FileUtil.java:1714)"));
         assertTrue(StackLineAnalyser.matches("at java.base/java.lang.String.lastIndexOf(String.java:1627)"));
         assertTrue(StackLineAnalyser.matches(" at java.base/java.lang.String.lastIndexOf(String.java:1627)"));
+        // surefire + module info in src and test sources
+        assertTrue(StackLineAnalyser.matches("	at Mavenproject1/dev.mbien.mavenproject1.Mavenproject1.foo(Mavenproject1.java:15)"));
+        // surefire + module info in src but _no_ module info for test sources
+        assertTrue(StackLineAnalyser.matches("	at Mavenproject1@0.1-SNAPSHOT/dev.mbien.mavenproject1.Mavenproject1.foo(Mavenproject1.java:11)"));
         // some loggers (e.g. MavenSimpleLogger until MNG-7970/#1342 which is maven's default logger) seem to add a space before the '('
         assertTrue(StackLineAnalyser.matches("    at java.util.zip.ZipFile$CleanableResource.<init> (ZipFile.java:742)"));
     }

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/api/output/OutputUtilsTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/api/output/OutputUtilsTest.java
@@ -19,6 +19,8 @@
 package org.netbeans.modules.maven.api.output;
 
 import org.junit.Test;
+import org.netbeans.modules.maven.api.output.OutputUtils.StacktraceAttributes;
+
 import static org.junit.Assert.*;
 
 /**
@@ -28,14 +30,41 @@ import static org.junit.Assert.*;
 public class OutputUtilsTest {
 
     @Test
-    public void testStackTraceLinePattern() {
-        assertTrue(isStackTraceLine("\tat x.y.Test.z(Test.java:123)"));
-        assertTrue(isStackTraceLine("\tat x.y.Test.native(Native Method)"));
-        assertTrue(isStackTraceLine("[catch]\tat x.y.z.Test.z(Test.java:789)"));
-        assertFalse(isStackTraceLine("\tat some.other.line(Example)"));
+    public void testStackTraceLine1() {
+        checkStackTraceLineAttributes("\tat x.y.Test.z(Test.java:123)", "x.y.Test.z", "Test", "123");
     }
 
-    private boolean isStackTraceLine(String line) {
-        return OutputUtils.linePattern.matcher(line).find();
+    @Test
+    public void testStackTraceLine2() {
+        checkStackTraceLineAttributes("[catch]\tat x.y.z.Test.z(Test.java:789)", "x.y.z.Test.z", "Test", "789");
     }
+
+    @Test
+    public void testStackTraceLine3() {
+        checkStackTraceLineAttributes(" at Mavenproject1@0.1-SNAPSHOT/dev.mbien.mavenproject1.Mavenproject1.foo(Mavenproject1.java:11)",
+                "Mavenproject1@0.1-SNAPSHOT/dev.mbien.mavenproject1.Mavenproject1.foo", "Mavenproject1", "11");
+    }
+
+    @Test
+    public void testStackTraceLineWithNoLinkAttributes1() {
+        checkNoStackTraceLineAttributes("\tat some.other.line(Example)");
+    }
+
+    @Test
+    public void testStackTraceLineWithNoLinkAttributes2() {
+        checkNoStackTraceLineAttributes("\tat x.y.Test.native(Native Method)");
+    }
+
+    private static void checkStackTraceLineAttributes(String line, String method, String file, String lineNum) {
+        StacktraceAttributes attribs = OutputUtils.matchStackTraceLine(line);
+        assertNotNull(attribs);
+        assertEquals(method, attribs.method);
+        assertEquals(file, attribs.file);
+        assertEquals(lineNum, attribs.lineNum);
+    }
+    
+    private static void checkNoStackTraceLineAttributes(String line) {
+        assertNull(OutputUtils.matchStackTraceLine(line));
+    } 
+    
 }


### PR DESCRIPTION
Stack trace analyzer window:

 - module name part can go beyond java identifiers it seems

Maven stack trace output line matcher:

 - add compile class path to hyperlink logic in case the resource isn't in exec class path for some reason
 - other minor fixes

fixes #7385