### PR TITLE
Support for project JDK settings.

### DIFF
--- a/java/java.lsp.server/nbcode/integration/nbproject/project.xml
+++ b/java/java.lsp.server/nbcode/integration/nbproject/project.xml
@@ -119,6 +119,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.java.platform</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.66</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.parsing.api</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspJavaPlatformProviderOverride.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspJavaPlatformProviderOverride.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.nbcode.integration;
+
+import org.netbeans.modules.java.lsp.server.ui.AbstractJavaPlatformProviderOverride;
+import org.netbeans.modules.java.platform.implspi.JavaPlatformProvider;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author sdedic
+ */
+@ServiceProvider(service = JavaPlatformProvider.class, position = 10_000)
+public class LspJavaPlatformProviderOverride extends AbstractJavaPlatformProviderOverride {
+}

--- a/java/java.lsp.server/nbproject/project.xml
+++ b/java/java.lsp.server/nbproject/project.xml
@@ -401,6 +401,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.java.platform</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.66</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.java.project</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -695,12 +704,6 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>9.24</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>com.google.guava</code-name-base>
-                    <run-dependency>
-                        <specification-version>27.16</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -240,6 +240,7 @@ import org.netbeans.modules.refactoring.spi.Transaction;
 import org.netbeans.api.lsp.StructureElement;
 import org.netbeans.modules.editor.indent.api.Reformat;
 import org.netbeans.modules.java.lsp.server.URITranslator;
+import org.netbeans.modules.java.lsp.server.ui.AbstractJavaPlatformProviderOverride;
 import org.netbeans.modules.parsing.impl.SourceAccessor;
 import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.editor.hints.Fix;
@@ -2086,6 +2087,15 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
         reRunDiagnostics();
     }
     
+    void updateProjectJDKHome(JsonPrimitive configuration) {
+        if (configuration == null) {
+            client.logMessage(new MessageParams(MessageType.Log,"Project runtime JDK unset, defaults to NBLS JDK"));
+        } else {
+            client.logMessage(new MessageParams(MessageType.Log, "Project runtime JDK set to " + configuration.getAsString()));
+        }
+        AbstractJavaPlatformProviderOverride.setDefaultPlatformOverride(configuration != null ? configuration.getAsString() : null);
+    }
+
     private String key(ErrorProvider.Kind errorKind) {
         return errorKind.name().toLowerCase(Locale.ROOT);
     }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -1347,7 +1347,9 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
         String fullConfigPrefix = client.getNbCodeCapabilities().getConfigurationPrefix();
         String configPrefix = fullConfigPrefix.substring(0, fullConfigPrefix.length() - 1);
         server.openedProjects().thenAccept(projects -> {
+            // PENDING: invent a pluggable mechanism for this, this does not scale and the typecast to serviceImpl is ugly
             ((TextDocumentServiceImpl)server.getTextDocumentService()).updateJavaHintPreferences(((JsonObject) params.getSettings()).getAsJsonObject(configPrefix).getAsJsonObject(NETBEANS_JAVA_HINTS));
+            ((TextDocumentServiceImpl)server.getTextDocumentService()).updateProjectJDKHome(((JsonObject) params.getSettings()).getAsJsonObject(configPrefix).getAsJsonObject("project").getAsJsonPrimitive("jdkhome"));
             if (projects != null && projects.length > 0) {
                 updateJavaFormatPreferences(projects[0].getProjectDirectory(), ((JsonObject) params.getSettings()).getAsJsonObject(configPrefix).getAsJsonObject("format"));
                 updateJavaImportPreferences(projects[0].getProjectDirectory(), ((JsonObject) params.getSettings()).getAsJsonObject(configPrefix).getAsJsonObject("java").getAsJsonObject("imports"));

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractJavaPlatformProviderOverride.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractJavaPlatformProviderOverride.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.ui;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import org.netbeans.api.java.platform.JavaPlatform;
+import org.netbeans.api.java.platform.JavaPlatformManager;
+import org.netbeans.modules.java.platform.implspi.JavaPlatformProvider;
+import org.netbeans.spi.java.platform.JavaPlatformFactory;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.Exceptions;
+import org.openide.util.Lookup;
+
+public abstract class AbstractJavaPlatformProviderOverride implements JavaPlatformProvider {
+
+    private static final JavaPlatform[] NO_PLATFORMS = new JavaPlatform[0];
+    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+    private FileObject defaultPlatformOverride;
+
+    @Override
+    @SuppressWarnings("ReturnOfCollectionOrArrayField")
+    public JavaPlatform[] getInstalledPlatforms() {
+        return NO_PLATFORMS;
+    }
+
+    @Override
+    public JavaPlatform getDefaultPlatform() {
+        FileObject override;
+
+        synchronized (this) {
+            override = defaultPlatformOverride;
+        }
+
+        if (override == null) {
+            return null;
+        }
+
+        Set<String> existingNames = new HashSet<>();
+        JavaPlatform found = null;
+
+        for (JavaPlatform platform : JavaPlatformManager.getDefault().getInstalledPlatforms()) {
+            if (platform.getInstallFolders().stream().anyMatch(folder -> folder.equals(override))) {
+                found = platform;
+                break;
+            }
+            existingNames.add(platform.getDisplayName());
+        }
+
+        if (found == null ){
+            String newName = defaultPlatformOverride.getPath();
+
+            while (existingNames.contains(newName)) {
+                newName += "1";
+            }
+
+            for (JavaPlatformFactory.Provider provider : Lookup.getDefault().lookupAll(JavaPlatformFactory.Provider.class)) {
+                JavaPlatformFactory factory = provider.forType("j2se");
+                if (factory != null) {
+                    try {
+                        found = factory.create(override, newName, true);
+                    } catch (IOException ex) {
+                        Exceptions.printStackTrace(ex);
+                    }
+                }
+            }
+        }
+
+        return found;
+    }
+
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        pcs.addPropertyChangeListener(listener);
+    }
+
+    @Override
+    public void removePropertyChangeListener(PropertyChangeListener listener) {
+        pcs.removePropertyChangeListener(listener);
+    }
+
+    private void dosetDefaultPlatformOverride(String defaultPlatformOverride) {
+        FileObject override = defaultPlatformOverride != null ? FileUtil.toFileObject(new File(defaultPlatformOverride))
+                                                              : null;
+
+        synchronized (this) {
+            this.defaultPlatformOverride = override;
+        }
+
+        pcs.firePropertyChange(null, null, null);
+    }
+
+    public static void setDefaultPlatformOverride(String defaultPlatformOverride) {
+        for (JavaPlatformProvider p : Lookup.getDefault().lookupAll(JavaPlatformProvider.class)) {
+            if (p instanceof AbstractJavaPlatformProviderOverride) {
+                ((AbstractJavaPlatformProviderOverride) p).dosetDefaultPlatformOverride(defaultPlatformOverride);
+            }
+        }
+    }
+
+}

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -115,8 +115,17 @@
 						"null"
 					],
 					"default": null,
-					"description": "Specifies JDK for the Apache NetBeans Language Server",
-					"scope": "machine"
+					"description": "Specifies the JDK on which the Apache NetBeans Language Server is run",
+					"scope": "machine-overridable"
+				},
+				"netbeans.project.jdkhome": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "Specifies the JDK on which user's project will be run. Defaults to the value of netbeans.jdkhome",
+					"scope": "machine-overridable"
 				},
 				"netbeans.verbose": {
 					"type": "boolean",

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -185,7 +185,8 @@ function findJDK(onChange: (path : string | null) => void): void {
     }
 
     let currentJdk = find();
-    validateJDKCompatibility(currentJdk);
+    let projectJdk : string | undefined = getProjectJDKHome();
+    validateJDKCompatibility(currentJdk, projectJdk);
     let timeout: NodeJS.Timeout | undefined = undefined;
     workspace.onDidChangeConfiguration(params => {
         if (timeout) {
@@ -208,10 +209,12 @@ function findJDK(onChange: (path : string | null) => void): void {
             let newJdk = find();
             let newD = isDarkColorTheme();
             let newJavaEnabled = isJavaSupportEnabled();
-            if (newJdk !== currentJdk || newD != nowDark || newJavaEnabled != nowJavaEnabled) {
+            let newProjectJDK : string | undefined = getProjectJDKHome();
+            if (newJdk !== currentJdk || newD != nowDark || newJavaEnabled != nowJavaEnabled || newProjectJDK != projectJdk) {
                 nowDark = newD;
                 nowJavaEnabled = newJavaEnabled;
                 currentJdk = newJdk;
+                projectJdk = newProjectJDK;
                 onChange(currentJdk);
             }
         }, 0);
@@ -961,6 +964,10 @@ function isJavaSupportEnabled() : boolean {
     return workspace.getConfiguration('netbeans')?.get('javaSupport.enabled') as boolean;
 }
 
+function getProjectJDKHome() : string {
+    return workspace.getConfiguration('netbeans')?.get('project.jdkhome') as string;
+}
+
 function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContext, log : vscode.OutputChannel, notifyKill: boolean,
     setClient : [(c : NbLanguageClient) => void, (err : any) => void]
 ): void {
@@ -1121,6 +1128,7 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
                 'netbeans.hints',
                 'netbeans.format',
                 'netbeans.java.imports',
+                'netbeans.project.jdkhome',
                 'java+.runConfig.vmOptions',
                 'java+.runConfig.cwd'
             ],

--- a/java/java.lsp.server/vscode/src/jdk/settings.ts
+++ b/java/java.lsp.server/vscode/src/jdk/settings.ts
@@ -306,7 +306,7 @@ class ProjectJavaSettings extends Setting {
                         name: version,
                         path: jdk.javaHome
                     });
-                }
+                    }
             }
             try {
                 await vscode.workspace.getConfiguration().update(this.property, definitions, scope);
@@ -324,8 +324,15 @@ const NBLS_EXTENSION_ID = 'asf.apache-netbeans-java';
 const NBLS_SETTINGS_NAME = 'Language Server by Apache NetBeans';
 const NBLS_SETTINGS_PROPERTY = 'netbeans.jdkhome';
 function nblsSetting(): Setting {
-    return new JavaSetting(NBLS_SETTINGS_NAME, NBLS_SETTINGS_PROPERTY, false);
+    return new JavaSetting(NBLS_SETTINGS_NAME, NBLS_SETTINGS_PROPERTY, true);
 }
+
+const NBLS_SETTINGS_PROJECT_NAME = 'Language Server by Apache NetBeans - Java Runtime for Projects';
+const NBLS_SETTINGS_PROJECT_PROPERTY = 'netbeans.project.jdkhome';
+function nblsProjectSetting(): Setting {
+    return new JavaSetting(NBLS_SETTINGS_PROJECT_NAME, NBLS_SETTINGS_PROJECT_PROPERTY, true);
+}
+
 
 const JDTLS_EXTENSION_ID = 'redhat.java';
 const JDTLS_SETTINGS_NAME = 'Language Server by RedHat';
@@ -334,7 +341,7 @@ function jdtlsSetting(): Setting {
     return new JavaSetting(JDTLS_SETTINGS_NAME, JDTLS_SETTINGS_PROPERTY);
 }
 
-const PROJECTS_SETTINGS_NAME = 'Java Runtime for Projects';
+const PROJECTS_SETTINGS_NAME = 'Language Server by RedHat - Java Runtime for Projects';
 const PROJECTS_SETTINGS_PROPERTY = 'java.configuration.runtimes';
 export function projectsSettings(): Setting {
     return new ProjectJavaSettings(PROJECTS_SETTINGS_NAME, PROJECTS_SETTINGS_PROPERTY);
@@ -364,6 +371,7 @@ export function getAvailable(): Setting[] {
 
     if (vscode.extensions.getExtension(NBLS_EXTENSION_ID)) {
         settings.push(nblsSetting());
+        settings.push(nblsProjectSetting());
     }
 
     if (vscode.extensions.getExtension(JDTLS_EXTENSION_ID)) {


### PR DESCRIPTION
This PR is based on prototype done by @lahodaj . I have just updated it to fit into the current codebase + integrated with the new JDK configuration command.

- NBLS now has a new setting: `netbeans.project.jdkhome`. This holds a path to a JDK that is used as a **default platform**.
- to avoid possible issues with default platform changing (i.e. changes from JDK21 to JDK8, ouch!), NBLS is still restarted when `netbeans.project.jdhome` changes

The **Project Runtime Java** setting in **JDK Configuration** command was changed, so it configures **both** JDK table in `java.configuration.runtimes` (JDT) and `netbeans.project.jdkhome` (NBLS).

![jdk-config](https://github.com/apache/netbeans/assets/26788611/8e5b376f-69b5-4a67-b100-8f91d0bf53c0)
// cc: @jisedlac -- pls review, can't put you as a reviewer.
