### PR TITLE
Fix incorrect warnings for the PSR1 hint [GH-7458]

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/PSR1Hint.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/PSR1Hint.java
@@ -132,7 +132,7 @@ public abstract class PSR1Hint extends HintRule {
 
     public static class MethodDeclarationHint extends PSR1Hint {
         private static final String HINT_ID = "PSR1.Hint.Method"; //NOI18N
-        private static final String MAGIC_METHODS = "__(construct|destruct|call|callStatic|get|set|isset|unset|sleep|wakeup|toString|invoke|set_state|clone)"; //NOI18N
+        private static final String MAGIC_METHODS = "__(construct|destruct|call|callStatic|get|set|isset|unset|sleep|wakeup|toString|invoke|set_state|clone|debugInfo|serialize|unserialize)"; //NOI18N
         private static final Pattern METHOD_PATTERN = Pattern.compile("([a-z]|" + MAGIC_METHODS + ")[a-zA-Z0-9]*"); //NOI18N
 
         @Override

--- a/php/php.editor/test/unit/data/testfiles/verification/PSR1/testMethodMagicOk/ClassName.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/PSR1/testMethodMagicOk/ClassName.php
@@ -16,6 +16,9 @@ class ClassName {
     function __invoke() {}
     function __set_state() {}
     function __clone() {}
+    function __debugInfo() {}
+    function __serialize() {}
+    function __unserialize() {}
 
 }
 


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/7458
- Ignore `__debugInfo`, `__serialize`, and ` __unserialize` magic methods
- Fix the unit test

Example:
```php
class GH7458 {
    public function __debugInfo(): array {}
    public function __serialize(): array {}
    public function __unserialize(array $data): void {}
}
```

Before:

![nb-php-gh-7458-before](https://github.com/apache/netbeans/assets/738383/5a4af224-8cfd-4453-b289-fd3127740784)

After:

![nb-php-gh-7458-after](https://github.com/apache/netbeans/assets/738383/1ab2ac51-c292-42cb-b3aa-7fbe99a450d7)
