### PR TITLE
Disable failing java.mx.project tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -891,9 +891,9 @@ jobs:
 #        run: ant $OPTS -f java/ant.grammar test
 
       # TODO next are JDK 21+ incompatibe steps
-      - name: java/java.mx.project
-        if: ${{ matrix.java == '17' }}
-        run: .github/retry.sh ant $OPTS -f java/java.mx.project test
+#      - name: java/java.mx.project
+#        if: ${{ matrix.java == '17' }}
+#        run: .github/retry.sh ant $OPTS -f java/java.mx.project test
 
       - name: java/gradle.java
         if: ${{ matrix.java == '17' }}

--- a/java/java.mx.project/build.xml
+++ b/java/java.mx.project/build.xml
@@ -47,11 +47,14 @@
         </exec>
     </target>
 
+    <!--
+    TODO the branches of https://github.com/graalvm/mx disappered
     <target name="test-preinit" depends="-checkout-graalvm">
         <exec dir="${graal.dir}/truffle" executable="${mx.dir}/mx" failonerror="true">
             <arg value="build"/>
         </exec>
     </target>
+    -->
     <target name="test-unit-build-datajar"/>
 
     <import file="../../nbbuild/templates/projectized.xml"/>


### PR DESCRIPTION
similar issue to https://github.com/apache/netbeans/issues/5196 resurfaced again, a graal repo removed branches/tags which causes tests to fail.

lets run all tests to get a picture if more repos removed their tags/branches other than https://github.com/graalvm/mx

result: this confirms that this is only about the mx repo and it affects only the mx tests. So we can easily disable it until it is fixed properly.


failure for reference:
```
-checkout-graalvm:
     [exec] Cloning into 'graal'...
     [exec] Note: switching to '2a0af49b3c8dfcc255992d3096aec02a81874c68'.
     [exec] 
     [exec] You are in 'detached HEAD' state. You can look around, make experimental
     [exec] changes and commit them, and you can discard any commits you make in this
     [exec] state without impacting any branches by switching back to a branch.
     [exec] 
     [exec] If you want to create a new branch to retain commits you create, you may
     [exec] do so (now or later) by using -c with the switch command. Example:
     [exec] 
     [exec]   git switch -c <new-branch-name>
     [exec] 
     [exec] Or undo this operation with:
     [exec] 
     [exec]   git switch -
     [exec] 
     [exec] Turn off this advice by setting config variable advice.detachedHead to false
     [exec] 
     [exec] Updating files:  89% (12679/14163)
     [exec] Updating files:  90% (12747/14163)Updating files:  91% (12889/14163)Updating files:  92% (13030/14163)Updating files:  93% (13172/14163)Updating files:  94% (13314/14163)Updating files:  95% (13455/14163)Updating files:  96% (13597/14163)Updating files:  97% (13739/14163)Updating files:  98% (13880/14163)Updating files:  99% (14022/14163)Updating files: 100% (14163/14163)Updating files: 100% (14163/14163), done.
     [exec] Cloning into 'mx'...
     [exec] warning: Could not find remote branch 6.7.0 to clone.
     [exec] fatal: Remote branch 6.7.0 not found in upstream origin

BUILD FAILED
/home/runner/work/netbeans/netbeans/java/java.mx.project/build.xml:40: exec returned: 128
```