### PR TITLE
Avoid ImageIcon use in more places, to preserve HiDPI icon resolution

### DIFF
--- a/platform/openide.awt/src/org/openide/awt/NotificationDisplayer.java
+++ b/platform/openide.awt/src/org/openide/awt/NotificationDisplayer.java
@@ -46,14 +46,14 @@ public abstract class NotificationDisplayer {
      * Priority of Notification
      */
     public static enum Priority {
-        HIGH(new ImageIcon(ImageUtilities.loadImage("org/openide/awt/resources/priority_high.png"))), //NOI18N
-        NORMAL(new ImageIcon(ImageUtilities.loadImage("org/openide/awt/resources/priority_normal.png"))), //NOI18N
-        LOW(new ImageIcon(ImageUtilities.loadImage("org/openide/awt/resources/priority_low.png"))), //NOI18N
+        HIGH(ImageUtilities.image2Icon(ImageUtilities.loadImage("org/openide/awt/resources/priority_high.png"))), //NOI18N
+        NORMAL(ImageUtilities.image2Icon(ImageUtilities.loadImage("org/openide/awt/resources/priority_normal.png"))), //NOI18N
+        LOW(ImageUtilities.image2Icon(ImageUtilities.loadImage("org/openide/awt/resources/priority_low.png"))), //NOI18N
         /** Priority that shows the notification without details.
          * Details shall be shown only later, per user request.
          * @since 7.18
          */
-        SILENT(new ImageIcon(ImageUtilities.loadImage("org/openide/awt/resources/priority_silent.png"))); //NOI18N
+        SILENT(ImageUtilities.image2Icon(ImageUtilities.loadImage("org/openide/awt/resources/priority_silent.png"))); //NOI18N
 
         private final Icon icon;
 

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/DescriptionComponent.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/DescriptionComponent.java
@@ -33,7 +33,6 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import javax.accessibility.AccessibleRole;
 import javax.swing.BorderFactory;
-import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JComponent.AccessibleJComponent;
@@ -114,7 +113,7 @@ class DescriptionComponent extends JComponent implements ActionListener, MouseLi
             } else {
                 Image help = ImageUtilities.loadImage("org/openide/resources/propertysheet/propertySheetHelp.png", true); //NOI18N
 
-                btn = new JButton(new ImageIcon(help));
+                btn = new JButton(ImageUtilities.image2Icon(help));
                 btn.addActionListener(this);
 
                 toolbar = new JToolBar ();

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/EditorPropertyDisplayer.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/EditorPropertyDisplayer.java
@@ -25,7 +25,6 @@ package org.openide.explorer.propertysheet;
 
 import org.openide.nodes.Node.Property;
 import org.openide.util.ImageUtilities;
-import org.openide.util.Utilities;
 
 import java.awt.Color;
 import java.awt.Component;
@@ -507,7 +506,7 @@ class EditorPropertyDisplayer extends JComponent implements PropertyDisplayer_In
             Object o = getProperty().getValue("valueIcon"); //NOI18N
 
             if (o instanceof Image) {
-                ic = new ImageIcon((Image) o);
+                ic = ImageUtilities.image2Icon((Image) o);
             } else {
                 ic = (Icon) o;
             }

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/RendererFactory.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/RendererFactory.java
@@ -50,7 +50,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.BorderFactory;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
@@ -66,7 +65,6 @@ import org.openide.awt.GraphicsUtils;
 import org.openide.awt.HtmlRenderer;
 import org.openide.nodes.Node.Property;
 import org.openide.util.ImageUtilities;
-import org.openide.util.Utilities;
 import org.openide.util.WeakListeners;
 
 /** 
@@ -972,7 +970,7 @@ final class RendererFactory {
             }
 
             if (i != null) {
-                setIcon(new ImageIcon(i));
+                setIcon(ImageUtilities.image2Icon(i));
             }
         }
 

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/SheetCellRenderer.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/SheetCellRenderer.java
@@ -32,6 +32,7 @@ import java.beans.FeatureDescriptor;
 
 import javax.swing.*;
 import javax.swing.table.TableCellRenderer;
+import org.openide.util.ImageUtilities;
 
 
 /** An implementation of SheetCellRenderer that wraps custom InplaceEditors
@@ -123,7 +124,7 @@ final class SheetCellRenderer implements TableCellRenderer {
                 if (o instanceof Icon) {
                     lbl.setIcon((Icon) o);
                 } else if (o instanceof Image) {
-                    lbl.setIcon(new ImageIcon((Image) o));
+                    lbl.setIcon(ImageUtilities.image2Icon((Image) o));
                 } else {
                     lbl.setIcon(null);
                 }

--- a/platform/openide.explorer/src/org/openide/explorer/view/MenuView.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/MenuView.java
@@ -34,12 +34,10 @@ import java.beans.*;
 
 import java.io.*;
 
-import java.net.URL;
-
-import java.util.*;
 
 import javax.swing.*;
 import javax.swing.event.*;
+import org.openide.util.ImageUtilities;
 
 
 /** An explorer view that shows the context hierarchy in
@@ -524,7 +522,7 @@ public class MenuView extends JPanel {
         static void initialize(final JMenuItem item, final Node node) {
             final class NI implements Runnable, NodeListener, ItemListener {
                 public void run() {
-                    item.setIcon(new ImageIcon(node.getIcon(java.beans.BeanInfo.ICON_COLOR_16x16)));
+                    item.setIcon(ImageUtilities.image2Icon(node.getIcon(java.beans.BeanInfo.ICON_COLOR_16x16)));
                     item.setText(node.getDisplayName());
 
                     /*

--- a/platform/openide.loaders/src/org/openide/actions/NewTemplateAction.java
+++ b/platform/openide.loaders/src/org/openide/actions/NewTemplateAction.java
@@ -278,7 +278,7 @@ public class NewTemplateAction extends NodeAction {
                 if (template == null) {
                     setIcon (NewTemplateAction.this.getIcon());
                 } else {
-                    setIcon (new ImageIcon(template.getNodeDelegate().getIcon(java.beans.BeanInfo.ICON_COLOR_16x16)));
+                    setIcon (ImageUtilities.image2Icon(template.getNodeDelegate().getIcon(java.beans.BeanInfo.ICON_COLOR_16x16)));
                 }
                 
                 addActionListener(this);

--- a/platform/openide.loaders/src/org/openide/awt/MenuBar.java
+++ b/platform/openide.loaders/src/org/openide/awt/MenuBar.java
@@ -39,7 +39,6 @@ import java.util.Objects;
 import java.util.logging.Logger;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
-import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JMenu;
@@ -63,6 +62,7 @@ import org.openide.nodes.NodeListener;
 import org.openide.nodes.NodeMemberEvent;
 import org.openide.nodes.NodeReorderEvent;
 import org.openide.util.Exceptions;
+import org.openide.util.ImageUtilities;
 import org.openide.util.Mutex;
 import org.openide.util.NbBundle;
 import org.openide.util.Task;
@@ -98,11 +98,6 @@ public class MenuBar extends JMenuBar implements Externalizable {
 
     /** the folder which represents and loads content of the menubar */
     private MenuBarFolder menuBarFolder;
-
-    /*
-    private static final Icon BLANK_ICON = new ImageIcon(
-        Utilities.loadImage("org/openide/loaders/empty.gif")); // NOI18N            
-     */
 
     static final long serialVersionUID =-4721949937356581268L;
     static {
@@ -656,8 +651,9 @@ public class MenuBar extends JMenuBar implements Externalizable {
                 // set the text and be aware of mnemonics
                 Node n = master.getNodeDelegate ();
                 Mnemonics.setLocalizedText(this, n.getDisplayName());
-                if (icon) setIcon (new ImageIcon (
-                n.getIcon (java.beans.BeanInfo.ICON_COLOR_16x16)));
+                if (icon) {
+                    setIcon(ImageUtilities.image2Icon(n.getIcon(java.beans.BeanInfo.ICON_COLOR_16x16)));
+                }
             } else {
                 setText(master.getName());
                 setIcon(null);

--- a/platform/spi.actions/src/org/netbeans/spi/actions/ContextAction.java
+++ b/platform/spi.actions/src/org/netbeans/spi/actions/ContextAction.java
@@ -25,7 +25,6 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Collection;
 import javax.swing.Action;
-import javax.swing.ImageIcon;
 
 /**
  * An action which operates in the global <i>selection context</i> (a
@@ -172,7 +171,7 @@ public abstract class ContextAction<T> extends NbAction {
             putValue (Action.NAME, displayName);
         }
         if (icon != null) {
-            putValue (Action.SMALL_ICON, new ImageIcon (icon));
+            putValue (Action.SMALL_ICON, ImageUtilities.image2Icon(icon));
         }
         putValue ("noIconInMenu", true);
     }


### PR DESCRIPTION
Replace various instances of 'new ImageIcon' with ImageUtilities.image2Icon in the platform module. This preserves HiDPI icons (e.g. SVG icons loaded by ImageUtilities) when relevant, and preserves rendering hints in ImageUtilities for bitmap icon scaling.

(These changes were made to ensure that the SVG icons added in https://github.com/apache/netbeans/pull/7463 actually show up in high resolution in various places.)