### PR TITLE
Update groovy.editor test data and test on JDK 17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1877,7 +1877,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '8' ]
+        java: [ '17' ]
       fail-fast: false
     steps:
 
@@ -1908,12 +1908,6 @@ jobs:
 
       - name: groovy/groovy.support
         run: ant $OPTS -f groovy/groovy.support test
-
-#      - name: groovy/groovy
-#        run: ant $OPTS -f groovy/groovy test
-
-#      - name: groovy/groovy.java
-#        run: ant $OPTS -f groovy/groovy.java test
 
 #      - name: groovy/groovy.kit
 #        run: ant $OPTS -f groovy/groovy.kit test

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/closures/insideClosure1/InsideClosure1.groovy.testInsideClosure1_1.14.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/closures/insideClosure1/InsideClosure1.groovy.testInsideClosure1_1.14.completion
@@ -499,6 +499,92 @@ CLASS      WeakHashMap                                null
 CLASS      Writable                                   null
 CLASS      WriteAbortedException                      null
 CLASS      Writer                                     null
+METHOD     addShutdownHook(Closure)                   void
+METHOD     any()                                      boolean
+METHOD     any(Closure)                               boolean
+METHOD     asBoolean()                                boolean
+METHOD     asType(Class)                              Object
+METHOD     clone()                         [PROTECTE  Object
+METHOD     collect()                                  Collection
+METHOD     collect(Closure)                           List
+METHOD     collect(Collection, Closure)               Collection
+METHOD     dump()                                     String
+METHOD     each(Closure)                              Object
+METHOD     eachWithIndex(Closure)                     Object
+METHOD     equals(Object)                  [PUBLIC]   boolean
+METHOD     evaluate(File)                  [PUBLIC]   Object
+METHOD     evaluate(String)                [PUBLIC]   Object
+METHOD     every()                                    boolean
+METHOD     every(Closure)                             boolean
+METHOD     finalize()                      [PROTECTE  void
+METHOD     find()                                     Object
+METHOD     find(Closure)                              Object
+METHOD     findAll()                                  Collection
+METHOD     findAll(Closure)                           Collection
+METHOD     findIndexOf(Closure)                       int
+METHOD     findIndexOf(int, Closure)                  int
+METHOD     findIndexValues(Closure)                   List
+METHOD     findIndexValues(Number, Closur             List
+METHOD     findLastIndexOf(Closure)                   int
+METHOD     findLastIndexOf(int, Closure)              int
+METHOD     findResult(Closure)                        Object
+METHOD     findResult(Object, Closure)                Object
+METHOD     getAt(String)                              Object
+METHOD     getBinding()                    [PUBLIC]   Binding
+METHOD     getClass()                      [PUBLIC]   Class<?>
+METHOD     getMetaClass()                             MetaClass
+METHOD     getMetaPropertyValues()                    List
+METHOD     getProperties()                            Map
+METHOD     getProperty(String)             [PUBLIC]   Object
+METHOD     grep()                                     Collection
+METHOD     grep(Object)                               Collection
+METHOD     hasProperty(String)                        MetaProperty
+METHOD     hashCode()                      [PUBLIC]   int
+METHOD     identity(Closure)                          Object
+METHOD     inject(Closure)                            Object
+METHOD     inject(Object, Closure)                    Object
+METHOD     inspect()                                  String
+METHOD     invokeMethod(String, Object)               Object
+METHOD     is(Object)                                 boolean
+METHOD     isCase(Object)                             boolean
+METHOD     iterator()                                 Iterator
+METHOD     main(String[])                  [STATIC,   void
+METHOD     metaClass(Closure)                         MetaClass
+METHOD     notify()                        [PUBLIC]   void
+METHOD     notifyAll()                     [PUBLIC]   void
+METHOD     print(Object)                              void
+METHOD     print(PrintWriter)                         void
+METHOD     printf(String, Object)                     void
+METHOD     printf(String, Object)                     void
+METHOD     println()                                  void
+METHOD     println(Object)                            void
+METHOD     println(PrintWriter)                       void
+METHOD     putAt(String, Object)                      void
+METHOD     respondsTo(String)                         List
+METHOD     respondsTo(String, Object)                 List
+METHOD     run()                           [PUBLIC]   Object
+METHOD     run(File, String[])             [PUBLIC]   void
+METHOD     setBinding(Binding)             [PUBLIC]   void
+METHOD     setMetaClass(MetaClass)                    void
+METHOD     setProperty(String, Object)     [PUBLIC]   void
+METHOD     sleep(long)                                void
+METHOD     sleep(long, Closure)                       void
+METHOD     split(Closure)                             Collection
+METHOD     sprintf(String, Object)                    String
+METHOD     sprintf(String, Object)                    String
+METHOD     stream()                                   Stream
+METHOD     tap(Closure)                               Object
+METHOD     test()                          [PUBLIC]   boolean
+METHOD     toString()                                 String
+METHOD     use(Class, Closure)                        Object
+METHOD     use(List, Closure)                         Object
+METHOD     use(Object[])                              Object
+METHOD     wait()                          [PUBLIC]   void
+METHOD     wait(long)                      [PUBLIC]   void
+METHOD     wait(long, int)                 [PUBLIC]   void
+METHOD     with(Closure)                              Object
+METHOD     with(boolean, Closure)                     Object
+METHOD     withTraits(Class[])                        Object
 FIELD      binding                         [PUBLIC]   Binding
 FIELD      class                           [PUBLIC]   Class
 FIELD      defaultMetaClass                [PRIVATE]  MetaClass

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/closures/insideClosure1/InsideClosure1.groovy.testInsideClosure1_1.16.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/closures/insideClosure1/InsideClosure1.groovy.testInsideClosure1_1.16.completion
@@ -500,6 +500,92 @@ CLASS      WeakHashMap                                null
 CLASS      Writable                                   null
 CLASS      WriteAbortedException                      null
 CLASS      Writer                                     null
+METHOD     addShutdownHook(Closure)                   void
+METHOD     any()                                      boolean
+METHOD     any(Closure)                               boolean
+METHOD     asBoolean()                                boolean
+METHOD     asType(Class)                              Object
+METHOD     clone()                         [PROTECTE  Object
+METHOD     collect()                                  Collection
+METHOD     collect(Closure)                           List
+METHOD     collect(Collection, Closure)               Collection
+METHOD     dump()                                     String
+METHOD     each(Closure)                              Object
+METHOD     eachWithIndex(Closure)                     Object
+METHOD     equals(Object)                  [PUBLIC]   boolean
+METHOD     evaluate(File)                  [PUBLIC]   Object
+METHOD     evaluate(String)                [PUBLIC]   Object
+METHOD     every()                                    boolean
+METHOD     every(Closure)                             boolean
+METHOD     finalize()                      [PROTECTE  void
+METHOD     find()                                     Object
+METHOD     find(Closure)                              Object
+METHOD     findAll()                                  Collection
+METHOD     findAll(Closure)                           Collection
+METHOD     findIndexOf(Closure)                       int
+METHOD     findIndexOf(int, Closure)                  int
+METHOD     findIndexValues(Closure)                   List
+METHOD     findIndexValues(Number, Closur             List
+METHOD     findLastIndexOf(Closure)                   int
+METHOD     findLastIndexOf(int, Closure)              int
+METHOD     findResult(Closure)                        Object
+METHOD     findResult(Object, Closure)                Object
+METHOD     getAt(String)                              Object
+METHOD     getBinding()                    [PUBLIC]   Binding
+METHOD     getClass()                      [PUBLIC]   Class<?>
+METHOD     getMetaClass()                             MetaClass
+METHOD     getMetaPropertyValues()                    List
+METHOD     getProperties()                            Map
+METHOD     getProperty(String)             [PUBLIC]   Object
+METHOD     grep()                                     Collection
+METHOD     grep(Object)                               Collection
+METHOD     hasProperty(String)                        MetaProperty
+METHOD     hashCode()                      [PUBLIC]   int
+METHOD     identity(Closure)                          Object
+METHOD     inject(Closure)                            Object
+METHOD     inject(Object, Closure)                    Object
+METHOD     inspect()                                  String
+METHOD     invokeMethod(String, Object)               Object
+METHOD     is(Object)                                 boolean
+METHOD     isCase(Object)                             boolean
+METHOD     iterator()                                 Iterator
+METHOD     main(String[])                  [STATIC,   void
+METHOD     metaClass(Closure)                         MetaClass
+METHOD     notify()                        [PUBLIC]   void
+METHOD     notifyAll()                     [PUBLIC]   void
+METHOD     print(Object)                              void
+METHOD     print(PrintWriter)                         void
+METHOD     printf(String, Object)                     void
+METHOD     printf(String, Object)                     void
+METHOD     println()                                  void
+METHOD     println(Object)                            void
+METHOD     println(PrintWriter)                       void
+METHOD     putAt(String, Object)                      void
+METHOD     respondsTo(String)                         List
+METHOD     respondsTo(String, Object)                 List
+METHOD     run()                           [PUBLIC]   Object
+METHOD     run(File, String[])             [PUBLIC]   void
+METHOD     setBinding(Binding)             [PUBLIC]   void
+METHOD     setMetaClass(MetaClass)                    void
+METHOD     setProperty(String, Object)     [PUBLIC]   void
+METHOD     sleep(long)                                void
+METHOD     sleep(long, Closure)                       void
+METHOD     split(Closure)                             Collection
+METHOD     sprintf(String, Object)                    String
+METHOD     sprintf(String, Object)                    String
+METHOD     stream()                                   Stream
+METHOD     tap(Closure)                               Object
+METHOD     test()                          [PUBLIC]   boolean
+METHOD     toString()                                 String
+METHOD     use(Class, Closure)                        Object
+METHOD     use(List, Closure)                         Object
+METHOD     use(Object[])                              Object
+METHOD     wait()                          [PUBLIC]   void
+METHOD     wait(long)                      [PUBLIC]   void
+METHOD     wait(long, int)                 [PUBLIC]   void
+METHOD     with(Closure)                              Object
+METHOD     with(boolean, Closure)                     Object
+METHOD     withTraits(Class[])                        Object
 FIELD      binding                         [PUBLIC]   Binding
 FIELD      class                           [PUBLIC]   Class
 FIELD      defaultMetaClass                [PRIVATE]  MetaClass

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/closures/insideClosure1/InsideClosure1.groovy.testInsideClosure1_1.17.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/closures/insideClosure1/InsideClosure1.groovy.testInsideClosure1_1.17.completion
@@ -501,6 +501,92 @@ CLASS      WeakHashMap                                null
 CLASS      Writable                                   null
 CLASS      WriteAbortedException                      null
 CLASS      Writer                                     null
+METHOD     addShutdownHook(Closure)                   void
+METHOD     any()                                      boolean
+METHOD     any(Closure)                               boolean
+METHOD     asBoolean()                                boolean
+METHOD     asType(Class)                              Object
+METHOD     clone()                         [PROTECTE  Object
+METHOD     collect()                                  Collection
+METHOD     collect(Closure)                           List
+METHOD     collect(Collection, Closure)               Collection
+METHOD     dump()                                     String
+METHOD     each(Closure)                              Object
+METHOD     eachWithIndex(Closure)                     Object
+METHOD     equals(Object)                  [PUBLIC]   boolean
+METHOD     evaluate(File)                  [PUBLIC]   Object
+METHOD     evaluate(String)                [PUBLIC]   Object
+METHOD     every()                                    boolean
+METHOD     every(Closure)                             boolean
+METHOD     finalize()                      [PROTECTE  void
+METHOD     find()                                     Object
+METHOD     find(Closure)                              Object
+METHOD     findAll()                                  Collection
+METHOD     findAll(Closure)                           Collection
+METHOD     findIndexOf(Closure)                       int
+METHOD     findIndexOf(int, Closure)                  int
+METHOD     findIndexValues(Closure)                   List
+METHOD     findIndexValues(Number, Closur             List
+METHOD     findLastIndexOf(Closure)                   int
+METHOD     findLastIndexOf(int, Closure)              int
+METHOD     findResult(Closure)                        Object
+METHOD     findResult(Object, Closure)                Object
+METHOD     getAt(String)                              Object
+METHOD     getBinding()                    [PUBLIC]   Binding
+METHOD     getClass()                      [PUBLIC]   Class<?>
+METHOD     getMetaClass()                             MetaClass
+METHOD     getMetaPropertyValues()                    List
+METHOD     getProperties()                            Map
+METHOD     getProperty(String)             [PUBLIC]   Object
+METHOD     grep()                                     Collection
+METHOD     grep(Object)                               Collection
+METHOD     hasProperty(String)                        MetaProperty
+METHOD     hashCode()                      [PUBLIC]   int
+METHOD     identity(Closure)                          Object
+METHOD     inject(Closure)                            Object
+METHOD     inject(Object, Closure)                    Object
+METHOD     inspect()                                  String
+METHOD     invokeMethod(String, Object)               Object
+METHOD     is(Object)                                 boolean
+METHOD     isCase(Object)                             boolean
+METHOD     iterator()                                 Iterator
+METHOD     main(String[])                  [STATIC,   void
+METHOD     metaClass(Closure)                         MetaClass
+METHOD     notify()                        [PUBLIC]   void
+METHOD     notifyAll()                     [PUBLIC]   void
+METHOD     print(Object)                              void
+METHOD     print(PrintWriter)                         void
+METHOD     printf(String, Object)                     void
+METHOD     printf(String, Object)                     void
+METHOD     println()                                  void
+METHOD     println(Object)                            void
+METHOD     println(PrintWriter)                       void
+METHOD     putAt(String, Object)                      void
+METHOD     respondsTo(String)                         List
+METHOD     respondsTo(String, Object)                 List
+METHOD     run()                           [PUBLIC]   Object
+METHOD     run(File, String[])             [PUBLIC]   void
+METHOD     setBinding(Binding)             [PUBLIC]   void
+METHOD     setMetaClass(MetaClass)                    void
+METHOD     setProperty(String, Object)     [PUBLIC]   void
+METHOD     sleep(long)                                void
+METHOD     sleep(long, Closure)                       void
+METHOD     split(Closure)                             Collection
+METHOD     sprintf(String, Object)                    String
+METHOD     sprintf(String, Object)                    String
+METHOD     stream()                                   Stream
+METHOD     tap(Closure)                               Object
+METHOD     test()                          [PUBLIC]   boolean
+METHOD     toString()                                 String
+METHOD     use(Class, Closure)                        Object
+METHOD     use(List, Closure)                         Object
+METHOD     use(Object[])                              Object
+METHOD     wait()                          [PUBLIC]   void
+METHOD     wait(long)                      [PUBLIC]   void
+METHOD     wait(long, int)                 [PUBLIC]   void
+METHOD     with(Closure)                              Object
+METHOD     with(boolean, Closure)                     Object
+METHOD     withTraits(Class[])                        Object
 FIELD      binding                         [PUBLIC]   Binding
 FIELD      class                           [PUBLIC]   Class
 FIELD      defaultMetaClass                [PRIVATE]  MetaClass

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/closures/insideClosure1/InsideClosure1.groovy.testInsideClosure1_1.9.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/closures/insideClosure1/InsideClosure1.groovy.testInsideClosure1_1.9.completion
@@ -497,6 +497,92 @@ CLASS      WeakHashMap                                null
 CLASS      Writable                                   null
 CLASS      WriteAbortedException                      null
 CLASS      Writer                                     null
+METHOD     addShutdownHook(Closure)                   void
+METHOD     any()                                      boolean
+METHOD     any(Closure)                               boolean
+METHOD     asBoolean()                                boolean
+METHOD     asType(Class)                              Object
+METHOD     clone()                         [PROTECTE  Object
+METHOD     collect()                                  Collection
+METHOD     collect(Closure)                           List
+METHOD     collect(Collection, Closure)               Collection
+METHOD     dump()                                     String
+METHOD     each(Closure)                              Object
+METHOD     eachWithIndex(Closure)                     Object
+METHOD     equals(Object)                  [PUBLIC]   boolean
+METHOD     evaluate(File)                  [PUBLIC]   Object
+METHOD     evaluate(String)                [PUBLIC]   Object
+METHOD     every()                                    boolean
+METHOD     every(Closure)                             boolean
+METHOD     finalize()                      [PROTECTE  void
+METHOD     find()                                     Object
+METHOD     find(Closure)                              Object
+METHOD     findAll()                                  Collection
+METHOD     findAll(Closure)                           Collection
+METHOD     findIndexOf(Closure)                       int
+METHOD     findIndexOf(int, Closure)                  int
+METHOD     findIndexValues(Closure)                   List
+METHOD     findIndexValues(Number, Closur             List
+METHOD     findLastIndexOf(Closure)                   int
+METHOD     findLastIndexOf(int, Closure)              int
+METHOD     findResult(Closure)                        Object
+METHOD     findResult(Object, Closure)                Object
+METHOD     getAt(String)                              Object
+METHOD     getBinding()                    [PUBLIC]   Binding
+METHOD     getClass()                      [PUBLIC]   Class<?>
+METHOD     getMetaClass()                             MetaClass
+METHOD     getMetaPropertyValues()                    List
+METHOD     getProperties()                            Map
+METHOD     getProperty(String)             [PUBLIC]   Object
+METHOD     grep()                                     Collection
+METHOD     grep(Object)                               Collection
+METHOD     hasProperty(String)                        MetaProperty
+METHOD     hashCode()                      [PUBLIC]   int
+METHOD     identity(Closure)                          Object
+METHOD     inject(Closure)                            Object
+METHOD     inject(Object, Closure)                    Object
+METHOD     inspect()                                  String
+METHOD     invokeMethod(String, Object)               Object
+METHOD     is(Object)                                 boolean
+METHOD     isCase(Object)                             boolean
+METHOD     iterator()                                 Iterator
+METHOD     main(String[])                  [STATIC,   void
+METHOD     metaClass(Closure)                         MetaClass
+METHOD     notify()                        [PUBLIC]   void
+METHOD     notifyAll()                     [PUBLIC]   void
+METHOD     print(Object)                              void
+METHOD     print(PrintWriter)                         void
+METHOD     printf(String, Object)                     void
+METHOD     printf(String, Object)                     void
+METHOD     println()                                  void
+METHOD     println(Object)                            void
+METHOD     println(PrintWriter)                       void
+METHOD     putAt(String, Object)                      void
+METHOD     respondsTo(String)                         List
+METHOD     respondsTo(String, Object)                 List
+METHOD     run()                           [PUBLIC]   Object
+METHOD     run(File, String[])             [PUBLIC]   void
+METHOD     setBinding(Binding)             [PUBLIC]   void
+METHOD     setMetaClass(MetaClass)                    void
+METHOD     setProperty(String, Object)     [PUBLIC]   void
+METHOD     sleep(long)                                void
+METHOD     sleep(long, Closure)                       void
+METHOD     split(Closure)                             Collection
+METHOD     sprintf(String, Object)                    String
+METHOD     sprintf(String, Object)                    String
+METHOD     stream()                                   Stream
+METHOD     tap(Closure)                               Object
+METHOD     test()                          [PUBLIC]   boolean
+METHOD     toString()                                 String
+METHOD     use(Class, Closure)                        Object
+METHOD     use(List, Closure)                         Object
+METHOD     use(Object[])                              Object
+METHOD     wait()                          [PUBLIC]   void
+METHOD     wait(long)                      [PUBLIC]   void
+METHOD     wait(long, int)                 [PUBLIC]   void
+METHOD     with(Closure)                              Object
+METHOD     with(boolean, Closure)                     Object
+METHOD     withTraits(Class[])                        Object
 FIELD      binding                         [PUBLIC]   Binding
 FIELD      class                           [PUBLIC]   Class
 FIELD      defaultMetaClass                [PRIVATE]  MetaClass

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/closures/insideClosure1/InsideClosure1.groovy.testInsideClosure1_2.9.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/closures/insideClosure1/InsideClosure1.groovy.testInsideClosure1_2.9.completion
@@ -50,6 +50,14 @@ CLASS      InvalidObjectException                     null
 CLASS      InvalidPropertiesFormatExcepti             null
 CLASS      Iterable                                   null
 CLASS      Iterator                                   null
+METHOD     identity(Closure)                          Object
+METHOD     inject(Closure)                            Object
+METHOD     inject(Object, Closure)                    Object
+METHOD     inspect()                                  String
+METHOD     invokeMethod(String, Object)               Object
+METHOD     is(Object)                                 boolean
+METHOD     isCase(Object)                             boolean
+METHOD     iterator()                                 Iterator
 VARIABLE   it                                         Object
 KEYWORD    if                                         null
 KEYWORD    in                                         null

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/closures/insideClosure1/InsideClosure1.groovy.testInsideClosure1_5.9.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/closures/insideClosure1/InsideClosure1.groovy.testInsideClosure1_5.9.completion
@@ -50,6 +50,14 @@ CLASS      InvalidObjectException                     null
 CLASS      InvalidPropertiesFormatExcepti             null
 CLASS      Iterable                                   null
 CLASS      Iterator                                   null
+METHOD     identity(Closure)                          Object
+METHOD     inject(Closure)                            Object
+METHOD     inject(Object, Closure)                    Object
+METHOD     inspect()                                  String
+METHOD     invokeMethod(String, Object)               Object
+METHOD     is(Object)                                 boolean
+METHOD     isCase(Object)                             boolean
+METHOD     iterator()                                 Iterator
 VARIABLE   it                                         Object
 KEYWORD    if                                         null
 KEYWORD    in                                         null

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/closures/insideClosure1/InsideClosure1.groovy.testInsideClosure1_7.9.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/closures/insideClosure1/InsideClosure1.groovy.testInsideClosure1_7.9.completion
@@ -50,6 +50,14 @@ CLASS      InvalidObjectException                     null
 CLASS      InvalidPropertiesFormatExcepti             null
 CLASS      Iterable                                   null
 CLASS      Iterator                                   null
+METHOD     identity(Closure)                          Object
+METHOD     inject(Closure)                            Object
+METHOD     inject(Object, Closure)                    Object
+METHOD     inspect()                                  String
+METHOD     invokeMethod(String, Object)               Object
+METHOD     is(Object)                                 boolean
+METHOD     isCase(Object)                             boolean
+METHOD     iterator()                                 Iterator
 KEYWORD    if                                         null
 KEYWORD    in                                         null
 KEYWORD    instanceof                                 null

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.12.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.12.completion
@@ -23,6 +23,7 @@ METHOD     collect(Closure)                           List
 METHOD     collect(Collection, Closure)               Collection
 METHOD     collectReplacements(Closure)               String
 METHOD     collectReplacements(List)                  String
+METHOD     compare(CharSequence, CharSequ  [STATIC,   int
 METHOD     compareTo(Object)               [PUBLIC]   int
 METHOD     compareTo(String)               [PUBLIC]   int
 METHOD     compareTo(T)                    [PUBLIC]   int
@@ -294,6 +295,7 @@ FIELD      CASE_INSENSITIVE_ORDER          [STATIC,   Comparator<String>
 FIELD      EMPTY                           [STATIC,   GString
 FIELD      EMPTY_OBJECT_ARRAY              [STATIC,   Object[]
 FIELD      EMPTY_STRING_ARRAY              [STATIC,   String[]
+FIELD      blank                           [PUBLIC]   boolean
 FIELD      bytes                           [PUBLIC]   byte[]
 FIELD      class                           [PUBLIC]   Class
 FIELD      empty                           [PUBLIC]   boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.13.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.13.completion
@@ -23,6 +23,7 @@ METHOD     collect(Closure)                           List
 METHOD     collect(Collection, Closure)               Collection
 METHOD     collectReplacements(Closure)               String
 METHOD     collectReplacements(List)                  String
+METHOD     compare(CharSequence, CharSequ  [STATIC,   int
 METHOD     compareTo(Object)               [PUBLIC]   int
 METHOD     compareTo(String)               [PUBLIC]   int
 METHOD     compareTo(T)                    [PUBLIC]   int
@@ -88,7 +89,7 @@ METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
 METHOD     format(Locale, String, Object.  [STATIC,   String
 METHOD     format(String, Object...)       [STATIC,   String
-METHOD     formatted(Object[])             [PUBLIC]   String
+METHOD     formatted(Object...)            [PUBLIC]   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
 METHOD     getAt(IntRange)                            String
@@ -220,6 +221,7 @@ METHOD     startsWith(String, int)         [PUBLIC]   boolean
 METHOD     startsWithAny(CharSequence[])              boolean
 METHOD     startsWithIgnoreCase(CharSeque             boolean
 METHOD     stream()                                   Stream
+METHOD     strip()                         [PUBLIC]   String
 METHOD     stripIndent()                              String
 METHOD     stripIndent(boolean)                       String
 METHOD     stripIndent(int)                           String
@@ -295,6 +297,7 @@ FIELD      CASE_INSENSITIVE_ORDER          [STATIC,   Comparator<String>
 FIELD      EMPTY                           [STATIC,   GString
 FIELD      EMPTY_OBJECT_ARRAY              [STATIC,   Object[]
 FIELD      EMPTY_STRING_ARRAY              [STATIC,   String[]
+FIELD      blank                           [PUBLIC]   boolean
 FIELD      bytes                           [PUBLIC]   byte[]
 FIELD      class                           [PUBLIC]   Class
 FIELD      empty                           [PUBLIC]   boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString2/CompletionNoPrefixString2.groovy.testCompletionNoPrefixString2.13.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString2/CompletionNoPrefixString2.groovy.testCompletionNoPrefixString2.13.completion
@@ -85,7 +85,7 @@ METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
 METHOD     format(Locale, String, Object.  [STATIC,   String
 METHOD     format(String, Object...)       [STATIC,   String
-METHOD     formatted(Object[])             [PUBLIC]   String
+METHOD     formatted(Object...)            [PUBLIC]   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
 METHOD     getAt(IntRange)                            String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator1/SpreadOperator1.groovy.testSpreadOperator1_stringArray_all.13.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator1/SpreadOperator1.groovy.testSpreadOperator1_stringArray_all.13.completion
@@ -85,7 +85,7 @@ METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
 METHOD     format(Locale, String, Object.  [STATIC,   String
 METHOD     format(String, Object...)       [STATIC,   String
-METHOD     formatted(Object[])             [PUBLIC]   String
+METHOD     formatted(Object...)            [PUBLIC]   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
 METHOD     getAt(IntRange)                            String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator3/SpreadOperator3.groovy.testSpreadOperator3_intArray_all.14.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator3/SpreadOperator3.groovy.testSpreadOperator3_intArray_all.14.completion
@@ -46,8 +46,6 @@ METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
 METHOD     floatValue()                    [PUBLIC]   float
-METHOD     formatUnsignedInt(int, int, by  [STATIC]   void
-METHOD     formatUnsignedInt(int, int, ch  [STATIC]   void
 METHOD     getAt(String)                              Object
 METHOD     getChars(int, int, byte[])      [STATIC]   int
 METHOD     getClass()                      [PUBLIC]   Class<?>

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton2/Singleton2.groovy.testSingleton2_withGetPrefix.14.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton2/Singleton2.groovy.testSingleton2_withGetPrefix.14.completion
@@ -1,0 +1,61 @@
+Code completion result for source line:
+Singleton2.get|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     getAnnotatedInterfaces()        [PUBLIC]   AnnotatedType[]
+METHOD     getAnnotatedSuperclass()        [PUBLIC]   AnnotatedType
+METHOD     getAnnotation(Class<A>)         [PUBLIC]   A
+METHOD     getAnnotations()                [PUBLIC]   Annotation[]
+METHOD     getAnnotationsByType(Class<A>)  [PUBLIC]   A[]
+METHOD     getAt(String)                              Object
+METHOD     getCanonicalName()              [PUBLIC]   String
+METHOD     getClass()                      [PUBLIC]   Class<?>
+METHOD     getClassLoader()                [PUBLIC]   ClassLoader
+METHOD     getClasses()                    [PUBLIC]   Class<?>[]
+METHOD     getComponentType()              [PUBLIC]   Class<?>
+METHOD     getConstructor(Class<?>...)     [PUBLIC]   Constructor<T>
+METHOD     getConstructors()               [PUBLIC]   Constructor<?>[]
+METHOD     getDeclaredAnnotation(Class<A>  [PUBLIC]   A
+METHOD     getDeclaredAnnotations()        [PUBLIC]   Annotation[]
+METHOD     getDeclaredAnnotationsByType(C  [PUBLIC]   A[]
+METHOD     getDeclaredClasses()            [PUBLIC]   Class<?>[]
+METHOD     getDeclaredConstructor(Class<?  [PUBLIC]   Constructor<T>
+METHOD     getDeclaredConstructors()       [PUBLIC]   Constructor<?>[]
+METHOD     getDeclaredField(String)        [PUBLIC]   Field
+METHOD     getDeclaredFields()             [PUBLIC]   Field[]
+METHOD     getDeclaredMethod(String, Clas  [PUBLIC]   Method
+METHOD     getDeclaredMethods()            [PUBLIC]   Method[]
+METHOD     getDeclaringClass()             [PUBLIC]   Class<?>
+METHOD     getEnclosingClass()             [PUBLIC]   Class<?>
+METHOD     getEnclosingConstructor()       [PUBLIC]   Constructor<?>
+METHOD     getEnclosingMethod()            [PUBLIC]   Method
+METHOD     getEnumConstants()              [PUBLIC]   T[]
+METHOD     getField(String)                [PUBLIC]   Field
+METHOD     getFields()                     [PUBLIC]   Field[]
+METHOD     getGenericInterfaces()          [PUBLIC]   Type[]
+METHOD     getGenericSuperclass()          [PUBLIC]   Type
+METHOD     getGroovydoc()                             Groovydoc
+METHOD     getInstance()                   [STATIC,   Singleton2
+METHOD     getInterfaces()                 [PUBLIC]   Class<?>[]
+METHOD     getLocation()                              URL
+METHOD     getMetaClass()                             MetaClass
+METHOD     getMetaPropertyValues()                    List
+METHOD     getMethod(String, Class<?>...)  [PUBLIC]   Method
+METHOD     getMethods()                    [PUBLIC]   Method[]
+METHOD     getModifiers()                  [PUBLIC]   int
+METHOD     getModule()                     [PUBLIC]   Module
+METHOD     getName()                       [PUBLIC]   String
+METHOD     getNestHost()                   [PUBLIC]   Class<?>
+METHOD     getNestMembers()                [PUBLIC]   Class<?>[]
+METHOD     getPackage()                    [PUBLIC]   Package
+METHOD     getPackageName()                [PUBLIC]   String
+METHOD     getProperties()                            Map
+METHOD     getProtectionDomain()           [PUBLIC]   ProtectionDomain
+METHOD     getRecordComponents()           [PUBLIC]   RecordComponent[]
+METHOD     getResource(String)             [PUBLIC]   URL
+METHOD     getResourceAsStream(String)     [PUBLIC]   InputStream
+METHOD     getSigners()                    [PUBLIC]   Object[]
+METHOD     getSimpleName()                 [PUBLIC]   String
+METHOD     getSuperclass()                 [PUBLIC]   Class<? super T>
+METHOD     getTypeName()                   [PUBLIC]   String
+METHOD     getTypeParameters()             [PUBLIC]   TypeVariable<Class<T>>[]

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton2/Singleton2.groovy.testSingleton2_withGetPrefix.16.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton2/Singleton2.groovy.testSingleton2_withGetPrefix.16.completion
@@ -1,0 +1,62 @@
+Code completion result for source line:
+Singleton2.get|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     getAnnotatedInterfaces()        [PUBLIC]   AnnotatedType[]
+METHOD     getAnnotatedSuperclass()        [PUBLIC]   AnnotatedType
+METHOD     getAnnotation(Class<A>)         [PUBLIC]   A
+METHOD     getAnnotations()                [PUBLIC]   Annotation[]
+METHOD     getAnnotationsByType(Class<A>)  [PUBLIC]   A[]
+METHOD     getAt(String)                              Object
+METHOD     getCanonicalName()              [PUBLIC]   String
+METHOD     getClass()                      [PUBLIC]   Class<?>
+METHOD     getClassLoader()                [PUBLIC]   ClassLoader
+METHOD     getClasses()                    [PUBLIC]   Class<?>[]
+METHOD     getComponentType()              [PUBLIC]   Class<?>
+METHOD     getConstructor(Class<?>...)     [PUBLIC]   Constructor<T>
+METHOD     getConstructors()               [PUBLIC]   Constructor<?>[]
+METHOD     getDeclaredAnnotation(Class<A>  [PUBLIC]   A
+METHOD     getDeclaredAnnotations()        [PUBLIC]   Annotation[]
+METHOD     getDeclaredAnnotationsByType(C  [PUBLIC]   A[]
+METHOD     getDeclaredClasses()            [PUBLIC]   Class<?>[]
+METHOD     getDeclaredConstructor(Class<?  [PUBLIC]   Constructor<T>
+METHOD     getDeclaredConstructors()       [PUBLIC]   Constructor<?>[]
+METHOD     getDeclaredField(String)        [PUBLIC]   Field
+METHOD     getDeclaredFields()             [PUBLIC]   Field[]
+METHOD     getDeclaredMethod(String, Clas  [PUBLIC]   Method
+METHOD     getDeclaredMethods()            [PUBLIC]   Method[]
+METHOD     getDeclaringClass()             [PUBLIC]   Class<?>
+METHOD     getEnclosingClass()             [PUBLIC]   Class<?>
+METHOD     getEnclosingConstructor()       [PUBLIC]   Constructor<?>
+METHOD     getEnclosingMethod()            [PUBLIC]   Method
+METHOD     getEnumConstants()              [PUBLIC]   T[]
+METHOD     getField(String)                [PUBLIC]   Field
+METHOD     getFields()                     [PUBLIC]   Field[]
+METHOD     getGenericInterfaces()          [PUBLIC]   Type[]
+METHOD     getGenericSuperclass()          [PUBLIC]   Type
+METHOD     getGroovydoc()                             Groovydoc
+METHOD     getInstance()                   [STATIC,   Singleton2
+METHOD     getInterfaces()                 [PUBLIC]   Class<?>[]
+METHOD     getLocation()                              URL
+METHOD     getMetaClass()                             MetaClass
+METHOD     getMetaPropertyValues()                    List
+METHOD     getMethod(String, Class<?>...)  [PUBLIC]   Method
+METHOD     getMethods()                    [PUBLIC]   Method[]
+METHOD     getModifiers()                  [PUBLIC]   int
+METHOD     getModule()                     [PUBLIC]   Module
+METHOD     getName()                       [PUBLIC]   String
+METHOD     getNestHost()                   [PUBLIC]   Class<?>
+METHOD     getNestMembers()                [PUBLIC]   Class<?>[]
+METHOD     getPackage()                    [PUBLIC]   Package
+METHOD     getPackageName()                [PUBLIC]   String
+METHOD     getPermittedSubclasses()        [PUBLIC]   Class<?>[]
+METHOD     getProperties()                            Map
+METHOD     getProtectionDomain()           [PUBLIC]   ProtectionDomain
+METHOD     getRecordComponents()           [PUBLIC]   RecordComponent[]
+METHOD     getResource(String)             [PUBLIC]   URL
+METHOD     getResourceAsStream(String)     [PUBLIC]   InputStream
+METHOD     getSigners()                    [PUBLIC]   Object[]
+METHOD     getSimpleName()                 [PUBLIC]   String
+METHOD     getSuperclass()                 [PUBLIC]   Class<? super T>
+METHOD     getTypeName()                   [PUBLIC]   String
+METHOD     getTypeParameters()             [PUBLIC]   TypeVariable<Class<T>>[]

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton2/Singleton2.groovy.testSingleton2_withGetPrefix.9.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton2/Singleton2.groovy.testSingleton2_withGetPrefix.9.completion
@@ -1,0 +1,58 @@
+Code completion result for source line:
+Singleton2.get|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     getAnnotatedInterfaces()        [PUBLIC]   AnnotatedType[]
+METHOD     getAnnotatedSuperclass()        [PUBLIC]   AnnotatedType
+METHOD     getAnnotation(Class<A>)         [PUBLIC]   A
+METHOD     getAnnotations()                [PUBLIC]   Annotation[]
+METHOD     getAnnotationsByType(Class<A>)  [PUBLIC]   A[]
+METHOD     getAt(String)                              Object
+METHOD     getCanonicalName()              [PUBLIC]   String
+METHOD     getClass()                      [PUBLIC]   Class<?>
+METHOD     getClassLoader()                [PUBLIC]   ClassLoader
+METHOD     getClasses()                    [PUBLIC]   Class<?>[]
+METHOD     getComponentType()              [PUBLIC]   Class<?>
+METHOD     getConstructor(Class<?>...)     [PUBLIC]   Constructor<T>
+METHOD     getConstructors()               [PUBLIC]   Constructor<?>[]
+METHOD     getDeclaredAnnotation(Class<A>  [PUBLIC]   A
+METHOD     getDeclaredAnnotations()        [PUBLIC]   Annotation[]
+METHOD     getDeclaredAnnotationsByType(C  [PUBLIC]   A[]
+METHOD     getDeclaredClasses()            [PUBLIC]   Class<?>[]
+METHOD     getDeclaredConstructor(Class<?  [PUBLIC]   Constructor<T>
+METHOD     getDeclaredConstructors()       [PUBLIC]   Constructor<?>[]
+METHOD     getDeclaredField(String)        [PUBLIC]   Field
+METHOD     getDeclaredFields()             [PUBLIC]   Field[]
+METHOD     getDeclaredMethod(String, Clas  [PUBLIC]   Method
+METHOD     getDeclaredMethods()            [PUBLIC]   Method[]
+METHOD     getDeclaringClass()             [PUBLIC]   Class<?>
+METHOD     getEnclosingClass()             [PUBLIC]   Class<?>
+METHOD     getEnclosingConstructor()       [PUBLIC]   Constructor<?>
+METHOD     getEnclosingMethod()            [PUBLIC]   Method
+METHOD     getEnumConstants()              [PUBLIC]   T[]
+METHOD     getField(String)                [PUBLIC]   Field
+METHOD     getFields()                     [PUBLIC]   Field[]
+METHOD     getGenericInterfaces()          [PUBLIC]   Type[]
+METHOD     getGenericSuperclass()          [PUBLIC]   Type
+METHOD     getGroovydoc()                             Groovydoc
+METHOD     getInstance()                   [STATIC,   Singleton2
+METHOD     getInterfaces()                 [PUBLIC]   Class<?>[]
+METHOD     getLocation()                              URL
+METHOD     getMetaClass()                             MetaClass
+METHOD     getMetaPropertyValues()                    List
+METHOD     getMethod(String, Class<?>...)  [PUBLIC]   Method
+METHOD     getMethods()                    [PUBLIC]   Method[]
+METHOD     getModifiers()                  [PUBLIC]   int
+METHOD     getModule()                     [PUBLIC]   Module
+METHOD     getName()                       [PUBLIC]   String
+METHOD     getPackage()                    [PUBLIC]   Package
+METHOD     getPackageName()                [PUBLIC]   String
+METHOD     getProperties()                            Map
+METHOD     getProtectionDomain()           [PUBLIC]   ProtectionDomain
+METHOD     getResource(String)             [PUBLIC]   URL
+METHOD     getResourceAsStream(String)     [PUBLIC]   InputStream
+METHOD     getSigners()                    [PUBLIC]   Object[]
+METHOD     getSimpleName()                 [PUBLIC]   String
+METHOD     getSuperclass()                 [PUBLIC]   Class<? super T>
+METHOD     getTypeName()                   [PUBLIC]   String
+METHOD     getTypeParameters()             [PUBLIC]   TypeVariable<Class<T>>[]

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.12.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.12.completion
@@ -5,6 +5,7 @@ Singleton3.|
 METHOD     addShutdownHook(Closure)                   void
 METHOD     any()                                      boolean
 METHOD     any(Closure)                               boolean
+METHOD     arrayType()                     [PUBLIC]   Class<?>
 METHOD     asBoolean()                                boolean
 METHOD     asSubclass(Class<U>)            [PUBLIC]   Class<? extends U>
 METHOD     asType(Class)                              Object
@@ -12,6 +13,9 @@ METHOD     cast(Object)                    [PUBLIC]   T
 METHOD     collect()                                  Collection
 METHOD     collect(Closure)                           List
 METHOD     collect(Collection, Closure)               Collection
+METHOD     componentType()                 [PUBLIC]   Class<?>
+METHOD     describeConstable()             [PUBLIC]   Optional<ClassDesc>
+METHOD     descriptorString()              [PUBLIC]   String
 METHOD     desiredAssertionStatus()        [PUBLIC]   boolean
 METHOD     dump()                                     String
 METHOD     each(Closure)                              Object

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.14.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.14.completion
@@ -5,6 +5,7 @@ Singleton3.|
 METHOD     addShutdownHook(Closure)                   void
 METHOD     any()                                      boolean
 METHOD     any(Closure)                               boolean
+METHOD     arrayType()                     [PUBLIC]   Class<?>
 METHOD     asBoolean()                                boolean
 METHOD     asSubclass(Class<U>)            [PUBLIC]   Class<? extends U>
 METHOD     asType(Class)                              Object
@@ -12,6 +13,9 @@ METHOD     cast(Object)                    [PUBLIC]   T
 METHOD     collect()                                  Collection
 METHOD     collect(Closure)                           List
 METHOD     collect(Collection, Closure)               Collection
+METHOD     componentType()                 [PUBLIC]   Class<?>
+METHOD     describeConstable()             [PUBLIC]   Optional<ClassDesc>
+METHOD     descriptorString()              [PUBLIC]   String
 METHOD     desiredAssertionStatus()        [PUBLIC]   boolean
 METHOD     dump()                                     String
 METHOD     each(Closure)                              Object
@@ -83,6 +87,7 @@ METHOD     getPackage()                    [PUBLIC]   Package
 METHOD     getPackageName()                [PUBLIC]   String
 METHOD     getProperties()                            Map
 METHOD     getProtectionDomain()           [PUBLIC]   ProtectionDomain
+METHOD     getRecordComponents()           [PUBLIC]   RecordComponent[]
 METHOD     getResource(String)             [PUBLIC]   URL
 METHOD     getResourceAsStream(String)     [PUBLIC]   InputStream
 METHOD     getSigners()                    [PUBLIC]   Object[]
@@ -113,6 +118,7 @@ METHOD     isLocalClass()                  [PUBLIC]   boolean
 METHOD     isMemberClass()                 [PUBLIC]   boolean
 METHOD     isNestmateOf(Class<?>)          [PUBLIC]   boolean
 METHOD     isPrimitive()                   [PUBLIC]   boolean
+METHOD     isRecord()                      [PUBLIC]   boolean
 METHOD     isSynthetic()                   [PUBLIC]   boolean
 METHOD     iterator()                                 Iterator
 METHOD     metaClass(Closure)                         MetaClass
@@ -194,6 +200,8 @@ FIELD      package                         [PUBLIC]   Package
 FIELD      packageName                     [PUBLIC]   String
 FIELD      primitive                       [PUBLIC]   boolean
 FIELD      protectionDomain                [PUBLIC]   ProtectionDomain
+FIELD      record                          [PUBLIC]   boolean
+FIELD      recordComponents                [PUBLIC]   RecordComponent[]
 FIELD      simpleName                      [PUBLIC]   String
 FIELD      superclass                      [PUBLIC]   Class
 FIELD      synthetic                       [PUBLIC]   boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.15.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.15.completion
@@ -5,6 +5,7 @@ Singleton3.|
 METHOD     addShutdownHook(Closure)                   void
 METHOD     any()                                      boolean
 METHOD     any(Closure)                               boolean
+METHOD     arrayType()                     [PUBLIC]   Class<?>
 METHOD     asBoolean()                                boolean
 METHOD     asSubclass(Class<U>)            [PUBLIC]   Class<? extends U>
 METHOD     asType(Class)                              Object
@@ -12,6 +13,9 @@ METHOD     cast(Object)                    [PUBLIC]   T
 METHOD     collect()                                  Collection
 METHOD     collect(Closure)                           List
 METHOD     collect(Collection, Closure)               Collection
+METHOD     componentType()                 [PUBLIC]   Class<?>
+METHOD     describeConstable()             [PUBLIC]   Optional<ClassDesc>
+METHOD     descriptorString()              [PUBLIC]   String
 METHOD     desiredAssertionStatus()        [PUBLIC]   boolean
 METHOD     dump()                                     String
 METHOD     each(Closure)                              Object
@@ -83,6 +87,7 @@ METHOD     getPackage()                    [PUBLIC]   Package
 METHOD     getPackageName()                [PUBLIC]   String
 METHOD     getProperties()                            Map
 METHOD     getProtectionDomain()           [PUBLIC]   ProtectionDomain
+METHOD     getRecordComponents()           [PUBLIC]   RecordComponent[]
 METHOD     getResource(String)             [PUBLIC]   URL
 METHOD     getResourceAsStream(String)     [PUBLIC]   InputStream
 METHOD     getSigners()                    [PUBLIC]   Object[]
@@ -107,12 +112,15 @@ METHOD     isArray()                       [PUBLIC]   boolean
 METHOD     isAssignableFrom(Class<?>)      [PUBLIC]   boolean
 METHOD     isCase(Object)                             boolean
 METHOD     isEnum()                        [PUBLIC]   boolean
+METHOD     isHidden()                      [PUBLIC]   boolean
 METHOD     isInstance(Object)              [PUBLIC]   boolean
 METHOD     isInterface()                   [PUBLIC]   boolean
 METHOD     isLocalClass()                  [PUBLIC]   boolean
 METHOD     isMemberClass()                 [PUBLIC]   boolean
 METHOD     isNestmateOf(Class<?>)          [PUBLIC]   boolean
 METHOD     isPrimitive()                   [PUBLIC]   boolean
+METHOD     isRecord()                      [PUBLIC]   boolean
+METHOD     isSealed()                      [PUBLIC]   boolean
 METHOD     isSynthetic()                   [PUBLIC]   boolean
 METHOD     iterator()                                 Iterator
 METHOD     metaClass(Closure)                         MetaClass
@@ -123,6 +131,7 @@ METHOD     newInstance()                   [PUBLIC]   T
 METHOD     newInstance(Object[])                      Object
 METHOD     notify()                        [PUBLIC]   void
 METHOD     notifyAll()                     [PUBLIC]   void
+METHOD     permittedSubclasses()           [PUBLIC]   ClassDesc[]
 METHOD     print(Object)                              void
 METHOD     print(PrintWriter)                         void
 METHOD     printf(String, Object)                     void
@@ -179,6 +188,7 @@ FIELD      enumConstants                   [PUBLIC]   Object[]
 FIELD      fields                          [PUBLIC]   Field[]
 FIELD      genericInterfaces               [PUBLIC]   Type[]
 FIELD      genericSuperclass               [PUBLIC]   Type
+FIELD      hidden                          [PUBLIC]   boolean
 FIELD      instance                        [STATIC,   Singleton3
 FIELD      interface                       [PUBLIC]   boolean
 FIELD      interfaces                      [PUBLIC]   Class[]
@@ -194,6 +204,9 @@ FIELD      package                         [PUBLIC]   Package
 FIELD      packageName                     [PUBLIC]   String
 FIELD      primitive                       [PUBLIC]   boolean
 FIELD      protectionDomain                [PUBLIC]   ProtectionDomain
+FIELD      record                          [PUBLIC]   boolean
+FIELD      recordComponents                [PUBLIC]   RecordComponent[]
+FIELD      sealed                          [PUBLIC]   boolean
 FIELD      simpleName                      [PUBLIC]   String
 FIELD      superclass                      [PUBLIC]   Class
 FIELD      synthetic                       [PUBLIC]   boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.16.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.16.completion
@@ -5,6 +5,7 @@ Singleton3.|
 METHOD     addShutdownHook(Closure)                   void
 METHOD     any()                                      boolean
 METHOD     any(Closure)                               boolean
+METHOD     arrayType()                     [PUBLIC]   Class<?>
 METHOD     asBoolean()                                boolean
 METHOD     asSubclass(Class<U>)            [PUBLIC]   Class<? extends U>
 METHOD     asType(Class)                              Object
@@ -12,6 +13,9 @@ METHOD     cast(Object)                    [PUBLIC]   T
 METHOD     collect()                                  Collection
 METHOD     collect(Closure)                           List
 METHOD     collect(Collection, Closure)               Collection
+METHOD     componentType()                 [PUBLIC]   Class<?>
+METHOD     describeConstable()             [PUBLIC]   Optional<ClassDesc>
+METHOD     descriptorString()              [PUBLIC]   String
 METHOD     desiredAssertionStatus()        [PUBLIC]   boolean
 METHOD     dump()                                     String
 METHOD     each(Closure)                              Object
@@ -81,8 +85,10 @@ METHOD     getNestHost()                   [PUBLIC]   Class<?>
 METHOD     getNestMembers()                [PUBLIC]   Class<?>[]
 METHOD     getPackage()                    [PUBLIC]   Package
 METHOD     getPackageName()                [PUBLIC]   String
+METHOD     getPermittedSubclasses()        [PUBLIC]   Class<?>[]
 METHOD     getProperties()                            Map
 METHOD     getProtectionDomain()           [PUBLIC]   ProtectionDomain
+METHOD     getRecordComponents()           [PUBLIC]   RecordComponent[]
 METHOD     getResource(String)             [PUBLIC]   URL
 METHOD     getResourceAsStream(String)     [PUBLIC]   InputStream
 METHOD     getSigners()                    [PUBLIC]   Object[]
@@ -107,12 +113,15 @@ METHOD     isArray()                       [PUBLIC]   boolean
 METHOD     isAssignableFrom(Class<?>)      [PUBLIC]   boolean
 METHOD     isCase(Object)                             boolean
 METHOD     isEnum()                        [PUBLIC]   boolean
+METHOD     isHidden()                      [PUBLIC]   boolean
 METHOD     isInstance(Object)              [PUBLIC]   boolean
 METHOD     isInterface()                   [PUBLIC]   boolean
 METHOD     isLocalClass()                  [PUBLIC]   boolean
 METHOD     isMemberClass()                 [PUBLIC]   boolean
 METHOD     isNestmateOf(Class<?>)          [PUBLIC]   boolean
 METHOD     isPrimitive()                   [PUBLIC]   boolean
+METHOD     isRecord()                      [PUBLIC]   boolean
+METHOD     isSealed()                      [PUBLIC]   boolean
 METHOD     isSynthetic()                   [PUBLIC]   boolean
 METHOD     iterator()                                 Iterator
 METHOD     metaClass(Closure)                         MetaClass
@@ -179,6 +188,7 @@ FIELD      enumConstants                   [PUBLIC]   Object[]
 FIELD      fields                          [PUBLIC]   Field[]
 FIELD      genericInterfaces               [PUBLIC]   Type[]
 FIELD      genericSuperclass               [PUBLIC]   Type
+FIELD      hidden                          [PUBLIC]   boolean
 FIELD      instance                        [STATIC,   Singleton3
 FIELD      interface                       [PUBLIC]   boolean
 FIELD      interfaces                      [PUBLIC]   Class[]
@@ -192,8 +202,12 @@ FIELD      nestHost                        [PUBLIC]   Class
 FIELD      nestMembers                     [PUBLIC]   Class[]
 FIELD      package                         [PUBLIC]   Package
 FIELD      packageName                     [PUBLIC]   String
+FIELD      permittedSubclasses             [PUBLIC]   Class[]
 FIELD      primitive                       [PUBLIC]   boolean
 FIELD      protectionDomain                [PUBLIC]   ProtectionDomain
+FIELD      record                          [PUBLIC]   boolean
+FIELD      recordComponents                [PUBLIC]   RecordComponent[]
+FIELD      sealed                          [PUBLIC]   boolean
 FIELD      simpleName                      [PUBLIC]   String
 FIELD      superclass                      [PUBLIC]   Class
 FIELD      synthetic                       [PUBLIC]   boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.9.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.9.completion
@@ -77,8 +77,6 @@ METHOD     getMethods()                    [PUBLIC]   Method[]
 METHOD     getModifiers()                  [PUBLIC]   int
 METHOD     getModule()                     [PUBLIC]   Module
 METHOD     getName()                       [PUBLIC]   String
-METHOD     getNestHost()                   [PUBLIC]   Class<?>
-METHOD     getNestMembers()                [PUBLIC]   Class<?>[]
 METHOD     getPackage()                    [PUBLIC]   Package
 METHOD     getPackageName()                [PUBLIC]   String
 METHOD     getProperties()                            Map
@@ -111,7 +109,6 @@ METHOD     isInstance(Object)              [PUBLIC]   boolean
 METHOD     isInterface()                   [PUBLIC]   boolean
 METHOD     isLocalClass()                  [PUBLIC]   boolean
 METHOD     isMemberClass()                 [PUBLIC]   boolean
-METHOD     isNestmateOf(Class<?>)          [PUBLIC]   boolean
 METHOD     isPrimitive()                   [PUBLIC]   boolean
 METHOD     isSynthetic()                   [PUBLIC]   boolean
 METHOD     iterator()                                 Iterator
@@ -188,8 +185,6 @@ FIELD      methods                         [PUBLIC]   Method[]
 FIELD      modifiers                       [PUBLIC]   int
 FIELD      module                          [PUBLIC]   Module
 FIELD      name                            [PUBLIC]   String
-FIELD      nestHost                        [PUBLIC]   Class
-FIELD      nestMembers                     [PUBLIC]   Class[]
 FIELD      package                         [PUBLIC]   Package
 FIELD      packageName                     [PUBLIC]   String
 FIELD      primitive                       [PUBLIC]   boolean


### PR DESCRIPTION
 - update test files for OperatorsCCTest, MethodCCTest, ClosuresCCTest and TransformationsCCTest
 - checked all JDKs between 8 and 17

this should fix master again (https://github.com/apache/netbeans/pull/7401 bumped LSP lang level while groovy tests were locked to 8)

meta issue: https://github.com/apache/netbeans/issues/4904