### PR TITLE
Fix the mark ocurrences and the go to declaration for nested lambda functions #7348

### DIFF
--- a/php/php.editor/test/unit/data/testfiles/gotodeclaration/testIssueGH7348/testIssueGH7348.php
+++ b/php/php.editor/test/unit/data/testfiles/gotodeclaration/testIssueGH7348/testIssueGH7348.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function test() {
+    $lexical = function() {};
+
+    $closure = function() use ($lexical) {
+        $nestedClosure = function() {};
+        $lexical();
+        $nestedClosure();
+    };
+}

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/testIssueGH7348/testIssueGH7348.php
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/testIssueGH7348/testIssueGH7348.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function test() {
+    $lexical = function() {};
+
+    $closure = function() use ($lexical) {
+        $nestedClosure = function() {};
+        $lexical();
+        $nestedClosure();
+    };
+}

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/testIssueGH7348/testIssueGH7348.php.testIssueGH7348_01a.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/testIssueGH7348/testIssueGH7348.php.testIssueGH7348_01a.occurrences
@@ -1,0 +1,3 @@
+    $|>MARK_OCCURRENCES:lex^ical<| = function() {};
+    $closure = function() use ($|>MARK_OCCURRENCES:lexical<|) {
+        $|>MARK_OCCURRENCES:lexical<|();

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/testIssueGH7348/testIssueGH7348.php.testIssueGH7348_01b.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/testIssueGH7348/testIssueGH7348.php.testIssueGH7348_01b.occurrences
@@ -1,0 +1,3 @@
+    $|>MARK_OCCURRENCES:lexical<| = function() {};
+    $closure = function() use ($|>MARK_OCCURRENCES:lexic^al<|) {
+        $|>MARK_OCCURRENCES:lexical<|();

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/testIssueGH7348/testIssueGH7348.php.testIssueGH7348_01c.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/testIssueGH7348/testIssueGH7348.php.testIssueGH7348_01c.occurrences
@@ -1,0 +1,3 @@
+    $|>MARK_OCCURRENCES:lexical<| = function() {};
+    $closure = function() use ($|>MARK_OCCURRENCES:lexical<|) {
+        $|>MARK_OCCURRENCES:lexi^cal<|();

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/GotoDeclarationGH7348Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/GotoDeclarationGH7348Test.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.csl;
+
+public class GotoDeclarationGH7348Test extends GotoDeclarationTestBase {
+
+    public GotoDeclarationGH7348Test(String testName) {
+        super(testName);
+    }
+
+    public void testIssueGH7348_01a() throws Exception {
+        checkDeclaration(getTestPath(), "    $closure = function() use ($l^exical) {", "    $^lexical = function() {};");
+    }
+
+    public void testIssueGH7348_01b() throws Exception {
+        checkDeclaration(getTestPath(), "        $lexic^al();", "    $^lexical = function() {};");
+    }
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImplGH7348Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImplGH7348Test.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.csl;
+
+public class OccurrencesFinderImplGH7348Test extends OccurrencesFinderImplTestBase {
+
+    public OccurrencesFinderImplGH7348Test(String testName) {
+        super(testName);
+    }
+
+    public void testIssueGH7348_01a() throws Exception {
+        checkOccurrences(getTestPath(), "    $lex^ical = function() {};", true);
+    }
+
+    public void testIssueGH7348_01b() throws Exception {
+        checkOccurrences(getTestPath(), "    $closure = function() use ($lexic^al) {", true);
+    }
+
+    public void testIssueGH7348_01c() throws Exception {
+        checkOccurrences(getTestPath(), "        $lexi^cal();", true);
+    }
+}


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/7348
- Keep previous lexical variables and a scope
- Add unit tests

Example:
```php
$lexical = function() {};
$closure = function() use ($lexical) {
    $nestedClosure = function() {};
    $lexical();
    $nestedClosure();
};
```

Before:

![nb-php-gh-7348-before](https://github.com/apache/netbeans/assets/738383/423e92b0-a21e-467d-8fb4-76f643904985)

After:

![nb-php-gh-7348-after](https://github.com/apache/netbeans/assets/738383/e3372b80-f7a0-4507-bd47-1cac17beb83d)
