### PR TITLE
Fix formatting for typed field and const alignment #7190

### DIFF
--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedConstants01.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedConstants01.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7190_01 {
+
+    private const ?string C1   = '';
+    private const ?Test C2   = null;
+    private const Test1|Test2|null C3   = null;
+    private const array|(Test2&Test3) CONST4 = [];
+    private const CONSTANT5 = [];
+}
+
+class GH7190_02 {
+
+    private  const ?string CONST1   =   '';
+    public  const   Test CONST2   =    null;
+    private   const    ?int CONST3      = null;
+    protected   const ?array     CONST4 =    [];
+    private const CONSTANT5 = [];
+    const array  |  (  Test2 & Test3  ) CONST6 = [];
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedConstants01.php.testGroupAlignmentAssignmentTypedConstants01a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedConstants01.php.testGroupAlignmentAssignmentTypedConstants01a.formatted
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7190_01 {
+
+    private const ?string C1                 = '';
+    private const ?Test C2                   = null;
+    private const Test1|Test2|null C3        = null;
+    private const array|(Test2&Test3) CONST4 = [];
+    private const CONSTANT5                  = [];
+}
+
+class GH7190_02 {
+
+    private const ?string CONST1     = '';
+    public const Test CONST2         = null;
+    private const ?int CONST3        = null;
+    protected const ?array CONST4    = [];
+    private const CONSTANT5          = [];
+    const array|(Test2&Test3) CONST6 = [];
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedConstants01.php.testGroupAlignmentAssignmentTypedConstants01b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedConstants01.php.testGroupAlignmentAssignmentTypedConstants01b.formatted
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7190_01 {
+
+    private const ?string C1 = '';
+    private const ?Test C2 = null;
+    private const Test1|Test2|null C3 = null;
+    private const array|(Test2&Test3) CONST4 = [];
+    private const CONSTANT5 = [];
+}
+
+class GH7190_02 {
+
+    private const ?string CONST1 = '';
+    public const Test CONST2 = null;
+    private const ?int CONST3 = null;
+    protected const ?array CONST4 = [];
+    private const CONSTANT5 = [];
+    const array|(Test2&Test3) CONST6 = [];
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedConstants02.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedConstants02.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7190_01 {
+
+    private const ?string C1                 = '';
+    private const ?Test C2                   = null;
+    private const Test1|Test2|null C3        = null;
+    private const array|(Test2&Test3) CONST4 = [];
+    private const CONSTANT5                  = [];
+}
+
+class GH7190_02 {
+
+    private const ?string CONST1     = '';
+    public const Test CONST2         = null;
+    private const ?int CONST3        = null;
+    protected const ?array CONST4    = [];
+    private const CONSTANT5          = [];
+    const array|(Test2&Test3) CONST6 = [];
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedConstants02.php.testGroupAlignmentAssignmentTypedConstants02a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedConstants02.php.testGroupAlignmentAssignmentTypedConstants02a.formatted
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7190_01 {
+
+    private const ?string C1                 = '';
+    private const ?Test C2                   = null;
+    private const Test1|Test2|null C3        = null;
+    private const array|(Test2&Test3) CONST4 = [];
+    private const CONSTANT5                  = [];
+}
+
+class GH7190_02 {
+
+    private const ?string CONST1     = '';
+    public const Test CONST2         = null;
+    private const ?int CONST3        = null;
+    protected const ?array CONST4    = [];
+    private const CONSTANT5          = [];
+    const array|(Test2&Test3) CONST6 = [];
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedConstants02.php.testGroupAlignmentAssignmentTypedConstants02b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedConstants02.php.testGroupAlignmentAssignmentTypedConstants02b.formatted
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7190_01 {
+
+    private const ?string C1 = '';
+    private const ?Test C2 = null;
+    private const Test1|Test2|null C3 = null;
+    private const array|(Test2&Test3) CONST4 = [];
+    private const CONSTANT5 = [];
+}
+
+class GH7190_02 {
+
+    private const ?string CONST1 = '';
+    public const Test CONST2 = null;
+    private const ?int CONST3 = null;
+    protected const ?array CONST4 = [];
+    private const CONSTANT5 = [];
+    const array|(Test2&Test3) CONST6 = [];
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedFields01.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedFields01.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7190_01 {
+
+    private ?string $t1   = '';
+    private ?Test $t2   = null;
+    private Test1|Test2|null $t3   = null;
+    private array|(Test2&Test3) $test4 = [];
+    private $test5 = [];
+}
+
+class GH7190_02 {
+
+    private   ?string $test1   =   '';
+    private    Test $test2   =    null;
+    private      ?int $test3      = null;
+    private ?array     $test4 =    [];
+}
+
+class GH7190_03 {
+
+       private ?string $t1   = '';
+      private ?Test $t2;
+      private ?Test $t3       = null;
+    private readonly Test1&Test2 $t4;
+         private   array  |(  Test2  &  Test3 ) $test5 = [];
+}
+
+class GH7190_04 {
+
+       private const ?string C1   = '';
+    public const ?string CCCC2 = '';
+    const ?string CCCC3 = '';
+
+       private ?Test $t2;
+      private ?Test $t3       = null;
+    private readonly Test1&Test2 $t4;
+         private array|(Test2&Test3) $test5 = [];
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedFields01.php.testGroupAlignmentAssignmentTypedFields01a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedFields01.php.testGroupAlignmentAssignmentTypedFields01a.formatted
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7190_01 {
+
+    private ?string $t1                = '';
+    private ?Test $t2                  = null;
+    private Test1|Test2|null $t3       = null;
+    private array|(Test2&Test3) $test4 = [];
+    private $test5                     = [];
+}
+
+class GH7190_02 {
+
+    private ?string $test1 = '';
+    private Test $test2    = null;
+    private ?int $test3    = null;
+    private ?array $test4  = [];
+}
+
+class GH7190_03 {
+
+    private ?string $t1                = '';
+    private ?Test $t2;
+    private ?Test $t3                  = null;
+    private readonly Test1&Test2 $t4;
+    private array|(Test2&Test3) $test5 = [];
+}
+
+class GH7190_04 {
+
+    private const ?string C1   = '';
+    public const ?string CCCC2 = '';
+    const ?string CCCC3        = '';
+
+    private ?Test $t2;
+    private ?Test $t3                  = null;
+    private readonly Test1&Test2 $t4;
+    private array|(Test2&Test3) $test5 = [];
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedFields01.php.testGroupAlignmentAssignmentTypedFields01b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedFields01.php.testGroupAlignmentAssignmentTypedFields01b.formatted
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7190_01 {
+
+    private ?string $t1 = '';
+    private ?Test $t2 = null;
+    private Test1|Test2|null $t3 = null;
+    private array|(Test2&Test3) $test4 = [];
+    private $test5 = [];
+}
+
+class GH7190_02 {
+
+    private ?string $test1 = '';
+    private Test $test2 = null;
+    private ?int $test3 = null;
+    private ?array $test4 = [];
+}
+
+class GH7190_03 {
+
+    private ?string $t1 = '';
+    private ?Test $t2;
+    private ?Test $t3 = null;
+    private readonly Test1&Test2 $t4;
+    private array|(Test2&Test3) $test5 = [];
+}
+
+class GH7190_04 {
+
+    private const ?string C1 = '';
+    public const ?string CCCC2 = '';
+    const ?string CCCC3 = '';
+
+    private ?Test $t2;
+    private ?Test $t3 = null;
+    private readonly Test1&Test2 $t4;
+    private array|(Test2&Test3) $test5 = [];
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedFields02.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedFields02.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7190_01 {
+
+    private ?string $t1                = '';
+    private ?Test $t2                  = null;
+    private Test1|Test2|null $t3       = null;
+    private array|(Test2&Test3) $test4 = [];
+    private $test5                     = [];
+}
+
+class GH7190_02 {
+
+    private ?string $test1 = '';
+    private Test $test2    = null;
+    private ?int $test3    = null;
+    private ?array $test4  = [];
+}
+
+class GH7190_03 {
+
+    private ?string $t1                = '';
+    private ?Test $t2;
+    private ?Test $t3                  = null;
+    private readonly Test1&Test2 $t4;
+    private array|(Test2&Test3) $test5 = [];
+}
+
+class GH7190_04 {
+
+    private const ?string C1   = '';
+    public const ?string CCCC2 = '';
+    const ?string CCCC3        = '';
+
+    private ?Test $t2;
+    private ?Test $t3                  = null;
+    private readonly Test1&Test2 $t4;
+    private array|(Test2&Test3) $test5 = [];
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedFields02.php.testGroupAlignmentAssignmentTypedFields02a.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedFields02.php.testGroupAlignmentAssignmentTypedFields02a.formatted
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7190_01 {
+
+    private ?string $t1                = '';
+    private ?Test $t2                  = null;
+    private Test1|Test2|null $t3       = null;
+    private array|(Test2&Test3) $test4 = [];
+    private $test5                     = [];
+}
+
+class GH7190_02 {
+
+    private ?string $test1 = '';
+    private Test $test2    = null;
+    private ?int $test3    = null;
+    private ?array $test4  = [];
+}
+
+class GH7190_03 {
+
+    private ?string $t1                = '';
+    private ?Test $t2;
+    private ?Test $t3                  = null;
+    private readonly Test1&Test2 $t4;
+    private array|(Test2&Test3) $test5 = [];
+}
+
+class GH7190_04 {
+
+    private const ?string C1   = '';
+    public const ?string CCCC2 = '';
+    const ?string CCCC3        = '';
+
+    private ?Test $t2;
+    private ?Test $t3                  = null;
+    private readonly Test1&Test2 $t4;
+    private array|(Test2&Test3) $test5 = [];
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedFields02.php.testGroupAlignmentAssignmentTypedFields02b.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/alignment/groupAlignmentAssignmentTypedFields02.php.testGroupAlignmentAssignmentTypedFields02b.formatted
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7190_01 {
+
+    private ?string $t1 = '';
+    private ?Test $t2 = null;
+    private Test1|Test2|null $t3 = null;
+    private array|(Test2&Test3) $test4 = [];
+    private $test5 = [];
+}
+
+class GH7190_02 {
+
+    private ?string $test1 = '';
+    private Test $test2 = null;
+    private ?int $test3 = null;
+    private ?array $test4 = [];
+}
+
+class GH7190_03 {
+
+    private ?string $t1 = '';
+    private ?Test $t2;
+    private ?Test $t3 = null;
+    private readonly Test1&Test2 $t4;
+    private array|(Test2&Test3) $test5 = [];
+}
+
+class GH7190_04 {
+
+    private const ?string C1 = '';
+    public const ?string CCCC2 = '';
+    const ?string CCCC3 = '';
+
+    private ?Test $t2;
+    private ?Test $t3 = null;
+    private readonly Test1&Test2 $t4;
+    private array|(Test2&Test3) $test5 = [];
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterAlignmentTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterAlignmentTest.java
@@ -494,4 +494,54 @@ public class PHPFormatterAlignmentTest extends PHPFormatterTestBase {
         options.put(FmtOptions.GROUP_ALIGNMENT_ARRAY_INIT, false);
         reformatFileContents(getTestFilePath("groupAlignmentMatchArmArrow_02.php"), options, false, true);
     }
+
+    // GH-7190
+    public void testGroupAlignmentAssignmentTypedFields01a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.GROUP_ALIGNMENT_ASSIGNMENT, true);
+        reformatFileContents(getTestFilePath("groupAlignmentAssignmentTypedFields01.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentAssignmentTypedFields01b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.GROUP_ALIGNMENT_ASSIGNMENT, false);
+        reformatFileContents(getTestFilePath("groupAlignmentAssignmentTypedFields01.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentAssignmentTypedFields02a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.GROUP_ALIGNMENT_ASSIGNMENT, true);
+        reformatFileContents(getTestFilePath("groupAlignmentAssignmentTypedFields02.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentAssignmentTypedFields02b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.GROUP_ALIGNMENT_ASSIGNMENT, false);
+        reformatFileContents(getTestFilePath("groupAlignmentAssignmentTypedFields02.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentAssignmentTypedConstants01a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.GROUP_ALIGNMENT_ASSIGNMENT, true);
+        reformatFileContents(getTestFilePath("groupAlignmentAssignmentTypedConstants01.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentAssignmentTypedConstants01b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.GROUP_ALIGNMENT_ASSIGNMENT, false);
+        reformatFileContents(getTestFilePath("groupAlignmentAssignmentTypedConstants01.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentAssignmentTypedConstants02a() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.GROUP_ALIGNMENT_ASSIGNMENT, true);
+        reformatFileContents(getTestFilePath("groupAlignmentAssignmentTypedConstants02.php"), options, false, true);
+    }
+
+    public void testGroupAlignmentAssignmentTypedConstants02b() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.GROUP_ALIGNMENT_ASSIGNMENT, false);
+        reformatFileContents(getTestFilePath("groupAlignmentAssignmentTypedConstants02.php"), options, false, true);
+    }
+
 }


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/7190
- Add a field type name length
- Fix const name length
- Add unit tests

Example:

```php
class GH7190 {

       private const ?string C1   = '';
    public const ?string CCCC2 = '';
    const ?string CCCC3 = '';

       private ?Test $t2;
      private ?Test $t3       = null;
    private readonly Test1&Test2 $t4;
         private array|(Test2&Test3) $test5 = [];
}
```

Before:

```php
class GH7190 {

    private const ?string C1    = '';
    public const ?string CCCC2 = '';
    const ?string CCCC3 = '';

    private ?Test $t2;
    private ?Test $t3    = null;
    private readonly Test1&Test2 $t4;
    private array|(Test2&Test3) $test5 = [];
}
```

After:

```php
class GH7190 {

    private const ?string C1   = '';
    public const ?string CCCC2 = '';
    const ?string CCCC3        = '';

    private ?Test $t2;
    private ?Test $t3                  = null;
    private readonly Test1&Test2 $t4;
    private array|(Test2&Test3) $test5 = [];
}
```