### PR TITLE
NBI: disable update check again

### DIFF
--- a/nbbuild/installer/engine/src/org/netbeans/installer/wizard/components/panels/netbeans/NbPreInstallSummaryPanel.java
+++ b/nbbuild/installer/engine/src/org/netbeans/installer/wizard/components/panels/netbeans/NbPreInstallSummaryPanel.java
@@ -495,7 +495,7 @@ public class NbPreInstallSummaryPanel extends ErrorMessagePanel {
                 removeUserdirCheckbox.doClick();
             }
 
-            if (nbBasePresent) {
+            if (nbBasePresent && Boolean.getBoolean(CHECK_FOR_UPDATES_PROPERTY)) {
                 checkForUpdatesCheckbox.setSelected(true);
                 System.setProperty(CHECK_FOR_UPDATES_CHECKBOX_PROPERTY, Boolean.TRUE.toString());
                 


### PR DESCRIPTION
 - Hide check-for-updates step from the (windows) installer again since it is a no-op with the current NB release model
 - semantically reverts #1348 without changing codepaths outside the checkbox UI to reduce risks of other side effects
 - can be re-enabled using a property

before:
![nbi-check-for-updates](https://github.com/apache/netbeans/assets/114367/8a22f99a-3ed9-42c5-93ac-74866eb436f0)

after:
![nbi-no-check-for-updates](https://github.com/apache/netbeans/assets/114367/9c751dc7-8af3-40ce-9cb4-2d30903edc1a)
