### PR TITLE
Updating org.netbeans.modules.gototest/ org.netbeans.modules.gsf.codecoverage and  org.netbeans.modules.gsf.testrunner as public packages

### DIFF
--- a/ide/gototest/manifest.mf
+++ b/ide/gototest/manifest.mf
@@ -2,4 +2,4 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.gototest/1
 OpenIDE-Module-Layer: org/netbeans/modules/gototest/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gototest/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.58
+OpenIDE-Module-Specification-Version: 1.59

--- a/ide/gototest/nbproject/project.xml
+++ b/ide/gototest/nbproject/project.xml
@@ -153,6 +153,7 @@
                 <friend>org.netbeans.modules.testng</friend>
                 <friend>org.netbeans.modules.web.clientproject.api</friend>
                 <package>org.netbeans.api.gototest</package>
+                <package>org.netbeans.modules.gototest</package>
                 <package>org.netbeans.spi.gototest</package>
             </friend-packages>
         </data>

--- a/ide/gsf.codecoverage/manifest.mf
+++ b/ide/gsf.codecoverage/manifest.mf
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.gsf.codecoverage
 OpenIDE-Module-Layer: org/netbeans/modules/gsf/codecoverage/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gsf/codecoverage/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.57
+OpenIDE-Module-Specification-Version: 1.58
 AutoUpdate-Show-In-Client: false
 

--- a/ide/gsf.codecoverage/nbproject/project.xml
+++ b/ide/gsf.codecoverage/nbproject/project.xml
@@ -195,6 +195,7 @@
                 <friend>org.netbeans.modules.ruby.codecoverage</friend>
                 <friend>org.netbeans.modules.web.clientproject</friend>
                 <friend>org.netbeans.modules.web.clientproject.api</friend>
+                <package>org.netbeans.modules.gsf.codecoverage</package>
                 <package>org.netbeans.modules.gsf.codecoverage.api</package>
             </friend-packages>
         </data>

--- a/ide/gsf.testrunner/manifest.mf
+++ b/ide/gsf.testrunner/manifest.mf
@@ -3,5 +3,5 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.gsf.testrunner/2
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gsf/testrunner/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/gsf/testrunner/layer.xml
-OpenIDE-Module-Specification-Version: 2.37
+OpenIDE-Module-Specification-Version: 2.38
 

--- a/ide/gsf.testrunner/nbproject/project.xml
+++ b/ide/gsf.testrunner/nbproject/project.xml
@@ -69,6 +69,7 @@
                 </dependency>
             </module-dependencies>
             <public-packages>
+                <package>org.netbeans.modules.gsf.testrunner</package>
                 <package>org.netbeans.modules.gsf.testrunner.api</package>
                 <package>org.netbeans.modules.gsf.testrunner.plugin</package>
             </public-packages>


### PR DESCRIPTION
Fix for #6871 
Making gototest/gsf.codecoverage/gsf.testrunner public APIs