### PR TITLE
Fix formatting issues [GH-7140] [GH-7454]

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
@@ -1546,6 +1546,17 @@ public class FormatVisitor extends DefaultVisitor {
 
     @Override
     public void visit(LambdaFunctionDeclaration node) {
+        // GH-7454 keep isMethodInvocationShifted
+        // e.g.
+        // Example::staticMethod()
+        //    ->method(function() {
+        //        Example::staticMethod()
+        //            ->method();
+        //        });
+        boolean isMethodInvocationShiftedHolder = isMethodInvocationShifted;
+        if (isMethodInvocationShifted) {
+            isMethodInvocationShifted = false;
+        }
         boolean disableIndent = disableIndentForFunctionInvocation(node.getStartOffset());
         scan(node.getAttributes());
         List<FormalParameter> parameters = node.getFormalParameters();
@@ -1591,6 +1602,7 @@ public class FormatVisitor extends DefaultVisitor {
         if (disableIndent) {
             enableIndentForFunctionInvocation(node.getEndOffset());
         }
+        isMethodInvocationShifted = isMethodInvocationShiftedHolder;
     }
 
     private boolean disableIndentForFunctionInvocation(int offset) {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
@@ -2165,7 +2165,7 @@ public class FormatVisitor extends DefaultVisitor {
         }
 
         boolean addIndent = !isAnonymousClass(node.getExpression())
-                && !(path.size() > 2 && path.get(2) instanceof LambdaFunctionDeclaration) // #259111
+                && !(path.size() > 3 && path.get(2) instanceof LambdaFunctionDeclaration && !(path.get(3) instanceof FunctionInvocation)) // #259111 GH-7140
                 && !(node.getExpression() instanceof LambdaFunctionDeclaration) // NETBEANS-4970
                 && !(node.getExpression() instanceof MatchExpression);
 

--- a/php/php.editor/test/unit/data/testfiles/formatting/issueGH7140.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/issueGH7140.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7140 {
+
+    public function test1(): void {
+        $this->test->test(Test::class,
+            function (): Test {
+                return new Test(
+                test: 0,
+                );
+            });
+    }
+
+    public function test2(): void {
+        test(Test::class,
+            function (): Test {
+                return new Test(
+                test: 0,
+                );
+            }
+            );
+    }
+
+    public function test3(): Test {
+        return new Test(
+            test: 0,
+        );
+    }
+}
+
+function test(): Test {
+        test(Test::class,
+            function (): Test {
+                return new Test(
+                test: 0,
+                );
+            }
+            );
+}
+        test(Test::class,
+            function (): Test {
+                return new Test(
+                test: 0,
+                );
+            }
+            );
+
+// formatted
+class GH7140_2 {
+
+    public function test1(): void {
+        $this->test->test(Test::class,
+            function (): Test {
+                return new Test(
+                    test: 0,
+                );
+            });
+    }
+
+    public function test2(): void {
+        test(Test::class,
+            function (): Test {
+                return new Test(
+                    test: 0,
+                );
+            }
+        );
+    }
+
+    public function test3(): Test {
+        return new Test(
+            test: 0,
+        );
+    }
+}
+
+function test(): Test {
+    test(Test::class,
+        function (): Test {
+            return new Test(
+                test: 0,
+            );
+        }
+    );
+}
+
+test(Test::class,
+    function (): Test {
+        return new Test(
+            test: 0,
+        );
+    }
+);

--- a/php/php.editor/test/unit/data/testfiles/formatting/issueGH7140.php.testGH7140_01.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/issueGH7140.php.testGH7140_01.formatted
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7140 {
+
+    public function test1(): void {
+        $this->test->test(Test::class,
+            function (): Test {
+                return new Test(
+                    test: 0,
+                );
+            });
+    }
+
+    public function test2(): void {
+        test(Test::class,
+            function (): Test {
+                return new Test(
+                    test: 0,
+                );
+            }
+        );
+    }
+
+    public function test3(): Test {
+        return new Test(
+            test: 0,
+        );
+    }
+}
+
+function test(): Test {
+    test(Test::class,
+        function (): Test {
+            return new Test(
+                test: 0,
+            );
+        }
+    );
+}
+
+test(Test::class,
+    function (): Test {
+        return new Test(
+            test: 0,
+        );
+    }
+);
+
+// formatted
+class GH7140_2 {
+
+    public function test1(): void {
+        $this->test->test(Test::class,
+            function (): Test {
+                return new Test(
+                    test: 0,
+                );
+            });
+    }
+
+    public function test2(): void {
+        test(Test::class,
+            function (): Test {
+                return new Test(
+                    test: 0,
+                );
+            }
+        );
+    }
+
+    public function test3(): Test {
+        return new Test(
+            test: 0,
+        );
+    }
+}
+
+function test(): Test {
+    test(Test::class,
+        function (): Test {
+            return new Test(
+                test: 0,
+            );
+        }
+    );
+}
+
+test(Test::class,
+    function (): Test {
+        return new Test(
+            test: 0,
+        );
+    }
+);

--- a/php/php.editor/test/unit/data/testfiles/formatting/issueGH7140.php.testGH7140_02.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/issueGH7140.php.testGH7140_02.formatted
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class GH7140 {
+
+    public function test1(): void {
+        $this->test->test(Test::class,
+                function (): Test {
+                    return new Test(
+                            test: 0,
+                    );
+                });
+    }
+
+    public function test2(): void {
+        test(Test::class,
+                function (): Test {
+                    return new Test(
+                            test: 0,
+                    );
+                }
+        );
+    }
+
+    public function test3(): Test {
+        return new Test(
+                test: 0,
+        );
+    }
+}
+
+function test(): Test {
+    test(Test::class,
+            function (): Test {
+                return new Test(
+                        test: 0,
+                );
+            }
+    );
+}
+
+test(Test::class,
+        function (): Test {
+            return new Test(
+                    test: 0,
+            );
+        }
+);
+
+// formatted
+class GH7140_2 {
+
+    public function test1(): void {
+        $this->test->test(Test::class,
+                function (): Test {
+                    return new Test(
+                            test: 0,
+                    );
+                });
+    }
+
+    public function test2(): void {
+        test(Test::class,
+                function (): Test {
+                    return new Test(
+                            test: 0,
+                    );
+                }
+        );
+    }
+
+    public function test3(): Test {
+        return new Test(
+                test: 0,
+        );
+    }
+}
+
+function test(): Test {
+    test(Test::class,
+            function (): Test {
+                return new Test(
+                        test: 0,
+                );
+            }
+    );
+}
+
+test(Test::class,
+        function (): Test {
+            return new Test(
+                    test: 0,
+            );
+        }
+);

--- a/php/php.editor/test/unit/data/testfiles/formatting/issueGH7454.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/issueGH7454.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+Example::staticMethod()
+    ->method(function () {
+        Example::staticMethod()
+        ->method();
+    });
+
+Example::staticMethod()
+    ->method(function () {
+        Example::staticMethod()
+        ->method();
+    });
+
+Example::staticMethod()
+    ->method(function () {
+        Example::staticMethod()
+        ->method();
+    })
+    ->method2();
+
+$test->method1()
+    ->method(function () {
+        Example::staticMethod()
+        ->method();
+    });
+
+// formatted
+Example::staticMethod()
+    ->method(function () {
+        Example::staticMethod()
+            ->method();
+    });
+
+Example::staticMethod()
+    ->method(function () {
+        Example::staticMethod()
+            ->method();
+    });
+
+Example::staticMethod()
+    ->method(function () {
+        Example::staticMethod()
+            ->method();
+    })
+    ->method2();
+
+$test->method1()
+    ->method(function () {
+        Example::staticMethod()
+            ->method();
+    });

--- a/php/php.editor/test/unit/data/testfiles/formatting/issueGH7454.php.testGH7454_01.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/issueGH7454.php.testGH7454_01.formatted
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+Example::staticMethod()
+    ->method(function () {
+        Example::staticMethod()
+            ->method();
+    });
+
+Example::staticMethod()
+    ->method(function () {
+        Example::staticMethod()
+            ->method();
+    });
+
+Example::staticMethod()
+    ->method(function () {
+        Example::staticMethod()
+            ->method();
+    })
+    ->method2();
+
+$test->method1()
+    ->method(function () {
+        Example::staticMethod()
+            ->method();
+    });
+
+// formatted
+Example::staticMethod()
+    ->method(function () {
+        Example::staticMethod()
+            ->method();
+    });
+
+Example::staticMethod()
+    ->method(function () {
+        Example::staticMethod()
+            ->method();
+    });
+
+Example::staticMethod()
+    ->method(function () {
+        Example::staticMethod()
+            ->method();
+    })
+    ->method2();
+
+$test->method1()
+    ->method(function () {
+        Example::staticMethod()
+            ->method();
+    });

--- a/php/php.editor/test/unit/data/testfiles/formatting/issueGH7454.php.testGH7454_02.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/issueGH7454.php.testGH7454_02.formatted
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+Example::staticMethod()
+        ->method(function () {
+            Example::staticMethod()
+                    ->method();
+        });
+
+Example::staticMethod()
+        ->method(function () {
+            Example::staticMethod()
+                    ->method();
+        });
+
+Example::staticMethod()
+        ->method(function () {
+            Example::staticMethod()
+                    ->method();
+        })
+        ->method2();
+
+$test->method1()
+        ->method(function () {
+            Example::staticMethod()
+                    ->method();
+        });
+
+// formatted
+Example::staticMethod()
+        ->method(function () {
+            Example::staticMethod()
+                    ->method();
+        });
+
+Example::staticMethod()
+        ->method(function () {
+            Example::staticMethod()
+                    ->method();
+        });
+
+Example::staticMethod()
+        ->method(function () {
+            Example::staticMethod()
+                    ->method();
+        })
+        ->method2();
+
+$test->method1()
+        ->method(function () {
+            Example::staticMethod()
+                    ->method();
+        });

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
@@ -1164,4 +1164,16 @@ public class PHPFormatterTest extends PHPFormatterTestBase {
         reformatFileContents("testfiles/formatting/issueGH7185_05.php", options, false, false);
     }
 
+    public void testGH7140_01() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        reformatFileContents("testfiles/formatting/issueGH7140.php", options, false, true);
+    }
+
+    public void testGH7140_02() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 8);
+        reformatFileContents("testfiles/formatting/issueGH7140.php", options, false, true);
+    }
+
 }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
@@ -1176,4 +1176,16 @@ public class PHPFormatterTest extends PHPFormatterTestBase {
         reformatFileContents("testfiles/formatting/issueGH7140.php", options, false, true);
     }
 
+    public void testGH7454_01() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        reformatFileContents("testfiles/formatting/issueGH7454.php", options, false, true);
+    }
+
+    public void testGH7454_02() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 8);
+        reformatFileContents("testfiles/formatting/issueGH7454.php", options, false, true);
+    }
+
 }


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/7140
- Add an indent token to a return statement of a closure if a function invocation has the closure
- Add unit tests

Example:
```php
class GH7140 {
    public function test1(): void {
        $this->test->test(Test::class,
            function (): Test {
                return new Test(
                test: 0,
                );
            });
    }
}
```

Before:
```php
class GH7140 {
    public function test1(): void {
        $this->test->test(Test::class,
            function (): Test {
                return new Test(
                test: 0,
                );
            });
    }
}
```

After:
```php
class GH7140 {
    public function test1(): void {
        $this->test->test(Test::class,
            function (): Test {
                return new Test(
                    test: 0,
                );
            });
    }
}
```

- https://github.com/apache/netbeans/issues/7454
- Disable the shift flag in a closure
- Add unit tests

Example:
```php
Example::staticMethod()
    ->method(function () {
        Example::staticMethod()
        ->method();
    });
```

Before:
```php
Example::staticMethod()
    ->method(function () {
        Example::staticMethod()
        ->method();
    });
```

After:
```php
Example::staticMethod()
    ->method(function () {
        Example::staticMethod()
            ->method();
    });
```
