### PR TITLE
Introduce-method refactoring should suggest a method name

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceExpressionBasedMethodFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceExpressionBasedMethodFix.java
@@ -179,7 +179,8 @@ final class IntroduceExpressionBasedMethodFix extends IntroduceFixBase implement
     public ChangeInfo implement() throws Exception {
         JButton btnOk = new JButton(NbBundle.getMessage(IntroduceHint.class, "LBL_Ok"));
         JButton btnCancel = new JButton(NbBundle.getMessage(IntroduceHint.class, "LBL_Cancel"));
-        IntroduceMethodPanel panel = new IntroduceMethodPanel("", duplicatesCount, targets, targetIsInterface); //NOI18N
+        btnCancel.setDefaultCapable(false);
+        IntroduceMethodPanel panel = new IntroduceMethodPanel("method", duplicatesCount, targets, targetIsInterface); //NOI18N
         String caption = NbBundle.getMessage(IntroduceHint.class, "CAP_IntroduceMethod");
         DialogDescriptor dd = new DialogDescriptor(panel, caption, true, new Object[]{btnOk, btnCancel}, btnOk, DialogDescriptor.DEFAULT_ALIGN, null, null);
         NotificationLineSupport notifier = dd.createNotificationLineSupport();

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceFieldFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceFieldFix.java
@@ -149,6 +149,7 @@ class IntroduceFieldFix extends IntroduceFixBase implements Fix {
         JButton btnOk = new JButton(NbBundle.getMessage(IntroduceHint.class, "LBL_Ok"));
         btnOk.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(IntroduceHint.class, "AD_IntrHint_OK"));
         JButton btnCancel = new JButton(NbBundle.getMessage(IntroduceHint.class, "LBL_Cancel"));
+        btnCancel.setDefaultCapable(false);
         btnCancel.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(IntroduceHint.class, "AD_IntrHint_Cancel"));
         IntroduceFieldPanel panel = createPanel(btnOk);
         FieldValidator fv = new FieldValidator(source, null, this.handle);

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceFieldPanel.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceFieldPanel.java
@@ -18,27 +18,19 @@
  */
 package org.netbeans.modules.java.hints.introduce;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.prefs.Preferences;
-import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
-import javax.lang.model.element.TypeElement;
 import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JTextField;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-import org.netbeans.api.java.source.ElementHandle;
 import org.netbeans.api.java.source.TreePathHandle;
 import org.openide.NotificationLineSupport;
 import org.openide.util.NbBundle;
 import org.openide.util.NbPreferences;
-import org.openide.util.Utilities;
 
 /**
  * Panel that contains options for creating a field or a local variable.
@@ -203,9 +195,9 @@ public class IntroduceFieldPanel extends javax.swing.JPanel implements ChangeLis
                 ok = true;
             } else if (result.getConflictingKind() != null) {
                 if (result.getConflictingKind() != ElementKind.FIELD) {
-                    notifier.setErrorMessage(Bundle.ERR_LocalVarOrParameterHidden());
+                    notifyNameError(Bundle.ERR_LocalVarOrParameterHidden());
                 } else {
-                    notifier.setErrorMessage(Bundle.ERR_ConflictingField());
+                    notifyNameError(Bundle.ERR_ConflictingField());
                 }
                 ok = false;
             } else if (result.getOverriden() != null) {
@@ -574,24 +566,24 @@ public class IntroduceFieldPanel extends javax.swing.JPanel implements ChangeLis
     }// </editor-fold>//GEN-END:initComponents
 
     private void declareFinalActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_declareFinalActionPerformed
-    // TODO add your handling code here:
-}//GEN-LAST:event_declareFinalActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_declareFinalActionPerformed
 
-private void initConstructorsActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_initConstructorsActionPerformed
-    adjustFinal();
-}//GEN-LAST:event_initConstructorsActionPerformed
+    private void initConstructorsActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_initConstructorsActionPerformed
+        adjustFinal();
+    }//GEN-LAST:event_initConstructorsActionPerformed
 
-private void initFieldActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_initFieldActionPerformed
-    adjustFinal();
-}//GEN-LAST:event_initFieldActionPerformed
+    private void initFieldActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_initFieldActionPerformed
+        adjustFinal();
+    }//GEN-LAST:event_initFieldActionPerformed
 
-private void initMethodActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_initMethodActionPerformed
-    adjustFinal();
-}//GEN-LAST:event_initMethodActionPerformed
+    private void initMethodActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_initMethodActionPerformed
+        adjustFinal();
+    }//GEN-LAST:event_initMethodActionPerformed
 
-private void replaceAllActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_replaceAllActionPerformed
+    private void replaceAllActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_replaceAllActionPerformed
         adjustInitializeIn();
-}//GEN-LAST:event_replaceAllActionPerformed
+    }//GEN-LAST:event_replaceAllActionPerformed
 
     private void checkRefactorExistingActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_checkRefactorExistingActionPerformed
         if (checkRefactorExisting.isEnabled()) {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceMethodFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceMethodFix.java
@@ -419,7 +419,8 @@ public final class IntroduceMethodFix extends IntroduceFixBase implements Fix {
     public ChangeInfo implement() throws Exception {
         JButton btnOk = new JButton(NbBundle.getMessage(IntroduceHint.class, "LBL_Ok"));
         JButton btnCancel = new JButton(NbBundle.getMessage(IntroduceHint.class, "LBL_Cancel"));
-        IntroduceMethodPanel panel = new IntroduceMethodPanel("", duplicatesCount, targets, targetIsInterface); //NOI18N
+        btnCancel.setDefaultCapable(false);
+        IntroduceMethodPanel panel = new IntroduceMethodPanel("method", duplicatesCount, targets, targetIsInterface); //NOI18N
         String caption = NbBundle.getMessage(IntroduceHint.class, "CAP_IntroduceMethod");
         DialogDescriptor dd = new DialogDescriptor(panel, caption, true, new Object[]{btnOk, btnCancel}, btnOk, DialogDescriptor.DEFAULT_ALIGN, null, null);
         NotificationLineSupport notifier = dd.createNotificationLineSupport();

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceMethodPanel.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceMethodPanel.java
@@ -23,7 +23,6 @@ import java.awt.event.ItemListener;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.prefs.Preferences;
 import javax.lang.model.element.Modifier;
@@ -73,15 +72,17 @@ public class IntroduceMethodPanel extends CommonMembersPanel implements ChangeLi
         initComponents();
         
         this.targetInterface = targetInterface;
-        this.name.setText(name);
+
+        this.changeSupport = new MethodNameSupport(this.name, true);
+        this.changeSupport.setChangeListener(this);
+
+        this.name.setText(name); // triggers validation task
         if ( name != null && name.trim().length() > 0 ) {
             this.name.setCaretPosition(name.length());
             this.name.setSelectionStart(0);
             this.name.setSelectionEnd(name.length());
         }
-        this.changeSupport = new MethodNameSupport(this.name);
-        this.changeSupport.setChangeListener(this);
-        
+
         Preferences pref = getPreferences();
         
         if (!targetInterface) {
@@ -127,8 +128,9 @@ public class IntroduceMethodPanel extends CommonMembersPanel implements ChangeLi
     }
 
     private class MethodNameSupport extends NameChangeSupport {
-        public MethodNameSupport(JTextField control) {
-            super(control);
+
+        public MethodNameSupport(JTextField control, boolean initAsValid) {
+            super(control, initAsValid);
         }
 
         @Override

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceVariableFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceVariableFix.java
@@ -128,6 +128,7 @@ final class IntroduceVariableFix extends IntroduceFixBase implements Fix {
     public ChangeInfo implement() throws IOException, BadLocationException, ParseException {
         JButton btnOk = new JButton(NbBundle.getMessage(IntroduceHint.class, "LBL_Ok"));
         JButton btnCancel = new JButton(NbBundle.getMessage(IntroduceHint.class, "LBL_Cancel"));
+        btnCancel.setDefaultCapable(false);
         IntroduceFieldPanel panel = new IntroduceFieldPanel(guessedName, null, duplicatesCount,
                 true, handle.getKind() == Tree.Kind.VARIABLE,
                 IntroduceFieldPanel.VARIABLE,


### PR DESCRIPTION
if the test field is left empty, it creates the following problem:

 - cancel button has focus, ok button is disabled until validation
 - method name validation is delayed by 200ms which can cause users to cancel the hint after filling out the method name and pressing enter quickly, giving the wrong impression of a not functioning refactoring action
 
This can be avoided by initializing the test field with a method name.

bonus: Fixed an issue where a name conflict did not disable the introduce field dialog's ok-button

how to test:
 - select `System.out.println();`
 - `alt+enter`, select `introduce method`
 - type something and hit enter quickly