### PR TITLE
Use StructureProvider to populate navigator

### DIFF
--- a/ide/lsp.client/nbproject/project.xml
+++ b/ide/lsp.client/nbproject/project.xml
@@ -59,6 +59,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.api.lsp</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.28</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.api.progress</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/AbstractNavigatorPanel.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/AbstractNavigatorPanel.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.lsp.client.bindings;
+
+import java.awt.BorderLayout;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.logging.Logger;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import org.netbeans.spi.navigator.NavigatorPanel;
+import org.openide.explorer.ExplorerManager;
+import org.openide.explorer.view.BeanTreeView;
+import org.openide.filesystems.FileObject;
+import org.openide.nodes.AbstractNode;
+import org.openide.nodes.Children;
+import org.openide.nodes.Node;
+import org.openide.util.Lookup;
+import org.openide.util.LookupEvent;
+import org.openide.util.LookupListener;
+import org.openide.util.NbBundle.Messages;
+
+abstract class AbstractNavigatorPanel<K> extends Children.Keys<K> implements NavigatorPanel, LookupListener {
+    static final Logger LOG = Logger.getLogger(AbstractNavigatorPanel.class.getName());
+
+    private final ExplorerManager manager;
+    private View view;
+    private Lookup.Result<FileObject> result;
+    private FileObject file;
+
+    public AbstractNavigatorPanel() {
+        manager = new ExplorerManager();
+        manager.setRootContext(new AbstractNode(this));
+    }
+
+    abstract void addBackgroundTask(FileObject fo);
+    abstract void removeBackgroundTask(FileObject fo);
+    abstract Node[] createNodes(FileObject fo, K sym);
+
+    @Override
+    protected final Node[] createNodes(K key) {
+        return createNodes(file, key);
+    }
+
+    final boolean isCurrentFile(FileObject fo) {
+        return Objects.equals(file, fo);
+    }
+
+    final void expandAll() {
+        SwingUtilities.invokeLater(view::expandAll);
+    }
+
+    @Override
+    @Messages("DN_Symbols=Symbols")
+    public final String getDisplayName() {
+        return Bundle.DN_Symbols();
+    }
+
+    @Override
+    public final String getDisplayHint() {
+        return "symbols";
+    }
+
+    @Override
+    public final JComponent getComponent() {
+        if (view == null) {
+            view = new View();
+        }
+        return view;
+    }
+
+    @Override
+    public final void panelActivated(Lookup context) {
+        result = context.lookupResult(FileObject.class);
+        result.addLookupListener(this);
+        updateFile();
+    }
+
+    @Override
+    public final void panelDeactivated() {
+        result.removeLookupListener(this);
+        result = null;
+        updateFile();
+    }
+
+    private void updateFile() {
+        if (file != null) {
+            removeBackgroundTask(file);
+            setKeys(Collections.emptyList());
+            file = null;
+        }
+        Collection<? extends FileObject> files = result != null ? result.allInstances() : Collections.emptyList();
+        file = files.isEmpty() ? null : files.iterator().next();
+        if (file != null) {
+            addBackgroundTask(file);
+        }
+    }
+
+    @Override
+    public final Lookup getLookup() {
+        return Lookup.EMPTY;
+    }
+
+    @Override
+    public final void resultChanged(LookupEvent arg0) {
+        updateFile();
+    }
+
+    private class View extends JPanel implements ExplorerManager.Provider {
+
+        private final BeanTreeView internalView;
+
+        public View() {
+            setLayout(new BorderLayout());
+            this.internalView = new BeanTreeView();
+            add(internalView, BorderLayout.CENTER);
+
+            internalView.setRootVisible(false);
+        }
+
+        @Override
+        public ExplorerManager getExplorerManager() {
+            return manager;
+        }
+
+        public void expandAll() {
+            boolean scrollsOnExpand = internalView.getScrollsOnExpand();
+            internalView.setScrollsOnExpand(false);
+            internalView.expandAll();
+            internalView.setScrollsOnExpand(scrollsOnExpand);
+        }
+    }
+
+}

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/Icons.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/Icons.java
@@ -60,7 +60,7 @@ public final class Icons {
         
     }
     
-    public static String getSymbolIconBase(SymbolKind symbolKind) {
+    public static String getSymbolIconBase(Enum<?> symbolKind) {
         if (symbolKind == null) {
             return ICON_BASE + "empty.png";
         }

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/LspNavigatorPanelDynamicRegistration.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/LspNavigatorPanelDynamicRegistration.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.lsp.client.bindings;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+import org.netbeans.api.editor.mimelookup.MimeLookup;
+import org.netbeans.modules.lsp.client.LSPBindings;
+import org.netbeans.spi.lsp.StructureProvider;
+import org.netbeans.spi.navigator.NavigatorPanel;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.URLMapper;
+import org.openide.util.lookup.ServiceProvider;
+
+@ServiceProvider(service = NavigatorPanel.DynamicRegistration.class)
+public final class LspNavigatorPanelDynamicRegistration implements NavigatorPanel.DynamicRegistration {
+
+    @Override
+    public Collection<? extends NavigatorPanel> panelsFor(URI uri) {
+        try {
+            FileObject file = URLMapper.findFileObject(uri.toURL());
+            if (file != null) {
+                LSPBindings bindings = LSPBindings.getBindings(file);
+                if (bindings != null) {
+                    return Collections.singletonList(NavigatorPanelImpl.INSTANCE);
+                } else {
+                    for (StructureProvider sp : MimeLookup.getLookup(file.getMIMEType()).lookupAll(StructureProvider.class)) {
+                        if (sp != null) {
+                            return Collections.singletonList(LspStructureNavigatorPanel.INSTANCE);
+                        }
+                    }
+                }
+            }
+        } catch (MalformedURLException ex) {
+            //ignore
+        }
+        return Collections.emptyList();
+    }
+
+}

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/LspNavigatorPanelDynamicRegistration.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/LspNavigatorPanelDynamicRegistration.java
@@ -27,6 +27,7 @@ import org.netbeans.modules.lsp.client.LSPBindings;
 import org.netbeans.spi.lsp.StructureProvider;
 import org.netbeans.spi.navigator.NavigatorPanel;
 import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -42,8 +43,18 @@ public final class LspNavigatorPanelDynamicRegistration implements NavigatorPane
                 if (bindings != null) {
                     return Collections.singletonList(NavigatorPanelImpl.INSTANCE);
                 } else {
-                    for (StructureProvider sp : MimeLookup.getLookup(file.getMIMEType()).lookupAll(StructureProvider.class)) {
+                    String mime = file.getMIMEType();
+                    for (StructureProvider sp : MimeLookup.getLookup(mime).lookupAll(StructureProvider.class)) {
                         if (sp != null) {
+                            FileObject navigators = FileUtil.getConfigFile("Navigator/Panels");
+                            if (navigators != null) {
+                                FileObject mimeFolder = navigators.getFileObject(mime);
+                                if (mimeFolder != null && mimeFolder.getChildren().length > 0) {
+                                    // don't use StructureProvider when there is normal
+                                    // NavigatorPanel registration for the MIME type
+                                    return Collections.emptyList();
+                                }
+                            }
                             return Collections.singletonList(LspStructureNavigatorPanel.INSTANCE);
                         }
                     }

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/LspStructureNavigatorPanel.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/LspStructureNavigatorPanel.java
@@ -139,6 +139,7 @@ final class LspStructureNavigatorPanel extends JPanel implements NavigatorPanel,
             super(StructureElementChildren.childrenFor(e.getChildren()));
             setName(e.getName());
             setShortDescription(e.getDetail());
+            setIconBaseWithExtension(Icons.getSymbolIconBase(e.getKind()));
         }
     }
 

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/LspStructureNavigatorPanel.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/LspStructureNavigatorPanel.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.lsp.client.bindings;
+
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.text.StyledDocument;
+import org.netbeans.api.editor.mimelookup.MimeLookup;
+import org.netbeans.api.lsp.StructureElement;
+import org.netbeans.spi.lsp.StructureProvider;
+import org.netbeans.spi.navigator.NavigatorPanel;
+import org.openide.cookies.EditorCookie;
+import org.openide.explorer.ExplorerManager;
+import org.openide.explorer.view.BeanTreeView;
+import org.openide.filesystems.FileObject;
+import org.openide.nodes.AbstractNode;
+import org.openide.nodes.Children;
+import org.openide.nodes.Node;
+import org.openide.util.Lookup;
+import org.openide.util.NbBundle;
+
+@NbBundle.Messages(value = {
+    "# {0} - name of the file",
+    "CTL_StructureForFile=Structure for {0}",
+    "# {0} - mime type",
+    "CTL_StructureForMimeType=Structure for {0}"
+})
+final class LspStructureNavigatorPanel extends JPanel implements NavigatorPanel, ExplorerManager.Provider {
+
+    private static final Logger LOG = Logger.getLogger(LspStructureNavigatorPanel.class.getName());
+    static final LspStructureNavigatorPanel INSTANCE = new LspStructureNavigatorPanel();
+    private final ExplorerManager em;
+    private FileObject fo;
+
+    private LspStructureNavigatorPanel() {
+        this.em = new ExplorerManager();
+        setLayout(new BorderLayout());
+        final BeanTreeView view = new BeanTreeView();
+        view.setRootVisible(false);
+        add(BorderLayout.CENTER, view);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Bundle.CTL_StructureForFile(fo.getNameExt());
+    }
+
+    @Override
+    public String getDisplayHint() {
+        return Bundle.CTL_StructureForMimeType(fo.getMIMEType());
+    }
+
+    @Override
+    public JComponent getComponent() {
+        assert EventQueue.isDispatchThread();
+        return this;
+    }
+
+    @Override
+    public void panelActivated(Lookup context) {
+        assert EventQueue.isDispatchThread();
+        fo = context.lookup(FileObject.class);
+        if (fo != null) {
+            LOG.log(Level.INFO, "panelActivated: {0}", fo);
+            EditorCookie ec = context.lookup(EditorCookie.class);
+            if (ec != null) {
+                StyledDocument doc = ec.getDocument();
+                if (doc != null) {
+                    for (StructureProvider sp : MimeLookup.getLookup(fo.getMIMEType()).lookupAll(StructureProvider.class)) {
+                        Children ch = StructureElementChildren.childrenFor(sp.getStructure(doc));
+                        em.setRootContext(new AbstractNode(ch));
+                        return;
+                    }
+                }
+            }
+        }
+        em.setRootContext(Node.EMPTY);
+    }
+
+    @Override
+    public void panelDeactivated() {
+        assert EventQueue.isDispatchThread();
+        LOG.log(Level.INFO, "panelDeactivated: {0}", fo);
+        fo = null;
+    }
+
+    @Override
+    public Lookup getLookup() {
+        return null;
+    }
+
+    @Override
+    public ExplorerManager getExplorerManager() {
+        return em;
+    }
+
+    private static final class StructureElementChildren extends Children.Keys<StructureElement> {
+
+        static Children childrenFor(Collection<? extends StructureElement> elements) {
+            if (elements == null) {
+                return Children.LEAF;
+            } else {
+                StructureElementChildren ch = new StructureElementChildren();
+                ch.setKeys(elements);
+                return ch;
+            }
+        }
+
+        @Override
+        protected Node[] createNodes(StructureElement key) {
+            return new Node[]{new StructureElementNode(key)};
+        }
+    }
+
+    private static final class StructureElementNode extends AbstractNode {
+
+        StructureElementNode(StructureElement e) {
+            super(StructureElementChildren.childrenFor(e.getChildren()));
+            setName(e.getName());
+            setShortDescription(e.getDetail());
+        }
+    }
+
+}

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/NavigatorPanelImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/NavigatorPanelImpl.java
@@ -20,8 +20,6 @@ package org.netbeans.modules.lsp.client.bindings;
 
 import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
-import java.net.MalformedURLException;
-import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -46,7 +44,6 @@ import org.netbeans.spi.navigator.NavigatorPanel;
 import org.openide.explorer.ExplorerManager;
 import org.openide.explorer.view.BeanTreeView;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.URLMapper;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
@@ -54,7 +51,6 @@ import org.openide.util.Lookup;
 import org.openide.util.LookupEvent;
 import org.openide.util.LookupListener;
 import org.openide.util.NbBundle.Messages;
-import org.openide.util.lookup.ServiceProvider;
 
 /**
  *
@@ -63,7 +59,7 @@ import org.openide.util.lookup.ServiceProvider;
 public class NavigatorPanelImpl extends Children.Keys<Either<SymbolInformation, DocumentSymbol>> implements NavigatorPanel, BackgroundTask, LookupListener {
 
     private static final Logger LOG = Logger.getLogger(NavigatorPanelImpl.class.getName());
-    private static final NavigatorPanelImpl INSTANCE = new NavigatorPanelImpl();
+    static final NavigatorPanelImpl INSTANCE = new NavigatorPanelImpl();
 
     private final ExplorerManager manager;
     private View view;
@@ -255,23 +251,4 @@ public class NavigatorPanelImpl extends Children.Keys<Either<SymbolInformation, 
         }
     }
 
-    @ServiceProvider(service=DynamicRegistration.class)
-    public static final class DynamicRegistrationImpl implements DynamicRegistration {
-
-        @Override
-        public Collection<? extends NavigatorPanel> panelsFor(URI uri) {
-            try {
-                FileObject file = URLMapper.findFileObject(uri.toURL());
-                if (file != null) {
-                    return LSPBindings.getBindings(file) != null ? Collections.singletonList(INSTANCE) : Collections.emptyList();
-                } else {
-                    return Collections.emptyList();
-                }
-            } catch (MalformedURLException ex) {
-                //ignore
-                return Collections.emptyList();
-            }
-        }
-
-    }
 }

--- a/ide/spi.navigator/src/org/netbeans/spi/navigator/NavigatorPanel.java
+++ b/ide/spi.navigator/src/org/netbeans/spi/navigator/NavigatorPanel.java
@@ -28,8 +28,6 @@ import java.util.Collection;
 import javax.swing.JComponent;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
-import org.netbeans.api.annotations.common.NullAllowed;
-import org.openide.filesystems.FileObject;
 import org.openide.util.Lookup;
 
 /** Navigation related view description.


### PR DESCRIPTION
We at [Enso](http://enso.org) are finally adding _VSCode outline view_ into [Enso VSCode extension](https://marketplace.visualstudio.com/items?itemName=Enso.enso4vscode):

- https://github.com/enso-org/enso/pull/7054

We had to write our own [EnsoStructure provider](https://github.com/enso-org/enso/pull/7054/files#diff-48e5e6c6cd09cd1d1398cb39973470e4d85a212d0df83d8240186235e55fb483R19). As the snapshots in the [pull request demonstrate](https://github.com/enso-org/enso/pull/7054) it is _working fine in VSCode_.

However: I also **want it to work in NetBeans** and IGV!

I see little point writing own navigator implementation and registering it in the Enso NBM. Especially when my _original vision_ of the [LSP API](https://bits.netbeans.org/22/javadoc/org-netbeans-api-lsp/) saw it as a way to hook into VSCode **as well as** NetBeans by _writing one implementation_ and _using it in both_ systems. This PR is my attempt to contribute to that vision.

- Existing `lsp.client` module now checks for presence of [StructureProvider](https://bits.netbeans.org/22/javadoc/org-netbeans-api-lsp/org/netbeans/spi/lsp/StructureProvider.html)
- When found, it extracts the `StructureElement` hierarchy and builds nodes for the elements

The functionality is very close to the already existing functionality that works via LSP4J interfaces. Maybe there is a way to _share the navigators_ - either by abstracting the functionality to common interfaces or by bridging (now deprecated) `org.eclipse.lsp4j.SymbolInformation` to `StructureElement` - what do you think? **Abstracted common functionality** in 47d411b and **using it** in edf081f

In any case, I'd be thankful if NetBeans recognized various  [LSP API providers](https://bits.netbeans.org/22/javadoc/org-netbeans-api-lsp/) and used them in the classical UI where appropriate. This is how NetBeans look with this PR and [Enso4Igv NBM version v1.36.114](https://github.com/enso-org/enso/actions/runs/9509862775?pr=7054):

![Enso Structure in NetBeans 22+](https://github.com/apache/netbeans/assets/1842422/2ab8ce08-b6b5-4516-87db-3753c27f30c9)
