### PR TITLE
Don't fold empty arrays #7187

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/csl/FoldingScanner.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/csl/FoldingScanner.java
@@ -518,6 +518,10 @@ public final class FoldingScanner {
                 return;
             }
             super.visit(node);
+            if (node.getElements().isEmpty()) {
+                // GH-7187 don't fold an empty array
+                return;
+            }
             ArrayCreation.Type type = node.getType();
             if (type == ArrayCreation.Type.NEW) {
                 addFold(node, TYPE_ARRAY);

--- a/php/php.editor/test/unit/data/testfiles/foldingEmptyArrays.php.folds
+++ b/php/php.editor/test/unit/data/testfiles/foldingEmptyArrays.php.folds
@@ -1,0 +1,50 @@
+  <?php
++ /*
+|  * Licensed to the Apache Software Foundation (ASF) under one
+|  * or more contributor license agreements.  See the NOTICE file
+|  * distributed with this work for additional information
+|  * regarding copyright ownership.  The ASF licenses this file
+|  * to you under the Apache License, Version 2.0 (the
+|  * "License"); you may not use this file except in compliance
+|  * with the License.  You may obtain a copy of the License at
+|  *
+|  *   http://www.apache.org/licenses/LICENSE-2.0
+|  *
+|  * Unless required by applicable law or agreed to in writing,
+|  * software distributed under the License is distributed on an
+|  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+|  * KIND, either express or implied.  See the License for the
+|  * specific language governing permissions and limitations
+|  * under the License.
+-  */
+  
+  $new1 = []; // don't fold
++ $new2 = [
++     "not empty" => [1, 2],
+|     "empty" => [], // don't fold
+- ];
++ $new3 = [
+|     1,
+|     2,
+|     [], // don't fold
++     [1, 2, 3],
+- ];
++ $new4 = [1, 2];
++ $new5 = array_merge([], [1, 2]);
++ $new6 = ["a" => [1, 2], "b", "c" => []];
+  
+  $old1 = array(); // don't fold
++ $old2 = array(
++     "not empty" => array(1, 2),
+|     "empty" => array(), // don't fold
+- );
++ $old3 = array(
+|     1,
+|     2,
+|     array(), // don't fold
++     array(1, 2, 3),
+- );
++ $old4 = array(1, 2);
++ $old5 = array_merge(array(), array(1, 2));
++ $old6 = ["a" => array(1, 2), "b", "c" => array()];
+  

--- a/php/php.editor/test/unit/data/testfiles/parser/foldingEmptyArrays.php
+++ b/php/php.editor/test/unit/data/testfiles/parser/foldingEmptyArrays.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$new1 = []; // don't fold
+$new2 = [
+    "not empty" => [1, 2],
+    "empty" => [], // don't fold
+];
+$new3 = [
+    1,
+    2,
+    [], // don't fold
+    [1, 2, 3],
+];
+$new4 = [1, 2];
+$new5 = array_merge([], [1, 2]);
+$new6 = ["a" => [1, 2], "b", "c" => []];
+
+$old1 = array(); // don't fold
+$old2 = array(
+    "not empty" => array(1, 2),
+    "empty" => array(), // don't fold
+);
+$old3 = array(
+    1,
+    2,
+    array(), // don't fold
+    array(1, 2, 3),
+);
+$old4 = array(1, 2);
+$old5 = array_merge(array(), array(1, 2));
+$old6 = ["a" => array(1, 2), "b", "c" => array()];

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/FoldingTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/FoldingTest.java
@@ -83,6 +83,11 @@ public class FoldingTest extends PHPTestBase {
         checkFolds("testfiles/parser/foldingArrays.php");
     }
 
+    // GH-7187
+    public void testEmptyArrays() throws Exception {
+        checkFolds("testfiles/parser/foldingEmptyArrays.php");
+    }
+
     // #254432
     public void testUses() throws Exception {
         checkFolds("testfiles/parser/foldingUses.php");


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/7187
- Ignore empty arrays
- Add an unit test

Before:

![nb-php-gh-7187-before01](https://github.com/apache/netbeans/assets/738383/1b8e31a0-af11-4d3a-94fe-e7294e1da608)

![nb-php-gh-7187-before02](https://github.com/apache/netbeans/assets/738383/4128d068-ca69-4600-9a89-d00796144906)


After:

![nb-php-gh-7187-after01](https://github.com/apache/netbeans/assets/738383/d13cedb7-fa90-494c-bcf6-4f7e59b28748)

![nb-php-gh-7187-after02](https://github.com/apache/netbeans/assets/738383/b9eaebe9-829c-463d-a1b8-08c18b4a58d6)

