### PR TITLE
Add border on quick search box in Outline and TreeView components

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
@@ -89,6 +89,8 @@ public class FlatLFCustoms extends LFCustoms {
 
             EDITOR_TABSCOMPONENT_BORDER, BorderFactory.createEmptyBorder(),
             EDITOR_TOOLBAR_BORDER, new CompoundBorder(DPISafeBorder.matte(0, 0, 1, 0, editorContentBorderColor), BorderFactory.createEmptyBorder(1, 0, 1, 0)),
+            "NbExplorerView.quicksearch.border.instance",
+                new CompoundBorder(DPISafeBorder.matte(1, 0, 0, 0, editorContentBorderColor), BorderFactory.createEmptyBorder(2, 6, 2, 2)),
             EDITOR_TAB_CONTENT_BORDER, DPISafeBorder.matte(0, 1, 1, 1, editorContentBorderColor),
             VIEW_TAB_CONTENT_BORDER, DPISafeBorder.matte(0, 1, 1, 1, UIManager.getColor("TabbedContainer.view.contentBorderColor")), // NOI18N
 

--- a/platform/openide.awt/src/org/openide/awt/QuickSearch.java
+++ b/platform/openide.awt/src/org/openide/awt/QuickSearch.java
@@ -23,6 +23,7 @@ import java.awt.event.*;
 import java.lang.ref.WeakReference;
 import java.util.function.Consumer;
 import javax.swing.*;
+import javax.swing.border.Border;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.event.PopupMenuEvent;
@@ -610,7 +611,11 @@ public class QuickSearch {
         public SearchPanel(JComponent component, boolean alwaysShown) {
             this.component = component;
             this.alwaysShown = alwaysShown;
-            if (isAquaLaF) {
+
+            Border customBorder = UIManager.getBorder("NbExplorerView.quicksearch.border.instance");
+            if (customBorder != null) {
+                setBorder(customBorder);
+            } else if (isAquaLaF) {
                 setBorder(BorderFactory.createEmptyBorder(9,6,8,2));
             } else {
                 setBorder(BorderFactory.createEmptyBorder(2,6,2,2));


### PR DESCRIPTION
A small cosmetic change on FlatLAF: Add a thin top border on the quick search pane that is shown when the user starts typing in an Outline or TreeView component. Before/after screenshot:

![image](https://github.com/apache/netbeans/assets/886243/8824a327-3c5e-4036-9e24-f999e5ad315c)
