### PR TITLE
Minor action items window fixes

### DIFF
--- a/ide/csl.api/src/org/netbeans/modules/csl/core/TasklistStateBackdoor.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/core/TasklistStateBackdoor.java
@@ -19,8 +19,6 @@
 
 package org.netbeans.modules.csl.core;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.netbeans.modules.parsing.api.indexing.IndexingManager;
 import org.netbeans.spi.tasklist.PushTaskScanner;
 import org.netbeans.spi.tasklist.TaskScanningScope;
@@ -37,8 +35,8 @@ import static org.netbeans.modules.csl.core.Bundle.*;
  * @author sdedic
  */
 @NbBundle.Messages({
-    "DN_tlIndexerName=Hints-based tasks",
-    "DESC_tlIndexerName=Tasks provided by language hints"
+    "DN_tlIndexerName=CSL Hints-based tasks",
+    "DESC_tlIndexerName=Common-Scripting-Language Tasks provided by language hints"
 })
 class TasklistStateBackdoor extends PushTaskScanner {
     private static final TasklistStateBackdoor INSTANCE = new TasklistStateBackdoor();

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/Bundle.properties
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/Bundle.properties
@@ -17,5 +17,5 @@
 # under the License.
 #
 
-LBL_ProviderName=Compiler Errors
-LBL_ProviderDescription=Compiler errors and warnings
+LBL_ProviderName=Errors and Warnings
+LBL_ProviderDescription=Errors and Warnings from parsers, compilers or annotation processors

--- a/ide/tasklist.todo/src/org/netbeans/modules/tasklist/todo/SourceCodeCommentParser.java
+++ b/ide/tasklist.todo/src/org/netbeans/modules/tasklist/todo/SourceCodeCommentParser.java
@@ -131,7 +131,7 @@ final class SourceCodeCommentParser {
          * @param buf destination buffer
          * @param str the string to append
          */
-        protected void appendEncodedChars(StringBuffer buf, String str) {
+        protected void appendEncodedChars(StringBuilder buf, String str) {
             int len = str.length();
             
             for (int ii = 0; ii < len; ++ii) {
@@ -190,11 +190,11 @@ final class SourceCodeCommentParser {
             this.blockStart = blockStart;
             this.blockEnd = blockEnd;
 
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             
             boolean needor = false;
 
-            if (lineComment != null) {
+            if (lineComment != null && !lineComment.isEmpty()) {
                 appendEncodedChars(sb, lineComment);
                 needor = true;
             }
@@ -217,6 +217,7 @@ final class SourceCodeCommentParser {
          * @throws java.io.IOException if a read error occurs on the input
          *         stream.
          */
+        @Override
         public boolean nextRegion(CommentRegion reg) throws IOException {
             boolean ret = false;
             

--- a/ide/tasklist.todo/src/org/netbeans/modules/tasklist/todo/TodoTaskScanner.java
+++ b/ide/tasklist.todo/src/org/netbeans/modules/tasklist/todo/TodoTaskScanner.java
@@ -72,6 +72,7 @@ public class TodoTaskScanner extends FileTaskScanner implements PropertyChangeLi
                 NbBundle.getBundle( TodoTaskScanner.class ).getString( "HINT_todotask" ) ); //NOI18N
     }
 
+    @Override
     public List<? extends Task> scan( FileObject resource ) {
         if( !isSupported( resource ) )
             return null;
@@ -277,7 +278,7 @@ public class TodoTaskScanner extends FileTaskScanner implements PropertyChangeLi
     Pattern getScanRegexp() {
         // Create regexp from tags
         if (regexp == null) {
-            StringBuffer sb = new StringBuffer(200);
+            StringBuilder sb = new StringBuilder(200);
             Collection<String> patterns = Settings.getDefault().getPatterns();
             boolean needSeparator = false;
             for( String s : patterns ) {
@@ -344,7 +345,7 @@ public class TodoTaskScanner extends FileTaskScanner implements PropertyChangeLi
         if( null == input )
             return "";
         char[] buf = new char[1024*64];
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         Charset charset = FileEncodingQuery.getEncoding( fileObject );
         Reader r = new BufferedReader( new InputStreamReader( input, charset ) );
         int len;
@@ -369,6 +370,7 @@ public class TodoTaskScanner extends FileTaskScanner implements PropertyChangeLi
         return res;
     }
 
+    @Override
     public void attach( Callback callback ) {
         if( null == callback && null != this.callback ) {
             regexp = null;
@@ -379,6 +381,7 @@ public class TodoTaskScanner extends FileTaskScanner implements PropertyChangeLi
         this.callback = callback;
     }
 
+    @Override
     public void propertyChange( PropertyChangeEvent e ) {
         if( Settings.PROP_PATTERN_LIST.equals( e.getPropertyName() )
          || Settings.PROP_SCAN_COMMENTS_ONLY.equals( e.getPropertyName() )


### PR DESCRIPTION
 - fixed the hardcoded javac warnings filter (error key changed)
 - updated the "Errors" scanner description to be more correct
 - fixed the TODO scanner which didn't work if the "lineComment" field was empty (default for html, xml etc)

it isn't obvious (e.g https://github.com/apache/netbeans/issues/4790, ) that the "action items" (ctrl+6) window can't show java hints/inspections but only javac errors/warnings. This clarifies the labels a bit.