### PR TITLE
Correctly register weak property change listener on InputOutput 

### DIFF
--- a/ide/dlight.terminal/nbproject/project.properties
+++ b/ide/dlight.terminal/nbproject/project.properties
@@ -16,4 +16,4 @@
 # under the License.
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-spec.version.base=1.48.0
+spec.version.base=1.49.0

--- a/ide/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/TerminalSupportImpl.java
+++ b/ide/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/TerminalSupportImpl.java
@@ -52,6 +52,7 @@ import org.netbeans.modules.nativeexecution.api.util.ConnectionManager.Cancellat
 import org.netbeans.modules.nativeexecution.api.util.HostInfoUtils;
 import org.netbeans.modules.nativeexecution.api.util.PathUtils;
 import org.netbeans.modules.terminal.api.IONotifier;
+import org.netbeans.modules.terminal.api.ui.IOTerm;
 import org.netbeans.modules.terminal.api.ui.IOVisibility;
 import org.netbeans.modules.terminal.support.TerminalPinSupport;
 import org.netbeans.modules.terminal.support.TerminalPinSupport.TerminalCreationDetails;
@@ -70,7 +71,6 @@ import org.openide.windows.OutputListener;
 import org.openide.windows.OutputWriter;
 
 import static org.netbeans.lib.terminalemulator.Term.ExternalCommandsConstants.*;
-import org.netbeans.modules.terminal.api.ui.IOTerm;
 
 /**
  *
@@ -122,7 +122,7 @@ public final class TerminalSupportImpl {
             final long termId) {
         final IOProvider ioProvider = IOProvider.get("Terminal"); // NOI18N
         if (ioProvider != null) {
-            final AtomicReference<InputOutput> ioRef = new AtomicReference<InputOutput>();
+            final AtomicReference<InputOutput> ioRef = new AtomicReference<>();
             // Create a tab in EDT right after we call the method, don't let this 
             // work to be done in RP in asynchronous manner. We need this to
             // save tab order 
@@ -131,17 +131,15 @@ public final class TerminalSupportImpl {
             final AtomicBoolean destroyed = new AtomicBoolean(false);
             
             final Runnable runnable = new Runnable() {
-                private final Runnable delegate = new Runnable() {
-                    @Override
-                    public void run() {
-                        if (SwingUtilities.isEventDispatchThread()) {
-                            ioContainer.requestActive();
-                        } else {
-                            doWork();
-                        }
+                private final Runnable delegate = () -> {
+                    if (SwingUtilities.isEventDispatchThread()) {
+                        ioContainer.requestActive();
+                    } else {
+                        doWork();
                     }
                 };
 
+                @SuppressWarnings("PackageVisibleField")
                 RequestProcessor.Task task = RP.create(delegate);
 
                 private final HyperlinkAdapter retryLink = new HyperlinkAdapter() {
@@ -177,7 +175,8 @@ public final class TerminalSupportImpl {
                                     } catch (IOException ignored) {
                                     }
                                 }
-                                String error = ex.getCause() == null ? ex.getMessage() : ex.getCause().getMessage();
+                                Throwable cause = ex.getCause();
+                                String error = cause == null ? ex.getMessage() : cause.getMessage();
                                 String msg = NbBundle.getMessage(TerminalSupportImpl.class, "TerminalAction.FailedToStart.text", error); // NOI18N
                                 DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(msg, NotifyDescriptor.ERROR_MESSAGE));
                             }
@@ -217,9 +216,7 @@ public final class TerminalSupportImpl {
                                     return;
                                 }
                             }
-                        } catch (ConnectException ex) {
-                            Exceptions.printStackTrace(ex);
-                        } catch (InterruptedException ex) {
+                        } catch (ConnectException | InterruptedException ex) {
                             Exceptions.printStackTrace(ex);
                         }
 
@@ -240,10 +237,7 @@ public final class TerminalSupportImpl {
                             }
                             return;
                         }
-                    } catch (IOException ex) {
-                        Exceptions.printStackTrace(ex);
-                        return;
-                    } catch (CancellationException ex) {
+                    } catch (IOException | CancellationException ex) {
                         Exceptions.printStackTrace(ex);
                         return;
                     }
@@ -331,13 +325,9 @@ public final class TerminalSupportImpl {
                         
                         NativeExecutionDescriptor descr;
                         descr = new NativeExecutionDescriptor().controllable(true).frontWindow(true).inputVisible(true).inputOutput(ioRef.get());
-                        descr.postExecution(new Runnable() {
-
-                            @Override
-                            public void run() {
-                                ioRef.get().closeInputOutput();
-                                support.close(term);
-                            }
+                        descr.postExecution(() -> {
+                            ioRef.get().closeInputOutput();
+                            support.close(term);
                         });
                         NativeExecutionService es = NativeExecutionService.newService(npb, descr, "Terminal Emulator"); // NOI18N
                         Future<Integer> result = es.run();
@@ -362,7 +352,8 @@ public final class TerminalSupportImpl {
                             Exceptions.printStackTrace(ex);
                         } catch (ExecutionException ex) {
                             if (!destroyed.get()) {
-                                String error = ex.getCause() == null ? ex.getMessage() : ex.getCause().getMessage();
+                                Throwable cause = ex.getCause();
+                                String error = cause == null ? ex.getMessage() : cause.getMessage();
                                 String msg = NbBundle.getMessage(TerminalSupportImpl.class, "TerminalAction.FailedToStart.text", error); // NOI18N
                                 DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(msg, NotifyDescriptor.ERROR_MESSAGE));
                             }
@@ -391,7 +382,7 @@ public final class TerminalSupportImpl {
         public NativeProcessListener(InputOutput io, AtomicBoolean destroyed) {
             assert destroyed != null;
             this.destroyed = destroyed;
-            this.processRef = new AtomicReference<NativeProcess>();
+            this.processRef = new AtomicReference<>();
             IONotifier.addPropertyChangeListener(io, WeakListeners.propertyChange(NativeProcessListener.this, io));
         }
 
@@ -410,14 +401,10 @@ public final class TerminalSupportImpl {
                     // term is closing => destroy process
                     final NativeProcess proc = processRef.get();
                     if (proc != null) {
-                        RP.submit(new Runnable() {
-
-                            @Override
-                            public void run() {
-                                try {
-                                    proc.destroy();
-                                } catch (Throwable th) {
-                                }
+                        RP.submit(() -> {
+                            try {
+                                proc.destroy();
+                            } catch (Throwable th) {
                             }
                         });
                     }


### PR DESCRIPTION
This warning was observed:

```
WARNING [org.openide.util.WeakListenerImpl]: Can't remove java.beans.PropertyChangeListener using method org.netbeans.modules.terminal.ioprovider.TerminalInputOutput.removePropertyChangeListener from org.netbeans.modules.terminal.ioprovider.TerminalInputOutput@10efb8c9
WARNING [org.openide.util.WeakListenerImpl]: Can't remove java.beans.PropertyChangeListener using method org.netbeans.modules.terminal.ioprovider.TerminalInputOutput.removePropertyChangeListener from org.netbeans.modules.terminal.ioprovider.TerminalInputOutput@3a72784a
```

This was one of the candidates for the source of the problem.