### PR TITLE
Restore maven archetypes for JavaEE 5 and J2EE 1.4 projects

### DIFF
--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/J2eeArchetypeFactory.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ui/wizard/archetype/J2eeArchetypeFactory.java
@@ -160,8 +160,8 @@ public final class J2eeArchetypeFactory {
             addJavaEE8Archetype(Profile.JAVA_EE_8_WEB,"mvn.archetypeGroupId.JavaEE8", "mvn.archetypeVersion.JavaEE8", "mvn.archetypeArtifactId.JavaEE8"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_7_WEB, "1.1", "webapp-javaee7"); //NOI18N
             addMojoArchetype(Profile.JAVA_EE_6_WEB, "1.5", "webapp-javaee6"); //NOI18N
-          //  addMojoArchetype(Profile.JAVA_EE_5, "1.3", "webapp-jee5"); //NOI18N
-          //  addMojoArchetype(Profile.J2EE_14, "1.3", "webapp-j2ee14"); //NOI18N
+            addMojoArchetype(Profile.JAVA_EE_5, "1.3", "webapp-jee5"); //NOI18N
+            addMojoArchetype(Profile.J2EE_14, "1.3", "webapp-j2ee14"); //NOI18N
 
             // This need to be here! It isn't one of an options when creating Web projects, but when creating Java EE projects
             // using Java EE 6 Full profile, then the same profile applies to Ejb, Web and Parent project creation - In that case


### PR DESCRIPTION
They were commented out when updating for JavaEE/JakartaEE 8 and it can't be reconstructed why.
As the author speculated, that this was an accident, revert it.

Closes: #3681 