### PR TITLE
Fix the Code Completion for `static` return type #7192

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/FunctionScopeImpl.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/FunctionScopeImpl.java
@@ -283,7 +283,8 @@ class FunctionScopeImpl extends ScopeImpl implements FunctionScope, VariableName
                 && inScope instanceof TypeScope) {
             TypeScope typeScope = (TypeScope) inScope;
             for (TypeScope callerType : callerTypes) {
-                if (callerType.isSubTypeOf(typeScope)) {
+                if (callerType.isSubTypeOf(typeScope)
+                        || (typeScope.isTrait() && callerType != typeScope)) { // GH-7192
                     cTypes.add(callerType);
                 } else {
                     cTypes.add(typeScope);

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh7192/gh7192.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh7192/gh7192.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+trait EmptyTrait {}
+
+trait TestTrait {
+    /**
+     * @return static
+     */
+    public static function returnStaticPhpDocMethod()
+    {
+        return new static();
+    }
+
+    public static function returnStaticReturnTypeMethod(): static
+    {
+        return new static();
+    }
+
+    public static function testStaticTraitMethod() {
+        self::returnStaticMethod->traitMethod();
+    }
+
+    public function traitMethod(): void {
+    }
+}
+
+abstract class AbstractClass {
+    use TestTrait;
+}
+
+class TestClass extends AbstractClass {
+    use EmptyTrait;
+
+    public int $field = 1;
+
+    public function testClassMethod(): void {}
+    public static function testStaticClassMethod(): void {}
+}
+
+TestClass::returnStaticPhpDocMethod()->testClassMethod();
+TestClass::returnStaticReturnTypeMethod()->testClassMethod();

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh7192/gh7192.php.testGH7192_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh7192/gh7192.php.testGH7192_01.completion
@@ -1,0 +1,10 @@
+Code completion result for source line:
+TestClass::returnStaticPhpDocMethod()->|testClassMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnStaticPhpDocMethod()      [STATIC]   TestTrait
+METHOD     returnStaticReturnTypeMethod()  [STATIC]   TestTrait
+METHOD     testClassMethod()               [PUBLIC]   TestClass
+METHOD     testStaticClassMethod()         [STATIC]   TestClass
+METHOD     testStaticTraitMethod()         [STATIC]   TestTrait
+METHOD     traitMethod()                   [PUBLIC]   TestTrait
+VARIABLE   int field                       [PUBLIC]   TestClass

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh7192/gh7192.php.testGH7192_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh7192/gh7192.php.testGH7192_02.completion
@@ -1,0 +1,10 @@
+Code completion result for source line:
+TestClass::returnStaticReturnTypeMethod()->|testClassMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnStaticPhpDocMethod()      [STATIC]   TestTrait
+METHOD     returnStaticReturnTypeMethod()  [STATIC]   TestTrait
+METHOD     testClassMethod()               [PUBLIC]   TestClass
+METHOD     testStaticClassMethod()         [STATIC]   TestClass
+METHOD     testStaticTraitMethod()         [STATIC]   TestTrait
+METHOD     traitMethod()                   [PUBLIC]   TestTrait
+VARIABLE   int field                       [PUBLIC]   TestClass

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh7192/gh7192.php.testGH7192_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh7192/gh7192.php.testGH7192_03.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+self::returnStaticMethod->|traitMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnStaticPhpDocMethod()      [STATIC]   TestTrait
+METHOD     returnStaticReturnTypeMethod()  [STATIC]   TestTrait
+METHOD     testStaticTraitMethod()         [STATIC]   TestTrait
+METHOD     traitMethod()                   [PUBLIC]   TestTrait

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionGH7192Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionGH7192Test.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class PHPCodeCompletionGH7192Test extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionGH7192Test(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected FileObject[] createSourceClassPathsForTest() {
+        return new FileObject[]{FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/gh7192/"))};
+    }
+
+    public void testGH7192_01() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh7192/gh7192.php", "TestClass::returnStaticPhpDocMethod()->^testClassMethod();", false);
+    }
+
+    public void testGH7192_02() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh7192/gh7192.php", "TestClass::returnStaticReturnTypeMethod()->^testClassMethod();", false);
+    }
+
+    public void testGH7192_03() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh7192/gh7192.php", "        self::returnStaticMethod->^traitMethod();", false);
+    }
+}


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/7192
- Set a caller type when a method type is a trait and the caller type is not the same as the method type
- Add unit tests