### PR TITLE
Docker - Load images

### DIFF
--- a/ide/docker.api/src/org/netbeans/modules/docker/api/DockerAction.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/api/DockerAction.java
@@ -148,9 +148,9 @@ public class DockerAction {
                 JSONObject json = (JSONObject) o;
                 JSONArray repoTags = (JSONArray) json.get("RepoTags");
                 String id = (String) json.get("Id");
-                long created = (long) json.get("Created");
-                long size = (long) json.get("Size");
-                long virtualSize = (long) json.get("VirtualSize");
+                long created = (long) json.getOrDefault("Created", 0L);
+                long size = (long) json.getOrDefault("Size", 0L);
+                long virtualSize = (long) json.getOrDefault("VirtualSize", size);
                 ret.add(new DockerImage(instance, repoTags, id, created, size, virtualSize));
             }
             return ret;

--- a/ide/docker.api/src/org/netbeans/modules/docker/api/DockerImage.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/api/DockerImage.java
@@ -88,6 +88,11 @@ public final class DockerImage implements DockerInstanceEntity {
         return size;
     }
 
+    /**
+     * @deprecated Removed from Docker Engine in v1.44. Return size value.
+     * @return 
+     */
+    @Deprecated
     public long getVirtualSize() {
         return virtualSize;
     }


### PR DESCRIPTION
Docker's images don't load because attribute "VirtualSize" was removed from docker engine.

Removing docker's attribute "VirtualSize" that was removed from docker engine.