### PR TITLE
Avoid a missing JCheckBoxItem checkmark for boolean actions without an icon

### DIFF
--- a/platform/openide.awt/src/org/openide/awt/Actions.java
+++ b/platform/openide.awt/src/org/openide/awt/Actions.java
@@ -1557,7 +1557,10 @@ public class Actions {
                 return;
             }
 
-            if (!popup) {
+            /* I believe the empty icon was originally set to make the text of items with and
+            without icons align. But a JCheckBoxMenuItem without an icon will include its own
+            checkmark icon, which we want to preserve. */
+            if (!popup && !(button instanceof JCheckBoxMenuItem)) {
                 button.setIcon(ImageUtilities.loadImageIcon("org/openide/resources/actions/empty.gif", true)); // NOI18N
             }
         }


### PR DESCRIPTION
In menu bars, a boolean action will become a JCheckBoxMenuItem which can work with or without a custom icon. If the action has no icon of its own, the LAF will provide a checkmark icon instead, which is good. But due to a bug in org.openide.awt.Actions, a blank icon is used instead. Fix this so the checkmark properly appears in this case.

(Mostly relevant for NetBeans Platform apps; I haven't seen this case appear in the NetBeans IDE.)