### PR TITLE
Fix formatting for method chaining [GH-7172]

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/TokenFormatter.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/TokenFormatter.java
@@ -2025,12 +2025,23 @@ public class TokenFormatter {
                                 if (wasARule) {
                                     if ((!indentRule || newLines == -1) && indentLine) {
                                         boolean handlingSpecialCases = false;
+                                        boolean checkHandlingSpecialCases = true;
                                         if (FormatToken.Kind.TEXT == formatToken.getId()
                                                 && (")".equals(formatToken.getOldText()) || "]".equals(formatToken.getOldText()))) {
+                                            if (formatTokens.get(index - 1).getId() == FormatToken.Kind.WHITESPACE_WITHIN_METHOD_CALL_PARENS
+                                                    && formatTokens.get(index - 2).getId() == FormatToken.Kind.INDENT) {
+                                                // GH-7172
+                                                // e.g.
+                                                // $example = (new Ex())
+                                                //     ->method(
+                                                //         $param
+                                                //     );
+                                                checkHandlingSpecialCases = false;
+                                            }
                                             // tryin find out and handling cases when )) folows.
                                             int hIndex = index + 1;
                                             int hindent = indent;
-                                            if (hIndex < formatTokens.size()) {
+                                            if (hIndex < formatTokens.size() && checkHandlingSpecialCases) {
                                                 FormatToken token;
                                                 int lastIndent = 0;
                                                 boolean bracketsInLine = false;

--- a/php/php.editor/test/unit/data/testfiles/formatting/issueGH7172.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/issueGH7172.php
@@ -1,0 +1,263 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function gh7172($param): void {
+    $test1 = (new Example())
+            ->method(
+        test: $param,
+    );
+
+    $test2 = (new Example())
+            ->method(
+            test1: $param1,
+            test2: $param2,
+        )
+        ->field;
+
+    $test3 = (new Example())
+            ->method(
+            test1: $param1,
+            test2: $param2
+        )
+            ->method2()
+        ->field;
+
+    $test4 = (new Example())
+            ->method(
+            test1: $param1,
+        )
+            ->field
+        ->field2;
+
+    $test5 = (new Example())
+            ->method(
+            test: $param,
+        )
+        ->method2();
+
+    $test6 = (new Example())
+            ?->method(
+        test1: $param1,
+        test2: $param2,
+    );
+
+    $test7 = (new Example())
+            ?->method(
+            test: $param,
+        )
+        ?->field;
+
+    $test8 = (new Example())
+            ?->method(
+            test: $param,
+        )
+        ?->method2();
+
+    $test9 = (new Example())
+            ?->method(
+            test: $param,
+        )
+            ?->field
+        ?->method2(
+        test: $param,
+        );
+}
+
+    $test1 = $example
+            ->method(
+        test: $param,
+    );
+
+    $test2 = $example
+            ->method(
+            test: $param,
+        )
+        ->field;
+
+    $test3 = $example
+            ->method(
+            test1: $param1,
+            test2: $param2
+        )
+            ->method2()
+        ->field;
+
+    $test4 = $example
+            ->method(
+            test1: $param1,
+        )
+            ->field
+        ->field2;
+
+    $test5 = $example
+            ->method(
+            test: $param,
+        )
+        ->method2();
+
+    $test6 = $example
+            ?->method(
+        test1: $param1,
+        test2: $param2,
+    );
+
+    $test7 = $example
+            ?->method(
+            test: $param,
+        )
+        ?->field;
+
+    $test8 = $example
+            ?->method(
+            test: $param,
+        )
+        ?->method2();
+
+    $test9 = $example
+            ?->method(
+            test: $param,
+        )
+            ?->field
+        ?->method2(
+            test: $param,
+        );
+
+// formatted
+function gh7172_2($param): void {
+    $test1 = (new Example())
+        ->method(
+            test: $param,
+        );
+
+    $test2 = (new Example())
+        ->method(
+            test1: $param1,
+            test2: $param2,
+        )
+        ->field;
+
+    $test3 = (new Example())
+        ->method(
+            test1: $param1,
+            test2: $param2
+        )
+        ->method2()
+        ->field;
+
+    $test4 = (new Example())
+        ->method(
+            test1: $param1,
+        )
+        ->field
+        ->field2;
+
+    $test5 = (new Example())
+        ->method(
+            test: $param,
+        )
+        ->method2();
+
+    $test6 = (new Example())
+        ?->method(
+            test1: $param1,
+            test2: $param2,
+        );
+
+    $test7 = (new Example())
+        ?->method(
+            test: $param,
+        )
+        ?->field;
+
+    $test8 = (new Example())
+        ?->method(
+            test: $param,
+        )
+        ?->method2();
+
+    $test9 = (new Example())
+        ?->method(
+            test: $param,
+        )
+        ?->field
+        ?->method2(
+            test: $param,
+        );
+}
+
+$test1 = $example
+    ->method(
+        test: $param,
+    );
+
+$test2 = $example
+    ->method(
+        test: $param,
+    )
+    ->field;
+
+$test3 = $example
+    ->method(
+        test1: $param1,
+        test2: $param2
+    )
+    ->method2()
+    ->field;
+
+$test4 = $example
+    ->method(
+        test1: $param1,
+    )
+    ->field
+    ->field2;
+
+$test5 = $example
+    ->method(
+        test: $param,
+    )
+    ->method2();
+
+$test6 = $example
+    ?->method(
+        test1: $param1,
+        test2: $param2,
+    );
+
+$test7 = $example
+    ?->method(
+        test: $param,
+    )
+    ?->field;
+
+$test8 = $example
+    ?->method(
+        test: $param,
+    )
+    ?->method2();
+
+$test9 = $example
+    ?->method(
+        test: $param,
+    )
+    ?->field
+    ?->method2(
+        test: $param,
+    );

--- a/php/php.editor/test/unit/data/testfiles/formatting/issueGH7172.php.testGH7172_01.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/issueGH7172.php.testGH7172_01.formatted
@@ -1,0 +1,263 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function gh7172($param): void {
+    $test1 = (new Example())
+        ->method(
+            test: $param,
+        );
+
+    $test2 = (new Example())
+        ->method(
+            test1: $param1,
+            test2: $param2,
+        )
+        ->field;
+
+    $test3 = (new Example())
+        ->method(
+            test1: $param1,
+            test2: $param2
+        )
+        ->method2()
+        ->field;
+
+    $test4 = (new Example())
+        ->method(
+            test1: $param1,
+        )
+        ->field
+        ->field2;
+
+    $test5 = (new Example())
+        ->method(
+            test: $param,
+        )
+        ->method2();
+
+    $test6 = (new Example())
+        ?->method(
+            test1: $param1,
+            test2: $param2,
+        );
+
+    $test7 = (new Example())
+        ?->method(
+            test: $param,
+        )
+        ?->field;
+
+    $test8 = (new Example())
+        ?->method(
+            test: $param,
+        )
+        ?->method2();
+
+    $test9 = (new Example())
+        ?->method(
+            test: $param,
+        )
+        ?->field
+        ?->method2(
+            test: $param,
+        );
+}
+
+$test1 = $example
+    ->method(
+        test: $param,
+    );
+
+$test2 = $example
+    ->method(
+        test: $param,
+    )
+    ->field;
+
+$test3 = $example
+    ->method(
+        test1: $param1,
+        test2: $param2
+    )
+    ->method2()
+    ->field;
+
+$test4 = $example
+    ->method(
+        test1: $param1,
+    )
+    ->field
+    ->field2;
+
+$test5 = $example
+    ->method(
+        test: $param,
+    )
+    ->method2();
+
+$test6 = $example
+    ?->method(
+        test1: $param1,
+        test2: $param2,
+    );
+
+$test7 = $example
+    ?->method(
+        test: $param,
+    )
+    ?->field;
+
+$test8 = $example
+    ?->method(
+        test: $param,
+    )
+    ?->method2();
+
+$test9 = $example
+    ?->method(
+        test: $param,
+    )
+    ?->field
+    ?->method2(
+        test: $param,
+    );
+
+// formatted
+function gh7172_2($param): void {
+    $test1 = (new Example())
+        ->method(
+            test: $param,
+        );
+
+    $test2 = (new Example())
+        ->method(
+            test1: $param1,
+            test2: $param2,
+        )
+        ->field;
+
+    $test3 = (new Example())
+        ->method(
+            test1: $param1,
+            test2: $param2
+        )
+        ->method2()
+        ->field;
+
+    $test4 = (new Example())
+        ->method(
+            test1: $param1,
+        )
+        ->field
+        ->field2;
+
+    $test5 = (new Example())
+        ->method(
+            test: $param,
+        )
+        ->method2();
+
+    $test6 = (new Example())
+        ?->method(
+            test1: $param1,
+            test2: $param2,
+        );
+
+    $test7 = (new Example())
+        ?->method(
+            test: $param,
+        )
+        ?->field;
+
+    $test8 = (new Example())
+        ?->method(
+            test: $param,
+        )
+        ?->method2();
+
+    $test9 = (new Example())
+        ?->method(
+            test: $param,
+        )
+        ?->field
+        ?->method2(
+            test: $param,
+        );
+}
+
+$test1 = $example
+    ->method(
+        test: $param,
+    );
+
+$test2 = $example
+    ->method(
+        test: $param,
+    )
+    ->field;
+
+$test3 = $example
+    ->method(
+        test1: $param1,
+        test2: $param2
+    )
+    ->method2()
+    ->field;
+
+$test4 = $example
+    ->method(
+        test1: $param1,
+    )
+    ->field
+    ->field2;
+
+$test5 = $example
+    ->method(
+        test: $param,
+    )
+    ->method2();
+
+$test6 = $example
+    ?->method(
+        test1: $param1,
+        test2: $param2,
+    );
+
+$test7 = $example
+    ?->method(
+        test: $param,
+    )
+    ?->field;
+
+$test8 = $example
+    ?->method(
+        test: $param,
+    )
+    ?->method2();
+
+$test9 = $example
+    ?->method(
+        test: $param,
+    )
+    ?->field
+    ?->method2(
+        test: $param,
+    );

--- a/php/php.editor/test/unit/data/testfiles/formatting/issueGH7172.php.testGH7172_02.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/issueGH7172.php.testGH7172_02.formatted
@@ -1,0 +1,263 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function gh7172($param): void {
+    $test1 = (new Example())
+            ->method(
+                    test: $param,
+            );
+
+    $test2 = (new Example())
+            ->method(
+                    test1: $param1,
+                    test2: $param2,
+            )
+            ->field;
+
+    $test3 = (new Example())
+            ->method(
+                    test1: $param1,
+                    test2: $param2
+            )
+            ->method2()
+            ->field;
+
+    $test4 = (new Example())
+            ->method(
+                    test1: $param1,
+            )
+            ->field
+            ->field2;
+
+    $test5 = (new Example())
+            ->method(
+                    test: $param,
+            )
+            ->method2();
+
+    $test6 = (new Example())
+            ?->method(
+                    test1: $param1,
+                    test2: $param2,
+            );
+
+    $test7 = (new Example())
+            ?->method(
+                    test: $param,
+            )
+            ?->field;
+
+    $test8 = (new Example())
+            ?->method(
+                    test: $param,
+            )
+            ?->method2();
+
+    $test9 = (new Example())
+            ?->method(
+                    test: $param,
+            )
+            ?->field
+            ?->method2(
+                    test: $param,
+            );
+}
+
+$test1 = $example
+        ->method(
+                test: $param,
+        );
+
+$test2 = $example
+        ->method(
+                test: $param,
+        )
+        ->field;
+
+$test3 = $example
+        ->method(
+                test1: $param1,
+                test2: $param2
+        )
+        ->method2()
+        ->field;
+
+$test4 = $example
+        ->method(
+                test1: $param1,
+        )
+        ->field
+        ->field2;
+
+$test5 = $example
+        ->method(
+                test: $param,
+        )
+        ->method2();
+
+$test6 = $example
+        ?->method(
+                test1: $param1,
+                test2: $param2,
+        );
+
+$test7 = $example
+        ?->method(
+                test: $param,
+        )
+        ?->field;
+
+$test8 = $example
+        ?->method(
+                test: $param,
+        )
+        ?->method2();
+
+$test9 = $example
+        ?->method(
+                test: $param,
+        )
+        ?->field
+        ?->method2(
+                test: $param,
+        );
+
+// formatted
+function gh7172_2($param): void {
+    $test1 = (new Example())
+            ->method(
+                    test: $param,
+            );
+
+    $test2 = (new Example())
+            ->method(
+                    test1: $param1,
+                    test2: $param2,
+            )
+            ->field;
+
+    $test3 = (new Example())
+            ->method(
+                    test1: $param1,
+                    test2: $param2
+            )
+            ->method2()
+            ->field;
+
+    $test4 = (new Example())
+            ->method(
+                    test1: $param1,
+            )
+            ->field
+            ->field2;
+
+    $test5 = (new Example())
+            ->method(
+                    test: $param,
+            )
+            ->method2();
+
+    $test6 = (new Example())
+            ?->method(
+                    test1: $param1,
+                    test2: $param2,
+            );
+
+    $test7 = (new Example())
+            ?->method(
+                    test: $param,
+            )
+            ?->field;
+
+    $test8 = (new Example())
+            ?->method(
+                    test: $param,
+            )
+            ?->method2();
+
+    $test9 = (new Example())
+            ?->method(
+                    test: $param,
+            )
+            ?->field
+            ?->method2(
+                    test: $param,
+            );
+}
+
+$test1 = $example
+        ->method(
+                test: $param,
+        );
+
+$test2 = $example
+        ->method(
+                test: $param,
+        )
+        ->field;
+
+$test3 = $example
+        ->method(
+                test1: $param1,
+                test2: $param2
+        )
+        ->method2()
+        ->field;
+
+$test4 = $example
+        ->method(
+                test1: $param1,
+        )
+        ->field
+        ->field2;
+
+$test5 = $example
+        ->method(
+                test: $param,
+        )
+        ->method2();
+
+$test6 = $example
+        ?->method(
+                test1: $param1,
+                test2: $param2,
+        );
+
+$test7 = $example
+        ?->method(
+                test: $param,
+        )
+        ?->field;
+
+$test8 = $example
+        ?->method(
+                test: $param,
+        )
+        ?->method2();
+
+$test9 = $example
+        ?->method(
+                test: $param,
+        )
+        ?->field
+        ?->method2(
+                test: $param,
+        );

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
@@ -1188,4 +1188,16 @@ public class PHPFormatterTest extends PHPFormatterTestBase {
         reformatFileContents("testfiles/formatting/issueGH7454.php", options, false, true);
     }
 
+    public void testGH7172_01() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        reformatFileContents("testfiles/formatting/issueGH7172.php", options, false, true);
+    }
+
+    public void testGH7172_02() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 8);
+        reformatFileContents("testfiles/formatting/issueGH7172.php", options, false, true);
+    }
+
 }


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/7172
- Check whether there is a new line between an object operator(or nullsafe operator) and a dispatcher
- Check whether a parent node is `FieldAccess`
- Add unit tests

Example:
```php
    $test1 = $example
            ->method(
        test: $param,
    );

    $test2 = $example
            ->method(
            test: $param,
        )
        ->field;

    $test3 = $example
            ->method(
            test: $param,
        )
        ->method2();
```

Before:
```php
$test1 = $example
    ->method(
    test: $param,
);

$test2 = $example
        ->method(
            test: $param,
        )
    ->field;

$test3 = $example
    ->method(
        test: $param,
    )
    ->method2();
```

After:
```php
$test1 = $example
    ->method(
        test: $param,
    );

$test2 = $example
    ->method(
        test: $param,
    )
    ->field;

$test3 = $example
    ->method(
        test: $param,
    )
    ->method2();
```