### PR TITLE
Fix the brace context #7124

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/PHPBracesMatcher.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/PHPBracesMatcher.java
@@ -309,6 +309,7 @@ public final class PHPBracesMatcher implements BracesMatcher, BracesMatcher.Cont
                 return null;
             }
             List<PHPTokenId> lookfor = Arrays.asList(
+                    PHPTokenId.PHP_CURLY_OPEN, // terminator e.g. ${a} GH-7124
                     PHPTokenId.PHP_CURLY_CLOSE, // terminator
                     PHPTokenId.PHP_CLASS, PHPTokenId.PHP_INTERFACE, PHPTokenId.PHP_TRAIT, PHPTokenId.PHP_FUNCTION,
                     PHPTokenId.PHP_FOR, PHPTokenId.PHP_FOREACH,
@@ -317,8 +318,14 @@ public final class PHPBracesMatcher implements BracesMatcher, BracesMatcher.Cont
                     PHPTokenId.PHP_IF, PHPTokenId.PHP_ELSE, PHPTokenId.PHP_ELSEIF,
                     PHPTokenId.PHP_SWITCH, PHPTokenId.PHP_USE, PHPTokenId.PHP_MATCH, PHPTokenId.PHP_ENUM
             );
+            if (!ts.movePrevious()) {
+                // consume the current token("{" or ":")
+                return null;
+            }
             Token<? extends PHPTokenId> previousToken = LexUtilities.findPreviousToken(ts, lookfor);
-            if (previousToken == null || previousToken.id() == PHPTokenId.PHP_CURLY_CLOSE) {
+            if (previousToken == null
+                    || previousToken.id() == PHPTokenId.PHP_CURLY_OPEN
+                    || previousToken.id() == PHPTokenId.PHP_CURLY_CLOSE) {
                 return null;
             }
 

--- a/php/php.editor/test/unit/data/testfiles/bracematching/braceContextGH7124.php
+++ b/php/php.editor/test/unit/data/testfiles/bracematching/braceContextGH7124.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7124
+{
+    public function testGH7124()
+    {
+        $test = 1;
+        {test}
+        ${test};
+    } // method
+}

--- a/php/php.editor/test/unit/data/testfiles/bracematching/braceContextGH7124.php.testFindContextGH7124_03.bracecontext
+++ b/php/php.editor/test/unit/data/testfiles/bracematching/braceContextGH7124.php.testFindContextGH7124_03.bracecontext
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7124
+{
+    public |>MARK_BC:function testGH7124()
+    {<|
+        $test = 1;
+        {test}
+        ${test};
+    } // method
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/PHPBracesMatcherTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/PHPBracesMatcherTest.java
@@ -884,6 +884,20 @@ public class PHPBracesMatcherTest extends PHPTestBase {
         checkBraceContext("php81/enumerations.php", "^} // enum 6", true);
     }
 
+    public void testFindContextGH7124_01() throws Exception {
+        BraceContext braceContext = getBraceContext("braceContextGH7124.php", "        {test^}", true);
+        assertNull(braceContext);
+    }
+
+    public void testFindContextGH7124_02() throws Exception {
+        BraceContext braceContext = getBraceContext("braceContextGH7124.php", "        ${test^};", true);
+        assertNull(braceContext);
+    }
+
+    public void testFindContextGH7124_03() throws Exception {
+        checkBraceContext("braceContextGH7124.php", "^} // method", true);
+    }
+
     private void matchesBackward(String original) throws BadLocationException {
         matches(original, true);
     }
@@ -938,6 +952,16 @@ public class PHPBracesMatcherTest extends PHPTestBase {
      * @throws Exception
      */
     private void checkBraceContext(String filePath, String caretLine, boolean backward) throws Exception {
+        BraceContext context = getBraceContext(filePath, caretLine, backward);
+        assertNotNull(context);
+
+        Source testSource = getTestSource(getTestFile(TEST_DIRECTORY + filePath));
+        Document doc = testSource.getDocument(true);
+        String result = annoteteBraceContextRanges(doc, context);
+        assertDescriptionMatches(testSource.getFileObject(), result, true, ".bracecontext", true);
+    }
+
+    private BraceContext getBraceContext(String filePath, String caretLine, boolean backward) throws Exception {
         Source testSource = getTestSource(getTestFile(TEST_DIRECTORY + filePath));
 
         Document doc = testSource.getDocument(true);
@@ -955,11 +979,7 @@ public class PHPBracesMatcherTest extends PHPTestBase {
         assertNotNull(origin);
         assertNotNull(matches);
 
-        BraceContext context = matcher.findContext(origin[0]);
-        assertNotNull(context);
-
-        String result = annoteteBraceContextRanges(doc, context);
-        assertDescriptionMatches(testSource.getFileObject(), result, true, ".bracecontext", true);
+        return matcher.findContext(origin[0]);
     }
 
     private String annoteteBraceContextRanges(Document document, final BraceContext context) throws BadLocationException {


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/7124
- `{example}` and `${example}` don't have the brace context
- Add unit tests

Before:

![nb-php-gh-7124-before](https://github.com/apache/netbeans/assets/738383/4c0cc902-5f84-48cc-ac4e-1db96e8d6328)

After:

![nb-php-gh-7124-after](https://github.com/apache/netbeans/assets/738383/d24f1def-b655-436d-95c9-5e61e95112b3)
