### PR TITLE
Make F2 work to rename in the Outline component

### DIFF
--- a/platform/o.n.swing.outline/src/org/netbeans/swing/outline/Outline.java
+++ b/platform/o.n.swing.outline/src/org/netbeans/swing/outline/Outline.java
@@ -801,7 +801,11 @@ public class Outline extends ETable {
         }
             
         boolean res = false;
-        if (!isTreeColumn || e instanceof MouseEvent && row >= 0 && isEditEvent(row, column, (MouseEvent) e)) {
+        if (!isTreeColumn ||
+                e instanceof MouseEvent && row >= 0 && isEditEvent(row, column, (MouseEvent) e) ||
+                // Allow F2 to be used to invoke Rename.
+                e instanceof ActionEvent && row >= 0)
+        {
             res = super.editCellAt(row, column, e);
         }
         if( res && isTreeColumn && row >= 0 && null != getEditorComponent() ) {


### PR DESCRIPTION
In the Outline tree table component, make F2 work to edit the selected cell, like in JTable and JTree.

In my case I needed this for my NetBeans Platform application. In the NetBeans IDE, it can be tested e.g. from the Search Results pane, where selecting a file name and pressing F2 should allow the file to be renamed (per the usual functionality of the file's Node implementation).