### PR TITLE
Turn remaining few EE tests off which can't run on JDK 17 yet

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1936,7 +1936,7 @@ jobs:
 
 
   enterprise-test:
-    name: Enterprise on Linux/JDK ${{ matrix.java }} (some on 8)
+    name: Enterprise on Linux/JDK ${{ matrix.java }}
     # equals env.test_enterprise == 'true'
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Java EE/Jakarta EE') || contains(github.event.pull_request.labels.*.name, 'Micronaut') || contains(github.event.pull_request.labels.*.name, 'enterprise') || contains(github.event.pull_request.labels.*.name, 'ci:all-tests') || github.event_name != 'pull_request' }}
     needs: base-build
@@ -2168,14 +2168,9 @@ jobs:
       - name: websvc.wsstackapi
         run: ant $OPTS -f enterprise/websvc.wsstackapi test
 
-      - name: Set up JDK 8 for incompatible tests
-        uses: actions/setup-java@v4
-        with:
-          java-version: 8
-          distribution: ${{ env.DEFAULT_JAVA_DISTRIBUTION }}
-
-      - name: websvc.editor.hints
-        run: ant $OPTS -f enterprise/websvc.editor.hints test
+# TODO fails on JDK11+ (#4904)
+#      - name: websvc.editor.hints
+#        run: ant $OPTS -f enterprise/websvc.editor.hints test
 
       - name: j2ee.dd.webservice
         run: ant $OPTS -f enterprise/j2ee.dd.webservice test

--- a/enterprise/j2ee.dd.webservice/nbproject/project.properties
+++ b/enterprise/j2ee.dd.webservice/nbproject/project.properties
@@ -27,6 +27,8 @@ javadoc.docfiles=${basedir}/doc
 test.unit.cp.extra=\
     ${nb_all}/enterprise/j2ee.dd/external/javaee-api-5.jar:\
     ${websvc.jaxws21api.dir}/modules/ext/jaxws22/api/jakarta.jws-api.jar
-test.config.stableBTD.includes=**/*Test.class
+
+# TODO fails on 11+
+test.config.default.excludes=**/WebServicesMetadataModelTest.class
 
 requires.nb.javac=true


### PR DESCRIPTION
those were locked to JDK 8 but kept causing problems to other modules which tried to bump the lang level

Once this is merged, everything would be testing consistently on JDK 17 or later

meta issue: https://github.com/apache/netbeans/issues/4904