### PR TITLE
Shield against NPE in VSCode

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -2001,7 +2001,13 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                 try {
                     doc.addDocumentListener(l);
                     l.checkCancel();
-                    errors = errorProviders.stream().flatMap(errorPorvider -> errorPorvider.computeErrors(context).stream()).collect(Collectors.toList());
+                    errors = errorProviders.stream().flatMap(provider -> {
+                        List<? extends org.netbeans.api.lsp.Diagnostic> errorsOrNull = provider.computeErrors(context);
+                        if (errorsOrNull == null) {
+                            errorsOrNull = Collections.emptyList();
+                        }
+                        return errorsOrNull.stream();
+                    }).collect(Collectors.toList());
                 } finally {
                     doc.removeDocumentListener(l);
                 }


### PR DESCRIPTION
We are experiencing [NPE when running Enso VSCode extension](https://github.com/enso-org/enso/pull/7054#issuecomment-2165921769):
```
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" 
because the return value of 
"org.netbeans.spi.lsp.ErrorProvider.computeErrors(org.netbeans.spi.lsp.ErrorProvider$Context)" 
is null
	at org.netbeans.modules.java.lsp.server.protocol.TextDocumentServiceImpl.lambda$computeDiags$46(TextDocumentServiceImpl.java:2027)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273)
```
after some debugging I found that the [code in TextDocumentServiceImpl](https://github.com/apache/netbeans/blob/b332b296700219ecd1d6ee6255124f3486171af3/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java#L2004) added by Dušan [four months ago](https://github.com/apache/netbeans/commit/adde5d9277b71318e498d3c38a7d0de74a491bcd) and the code written by Sváťa [two years ago](https://github.com/apache/netbeans/blame/b332b296700219ecd1d6ee6255124f3486171af3/ide/spi.editor.hints/src/org/netbeans/modules/editor/hints/lsp/HintsDiagnosticsProvider.java#L53) disagree on whether a `null` is valid return type or not which leads to `NullPointerException`.

This PR is fixing that by checking for `null` on the caller side.