### PR TITLE
Revert "Disable failing java.mx.project tests"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -891,9 +891,9 @@ jobs:
 #        run: ant $OPTS -f java/ant.grammar test
 
       # TODO next are JDK 21+ incompatibe steps
-#      - name: java/java.mx.project
-#        if: ${{ matrix.java == '17' }}
-#        run: .github/retry.sh ant $OPTS -f java/java.mx.project test
+      - name: java/java.mx.project
+        if: ${{ matrix.java == '17' }}
+        run: .github/retry.sh ant $OPTS -f java/java.mx.project test
 
       - name: java/gradle.java
         if: ${{ matrix.java == '17' }}

--- a/java/java.mx.project/build.xml
+++ b/java/java.mx.project/build.xml
@@ -47,14 +47,11 @@
         </exec>
     </target>
 
-    <!--
-    TODO the branches of https://github.com/graalvm/mx disappered
     <target name="test-preinit" depends="-checkout-graalvm">
         <exec dir="${graal.dir}/truffle" executable="${mx.dir}/mx" failonerror="true">
             <arg value="build"/>
         </exec>
     </target>
-    -->
     <target name="test-unit-build-datajar"/>
 
     <import file="../../nbbuild/templates/projectized.xml"/>


### PR DESCRIPTION
This reverts commit e3abd18ba59c5536737aeae76e99e7266d3a677d / https://github.com/apache/netbeans/pull/7471.

branches should be back https://github.com/graalvm/mx/issues/282

closes #7479