### PR TITLE
Implement suppress warnings on for Unused hint and codeAction for suppress warnings annotations

### DIFF
--- a/ide/spi.editor.hints/src/org/netbeans/spi/editor/hints/Fix.java
+++ b/ide/spi.editor.hints/src/org/netbeans/spi/editor/hints/Fix.java
@@ -19,6 +19,8 @@
 
 package org.netbeans.spi.editor.hints;
 
+import org.netbeans.modules.editor.hints.HintsControllerImpl;
+
 /**
  * Allows to perform a change when the user selects the hint.
  * @author Jan Lahoda
@@ -39,4 +41,8 @@ public interface Fix {
      *  determined.
      */
     public abstract ChangeInfo implement() throws Exception;
+    
+    default Iterable<? extends Fix> getSubfixes() {
+        return HintsControllerImpl.getSubfixes(this);
+    }
 }

--- a/java/java.hints/nbproject/project.properties
+++ b/java/java.hints/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 spec.version.base=1.108.0
 
-javac.source=1.8
+javac.release=17
 
 nbroot=../..
 jbrowse.external=${nbroot}/retouche

--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unused.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unused.java
@@ -19,7 +19,6 @@
 package org.netbeans.modules.java.hints.bugs;
 
 import com.sun.source.tree.Tree.Kind;
-import java.util.ArrayList;
 import java.util.List;
 import javax.lang.model.element.ElementKind;
 import org.netbeans.modules.java.editor.base.semantic.UnusedDetector;
@@ -33,6 +32,8 @@ import org.netbeans.spi.java.hints.HintContext;
 import org.netbeans.spi.java.hints.JavaFixUtilities;
 import org.netbeans.spi.java.hints.TriggerTreeKind;
 import org.openide.util.NbBundle.Messages;
+
+import static org.netbeans.api.java.source.CompilationInfo.CacheClearPolicy.ON_TASK_END;
 
 /**
  *
@@ -52,24 +53,46 @@ public class Unused {
     @BooleanOption(displayName="#LBL_UnusedPackagePrivate", tooltip="#TP_UnusedPackagePrivate", defaultValue=DETECT_UNUSED_PACKAGE_PRIVATE_DEFAULT)
     public static final String DETECT_UNUSED_PACKAGE_PRIVATE = "detect.unused.package.private";
 
-    @TriggerTreeKind(Kind.COMPILATION_UNIT)
+    @TriggerTreeKind({
+        //class-like kinds:
+        Kind.ANNOTATION_TYPE, Kind.CLASS, Kind.ENUM, Kind.INTERFACE, Kind.RECORD,
+        Kind.VARIABLE,
+        Kind.METHOD
+    })
     public static List<ErrorDescription> unused(HintContext ctx) {
         List<UnusedDescription> unused = UnusedDetector.findUnused(ctx.getInfo(), () -> ctx.isCanceled());
-        List<ErrorDescription> result = new ArrayList<>(unused.size());
-        boolean detectUnusedPackagePrivate = ctx.getPreferences().getBoolean(DETECT_UNUSED_PACKAGE_PRIVATE, DETECT_UNUSED_PACKAGE_PRIVATE_DEFAULT);
+        if (unused.isEmpty()) {
+            return null;
+        }
+        boolean detectUnusedPackagePrivate = getTaskCachedBoolean(ctx, DETECT_UNUSED_PACKAGE_PRIVATE, DETECT_UNUSED_PACKAGE_PRIVATE_DEFAULT);
         for (UnusedDescription ud : unused) {
             if (ctx.isCanceled()) {
                 break;
+            }
+            if (ud.unusedElementPath.getLeaf() != ctx.getPath().getLeaf()) {
+                continue;
             }
             if (!detectUnusedPackagePrivate && ud.packagePrivate) {
                 continue;
             }
             ErrorDescription err = convertUnused(ctx, ud);
             if (err != null) {
-                result.add(err);
+                return List.of(err);
             }
+            break;
         }
-        return result;
+        return null;
+    }
+
+    // reading from AuxiliaryConfigBasedPreferences in inner loops is not cheap since it needs a mutex
+    private static boolean getTaskCachedBoolean(HintContext ctx, String key, boolean defaultVal) {
+        Object cached = ctx.getInfo().getCachedValue(key);
+        if (cached instanceof Boolean val) {
+            return val;
+        }
+        boolean fromPrefs = ctx.getPreferences().getBoolean(key, defaultVal);
+        ctx.getInfo().putCachedValue(key, fromPrefs, ON_TASK_END);
+        return fromPrefs;
     }
 
     @Messages({


### PR DESCRIPTION
Unused suppress warning was not showing up in netbeans IDE, so fixed that. 
Netbeans already had option for providing suppress warnings hint in the sub-menu. So, leveraged that piece of code to extend this capability in the VS Code CodeActions as well.
Introduced suppress warnings hint in vscode. 

<img width="456" alt="image" src="https://github.com/apache/netbeans/assets/55803675/57a6a4a8-d14a-408d-94da-550fa3b14263">

In the above image. "- >" represents subfixes.

For more info refer: https://github.com/oracle/javavscode/issues/96