### PR TITLE
Add global maven goal presets

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/ActionProviderImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/ActionProviderImpl.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -35,6 +34,7 @@ import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
+import javax.swing.JSeparator;
 import javax.swing.SwingUtilities;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.versioning.ComparableVersion;
@@ -45,9 +45,7 @@ import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectInformation;
 import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.api.project.ui.OpenProjects;
-import static org.netbeans.modules.maven.Bundle.*;
 import org.netbeans.modules.maven.api.Constants;
-import org.netbeans.modules.maven.api.MavenConfiguration;
 import org.netbeans.modules.maven.api.ModelUtils;
 import org.netbeans.modules.maven.api.ModuleInfoUtils;
 import org.netbeans.modules.maven.api.NbMavenProject;
@@ -72,6 +70,7 @@ import org.netbeans.modules.maven.model.pom.DependencyManagement;
 import org.netbeans.modules.maven.model.pom.POMModel;
 import org.netbeans.modules.maven.operations.Operations;
 import org.netbeans.modules.maven.options.MavenSettings;
+import org.netbeans.modules.maven.options.SettingsPanel;
 import org.netbeans.modules.maven.spi.actions.AbstractMavenActionsProvider;
 import org.netbeans.modules.maven.spi.actions.ActionConvertor;
 import org.netbeans.modules.maven.spi.actions.MavenActionsProvider;
@@ -79,9 +78,9 @@ import org.netbeans.modules.maven.spi.actions.ReplaceTokenProvider;
 import org.netbeans.spi.project.ActionProgress;
 import org.netbeans.spi.project.ActionProvider;
 import org.netbeans.spi.project.ProjectConfiguration;
-import org.netbeans.spi.project.ProjectConfigurationProvider;
 import org.netbeans.spi.project.ProjectServiceProvider;
 import org.netbeans.spi.project.SingleMethod;
+import org.netbeans.spi.project.ui.CustomizerProvider2;
 import org.netbeans.spi.project.ui.support.DefaultProjectOperations;
 import org.netbeans.spi.project.ui.support.ProjectSensitiveActions;
 import org.openide.DialogDescriptor;
@@ -105,6 +104,8 @@ import org.openide.util.Task;
 import org.openide.util.actions.Presenter;
 import org.openide.util.lookup.Lookups;
 import org.openide.util.lookup.ProxyLookup;
+
+import static org.netbeans.modules.maven.Bundle.*;
 
 /**
  *
@@ -185,7 +186,7 @@ public class ActionProviderImpl implements ActionProvider {
 
     @Override
     public String[] getSupportedActions() {
-        Set<String> supp = new HashSet<String>();
+        Set<String> supp = new HashSet<>();
         supp.addAll( Arrays.asList(supported));
         
         M2ConfigProvider configs = proj.getLookup().lookup(M2ConfigProvider.class);
@@ -196,7 +197,7 @@ public class ActionProviderImpl implements ActionProvider {
                 supp.addAll( added);
             }
         }
-        return supp.toArray(new String[0]);
+        return supp.toArray(String[]::new);
     }
 
     private boolean usingSurefire28() {
@@ -275,11 +276,8 @@ public class ActionProviderImpl implements ActionProvider {
         }
         
         if (SwingUtilities.isEventDispatchThread()) {
-            RP.post(new Runnable() {
-                @Override
-                public void run() {
-                    invokeAction(action, lookup, false);
-                }
+            RP.post(() -> {
+                invokeAction(action, lookup, false);
             });
             return;
         }
@@ -364,9 +362,7 @@ public class ActionProviderImpl implements ActionProvider {
                                 
                                 Utilities.performPOMModelOperations(
                                         proj.getProjectDirectory().getFileObject("pom.xml"),
-                                        Collections.singletonList(new UpdateSurefireOperation(
-                                                surefireVersion, junitVersion
-                                        ))
+                                        List.of(new UpdateSurefireOperation(surefireVersion, junitVersion))
                                 );
                                 //this appears to run too fast, before the resolved model is updated.
 //                                SwingUtilities.invokeLater(new Runnable() {
@@ -412,7 +408,7 @@ public class ActionProviderImpl implements ActionProvider {
                         RequestProcessor.getDefault().post(() -> {
                             Utilities.performPOMModelOperations(
                                     proj.getProjectDirectory().getFileObject("pom.xml"),
-                                    Collections.singletonList(new UpdateCompilerOperation()));                            
+                                    List.of(new UpdateCompilerOperation()));                            
                         });
                         return false; // false means do not continue
                     }
@@ -423,7 +419,7 @@ public class ActionProviderImpl implements ActionProvider {
     }
     
     public static Map<String,String> replacements(Project proj, String action, Lookup lookup) {
-        Map<String,String> replacements = new HashMap<String,String>();
+        Map<String,String> replacements = new HashMap<>();
         for (ReplaceTokenProvider prov : proj.getLookup().lookupAll(ReplaceTokenProvider.class)) {
             replacements.putAll(prov.createReplacements(action, lookup));
         }
@@ -549,13 +545,10 @@ public class ActionProviderImpl implements ActionProvider {
 
             if (!showUI) {
                 final M2ConfigProvider conf = proj.getLookup().lookup(M2ConfigProvider.class);
-                RP.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        ModelRunConfig rc = createCustomRunConfig(conf);
-                        setupTaskName("custom", rc, context);
-                        RunUtils.run(rc);
-                    }
+                RP.post(() -> {
+                    ModelRunConfig rc = createCustomRunConfig(conf);
+                    setupTaskName("custom", rc, context);
+                    RunUtils.run(rc);
                 });
                 return;
             }
@@ -574,39 +567,33 @@ public class ActionProviderImpl implements ActionProvider {
                 }
                 maps.getActions().add(mapping);
                 final String remembered = pnl.isRememberedAs();
-                final Boolean offline = Boolean.valueOf(pnl.isOffline());
+                final Boolean offline = pnl.isOffline();
                 final boolean debug = pnl.isShowDebug();
                 final boolean recursive = pnl.isRecursive();
                 final boolean updateSnapshots = pnl.isUpdateSnapshots();
-                RP.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        M2ConfigProvider conf = proj.getLookup().lookup(M2ConfigProvider.class);
-                        ActionToGoalUtils.writeMappingsToFileAttributes(proj.getProjectDirectory(), maps);
-                        if (remembered != null) {
-                            try {
-
-                                String tit = "CUSTOM-" + remembered; //NOI18N
-                                mapping.setActionName(tit);
-                                mapping.setDisplayName(remembered);
-                                //TODO shall we write to configuration based files or not?
-                                ModelHandle2.putMapping(mapping, proj, conf.getDefaultConfig());
-                            } catch (IOException ex) {
-                                LOG.log(Level.INFO, "Cannot write custom action mapping", ex);
-                            }
+                RP.post(() -> {
+                    M2ConfigProvider conf = proj.getLookup().lookup(M2ConfigProvider.class);
+                    ActionToGoalUtils.writeMappingsToFileAttributes(proj.getProjectDirectory(), maps);
+                    if (remembered != null) {
+                        try {
+                            String tit = "CUSTOM-" + remembered; //NOI18N
+                            mapping.setActionName(tit);
+                            mapping.setDisplayName(remembered);
+                            //TODO shall we write to configuration based files or not?
+                            ModelHandle2.putMapping(mapping, proj, conf.getDefaultConfig());
+                        } catch (IOException ex) {
+                            LOG.log(Level.INFO, "Cannot write custom action mapping", ex);
                         }
-                        ModelRunConfig rc = createCustomRunConfig(conf);
-                        rc.setOffline(offline);
-                        rc.setShowDebug(debug);
-                        rc.setRecursive(recursive);
-                        rc.setUpdateSnapshots(updateSnapshots);
-
-                        setupTaskName("custom", rc, Lookup.EMPTY); //NOI18N
-                        RunUtils.run(rc);
                     }
+                    ModelRunConfig rc = createCustomRunConfig(conf);
+                    rc.setOffline(offline);
+                    rc.setShowDebug(debug);
+                    rc.setRecursive(recursive);
+                    rc.setUpdateSnapshots(updateSnapshots);
                     
+                    setupTaskName("custom", rc, Lookup.EMPTY); //NOI18N
+                    RunUtils.run(rc);
                 });
-                
 
             }
         }
@@ -615,15 +602,45 @@ public class ActionProviderImpl implements ActionProvider {
             ModelRunConfig rc = new ModelRunConfig(proj, mapping, mapping.getActionName(), null, Lookup.EMPTY, false);
 
             //#171086 also inject profiles from currently selected configuratiin
-            List<String> acts = new ArrayList<String>();
+            List<String> acts = new ArrayList<>();
             acts.addAll(rc.getActivatedProfiles());
             acts.addAll(conf.getActiveConfiguration().getActivatedProfiles());
             rc.setActivatedProfiles(acts);
-            Map<String, String> props = new HashMap<String, String>(rc.getProperties());
+            Map<String, String> props = new HashMap<>(rc.getProperties());
             props.putAll(conf.getActiveConfiguration().getProperties());
             rc.addProperties(props);
             rc.setTaskDisplayName(TXT_Build(proj.getLookup().lookup(NbMavenProject.class).getMavenProject().getArtifactId()));
             return rc;
+        }
+    }
+
+    @Messages("LBL_Edit_project_goals=Edit Project Goals...")
+    private final static class EditProjectGoalsAction extends AbstractAction {
+
+        private final Project project;
+
+        private EditProjectGoalsAction(Project project) {
+            putValue(Action.NAME, LBL_Edit_project_goals());
+            this.project = project;
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent ae) {
+            CustomizerProvider2 provider = project.getLookup().lookup(CustomizerProvider2.class);
+            provider.showCustomizer(ModelHandle2.PANEL_MAPPING, null);
+        }
+    }
+
+    @Messages("LBL_Edit_global_goals=Edit Global Goals...")
+    private final static class EditGlobalGoalsAction extends AbstractAction {
+
+        private EditGlobalGoalsAction() {
+            putValue(Action.NAME, LBL_Edit_global_goals());
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent ae) {
+            SettingsPanel.showGlobalMavenGoalCustomizer();
         }
     }
 
@@ -744,47 +761,50 @@ public class ActionProviderImpl implements ActionProvider {
         
         @Messages({
             "LBL_Loading=Loading...",
-            "LBL_Custom_run_goals=Goals..."
+            "LBL_Custom_run_goals=Other Goals..."
         })
         @Override public JMenuItem getPopupPresenter() {
 
-            final JMenu menu = new JMenu(onFile ? LBL_Custom_Run_File() : LBL_Custom_Run());
-            final JMenuItem loading = new JMenuItem(LBL_Loading());
+            JMenu menu = new JMenu(onFile ? LBL_Custom_Run_File() : LBL_Custom_Run());
+            JMenuItem loading = new JMenuItem(LBL_Loading());
 
             menu.add(loading);
             /*using lazy construction strategy*/
-            RP.post(new Runnable() {
-
-                @Override
-                public void run() {
-                    NetbeansActionMapping[] maps;
-                    if (onFile && !onPom) {
-                      maps = ActionToGoalUtils.getActiveCustomMappingsForFile(proj.getLookup().lookup(NbMavenProjectImpl.class));
-                    } else {
-                      maps = ActionToGoalUtils.getActiveCustomMappings(proj.getLookup().lookup(NbMavenProjectImpl.class));
-                    }
-                    final List<Action> acts = new ArrayList<Action>();
-                    for (NetbeansActionMapping mapp : maps) {
-                        Action act = createCustomMavenAction(mapp.getActionName(), mapp, false, lookup, proj);
-                        act.putValue(NAME, mapp.getDisplayName() == null ? mapp.getActionName() : mapp.getDisplayName());
-                        acts.add(act);
-                    }
-                    acts.add(createCustomMavenAction(LBL_Custom_run_goals(), new NetbeansActionMapping(), true, lookup, proj));
-                    SwingUtilities.invokeLater(new Runnable() {
-                        @Override
-                        public void run() {
-                            boolean selected = menu.isSelected();
-                            menu.remove(loading);
-                            for (Action a : acts) {
-                                menu.add(new JMenuItem(a));
-                            }
-                            menu.getPopupMenu().pack();
-                            menu.repaint();
-                            menu.updateUI();
-                            menu.setSelected(selected);
-                        }
-                    });
+            RP.post(() -> {
+                NetbeansActionMapping[] maps;
+                if (onFile && !onPom) {
+                    maps = ActionToGoalUtils.getActiveCustomMappingsForFile(proj.getLookup().lookup(NbMavenProjectImpl.class));
+                } else {
+                    maps = ActionToGoalUtils.getActiveCustomMappings(proj.getLookup().lookup(NbMavenProjectImpl.class));
                 }
+                List<Action> acts = new ArrayList<>();
+                for (NetbeansActionMapping mapp : maps) {
+                    Action act = createCustomMavenAction(mapp.getActionName(), mapp, false, lookup, proj);
+                    act.putValue(NAME, mapp.getDisplayName() == null ? mapp.getActionName() : mapp.getDisplayName());
+                    acts.add(act);
+                }
+                acts.add(createCustomMavenAction(LBL_Custom_run_goals(), new NetbeansActionMapping(), true, lookup, proj));
+                acts.add(new EditProjectGoalsAction(proj));
+                acts.add(new EditGlobalGoalsAction());
+                SwingUtilities.invokeLater(() -> {
+                    boolean selected = menu.isSelected();
+                    menu.remove(loading);
+                    for (Action a : acts) {
+                        menu.add(new JMenuItem(a));
+                    }
+                    // before edit actions
+                    if (menu.getItemCount() > 3) {
+                        menu.add(new JSeparator(), menu.getItemCount() - 3);
+                    }
+                    // between run and edit actions
+                    if (menu.getItemCount() > 2) {
+                        menu.add(new JSeparator(), menu.getItemCount() - 2);
+                    }
+                    menu.getPopupMenu().pack();
+                    menu.repaint();
+                    menu.updateUI();
+                    menu.setSelected(selected);
+                });
             }, 100);
             return menu;
         }
@@ -813,15 +833,11 @@ public class ActionProviderImpl implements ActionProvider {
             putValue(Action.NAME, ACT_CloseRequired());
         }
         public @Override void actionPerformed(ActionEvent e) {
-            RP.post(new Runnable() {
-                @Override
-                public void run() {
-                    Set<Project> res = ProjectUtils.getContainedProjects(project, true);
-                    Project[] arr = res.toArray(new Project[0]);
-                    OpenProjects.getDefault().close(arr);
-                }
+            RP.post(() -> {
+                Set<Project> res = ProjectUtils.getContainedProjects(project, true);
+                Project[] arr = res.toArray(Project[]::new);
+                OpenProjects.getDefault().close(arr);
             });
-            
         }
     }
 
@@ -842,8 +858,6 @@ public class ActionProviderImpl implements ActionProvider {
             this.newJUnit = newJUnit;
         }
 
-        
-        
         @Override
         public void performOperation(POMModel model) {
             org.netbeans.modules.maven.model.pom.Project prj = model.getProject();

--- a/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.form
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.form
@@ -60,7 +60,7 @@
       </AccessibilityProperties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="7" gridY="0" gridWidth="4" gridHeight="2" fill="0" ipadX="427" ipadY="0" insetsTop="0" insetsLeft="18" insetsBottom="0" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="7" gridY="0" gridWidth="4" gridHeight="2" fill="2" ipadX="427" ipadY="0" insetsTop="0" insetsLeft="18" insetsBottom="0" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -159,7 +159,7 @@
       </AccessibilityProperties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="7" gridY="7" gridWidth="4" gridHeight="2" fill="0" ipadX="455" ipadY="0" insetsTop="18" insetsLeft="18" insetsBottom="0" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="7" gridY="7" gridWidth="4" gridHeight="2" fill="2" ipadX="455" ipadY="0" insetsTop="18" insetsLeft="18" insetsBottom="0" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -186,7 +186,7 @@
       </AccessibilityProperties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="7" gridY="9" gridWidth="4" gridHeight="2" fill="0" ipadX="455" ipadY="0" insetsTop="6" insetsLeft="18" insetsBottom="0" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="7" gridY="9" gridWidth="4" gridHeight="2" fill="2" ipadX="455" ipadY="0" insetsTop="6" insetsLeft="18" insetsBottom="0" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -240,7 +240,7 @@
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="7" gridY="17" gridWidth="4" gridHeight="1" fill="1" ipadX="436" ipadY="120" insetsTop="2" insetsLeft="18" insetsBottom="0" insetsRight="12" anchor="18" weightX="1.0" weightY="1.0"/>
+          <GridBagConstraints gridX="7" gridY="17" gridWidth="4" gridHeight="1" fill="1" ipadX="436" ipadY="120" insetsTop="2" insetsLeft="18" insetsBottom="0" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
 
@@ -329,7 +329,7 @@
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="7" gridY="11" gridWidth="4" gridHeight="2" fill="0" ipadX="455" ipadY="0" insetsTop="6" insetsLeft="18" insetsBottom="0" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="7" gridY="11" gridWidth="4" gridHeight="2" fill="2" ipadX="455" ipadY="0" insetsTop="6" insetsLeft="18" insetsBottom="0" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>

--- a/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.java
@@ -108,7 +108,7 @@ public class ActionMappings extends javax.swing.JPanel implements HelpCtx.Provid
     private static final RequestProcessor RP = new RequestProcessor(ActionMappings.class);
     private NbMavenProjectImpl project;
     private ModelHandle2 handle;
-    private final HashMap<String, String> titles = new HashMap<String, String>();
+    private final HashMap<String, String> titles = new HashMap<>();
     
     private final GoalsListener goalsListener;
     private final TextValueCompleter goalcompleter;
@@ -222,12 +222,10 @@ public class ActionMappings extends javax.swing.JPanel implements HelpCtx.Provid
         
         loadMappings();
         clearFields();
-        comboListener = new ActionListener() {
-            @Override public void actionPerformed(ActionEvent e) {
-                clearFields();
-                loadMappings();
-                addListeners();
-            }
+        comboListener = (ActionEvent e) -> {
+            clearFields();
+            loadMappings();
+            addListeners();
         };
     }
     
@@ -269,7 +267,7 @@ public class ActionMappings extends javax.swing.JPanel implements HelpCtx.Provid
         addListeners();
         RP.post(new Runnable() {
             @Override public void run() {
-                final Set<String> strs = new HashSet<String>();
+                final Set<String> strs = new HashSet<>();
                 final GoalsProvider provider = Lookup.getDefault().lookup(GoalsProvider.class);
                 if (provider != null) {
                     strs.addAll(provider.getAvailableGoals());
@@ -288,12 +286,10 @@ public class ActionMappings extends javax.swing.JPanel implements HelpCtx.Provid
                 }
                 final List<String> profiles = allProfiles;
 
-                SwingUtilities.invokeLater(new Runnable() {
-                    @Override public void run() {
-                        goalcompleter.setValueList(strs, false); //do not bother about partial results, too many intermediate apis..
-                        if (profiles != null) {
-                            profilecompleter.setValueList(profiles, false);
-                        }
+                SwingUtilities.invokeLater(() -> {
+                    goalcompleter.setValueList(strs, false); //do not bother about partial results, too many intermediate apis..
+                    if (profiles != null) {
+                        profilecompleter.setValueList(profiles, false);
                     }
                 });
             }
@@ -348,6 +344,7 @@ public class ActionMappings extends javax.swing.JPanel implements HelpCtx.Provid
         gridBagConstraints.gridy = 0;
         gridBagConstraints.gridwidth = 4;
         gridBagConstraints.gridheight = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.ipadx = 427;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(0, 18, 0, 12);
@@ -426,6 +423,7 @@ public class ActionMappings extends javax.swing.JPanel implements HelpCtx.Provid
         gridBagConstraints.gridy = 7;
         gridBagConstraints.gridwidth = 4;
         gridBagConstraints.gridheight = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.ipadx = 455;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(18, 18, 0, 12);
@@ -446,6 +444,7 @@ public class ActionMappings extends javax.swing.JPanel implements HelpCtx.Provid
         gridBagConstraints.gridy = 9;
         gridBagConstraints.gridwidth = 4;
         gridBagConstraints.gridheight = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.ipadx = 455;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(6, 18, 0, 12);
@@ -494,8 +493,6 @@ public class ActionMappings extends javax.swing.JPanel implements HelpCtx.Provid
         gridBagConstraints.ipadx = 436;
         gridBagConstraints.ipady = 120;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
-        gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.weighty = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(2, 18, 0, 12);
         add(jScrollPane2, gridBagConstraints);
 
@@ -557,6 +554,7 @@ public class ActionMappings extends javax.swing.JPanel implements HelpCtx.Provid
         gridBagConstraints.gridy = 11;
         gridBagConstraints.gridwidth = 4;
         gridBagConstraints.gridheight = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.ipadx = 455;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(6, 18, 0, 12);
@@ -735,11 +733,11 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
                     }
                 }
 
-                DefaultComboBoxModel<String> cbModel = new DefaultComboBoxModel<String>(allIcons.toArray(new String[0]));
+                DefaultComboBoxModel<String> cbModel = new DefaultComboBoxModel<>(allIcons.toArray(String[]::new));
                 boolean hasAvailable;
                 if (cbModel.getSize() != 0) {
                     hasAvailable = true;
-                    JComboBox<String> cb = new JComboBox<String>();
+                    JComboBox<String> cb = new JComboBox<>();
                     cb.setModel(cbModel);
                     pnl.add(cb);
                     cb.setRenderer(new DefaultListCellRenderer() {
@@ -983,7 +981,7 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
     public static Map<String, String> convertStringToActionProperties(String text) {
         PropertySplitter split = new PropertySplitter(text);
         String tok = split.nextPair();
-        Map<String,String> props = new LinkedHashMap<String,String>();
+        Map<String,String> props = new LinkedHashMap<>();
         while (tok != null) {
             String[] prp = StringUtils.split(tok, "=", 2); //NOI18N
             if (prp.length >= 1 ) {
@@ -998,7 +996,7 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
                 if (key.endsWith("=")) {
                     key = key.substring(0, key.length() - 1);
                 }
-                if (key.trim().length() > 0 && Verifier.checkElementName(key.trim()) == null) {
+                if (!key.isBlank() && Verifier.checkElementName(key.trim()) == null) {
                     props.put(key.trim(), prp.length > 1 ? prp[1] : "");
                 }
             }
@@ -1203,7 +1201,7 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
                 String text = txtGoals.getText();
                 StringTokenizer tok = new StringTokenizer(text, " "); //NOI18N
                 NetbeansActionMapping mapp = wr.getMapping();
-                List<String> goals = new ArrayList<String>();
+                List<String> goals = new ArrayList<>();
                 while (tok.hasMoreTokens()) {
                     String token = tok.nextToken();
                     goals.add(token);
@@ -1228,7 +1226,7 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
                 String text = txtProfiles.getText();
                 StringTokenizer tok = new StringTokenizer(text, " ,"); //NOI18N
                 NetbeansActionMapping mapp = wr.getMapping();
-                List<String> profs = new ArrayList<String>();
+                List<String> profs = new ArrayList<>();
                 while (tok.hasMoreTokens()) {
                     String token = tok.nextToken();
                     profs.add(token);
@@ -1250,7 +1248,7 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
                 String text = txtPackagings.getText().trim();
                 StringTokenizer tok = new StringTokenizer(text, " ,"); //NOI18N
                 NetbeansActionMapping mapp = wr.getMapping();
-                List<String> packs = new ArrayList<String>();
+                List<String> packs = new ArrayList<>();
                 while (tok.hasMoreTokens()) {
                     String token = tok.nextToken();
                     packs.add(token.trim());
@@ -1415,7 +1413,7 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
                     if (expr != null) {
                         String props = area.getText();
                         String sep = "\n";//NOI18N
-                        if (props.endsWith("\n") || props.trim().length() == 0) {//NOI18N
+                        if (props.endsWith("\n") || props.isBlank()) {//NOI18N
                             sep = "";//NOI18N
                         }
                         props = props + sep + expr + "="; //NOI18N
@@ -1441,7 +1439,7 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
         @Override public void actionPerformed(ActionEvent e) {
             String props = area.getText();
             String sep = "\n";//NOI18N
-            if (props.endsWith("\n") || props.trim().length() == 0) {//NOI18N
+            if (props.endsWith("\n") || props.isBlank()) {//NOI18N
                 sep = "";//NOI18N
             }
             props = props + sep + "Env.FOO=bar"; //NOI18N
@@ -1498,7 +1496,7 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
         @Override public void actionPerformed(ActionEvent e) {
             String props = area.getText();
             String sep = "\n";//NOI18N
-            if (props.endsWith("\n") || props.trim().length() == 0) {//NOI18N
+            if (props.endsWith("\n") || props.isBlank()) {//NOI18N
                 sep = "";//NOI18N
             }
             String val = "Env.JAVA_HOME=" + value;
@@ -1584,7 +1582,7 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
             }
         } else {
             String sep = "\n";//NOI18N
-            if (props.endsWith("\n") || props.trim().length() == 0) {//NOI18N
+            if (props.endsWith("\n") || props.isBlank()) {//NOI18N
                 sep = "";//NOI18N
             }
             props = props + sep + replace; //NOI18N
@@ -1620,7 +1618,7 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
         }
 
         private void checkValid () {
-            setValid(textField.getText() != null && textField.getText().trim().length() > 0);
+            setValid(textField.getText() != null && !textField.getText().isBlank());
         }
 
     }

--- a/java/maven/src/org/netbeans/modules/maven/execute/ActionToGoalUtils.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/ActionToGoalUtils.java
@@ -26,9 +26,11 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.maven.model.Build;
 import org.netbeans.modules.maven.spi.actions.MavenActionsProvider;
 import org.netbeans.modules.maven.NbMavenProjectImpl;
@@ -41,7 +43,6 @@ import org.netbeans.api.project.Project;
 import org.netbeans.modules.maven.api.FileUtilities;
 import org.netbeans.modules.maven.api.NbMavenProject;
 import org.netbeans.modules.maven.api.execute.ExecutionContext;
-import org.netbeans.modules.maven.api.execute.RunUtils;
 import org.netbeans.modules.maven.execute.model.ActionToGoalMapping;
 import org.netbeans.modules.maven.execute.model.NetbeansActionMapping;
 import org.netbeans.modules.maven.execute.model.io.xpp3.NetbeansBuildActionXpp3Reader;
@@ -95,7 +96,7 @@ public final class ActionToGoalUtils {
      * @since 2.50
      */
     public static @NonNull List<? extends MavenActionsProvider> actionProviders(@NonNull Project project) {
-        List<MavenActionsProvider> providers = new ArrayList<MavenActionsProvider>();
+        List<MavenActionsProvider> providers = new ArrayList<>();
         providers.addAll(project.getLookup().lookupAll(MavenActionsProvider.class));        
         providers.addAll(Lookup.getDefault().lookupAll(MavenActionsProvider.class));
         return providers;
@@ -157,11 +158,11 @@ public final class ActionToGoalUtils {
             if (rc instanceof ModelRunConfig && ((ModelRunConfig)rc).isFallback()) {
                 return rc;
             }
-            List<String> acts = new ArrayList<String>(); 
+            List<String> acts = new ArrayList<>(); 
             acts.addAll(rc.getActivatedProfiles());
             acts.addAll(requested.getActivatedProfiles());
             rc.setActivatedProfiles(acts);
-            Map<String, String> props = new HashMap<String, String>(rc.getProperties());
+            Map<String, String> props = new HashMap<>(rc.getProperties());
             props.putAll(requested.getProperties());
             rc.addProperties(props);
         }
@@ -280,8 +281,8 @@ public final class ActionToGoalUtils {
     
     private static NetbeansActionMapping[] getActiveCustomMappingsImpl(NbMavenProjectImpl project, boolean forFiles) {
         M2ConfigProvider configs = project.getLookup().lookup(M2ConfigProvider.class);
-        List<NetbeansActionMapping> toRet = new ArrayList<NetbeansActionMapping>();
-        List<String> names = new ArrayList<String>();
+        List<NetbeansActionMapping> toRet = new ArrayList<>();
+        Set<String> names = new HashSet<>();
         // first add all project specific custom actions.
         for (NetbeansActionMapping map : configs.getActiveConfiguration().getCustomMappings()) {
             toRet.add(map);
@@ -320,7 +321,7 @@ public final class ActionToGoalUtils {
             }
             
         }
-        return toRet.toArray(new NetbeansActionMapping[0]);
+        return toRet.toArray(NetbeansActionMapping[]::new);
     }
         
 
@@ -347,9 +348,7 @@ public final class ActionToGoalUtils {
             NetbeansBuildActionXpp3Reader reader = new NetbeansBuildActionXpp3Reader();
             try {
                 mapp = reader.read(new StringReader(string));
-            } catch (IOException ex) {
-                ex.printStackTrace();
-            } catch (XmlPullParserException ex) {
+            } catch (IOException | XmlPullParserException ex) {
                 ex.printStackTrace();
             }
         }

--- a/java/maven/src/org/netbeans/modules/maven/execute/ui/RunGoalsPanel.form
+++ b/java/maven/src/org/netbeans/modules/maven/execute/ui/RunGoalsPanel.form
@@ -28,7 +28,7 @@
     <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_layoutCodeTarget" type="java.lang.Integer" value="1"/>
-    <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
+    <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="3"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
   </AuxValues>
@@ -52,12 +52,19 @@
                   </Group>
                   <Group type="102" alignment="0" attributes="0">
                       <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="lblGoals" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="lblProfiles" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="jLabel2" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="btnAddProps" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Group type="102" attributes="0">
+                              <Group type="103" groupAlignment="0" attributes="0">
+                                  <Component id="lblGoals" alignment="0" min="-2" max="-2" attributes="0"/>
+                                  <Component id="lblProfiles" alignment="0" min="-2" max="-2" attributes="0"/>
+                                  <Component id="jLabel2" alignment="0" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace min="-2" pref="13" max="-2" attributes="0"/>
+                          </Group>
+                          <Group type="102" alignment="1" attributes="0">
+                              <Component id="btnAddProps" min="-2" max="-2" attributes="0"/>
+                              <EmptySpace max="-2" attributes="0"/>
+                          </Group>
                       </Group>
-                      <EmptySpace max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Component id="txtGoals" alignment="0" max="32767" attributes="0"/>
                           <Component id="txtProfiles" alignment="0" max="32767" attributes="0"/>
@@ -82,36 +89,36 @@
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="lblGoals" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="txtGoals" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="lblProfiles" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="txtProfiles" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="0" max="-2" attributes="0">
+              <EmptySpace min="-2" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
                   <Group type="102" attributes="0">
                       <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace min="-2" pref="39" max="-2" attributes="0"/>
+                      <EmptySpace max="32767" attributes="0"/>
                       <Component id="btnAddProps" min="-2" max="-2" attributes="0"/>
                   </Group>
-                  <Component id="jScrollPane2" max="32767" attributes="0"/>
+                  <Component id="jScrollPane2" pref="110" max="32767" attributes="0"/>
               </Group>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <EmptySpace type="unrelated" min="-2" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="cbRecursive" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="cbUpdateSnapshots" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="cbOffline" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="cbDebug" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace min="-2" pref="34" max="-2" attributes="0"/>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Component id="jSeparator1" min="-2" pref="10" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
@@ -120,7 +127,7 @@
                   <Component id="cbRemember" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="txtRemember" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace max="32767" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>

--- a/java/maven/src/org/netbeans/modules/maven/nbactions.xml
+++ b/java/maven/src/org/netbeans/modules/maven/nbactions.xml
@@ -20,4 +20,42 @@
 
 -->
 <actions>
+    <action>
+        <actionName>CUSTOM-Add/Update Wrapper (mvnw)</actionName>
+        <displayName>Add/Update Wrapper (mvnw)</displayName>
+        <goals>
+            <goal>wrapper:wrapper</goal>
+        </goals>
+        <properties>
+            <type>only-script</type>
+        </properties>
+    </action>
+    <action>
+        <actionName>CUSTOM-Dependency Tree</actionName>
+        <displayName>Dependency Tree</displayName>
+        <goals>
+            <goal>eu.maveniverse.maven.plugins:toolbox:tree</goal>
+        </goals>
+    </action>
+    <action>
+        <actionName>CUSTOM-Dependency Tree (plugins)</actionName>
+        <displayName>Dependency Tree (plugins)</displayName>
+        <goals>
+            <goal>eu.maveniverse.maven.plugins:toolbox:plugin-tree</goal>
+        </goals>
+    </action>
+    <action>
+        <actionName>CUSTOM-Compute Libyear</actionName>
+        <displayName>Compute Libyear</displayName>
+        <goals>
+            <goal>eu.maveniverse.maven.plugins:toolbox:libyear</goal>
+        </goals>
+    </action>
+    <action>
+        <actionName>CUSTOM-Compute Libyear (plugins)</actionName>
+        <displayName>Compute Libyear (plugins)</displayName>
+        <goals>
+            <goal>eu.maveniverse.maven.plugins:toolbox:plugin-libyear</goal>
+        </goals>
+    </action>
 </actions>

--- a/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
@@ -159,27 +159,22 @@ public class SettingsPanel extends javax.swing.JPanel {
         comMavenHome.setRenderer(new ComboBoxRenderer());
 
         this.controller = controller;
-        listItemChangedListener = new ActionListener() {
-            
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                if (SEPARATOR.equals(comMavenHome.getSelectedItem())) {
-                    comMavenHome.setSelectedIndex(lastSelected);
-                    return;
-                }
-                
-                int selected = comMavenHome.getSelectedIndex();
-                if (selected == mavenHomeDataModel.getSize() - 1) {
-                    // browse
-                    comMavenHome.setSelectedIndex(lastSelected);
-                    SwingUtilities.invokeLater(SettingsPanel.this::browseAddNewRuntime);
-                    return;
-                }
-                
-                listDataChanged();
-                lastSelected = selected;
+        listItemChangedListener = (ActionEvent e) -> {
+            if (SEPARATOR.equals(comMavenHome.getSelectedItem())) {
+                comMavenHome.setSelectedIndex(lastSelected);
+                return;
             }
+            int selected = comMavenHome.getSelectedIndex();
+            if (selected == mavenHomeDataModel.getSize() - 1) {
+                // browse
+                comMavenHome.setSelectedIndex(lastSelected);
+                SwingUtilities.invokeLater(SettingsPanel.this::browseAddNewRuntime);
+                return;
+            }
+            listDataChanged();
+            lastSelected = selected;
         };
+
         comIndex.setSelectedIndex(0);
         listener = new ActionListenerImpl();
         comIndex.addActionListener(listener);
@@ -889,6 +884,10 @@ public class SettingsPanel extends javax.swing.JPanel {
     }//GEN-LAST:event_btnIndexActionPerformed
     
     private void btnGoalsActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnGoalsActionPerformed
+        showGlobalMavenGoalCustomizer();
+    }//GEN-LAST:event_btnGoalsActionPerformed
+
+    public static void showGlobalMavenGoalCustomizer() {
         NbGlobalActionGoalProvider provider = Lookup.getDefault().lookup(NbGlobalActionGoalProvider.class);
         assert provider != null;
         try {
@@ -907,7 +906,7 @@ public class SettingsPanel extends javax.swing.JPanel {
         } catch (Exception ex) {
             Exceptions.printStackTrace(ex);
         }
-    }//GEN-LAST:event_btnGoalsActionPerformed
+    }
 
     private void btnOptionsActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnOptionsActionPerformed
         GlobalOptionsPanel pnl = new GlobalOptionsPanel();
@@ -1033,7 +1032,7 @@ public class SettingsPanel extends javax.swing.JPanel {
         chooser.setFileHidingEnabled(false);
         int selected = comMavenHome.getSelectedIndex();
         String path = getSelectedRuntime(selected);
-        if (path == null || path.trim().length() == 0) {
+        if (path == null || path.isBlank()) {
             path = new File(System.getProperty("user.home")).getAbsolutePath(); //NOI18N
         }
         if (path.length() > 0) {
@@ -1146,9 +1145,9 @@ public class SettingsPanel extends javax.swing.JPanel {
         cbEnableIndexDownload.setSelected(RepositoryPreferences.isIndexDownloadEnabled());
         cbEnableMultiThreading.setSelected(RepositoryPreferences.isMultiThreadedIndexExtractionEnabled());
         switch (RepositoryPreferences.getIndexDateCutoffFilter()) {
-            case 5: rb5Years.setSelected(true); break;
-            case 2: rb2Years.setSelected(true); break;
-            default: rbFullIndex.setSelected(true); break;
+            case 5 -> rb5Years.setSelected(true);
+            case 2 -> rb2Years.setSelected(true);
+            default -> rbFullIndex.setSelected(true);
         }
         comBinaries.setSelectedItem(MavenSettings.getDefault().getBinaryDownloadStrategy());
         comJavadoc.setSelectedItem(MavenSettings.getDefault().getJavadocDownloadStrategy());


### PR DESCRIPTION
 - add `mvnw` updater and a few [maveniverse toolbox](https://github.com/maveniverse/toolbox) diagnostic goals as global preset
 - add right click menu actions which lead to the global and project rule editors for easy add/edit/remove
 - some layout adjustments to both global and custom goal windows so that they resize nicely
 - minor language level cleanup

![image](https://github.com/apache/netbeans/assets/114367/a74f8bbb-729a-4085-aa59-127ad2af2940)

"Edit Global Goals" (new) will open the (already existing) window:
![image](https://github.com/apache/netbeans/assets/114367/1b199f25-736a-4302-8cc1-b0ae0751ab61)

(also accessible from maven execution options)

note:
I reverted a few things to not change too much at once. What I originally planned was to combine the global and per-project goal editor windows and I wanted to move the global editor panel to a card in the main maven options. However, the problem is that the two windows and the tools->options windows have different ways how to handle persistence, so this would have been too much at once. Still something we can do at some point.