### PR TITLE
JDK Configuration action for VS Code

### DIFF
--- a/java/java.lsp.server/vscode/package-lock.json
+++ b/java/java.lsp.server/vscode/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@vscode/debugadapter": "1.55.1",
 				"@vscode/webview-ui-toolkit": "^1.2.2",
+				"jdk-utils": "^0.4.4",
 				"jsonc-parser": "3.0.0",
 				"vscode-languageclient": "8.0.1"
 			},
@@ -1050,6 +1051,15 @@
 			"version": "2.0.0",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/jdk-utils": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/jdk-utils/-/jdk-utils-0.4.6.tgz",
+			"integrity": "sha512-J4eyuwm4Vdtfcbl/z+xZdQjiOEq3XXGM1fl8YAKZfiKD3FkgCjL5zEEtNVFimWECasFuDogoYTmzu9GlB7ZxGA==",
+			"license": "MIT",
+			"bin": {
+				"jdk-utils": "bin/cli.js"
+			}
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
@@ -2226,6 +2236,11 @@
 		"isexe": {
 			"version": "2.0.0",
 			"dev": true
+		},
+		"jdk-utils": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/jdk-utils/-/jdk-utils-0.4.6.tgz",
+			"integrity": "sha512-J4eyuwm4Vdtfcbl/z+xZdQjiOEq3XXGM1fl8YAKZfiKD3FkgCjL5zEEtNVFimWECasFuDogoYTmzu9GlB7ZxGA=="
 		},
 		"js-tokens": {
 			"version": "4.0.0",

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -640,6 +640,11 @@
 				"command": "nbls.open.test",
 				"title": "Go To Test/Tested class...",
 				"category": "Java"
+			},
+			{
+				"command": "nbls.jdk.configuration",
+				"title": "JDK Configuration",
+				"category": "Java"
 			}
 		],
 		"keybindings": [
@@ -1154,6 +1159,7 @@
 	"dependencies": {
 		"@vscode/debugadapter": "1.55.1",
 		"@vscode/webview-ui-toolkit": "^1.2.2",
+		"jdk-utils": "^0.4.4",
 		"jsonc-parser": "3.0.0",
 		"vscode-languageclient": "8.0.1"
 	},

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -60,6 +60,8 @@ import { initializeRunConfiguration, runConfigurationProvider, runConfigurationN
 import { dBConfigurationProvider, onDidTerminateSession } from './dbConfigurationProvider';
 import { InputStep, MultiStepInput } from './utils';
 import { PropertiesView } from './propertiesView/propertiesView';
+import * as configuration from './jdk/configuration';
+import * as jdk from './jdk/jdk';
 
 const API_VERSION : string = "1.0";
 export const COMMAND_PREFIX : string = "nbls";
@@ -780,6 +782,9 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
     context.subscriptions.push(workspace.registerTextDocumentContentProvider('nbjrt', archiveFileProvider));
 
     launchConfigurations.updateLaunchConfig();
+
+    configuration.initialize(context);
+    jdk.initialize(context);
 
     // register completions:
     launchConfigurations.registerCompletion(context);

--- a/java/java.lsp.server/vscode/src/jdk/configuration.ts
+++ b/java/java.lsp.server/vscode/src/jdk/configuration.ts
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as vscode from 'vscode';
+import * as os from 'os';
+import * as path from 'path';
+import { MultiStepInput } from '../utils';
+import * as settings from './settings';
+import * as jdk from './jdk';
+
+
+const ACTION_NAME = 'JDK Configuration';
+
+export function initialize(context: vscode.ExtensionContext) {
+    const COMMAND_JDK_CONFIGURATION = 'nbls.jdk.configuration';
+    context.subscriptions.push(vscode.commands.registerCommand(COMMAND_JDK_CONFIGURATION, () => {
+        configure();
+    }));
+}
+
+type FeatureItem = { label: string; description: string; detail: string, setting: settings.Setting };
+type JdkItem = { label: string; description: string; detail: string, jdk: jdk.Java };
+type ScopeItem = { label: string; description: string; scope: vscode.ConfigurationTarget };
+
+interface State {
+    allSettings: FeatureItem[];
+    selectedSettings: FeatureItem[];
+    allJdks: JdkItem[];
+    selectedJdk: JdkItem;
+    allScopes: ScopeItem[];
+    selectedScope: ScopeItem;
+}
+
+async function configure() {
+    const state: Partial<State> = {};
+    await MultiStepInput.run(input => selectFeatures(input, state));
+    if (state.selectedSettings && state.selectedJdk && state.selectedScope) {
+        const jdk = state.selectedJdk.jdk;
+        for (const selectedSetting of state.selectedSettings) {
+            await selectedSetting.setting.setJdk(jdk, state.selectedScope.scope);
+        }
+        const GRAALVM_EXTENSION_ID = 'oracle-labs-graalvm.graalvm';
+        const GRAALVM_SETTINGS_NAME = 'GraalVM Tools for Java';
+        if (vscode.extensions.getExtension(GRAALVM_EXTENSION_ID)) {
+            vscode.window.showWarningMessage(`The ${GRAALVM_SETTINGS_NAME} extension may conflict with the ${ACTION_NAME} action. Please consider uninstalling it.`, 'Got It');
+        }
+    }
+}
+
+function totalSteps(_state: Partial<State>): number {
+    return 3;
+}
+
+async function selectFeatures(input: MultiStepInput, state: Partial<State>) {
+    if (!state.allSettings) {
+        const settings = allSettings();
+        state.allSettings = settings[0];
+        state.selectedSettings = settings[1];
+    }
+    const selected: any = await input.showQuickPick({
+        title: `${ACTION_NAME}: Settings`,
+        step: 1,
+        totalSteps: totalSteps(state),
+        placeholder: 'Select features and settings for which JDK will be configured',
+        items: state.allSettings,
+        selectedItems: state.selectedSettings,
+        canSelectMany: true,
+        validate: () => Promise.resolve(undefined),
+        shouldResume: () => Promise.resolve(false)
+    });
+    if (selected?.length) {
+        state.selectedSettings = selected;
+        return (input: MultiStepInput) => selectJDK(input, state);
+    }
+    return;
+}
+
+function allSettings(): FeatureItem[][] {
+    const allSettings = [];
+    const selectedSettings = [];
+    const availableSettings = settings.getAvailable();
+    for (const setting of availableSettings) {
+        const current = setting.getCurrent();
+        const item = { label: setting.name, description: setting.getSetting(), detail: `$(coffee) Current: ${current || 'not defined'}`, setting: setting };
+        allSettings.push(item);
+        if (current || setting.configureIfNotDefined()) {
+            selectedSettings.push(item);
+        }
+    }
+    return [ allSettings, selectedSettings ];
+}
+
+async function selectJDK(input: MultiStepInput, state: Partial<State>): Promise<any | undefined> {
+    if (!state.allJdks) {
+        state.allJdks = await allJdks(state);
+    }
+    const selectCustom = { label: '$(folder-opened) Select Custom JDK...' };
+    const selected: any = await input.showQuickPick({
+        title: `${ACTION_NAME}: JDK`,
+        step: 2,
+        totalSteps: totalSteps(state),
+        placeholder: 'Select JDK',
+        items: [ selectCustom, ...state.allJdks ],
+        validate: () => Promise.resolve(undefined),
+        shouldResume: () => Promise.resolve(false)
+    });
+    if (selected?.length) {
+        if (selected[0] === selectCustom) {
+            const javaHome = state.allJdks?.[1]?.jdk?.javaHome;
+            const javaRoot = javaHome ? path.dirname(javaHome) : undefined;
+            const customJdk = await selectCustomJdk(javaRoot);
+            if (customJdk) {
+                await jdk.registerCustom(customJdk);
+                state.allJdks = await allJdks(state);
+                for (const jdkItem of state.allJdks) {
+                    if (jdkItem.jdk?.javaHome === customJdk.javaHome) {
+                        state.selectedJdk = jdkItem;
+                        break;
+                    }
+                }
+            } else {
+                return (input: MultiStepInput) => selectJDK(input, state);
+            }
+        } else if (selected[0].jdk) {
+            state.selectedJdk = selected[0];
+        }
+    }
+    return (input: MultiStepInput) => selectScope(input, state);
+}
+
+async function allJdks(state: Partial<State>): Promise<JdkItem[]> {
+    const knownJavas: jdk.Java[] = [];
+    for (const setting of state.allSettings || []) {
+        knownJavas.push(...setting.setting.getJavas());
+    }
+    const jdks = await jdk.findAll(knownJavas);
+    jdks.sort((jdk1, jdk2) => jdk1 > jdk2 ? -1 : 1);
+
+    const jdkItems = [];
+    const jdkItemsNi: JdkItem | { jdk?: jdk.Java, kind?: vscode.QuickPickItemKind }[] = [];
+    const jdkItemsWoNi: JdkItem | { jdk?: jdk.Java, kind?: vscode.QuickPickItemKind }[] = [];
+    for (const jdk of jdks) {
+        const jdkItem = { label: `$(coffee) ${jdk.name()}`, description: `${jdk.javaHome}`, jdk: jdk, kind: vscode.QuickPickItemKind.Default };
+        if (jdk.hasNativeImage()) {
+            jdkItemsNi.push(jdkItem);
+        } else {
+            jdkItemsWoNi.push(jdkItem);
+        }
+    }
+
+    if (jdkItemsNi.length) {
+        jdkItems.push({ label: 'With Native Image', kind: vscode.QuickPickItemKind.Separator });
+        jdkItems.push(...jdkItemsNi);
+    }
+
+    if (jdkItemsWoNi.length) {
+        jdkItems.push({ label: 'Without Native Image', kind: vscode.QuickPickItemKind.Separator });
+        jdkItems.push(...jdkItemsWoNi);
+    }
+    return jdkItems as JdkItem[];
+}
+
+async function selectCustomJdk(javaRoot?: string): Promise<jdk.Java | null | undefined> {
+    const selected = await vscode.window.showOpenDialog({
+        title: 'Select Custom JDK',
+        canSelectFiles: false,
+        canSelectFolders: true,
+        canSelectMany: false,
+        defaultUri: vscode.Uri.file(javaRoot || os.homedir()),
+        openLabel: 'Select'
+    });
+    if (selected?.length === 1) {
+        const selectedJavaHome = selected[0].fsPath;
+        const selectedJdk = new jdk.Java(selectedJavaHome);
+        if (selectedJdk.isJdk()) {
+            return selectedJdk;
+        } else {
+            vscode.window.showWarningMessage(`Not a valid JDK installation: ${selectedJavaHome}`);
+            return null;
+        }
+    }
+    return undefined;
+}
+
+async function selectScope(input: MultiStepInput, state: Partial<State>) {
+    if (!state.allScopes) {
+        state.allScopes = allScopes();
+    }
+    const selected: any = await input.showQuickPick({
+        title: `${ACTION_NAME}: Scope`,
+        step: 3,
+        totalSteps: totalSteps(state),
+        placeholder: 'Select configuration scope',
+        items: state.allScopes,
+        validate: () => Promise.resolve(undefined),
+        shouldResume: () => Promise.resolve(false)
+    });
+    if (selected?.length && selected[0].scope) {
+        state.selectedScope = selected[0];
+    }
+}
+
+function allScopes(): ScopeItem[] {
+    const allScopes = [];
+    allScopes.push({ label: 'User', description: 'JDK will be configured for all workspaces, may be overriden by Workspace configuration', scope: vscode.ConfigurationTarget.Global });
+    if (vscode.workspace.workspaceFolders) {
+        allScopes.push({ label: 'Workspace', description: 'JDK will be configured for the current workspace, overrides User configuration', scope: vscode.ConfigurationTarget.Workspace });
+    }
+    return allScopes;
+}

--- a/java/java.lsp.server/vscode/src/jdk/jdk.ts
+++ b/java/java.lsp.server/vscode/src/jdk/jdk.ts
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as jdkUtils from 'jdk-utils';
+
+
+const CUSTOM_JAVA_ROOTS_KEY = 'nbls.jdk.customJavaRoots';
+
+let storage: vscode.Memento;
+
+export function initialize(context: vscode.ExtensionContext) {
+    storage = context.globalState;
+}
+
+export class Java {
+
+    readonly javaHome: string;
+
+    constructor(javaHome: string) {
+        this.javaHome = javaHome;
+    }
+
+    name(): string {
+        let name = path.basename(this.javaHome);
+        if (isMac() && name === 'Home') {
+            const javaHome = path.resolve(this.javaHome, '..', '..');
+            name = path.basename(javaHome);
+        }
+        return name;
+    }
+
+    isJava(): boolean {
+        const java = path.join(this.javaHome, 'bin', isWindows() ? 'java.exe' : 'java');
+        return fs.existsSync(java);
+    }
+
+    isJdk(): boolean {
+        const javac = path.join(this.javaHome, 'bin', isWindows() ? 'javac.exe' : 'javac');
+        return this.isJava() && fs.existsSync(javac);
+    }
+
+    hasNativeImage(): boolean {
+        const ni = path.join(this.javaHome, 'bin', isWindows() ? 'native-image.cmd' : 'native-image');
+        return fs.existsSync(ni);
+    }
+
+    async getVersion(): Promise<{ java_version: string; major: number; } | undefined> {
+        const java = await jdkUtils.getRuntime(this.javaHome, { withVersion: true });
+        return java?.version;
+    }
+
+}
+
+export async function findAll(knownJavas?: Java[]): Promise<Java[]> {
+    const javaRoots: string[] = [];
+    function addJavaRoot(javaHome: string) {
+        let javaRoot = path.dirname(javaHome);
+        if (isMac() && path.basename(javaRoot) === 'Contents') {
+            javaHome = path.resolve(javaHome, '..', '..');
+            javaRoot = path.dirname(javaHome);
+        }
+        const normalizedJavaRoot = normalizePath(javaRoot);
+        if (!javaRoots.includes(normalizedJavaRoot)) {
+            javaRoots.push(normalizedJavaRoot);
+        }
+    }
+
+    const systemJavas = await jdkUtils.findRuntimes();
+    for (const sytemJava of systemJavas) {
+        addJavaRoot(sytemJava.homedir);
+    }
+
+    if (knownJavas) {
+        for (const knownJava of knownJavas) {
+            addJavaRoot(knownJava.javaHome);
+        }
+    }
+
+    const customJavaRootsArr = await customJavaRoots();
+    for (const customJavaRoot of customJavaRootsArr) {
+        if (!javaRoots.includes(customJavaRoot)) {
+            javaRoots.push(customJavaRoot);
+        }
+    }
+
+    const jdks: Java[] = [];
+    for (const javaRoot of javaRoots) {
+        const dirents = fs.readdirSync(javaRoot, { withFileTypes: true });
+        for (const dirent of dirents) {
+            if (dirent.isDirectory()) {
+                const javaHome = path.join(javaRoot, dirent.name);
+                const java = new Java(javaHome);
+                if (java.isJdk()) {
+                    jdks.push(java);
+                } else if (isMac()) {
+                    const macJavaHome = path.join(javaHome, 'Contents', 'Home');
+                    const macJava = new Java(macJavaHome);
+                    if (macJava.isJdk()) {
+                        jdks.push(macJava);
+                    }
+                }
+            }
+        }
+    }
+
+    return jdks;
+}
+
+async function customJavaRoots(): Promise<string[]> {
+    const customJavaRoots = storage.get<string>(CUSTOM_JAVA_ROOTS_KEY) || '';
+    const customJavaRootsArr = customJavaRoots.split(path.delimiter);
+    const newCustomJavaRootsArr = [];
+    for (const customJavaRoot of customJavaRootsArr) {
+        if (fs.existsSync(customJavaRoot)) {
+            newCustomJavaRootsArr.push(customJavaRoot);
+        }
+    }
+    if (customJavaRoots.length !== newCustomJavaRootsArr.length) {
+        await storage.update(CUSTOM_JAVA_ROOTS_KEY, newCustomJavaRootsArr.join(path.delimiter));
+    }
+    return newCustomJavaRootsArr;
+}
+
+export async function registerCustom(java: Java) {
+    let customJavaRoot = path.dirname(java.javaHome);
+    if (isMac() && path.basename(customJavaRoot) === 'Contents') {
+        const javaHome = path.resolve(java.javaHome, '..', '..');
+        customJavaRoot = path.dirname(javaHome);
+    }
+    const customJavaRootsArr = await customJavaRoots();
+    if (!customJavaRootsArr.includes(customJavaRoot)) {
+        customJavaRootsArr.push(customJavaRoot);
+        await storage.update(CUSTOM_JAVA_ROOTS_KEY, customJavaRootsArr.join(path.delimiter));
+    }
+}
+
+function isWindows(): boolean {
+    return process.platform === 'win32';
+}
+
+function isMac(): boolean {
+    return process.platform === 'darwin';
+}
+
+function normalizePath(fsPath: string): string {
+    return vscode.Uri.file(path.normalize(fsPath)).fsPath;
+}

--- a/java/java.lsp.server/vscode/src/jdk/settings.ts
+++ b/java/java.lsp.server/vscode/src/jdk/settings.ts
@@ -1,0 +1,393 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as process from 'process';
+import * as jdk from './jdk';
+
+
+export abstract class Setting {
+
+    readonly name: string;
+    readonly property: string;
+    
+    constructor(name: string, property: string) {
+        this.name = name;
+        this.property = property;
+    }
+
+    // Name of the property defining this setting
+    abstract getSetting(): string;
+
+    // String to describe the current Java configuration for this setting or undefined if not defined
+    abstract getCurrent(): string | undefined;
+
+    // All Java installations currently mentioned within this setting (used as pointers for autodiscovery)
+    abstract getJavas(): jdk.Java[];
+
+    // True if the setting should be initially selected even if Java configuration is currently not defined
+    abstract configureIfNotDefined(): boolean;
+    
+    // Configure this setting for the specific JDK
+    abstract setJdk(jdk: jdk.Java, scope: vscode.ConfigurationTarget): Promise<boolean>;
+
+}
+
+class JavaSetting extends Setting {
+
+    readonly supportsWorkspaceScope: boolean;
+    private java: jdk.Java | null | undefined;
+
+    constructor(name: string, property: string, supportsWorkspaceScope: boolean = true) {
+        super(name, property);
+        this.supportsWorkspaceScope = supportsWorkspaceScope;
+    }
+
+    protected getJavaHome(): string | undefined {
+        return vscode.workspace.getConfiguration().get<string>(this.property);
+    }
+    
+    protected getJava(): jdk.Java | undefined {
+        if (this.java === undefined) {
+            const javaHome = this.getJavaHome();
+            this.java = javaHome ? new jdk.Java(javaHome) : null;
+        }
+        return this.java ? this.java : undefined;
+    }
+
+    getSetting(): string {
+        return this.property;
+    }
+
+    getCurrent(): string | undefined {
+        return this.getJava()?.javaHome;
+    }
+
+    getJavas(): jdk.Java[] {
+        const javas = [];
+        const java = this.getJava();
+        if (java) {
+            javas.push(java);
+        }
+        return javas;
+    }
+
+    configureIfNotDefined(): boolean {
+        return true;
+    }
+
+    protected getJdkSetting(jdk: jdk.Java): any {
+        return jdk.javaHome;
+    }
+
+    async setJdk(jdk: jdk.Java, scope: vscode.ConfigurationTarget): Promise<boolean> {
+        if (!this.supportsWorkspaceScope && scope !== vscode.ConfigurationTarget.Global) {
+            const proceedOption = 'Configure It in User Scope';
+            const skipOption = 'Skip';
+            const selected = await vscode.window.showWarningMessage(`JDK for ${this.name} can only be configured in User scope.`, proceedOption, skipOption);
+            if (selected === proceedOption) {
+                scope = vscode.ConfigurationTarget.Global;
+            } else {
+                return false;
+            }
+        }
+        try {
+            await vscode.workspace.getConfiguration().update(this.property, this.getJdkSetting(jdk), scope);
+            return true;
+        } catch (err) {
+            vscode.window.showErrorMessage(`Failed to update property ${this.getSetting()}: ${err}`);
+            return false;
+        }
+    }
+
+}
+
+class JavaEnvSetting extends JavaSetting {
+
+    readonly variable: string;
+    
+    constructor(name: string, property: string, variable: string) {
+        super(name, property);
+        this.variable = variable;
+    }
+
+    protected getEnv(): any | undefined {
+        return vscode.workspace.getConfiguration().get<any>(this.property);
+    }
+
+    protected getJavaHome(): string | undefined {
+        return this.getEnv()?.[this.variable];
+    }
+
+    getSetting(): string {
+        return `${this.property}.${this.variable}`;
+    }
+
+    protected getJdkSetting(jdk: jdk.Java): any {
+        const env = this.getEnv() || {};
+        env[this.variable] = jdk.javaHome;
+        return env;
+    }
+
+}
+
+class JavaEnvPathSetting extends JavaEnvSetting {
+
+    private static readonly ENV_PATH_MASK = '${env:PATH}';
+
+    constructor(name: string, property: string, variable: string) {
+        super(name, property, variable);
+    }
+
+    protected getJavaHome(): string | undefined {
+        const currentPath = this.getEnv()?.[this.variable];
+        if (currentPath) {
+            const expandedPath = `${currentPath}`.replace(/\$\{env\:PATH\}/g, this.expandEnvPath());
+            const paths = expandedPath.split(path.delimiter);
+            for (const binPath of paths) {
+                if (path.basename(binPath).toLowerCase() === 'bin') {
+                    const jdkPath = path.dirname(binPath);
+                    const java = new jdk.Java(jdkPath);
+                    if (java.isJava()) {
+                        return java.javaHome;
+                    }
+                }
+            }
+        }
+        return undefined;
+    }
+
+    protected getJdkSetting(newJdk: jdk.Java): any {
+        const env = this.getEnv() || {};
+        const binPath = path.join(newJdk.javaHome, 'bin');
+        const currentPath = env[this.variable];
+        if (!currentPath) {
+            env[this.variable] = `${binPath}${path.delimiter}${JavaEnvPathSetting.ENV_PATH_MASK}`;
+        } else {
+            const newPaths: string[] = [ binPath ];
+            const currentPaths = currentPath.split(path.delimiter);
+            for (const currentPath of currentPaths) {
+                const pathName = path.basename(currentPath).toLowerCase();
+                const parentPath = pathName === 'bin' ? path.dirname(currentPath) : undefined;
+                const java = parentPath ? new jdk.Java(parentPath) : undefined;
+                if (!java || !java.isJava()) {
+                    newPaths.push(currentPath);
+                }
+            }
+            env[this.variable] = newPaths.join(path.delimiter);
+        }
+        return env;
+    }
+
+    private expandEnvPath(): string {
+        const expandedPath = process.env[this.variable] || JavaEnvPathSetting.ENV_PATH_MASK;
+        return expandedPath.endsWith(path.delimiter) ? expandedPath.slice(0, -path.delimiter.length) : expandedPath;
+    }
+
+}
+
+class JavaEnvArrSetting extends JavaEnvSetting {
+
+    constructor(name: string, property: string, variable: string) {
+        super(name, property, variable);
+    }
+
+    protected getJavaHome(): string | undefined {
+        const env = this.getEnv();
+        if (Array.isArray(env)) {
+            for (const item of env) {
+                if (item.environmentVariable === this.variable) {
+                    return item.value;
+                }
+            }
+        }
+        return undefined;
+    }
+
+    protected getJdkSetting(jdk: jdk.Java): any {
+        const env = this.getEnv() || [];
+        let updated = false;
+        for (const item of env) {
+            if (item.environmentVariable === this.variable) {
+                item.value = jdk.javaHome;
+                updated = true;
+                break;
+            }
+        }
+        if (!updated) {
+            env.push({
+                environmentVariable: this.variable,
+                value: jdk.javaHome
+            });
+        }
+        return env;
+    }
+
+}
+
+class ProjectJavaSettings extends Setting {
+
+    constructor(name: string, property: string) {
+        super(name, property);
+    }
+
+    getSetting(): string {
+        return this.property;
+    }
+
+    private getDefinitions(): { name: string, path: string }[] | undefined {
+        return vscode.workspace.getConfiguration().get<any>(this.property);
+    }
+
+    getCurrent(): string | undefined {
+        const current = [];
+        const definitions = this.getDefinitions();
+        if (Array.isArray(definitions)) {
+            for (const definition of definitions) {
+                if (definition.name?.length && definition.path?.length) {
+                    current.push(`${definition.name}: ${definition.path}`);
+                }
+            }
+        }
+        return current.length ? current.join(', ') : undefined;
+    }
+
+    getJavas(): jdk.Java[] {
+        const javas = [];
+        const definitions = this.getDefinitions();
+        if (Array.isArray(definitions)) {
+            for (const definition of definitions) {
+                if (definition.path?.length) {
+                    javas.push(new jdk.Java(definition.path));
+                }
+            }
+        }
+        return javas;
+    }
+
+    configureIfNotDefined(): boolean {
+        return false;
+    }
+
+    async setJdk(jdk: jdk.Java, scope: vscode.ConfigurationTarget): Promise<boolean> {
+        const details = await jdk.getVersion();
+        if (details?.major) {
+            const major = `${details.major <= 8 ? '1.' : ''}${details.major}`;
+            const version = `JavaSE-${major}`;
+            const definitions = this.getDefinitions() || []; // NOTE: merges User & Workspace definitions
+            if (Array.isArray(definitions)) {
+                let updated = false;
+                for (const definition of definitions) {
+                    if (definition.name === version) {
+                        definition.path = jdk.javaHome;
+                        updated = true;
+                        break;
+                    }
+                }
+                if (!updated) {
+                    definitions.push({
+                        name: version,
+                        path: jdk.javaHome
+                    });
+                }
+            }
+            try {
+                await vscode.workspace.getConfiguration().update(this.property, definitions, scope);
+                return true;
+            } catch (err) {
+                vscode.window.showErrorMessage(`Failed to update property ${this.getSetting()}: ${err}`);
+            }
+        }
+        return false;
+    }
+
+}
+
+const NBLS_EXTENSION_ID = 'asf.apache-netbeans-java';
+const NBLS_SETTINGS_NAME = 'Language Server by Apache NetBeans';
+const NBLS_SETTINGS_PROPERTY = 'netbeans.jdkhome';
+function nblsSetting(): Setting {
+    return new JavaSetting(NBLS_SETTINGS_NAME, NBLS_SETTINGS_PROPERTY, false);
+}
+
+const JDTLS_EXTENSION_ID = 'redhat.java';
+const JDTLS_SETTINGS_NAME = 'Language Server by RedHat';
+const JDTLS_SETTINGS_PROPERTY = 'java.jdt.ls.java.home';
+function jdtlsSetting(): Setting {
+    return new JavaSetting(JDTLS_SETTINGS_NAME, JDTLS_SETTINGS_PROPERTY);
+}
+
+const PROJECTS_SETTINGS_NAME = 'Java Runtime for Projects';
+const PROJECTS_SETTINGS_PROPERTY = 'java.configuration.runtimes';
+export function projectsSettings(): Setting {
+    return new ProjectJavaSettings(PROJECTS_SETTINGS_NAME, PROJECTS_SETTINGS_PROPERTY);
+}
+
+const TERMINAL_JAVAHOME_SETTINGS_NAME = 'Integrated Terminal JAVA_HOME';
+const TERMINAL_JAVAHOME_SETTINGS_PROPERTY = `terminal.integrated.env.${platformProperty()}`;
+function terminalJavaHomeSetting(): Setting {
+    return new JavaEnvSetting(TERMINAL_JAVAHOME_SETTINGS_NAME, TERMINAL_JAVAHOME_SETTINGS_PROPERTY, 'JAVA_HOME');
+}
+
+const TERMINAL_PATH_SETTINGS_NAME = 'Integrated Terminal PATH';
+const TERMINAL_PATH_SETTINGS_PROPERTY = `terminal.integrated.env.${platformProperty()}`;
+function terminalPathSetting(): Setting {
+    return new JavaEnvPathSetting(TERMINAL_PATH_SETTINGS_NAME, TERMINAL_PATH_SETTINGS_PROPERTY, 'PATH');
+}
+
+const MAVEN_EXTENSION_ID = 'vscjava.vscode-maven';
+const MAVEN_JAVAHOME_SETTINGS_NAME = 'Maven Runtime JAVA_HOME';
+const MAVEN_JAVAHOME_SETTINGS_PROPERTY = 'maven.terminal.customEnv';
+function mavenJavaHomeSetting(): Setting {
+    return new JavaEnvArrSetting(MAVEN_JAVAHOME_SETTINGS_NAME, MAVEN_JAVAHOME_SETTINGS_PROPERTY, 'JAVA_HOME');
+}
+
+export function getAvailable(): Setting[] {
+    const settings = [];
+
+    if (vscode.extensions.getExtension(NBLS_EXTENSION_ID)) {
+        settings.push(nblsSetting());
+    }
+
+    if (vscode.extensions.getExtension(JDTLS_EXTENSION_ID)) {
+        settings.push(jdtlsSetting());
+        settings.push(projectsSettings());
+    }
+
+    settings.push(terminalJavaHomeSetting());
+    settings.push(terminalPathSetting());
+
+    if (vscode.extensions.getExtension(MAVEN_EXTENSION_ID)) {
+        settings.push(mavenJavaHomeSetting());
+    }
+
+    return settings;
+}
+
+
+function platformProperty(): string {
+    const platform = process.platform;
+    if (platform === 'win32') {
+        return 'windows';
+    } else if (platform === 'darwin') {
+        return 'osx';
+    }
+    return platform;
+}


### PR DESCRIPTION
Action to configure a user-selected JDK installation for various VS Code features and settings (like JDK for NBLS, JDK for PATH in integrated Terminal, etc.) in a single step.