### PR TITLE
Fix an 'illegal reflective access' warning on startup

### DIFF
--- a/platform/openide.util/src/org/openide/util/RequestProcessor.java
+++ b/platform/openide.util/src/org/openide/util/RequestProcessor.java
@@ -19,7 +19,6 @@
 
 package org.openide.util;
 
-import java.lang.reflect.Method;
 import java.security.PrivilegedAction;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -1051,37 +1050,10 @@ outer:  do {
     private static final TopLevelThreadGroup TOP_GROUP = new TopLevelThreadGroup();
     private static final class TopLevelThreadGroup implements PrivilegedAction<ThreadGroup> {
         public ThreadGroup getTopLevelThreadGroup() {
-            /* An old bugfix for Applet/JNLP environments now triggers an "Illegal reflective access"
-            warning on modern Java versions. Since Applets and JNLP have now long been deprecated,
-            we can disable said bugfix. I never ever saw the "differs from originally used" log
-            message below occur in a regular NetBeans IDE or NetBeans Platform application context
-            either. See https://bz.apache.org/netbeans/show_bug.cgi?id=184494 */
-            final boolean INCLUDE_APPLET_BUGFIX_184494 = false;
-
-            ThreadGroup orig = java.security.AccessController.doPrivileged(this);
-            if (INCLUDE_APPLET_BUGFIX_184494) {
-                ThreadGroup nuova = null;
-
-                try {
-                    Class<?> appContext = Class.forName("sun.awt.AppContext");
-                    Method instance = appContext.getMethod("getAppContext");
-                    Method getTG = appContext.getMethod("getThreadGroup");
-                    nuova = (ThreadGroup) getTG.invoke(instance.invoke(null));
-                } catch (Exception exception) {
-                    logger().log(Level.FINE, "Cannot access sun.awt.AppContext", exception);
-                    return orig;
-                }
-
-                assert nuova != null;
-
-                if (nuova != orig) {
-                    logger().log(Level.WARNING, "AppContext group {0} differs from originally used {1}", new Object[]{nuova, orig});
-                }
-                return nuova;
-            } else {
-                return orig;
-            }
-            
+            /* There used to be a workaround for
+            https://bz.apache.org/netbeans/show_bug.cgi?id=184494 here, relating to Applet and JNLP
+            environments. It was removed, since these environments are never used anymore. */
+            return java.security.AccessController.doPrivileged(this);
         }
         @Override
         public ThreadGroup run() {

--- a/platform/openide.util/src/org/openide/util/RequestProcessor.java
+++ b/platform/openide.util/src/org/openide/util/RequestProcessor.java
@@ -1051,25 +1051,36 @@ outer:  do {
     private static final TopLevelThreadGroup TOP_GROUP = new TopLevelThreadGroup();
     private static final class TopLevelThreadGroup implements PrivilegedAction<ThreadGroup> {
         public ThreadGroup getTopLevelThreadGroup() {
-            ThreadGroup orig = java.security.AccessController.doPrivileged(this);
-            ThreadGroup nuova = null;
+            /* An old bugfix for Applet/JNLP environments now triggers an "Illegal reflective access"
+            warning on modern Java versions. Since Applets and JNLP have now long been deprecated,
+            we can disable said bugfix. I never ever saw the "differs from originally used" log
+            message below occur in a regular NetBeans IDE or NetBeans Platform application context
+            either. See https://bz.apache.org/netbeans/show_bug.cgi?id=184494 */
+            final boolean INCLUDE_APPLET_BUGFIX_184494 = false;
 
-            try {
-                Class<?> appContext = Class.forName("sun.awt.AppContext");
-                Method instance = appContext.getMethod("getAppContext");
-                Method getTG = appContext.getMethod("getThreadGroup");
-                nuova = (ThreadGroup) getTG.invoke(instance.invoke(null));
-            } catch (Exception exception) {
-                logger().log(Level.FINE, "Cannot access sun.awt.AppContext", exception);
+            ThreadGroup orig = java.security.AccessController.doPrivileged(this);
+            if (INCLUDE_APPLET_BUGFIX_184494) {
+                ThreadGroup nuova = null;
+
+                try {
+                    Class<?> appContext = Class.forName("sun.awt.AppContext");
+                    Method instance = appContext.getMethod("getAppContext");
+                    Method getTG = appContext.getMethod("getThreadGroup");
+                    nuova = (ThreadGroup) getTG.invoke(instance.invoke(null));
+                } catch (Exception exception) {
+                    logger().log(Level.FINE, "Cannot access sun.awt.AppContext", exception);
+                    return orig;
+                }
+
+                assert nuova != null;
+
+                if (nuova != orig) {
+                    logger().log(Level.WARNING, "AppContext group {0} differs from originally used {1}", new Object[]{nuova, orig});
+                }
+                return nuova;
+            } else {
                 return orig;
             }
-
-            assert nuova != null;
-
-            if (nuova != orig) {
-                logger().log(Level.WARNING, "AppContext group {0} differs from originally used {1}", new Object[]{nuova, orig});
-            }
-            return nuova;
             
         }
         @Override


### PR DESCRIPTION
This commit removes the warning below, which was observed when starting a NetBeans Platform application:

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.openide.util.RequestProcessor$TopLevelThreadGroup (file:/C:/Users/ebakke/.m2/repository/org/netbeans/api/org-openide-util/RELEASE180ULT7/org-openide-util-RELEASE180ULT7.jar) to method sun.awt.AppContext.getAppContext()
WARNING: Please consider reporting this to the maintainers of org.openide.util.RequestProcessor$TopLevelThreadGroup
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```
