### PR TITLE
Fix incorrect formatting for a static method invocation [GH-7524]

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
@@ -1958,7 +1958,8 @@ public class FormatVisitor extends DefaultVisitor {
     private boolean addIndentToFunctionInvocation() {
         boolean addIndentation = !(path.get(1) instanceof ReturnStatement
                     || path.get(1) instanceof Assignment
-                    || (path.size() > 2 && path.get(1) instanceof MethodInvocation && path.get(2) instanceof Assignment));
+                    || (path.size() > 2 && path.get(1) instanceof MethodInvocation && path.get(2) instanceof Assignment)
+                    || (path.size() > 2 && path.get(1) instanceof StaticMethodInvocation && path.get(2) instanceof Assignment));
         if (!addIndentation && path.size() > 1 && path.get(1) instanceof MethodInvocation) {
             // GH-7172
             // e.g.

--- a/php/php.editor/test/unit/data/testfiles/formatting/issueGH7524.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/issueGH7524.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$test = Test::staticMethod(
+        test(
+            'test',
+            $arg1,
+            $arg2
+        ),
+        $arg
+);

--- a/php/php.editor/test/unit/data/testfiles/formatting/issueGH7524.php.testGH7524_01.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/issueGH7524.php.testGH7524_01.formatted
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$test = Test::staticMethod(
+    test(
+        'test',
+        $arg1,
+        $arg2
+    ),
+    $arg
+);

--- a/php/php.editor/test/unit/data/testfiles/formatting/issueGH7524.php.testGH7524_02.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/issueGH7524.php.testGH7524_02.formatted
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$test = Test::staticMethod(
+        test(
+                'test',
+                $arg1,
+                $arg2
+        ),
+        $arg
+);

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
@@ -1200,4 +1200,16 @@ public class PHPFormatterTest extends PHPFormatterTestBase {
         reformatFileContents("testfiles/formatting/issueGH7172.php", options, false, true);
     }
 
+    public void testGH7524_01() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
+        reformatFileContents("testfiles/formatting/issueGH7524.php", options, false, true);
+    }
+
+    public void testGH7524_02() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 8);
+        reformatFileContents("testfiles/formatting/issueGH7524.php", options, false, true);
+    }
+
 }


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/7524
- Don't add an indent token when a static method invocation assigns to a variable
- Add unit tests

Example:
```php
// Options: Continuation Indentation = 4
$test = Test::staticMethod(
        test(
            'test',
            $arg1,
            $arg2
        ),
        $arg
);
```

Before:
```php
$test = Test::staticMethod(
        test(
            'test',
            $arg1,
            $arg2
        ),
        $arg
);
```

After:
```php
$test = Test::staticMethod(
    test(
        'test',
        $arg1,
        $arg2
    ),
    $arg
);
```