### PR TITLE
Fix "Fix Imports" [GH-7546]

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/actions/ImportDataCreator.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/actions/ImportDataCreator.java
@@ -182,7 +182,28 @@ public class ImportDataCreator {
     private Collection<FullyQualifiedElement> filterExactUnqualifiedName(final Collection<FullyQualifiedElement> possibleFQElements, final String typeName) {
         Collection<FullyQualifiedElement> result = new HashSet<>();
         for (FullyQualifiedElement fqElement : possibleFQElements) {
-            if (fqElement.getFullyQualifiedName().toString().endsWith(typeName)) {
+            // type name: e.g. Foo, Name\Space\Foo, \Name\Space\Foo
+            // GH-7546 if an element name has the same prefix and suffix(e.g. Foo2Foo),
+            // the following check is incorrect
+            // `fqElement.getFullyQualifiedName().toString().endsWith(typeName)`
+            // so, compare the segments, instead
+            QualifiedName qualifiedTypeName = QualifiedName.create(typeName);
+            List<String> segments = qualifiedTypeName.getSegments();
+            Collections.reverse(segments);
+            List<String> elementSegments = fqElement.getFullyQualifiedName().getSegments();
+            Collections.reverse(elementSegments);
+            boolean exactUnqualifiedName = true;
+            if (!segments.isEmpty() && segments.size() <= elementSegments.size()) {
+                for (int i = 0; i < segments.size(); i++) {
+                    if (!segments.get(i).equals(elementSegments.get(i))) {
+                        exactUnqualifiedName = false;
+                        break;
+                    }
+                }
+            } else {
+                exactUnqualifiedName = false;
+            }
+            if (exactUnqualifiedName) {
                 result.add(fqElement);
             }
         }

--- a/php/php.editor/test/unit/data/testfiles/actions/testGH7546/testGH7546.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testGH7546/testGH7546.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NS1;
+
+class TestClass {}
+class TestClass2TestClass {}
+interface TestInterface {}
+interface TestInterface2TestInterface {}
+trait TestTrait {}
+trait TestTrait2TestTrait {}
+enum TestEnum {
+    case Test;
+}
+enum TestEnum2TestEnum {
+    case Test;
+}
+
+const CONSTANT = 1;
+const CONSTANT2CONSTANT = 2;
+
+function func(): void {}
+function func2func(): void {}
+
+namespace NS1\Sub1\Sub2\Sub3;
+
+class TestClass {}
+class TestClass2TestClass {}
+interface TestInterface {}
+interface TestInterface2TestInterface {}
+trait TestTrait {}
+trait TestTrait2TestTrait {}
+enum TestEnum {
+    case Test;
+}
+enum TestEnum2TestEnum {
+    case Test;
+}
+
+const CONSTANT = 1;
+const CONSTANT2CONSTANT = 2;
+
+function func(): void {}
+function func2func(): void {}

--- a/php/php.editor/test/unit/data/testfiles/actions/testGH7546/testGH7546_01.php
+++ b/php/php.editor/test/unit/data/testfiles/actions/testGH7546/testGH7546_01.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+
+class GH7546 {
+    private TestClass $testClass1;
+    private NS1\Sub1\TestClass $testClass2;
+    private TestInterface $testInterface;
+    private \NS1\Sub1\Sub2\Sub3\TestInterface $testInterface2;
+
+    public const CONSTANT = TestEnum::Test;
+    public const int CONSTANT2 = CONSTANT;
+
+    use TestTrait;
+
+    public function test(): void {
+        func();
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/actions/testGH7546/testGH7546_01.php.importData
+++ b/php/php.editor/test/unit/data/testfiles/actions/testGH7546/testGH7546_01.php.importData
@@ -1,0 +1,52 @@
+Caret position: 844
+Should show uses panel: true
+Defaults:
+ \NS1\Sub1\Sub2\Sub3\CONSTANT
+ <html><font color='#FF0000'>&lt;cannot be resolved&gt;
+ \NS1\TestClass
+ \NS1\TestEnum
+ \NS1\TestInterface
+ \NS1\TestTrait
+ \NS1\Sub1\Sub2\Sub3\TestInterface
+ \NS1\Sub1\Sub2\Sub3\func
+
+Names:
+ CONSTANT
+ NS1\Sub1\TestClass
+ TestClass
+ TestEnum
+ TestInterface
+ TestTrait
+ \NS1\Sub1\Sub2\Sub3\TestInterface
+ func
+
+Variants:
+ \NS1\CONSTANT
+ \NS1\Sub1\Sub2\Sub3\CONSTANT
+ Don't import.
+
+ <html><font color='#FF0000'>&lt;cannot be resolved&gt;
+
+ \NS1\Sub1\Sub2\Sub3\TestClass
+ \NS1\TestClass
+ Don't import.
+
+ \NS1\Sub1\Sub2\Sub3\TestEnum
+ \NS1\TestEnum
+ Don't import.
+
+ \NS1\Sub1\Sub2\Sub3\TestInterface
+ \NS1\TestInterface
+ Don't import.
+
+ \NS1\Sub1\Sub2\Sub3\TestTrait
+ \NS1\TestTrait
+ Don't import.
+
+ \NS1\Sub1\Sub2\Sub3\TestInterface
+ Don't import.
+
+ \NS1\func
+ \NS1\Sub1\Sub2\Sub3\func
+ Don't import.
+

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/ImportDataCreatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/actions/ImportDataCreatorTest.java
@@ -134,6 +134,10 @@ public class ImportDataCreatorTest extends PHPTestBase {
         performTest("public function test(): st^atic {");
     }
 
+    public void testGH7546_01() throws Exception {
+        performTest("class GH7546 ^{");
+    }
+
     private void performTest(String caretLine) throws Exception {
         performTest(caretLine, null);
     }


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/7546
- Compare segments of namespace names to avoid adding incorrect items
- Add a unit test

Example:
```php
<?php
namespace NS1;

class TestClass {}
class TestClass2TestClass {}
interface TestInterface {}
interface TestInterface2TestInterface {}
trait TestTrait {}
trait TestTrait2TestTrait {}
enum TestEnum {
    case Test;
}
enum TestEnum2TestEnum {
    case Test;
}

const CONSTANT = 1;
const CONSTANT2CONSTANT = 2;

function func(): void {}
function func2func(): void {}

namespace NS1\Sub1\Sub2\Sub3;

class TestClass {}
class TestClass2TestClass {}
interface TestInterface {}
interface TestInterface2TestInterface {}
trait TestTrait {}
trait TestTrait2TestTrait {}
enum TestEnum {
    case Test;
}
enum TestEnum2TestEnum {
    case Test;
}

const CONSTANT = 1;
const CONSTANT2CONSTANT = 2;

function func(): void {}
function func2func(): void {}
```

```php
namespace Test;

class GH7546 { // Fix Imports here
    private TestClass $testClass1;
    private NS1\Sub1\TestClass $testClass2;
    private TestInterface $testInterface;
    private \NS1\Sub1\Sub2\Sub3\TestInterface $testInterface2;

    public const CONSTANT = TestEnum::Test;
    public const int CONSTANT2 = CONSTANT;

    use TestTrait;

    public function test(): void {
        func();
    }
}
```

Before:

![nb-php-gh-7546-before](https://github.com/apache/netbeans/assets/738383/20ef1df9-e656-4004-88f7-96cb82886051)

After:

![nb-php-gh-7546-after](https://github.com/apache/netbeans/assets/738383/d32c2717-70ec-4b57-8ec0-9351e43c6003)
