### PR TITLE
Reduce redundant cast warnings

### DIFF
--- a/enterprise/jakarta.web.beans/src/org/netbeans/modules/jakarta/web/beans/completion/CCPaintComponent.java
+++ b/enterprise/jakarta.web.beans/src/org/netbeans/modules/jakarta/web/beans/completion/CCPaintComponent.java
@@ -215,7 +215,7 @@ public class CCPaintComponent extends JPanel {
     }
     
     protected int getWidth(String s) {
-        Integer i = (Integer)widths.get(s);
+        Integer i = widths.get(s);
         if (i != null) {
             return i;
         } else {

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/DomainEditor.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/DomainEditor.java
@@ -481,7 +481,7 @@ public class DomainEditor {
 
     private Map<String,String> getPoolValues(Map<String, Node> cpMap, String poolName) {
         Map<String,String> pValues = new HashMap<>();
-        Node cpNode = (Node) cpMap.get(poolName);
+        Node cpNode = cpMap.get(poolName);
         NamedNodeMap cpAttrMap = cpNode.getAttributes();
         Node dsClassName = cpAttrMap.getNamedItem(CONST_DS_CLASS);
         Node resType = cpAttrMap.getNamedItem(CONST_RES_TYPE);

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/optional/StartTomcat.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/optional/StartTomcat.java
@@ -772,7 +772,7 @@ public final class StartTomcat extends StartServer implements ProgressObject {
     }
     
     private String getJavaHome(JavaPlatform platform) {
-        FileObject fo = (FileObject)platform.getInstallFolders().iterator().next();
+        FileObject fo = platform.getInstallFolders().iterator().next();
         return FileUtil.toFile(fo).getAbsolutePath();
     }
     

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/LogManager.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/LogManager.java
@@ -268,7 +268,7 @@ public class LogManager {
         if (!moduleConfig.hasLogger()) {
             return;
         }
-        contextLog = (LogViewer)contextLogViewers.get(moduleID);
+        contextLog = contextLogViewers.get(moduleID);
         LogViewer newContextLog = null;
         try {
             newContextLog = new LogViewer(

--- a/enterprise/web.jsf.navigation/src/org/netbeans/modules/web/jsf/navigation/graph/actions/SystemFileSystemSupport.java
+++ b/enterprise/web.jsf.navigation/src/org/netbeans/modules/web/jsf/navigation/graph/actions/SystemFileSystemSupport.java
@@ -88,7 +88,7 @@ public final class SystemFileSystemSupport {
         }
 
         synchronized (dataFolder2actionsProvider) {
-            ActionsProvider actionsProvider = (ActionsProvider)dataFolder2actionsProvider.get(dataFolder);
+            ActionsProvider actionsProvider = dataFolder2actionsProvider.get(dataFolder);
             if (actionsProvider == null) {
                 actionsProvider = new DefaultActionsProvider(dataFolder);
                 dataFolder2actionsProvider.put(dataFolder, actionsProvider);

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/client/Util.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/client/Util.java
@@ -112,7 +112,7 @@ public class Util  {
 	Enumeration<String> e = ht.keys();
 
 	while(e.hasMoreElements()) {
-	    String name = (String)e.nextElement();
+	    String name = e.nextElement();
 	    try {
 		String[] value = (String[])(ht.get(name));
 		for(int i=0; i<value.length; ++i) {
@@ -141,7 +141,7 @@ public class Util  {
 	if(ht != null && ht.size() > 0) {
 	    Enumeration<String> e = ht.keys();
 	    while(e.hasMoreElements()) {
-		String name = (String)e.nextElement();
+		String name = e.nextElement();
 		String[] value = (String[])(ht.get(name));
 		for(int i=0; i<value.length; ++i) {
 		    if(debug) 

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/WebActionProvider.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/WebActionProvider.java
@@ -835,7 +835,7 @@ public class WebActionProvider extends BaseActionProvider {
     }
 
     private boolean isDebugged() {
-        J2eeModuleProvider jmp = (J2eeModuleProvider) getWebProject().getLookup().lookup(J2eeModuleProvider.class);
+        J2eeModuleProvider jmp = getWebProject().getLookup().lookup(J2eeModuleProvider.class);
         Session[] sessions = DebuggerManager.getDebuggerManager().getSessions();
         ServerDebugInfo sdi = null;
         if (sessions != null && sessions.length > 0) {

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/WebJPAModuleInfo.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/WebJPAModuleInfo.java
@@ -55,7 +55,7 @@ class WebJPAModuleInfo implements JPAModuleInfo{
 
     @Override
     public Boolean isJPAVersionSupported(String version) {
-        J2eeModuleProvider j2eeModuleProvider = (J2eeModuleProvider) project.getLookup().lookup(J2eeModuleProvider.class);
+        J2eeModuleProvider j2eeModuleProvider = project.getLookup().lookup(J2eeModuleProvider.class);
         J2eePlatform platform  = Deployment.getDefault().getJ2eePlatform(j2eeModuleProvider.getServerInstanceID());
         
         if (platform == null) {

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/api/WebProjectUtilities.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/api/WebProjectUtilities.java
@@ -621,7 +621,7 @@ public class WebProjectUtilities {
         
         ep.setProperty(WebProjectProperties.JAVA_SOURCE_BASED,javaSourceBased+"");
         
-        UpdateHelper updateHelper = ((WebProject) p).getUpdateHelper();
+        UpdateHelper updateHelper = p.getUpdateHelper();
         
 // this enforcement is valid only for Web project for EE 6; non-EE6 containers may support JDK 7
 //        // #181215: JDK 6 should be the default source/binary format for Java EE 6 projects

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/jaxws/WebProjectJAXWSSupport.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/jaxws/WebProjectJAXWSSupport.java
@@ -103,7 +103,7 @@ public class WebProjectJAXWSSupport extends ProjectJAXWSSupport /*implements JAX
     @Override
     public String getWsdlLocation(String serviceName) {
         String localWsdl = serviceName+".wsdl"; //NOI18N
-        JaxWsModel jaxWsModel = (JaxWsModel)project.getLookup().lookup(JaxWsModel.class);
+        JaxWsModel jaxWsModel = project.getLookup().lookup(JaxWsModel.class);
         if (jaxWsModel!=null) {
             Service service = jaxWsModel.findServiceByName(serviceName);
             if (service!=null) {

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/ui/ConfFilesNodeFactory.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/ui/ConfFilesNodeFactory.java
@@ -98,7 +98,7 @@ public final class ConfFilesNodeFactory implements NodeFactory {
     }
 
     public NodeList createNodes(Project p) {
-        WebProject project = (WebProject) p.getLookup().lookup(WebProject.class);
+        WebProject project = p.getLookup().lookup(WebProject.class);
         assert project != null;
         return new ConfFilesNodeList(project);
     }
@@ -111,7 +111,7 @@ public final class ConfFilesNodeFactory implements NodeFactory {
 
         ConfFilesNodeList(WebProject proj) {
             project = proj;
-            WebLogicalViewProvider logView = (WebLogicalViewProvider) project.getLookup().lookup(WebLogicalViewProvider.class);
+            WebLogicalViewProvider logView = project.getLookup().lookup(WebLogicalViewProvider.class);
             assert logView != null;
         }
 
@@ -283,7 +283,7 @@ public final class ConfFilesNodeFactory implements NodeFactory {
                 Iterator it = groupsListeners.keySet().iterator();
                 while (it.hasNext()) {
                     SourceGroup group = (SourceGroup) it.next();
-                    PropertyChangeListener pcl = (PropertyChangeListener) groupsListeners.get(group);
+                    PropertyChangeListener pcl = groupsListeners.get(group);
                     group.removePropertyChangeListener(pcl);
                 }
             }
@@ -306,7 +306,7 @@ public final class ConfFilesNodeFactory implements NodeFactory {
                 Iterator it = fileSystemListeners.keySet().iterator();
                 while (it.hasNext()) {
                     FileSystem fs = (FileSystem) it.next();
-                    FileStatusListener fsl = (FileStatusListener) fileSystemListeners.get(fs);
+                    FileStatusListener fsl = fileSystemListeners.get(fs);
                     fs.removeFileStatusListener(fsl);
                 }
             }
@@ -357,8 +357,7 @@ public final class ConfFilesNodeFactory implements NodeFactory {
         }
         
         public static ConfFilesChildrenFactory forProject(Project project) {
-            ProjectWebModule pwm = (ProjectWebModule) project.getLookup().lookup(
-                    ProjectWebModule.class);
+            ProjectWebModule pwm = project.getLookup().lookup(ProjectWebModule.class);
             return new ConfFilesChildrenFactory(pwm);
         }
         
@@ -531,7 +530,7 @@ public final class ConfFilesNodeFactory implements NodeFactory {
             boolean result = false;
             start :
             for (int i = 0; i < providers.size(); i++) {
-                WebFrameworkProvider provider = (WebFrameworkProvider) providers.get(i);
+                WebFrameworkProvider provider = providers.get(i);
                 FileObject wmBase = getWebModule().getDocumentBase();
                 File[] files = null;
                 if (wmBase != null) {

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/ui/customizer/WebProjectProperties.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/ui/customizer/WebProjectProperties.java
@@ -364,13 +364,13 @@ public final class WebProjectProperties {
         EditableProperties projectProperties = updateHelper.getProperties( AntProjectHelper.PROJECT_PROPERTIES_PATH );
         EditableProperties privateProperties = updateHelper.getProperties( AntProjectHelper.PRIVATE_PROPERTIES_PATH );
 
-        JAVAC_CLASSPATH_MODEL = ClassPathTableModel.createTableModel( cs.itemsIterator( (String)projectProperties.get( ProjectProperties.JAVAC_CLASSPATH ), ClassPathSupportCallbackImpl.TAG_WEB_MODULE_LIBRARIES) );
+        JAVAC_CLASSPATH_MODEL = ClassPathTableModel.createTableModel( cs.itemsIterator(projectProperties.get( ProjectProperties.JAVAC_CLASSPATH ), ClassPathSupportCallbackImpl.TAG_WEB_MODULE_LIBRARIES) );
         String processorPath = projectProperties.get(ProjectProperties.JAVAC_PROCESSORPATH);
         processorPath = processorPath == null ? "${javac.classpath}" : processorPath;
         JAVAC_PROCESSORPATH_MODEL = ClassPathUiSupport.createListModel(cs.itemsIterator(processorPath));
-        JAVAC_TEST_CLASSPATH_MODEL = ClassPathUiSupport.createListModel( cs.itemsIterator( (String)projectProperties.get( ProjectProperties.JAVAC_TEST_CLASSPATH ), null ) );
-        RUN_TEST_CLASSPATH_MODEL = ClassPathUiSupport.createListModel( cs.itemsIterator( (String)projectProperties.get( ProjectProperties.RUN_TEST_CLASSPATH ), null ) );
-        ENDORSED_CLASSPATH_MODEL = ClassPathUiSupport.createListModel( cs.itemsIterator( (String)projectProperties.get( ProjectProperties.ENDORSED_CLASSPATH ), null ) );
+        JAVAC_TEST_CLASSPATH_MODEL = ClassPathUiSupport.createListModel( cs.itemsIterator(projectProperties.get( ProjectProperties.JAVAC_TEST_CLASSPATH ), null ) );
+        RUN_TEST_CLASSPATH_MODEL = ClassPathUiSupport.createListModel( cs.itemsIterator(projectProperties.get( ProjectProperties.RUN_TEST_CLASSPATH ), null ) );
+        ENDORSED_CLASSPATH_MODEL = ClassPathUiSupport.createListModel( cs.itemsIterator(projectProperties.get( ProjectProperties.ENDORSED_CLASSPATH ), null ) );
         PLATFORM_MODEL = PlatformUiSupport.createPlatformComboBoxModel (evaluator.getProperty(JAVA_PLATFORM));
         PLATFORM_LIST_RENDERER = PlatformUiSupport.createPlatformListCellRenderer();
         SpecificationVersion minimalSourceLevel = null;
@@ -427,7 +427,7 @@ public final class WebProjectProperties {
         WAR_NAME_MODEL = projectGroup.createStringDocument( evaluator, WAR_NAME );
         BUILD_CLASSES_EXCLUDES_MODEL = projectGroup.createStringDocument( evaluator, BUILD_CLASSES_EXCLUDES );
         WAR_COMPRESS_MODEL = projectGroup.createToggleButtonModel( evaluator, WAR_COMPRESS );
-        WAR_CONTENT_ADDITIONAL_MODEL = WarIncludesTableModel.createTableModel( cs.itemsIterator( (String)projectProperties.get( WAR_CONTENT_ADDITIONAL ), ClassPathSupportCallbackImpl.TAG_WEB_MODULE__ADDITIONAL_LIBRARIES));
+        WAR_CONTENT_ADDITIONAL_MODEL = WarIncludesTableModel.createTableModel( cs.itemsIterator(projectProperties.get( WAR_CONTENT_ADDITIONAL ), ClassPathSupportCallbackImpl.TAG_WEB_MODULE__ADDITIONAL_LIBRARIES));
 
         // CustomizerJavadoc
         JAVADOC_PRIVATE_MODEL = projectGroup.createToggleButtonModel( evaluator, JAVADOC_PRIVATE );
@@ -483,7 +483,7 @@ public final class WebProjectProperties {
         try {
             CONTEXT_PATH_MODEL = new PlainDocument();
             CONTEXT_PATH_MODEL.remove(0, CONTEXT_PATH_MODEL.getLength());
-            ProjectWebModule wm = (ProjectWebModule) project.getLookup().lookup(ProjectWebModule.class);
+            ProjectWebModule wm = project.getLookup().lookup(ProjectWebModule.class);
             String contextPath = wm.getContextPath();
             if (contextPath != null) {
                 CONTEXT_PATH_MODEL.insertString(0, contextPath, null);

--- a/enterprise/websvc.clientapi/src/org/netbeans/modules/websvc/api/client/WebServicesClientView.java
+++ b/enterprise/websvc.clientapi/src/org/netbeans/modules/websvc/api/client/WebServicesClientView.java
@@ -78,7 +78,7 @@ public final class WebServicesClientView {
 			}
 		}
 
-		WebServicesClientViewProvider impl = (WebServicesClientViewProvider) Lookup.getDefault().lookup(WebServicesClientViewProvider.class);
+		WebServicesClientViewProvider impl = Lookup.getDefault().lookup(WebServicesClientViewProvider.class);
 		if(impl != null) {
 			WebServicesClientView wsv = impl.findWebServicesClientView(f);
 			return wsv;

--- a/enterprise/websvc.clientapi/src/org/netbeans/modules/websvc/api/jaxws/client/JAXWSClientView.java
+++ b/enterprise/websvc.clientapi/src/org/netbeans/modules/websvc/api/jaxws/client/JAXWSClientView.java
@@ -72,7 +72,7 @@ public final class JAXWSClientView {
 			}
 		}
 
-		JAXWSClientViewProvider impl = (JAXWSClientViewProvider) Lookup.getDefault().lookup(JAXWSClientViewProvider.class);
+		JAXWSClientViewProvider impl = Lookup.getDefault().lookup(JAXWSClientViewProvider.class);
 		if(impl != null) {
 			JAXWSClientView wsv = impl.findJAXWSClientView();
 			return wsv;

--- a/enterprise/websvc.restapi/src/org/netbeans/modules/websvc/rest/MiscPrivateUtilities.java
+++ b/enterprise/websvc.restapi/src/org/netbeans/modules/websvc/rest/MiscPrivateUtilities.java
@@ -289,8 +289,7 @@ public class MiscPrivateUtilities {
     }
 
     public static boolean supportsTargetProfile(Project project, Profile profile){
-        J2eeModuleProvider provider = (J2eeModuleProvider) project.getLookup().
-                lookup(J2eeModuleProvider.class);
+        J2eeModuleProvider provider = project.getLookup().lookup(J2eeModuleProvider.class);
         String serverInstanceID = provider.getServerInstanceID();
         if ( serverInstanceID == null ){
             return false;

--- a/groovy/groovy.antproject/src/org/netbeans/modules/groovy/antproject/base/AbstractGroovyExtender.java
+++ b/groovy/groovy.antproject/src/org/netbeans/modules/groovy/antproject/base/AbstractGroovyExtender.java
@@ -208,7 +208,7 @@ public abstract class AbstractGroovyExtender implements GroovyExtenderImplementa
                 try {
                     Enumeration<JarEntry> entries = jf.entries();
                     while (entries.hasMoreElements()) {
-                        JarEntry entry = (JarEntry) entries.nextElement();
+                        JarEntry entry = entries.nextElement();
                         if (classFilePath.equals(entry.getName())) {
                             return true;
                         }

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderMetaData.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderMetaData.java
@@ -280,9 +280,9 @@ public class QueryBuilderMetaData {
             }
         } else {
             for (int icnt = 0; icnt < cols.size(); icnt++) {
-                if (columnName.equalsIgnoreCase((String) cols.get(icnt))) {
-                    col.setColumnName(col.getColumnName(), (String) cols.get(icnt));
-                    Log.getLogger().finest(" adjust colname to " + (String) cols.get(icnt));
+                if (columnName.equalsIgnoreCase(cols.get(icnt))) {
+                    col.setColumnName(col.getColumnName(), cols.get(icnt));
+                    Log.getLogger().finest(" adjust colname to " + cols.get(icnt));
                     if (col.getTableSpec() == null) {
                         col.setTableSpec(col.getTableSpec(), checkedTable);
                         Log.getLogger().finest(" adjust table to " + checkedTable);
@@ -435,8 +435,8 @@ public class QueryBuilderMetaData {
         // Convert from List<table, schema> to "table.schema", expected by query editor
         List<String> result = new ArrayList<>();
         for (List<String> fullTable : tables) {
-            String schema = (String) fullTable.get(0);
-            String table = (String) fullTable.get(1);
+            String schema = fullTable.get(0);
+            String table  = fullTable.get(1);
             result.add(((schema == null) || (schema.equals(""))) ? table : schema + "." + table);
         }
         return result;

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderResultTable.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querybuilder/QueryBuilderResultTable.java
@@ -299,7 +299,7 @@ public class QueryBuilderResultTable extends JTable
     }
     
     private void setClipboard(String contents) {
-        ExClipboard clipboard = (ExClipboard) Lookup.getDefault().lookup(ExClipboard.class);
+        ExClipboard clipboard = Lookup.getDefault().lookup(ExClipboard.class);
         StringSelection strSel = new StringSelection(contents);
         clipboard.setContents(strSel, strSel);
     }

--- a/ide/db/src/org/netbeans/modules/db/explorer/dlg/AddDriverDialog.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/dlg/AddDriverDialog.java
@@ -574,7 +574,7 @@ public final class AddDriverDialog extends javax.swing.JPanel {
                     try (JarFile jf = new JarFile(file)) {
                         Enumeration<JarEntry> entries = jf.entries();
                         while (entries.hasMoreElements()) {
-                            JarEntry entry = (JarEntry) entries.nextElement();
+                            JarEntry entry = entries.nextElement();
                             String className = entry.getName();
                             if (className.endsWith(".class")) { // NOI18N
                                 className = className.replace('/', '.');

--- a/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/ContentModel.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/ContentModel.java
@@ -598,7 +598,7 @@ abstract class ContentModel {
         public boolean hasNext() {
             if (list.size() > current) return true;
             if (en.hasMoreElements()) {
-                String next = (String) en.nextElement();
+                String next = en.nextElement();
                 return list.add(next);                
             } else {
                 return false;

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewDataObject.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewDataObject.java
@@ -504,7 +504,7 @@ public abstract class XmlMultiViewDataObject extends MultiDataObject implements 
         
         private synchronized FileLock getLock() {
             // How this week reference can be useful ?
-            FileLock l = lockReference == null ? null : (FileLock) lockReference.get();
+            FileLock l = lockReference == null ? null : lockReference.get();
             if (l != null && !l.isValid()) {
                 l = null;
             }

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewEditorSupport.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewEditorSupport.java
@@ -801,7 +801,7 @@ public class XmlMultiViewEditorSupport extends DataEditorSupport implements Seri
                             if (mvtc == topComponent) {
                                 if (en.hasMoreElements()) {
                                     // Remember next cloned top component
-                                    mvtc = (CloneableTopComponent) en.nextElement();
+                                    mvtc = en.nextElement();
                                 } else {
                                     // All cloned top components are closed
                                     notifyClosed();

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeEditorCookieImpl.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/cookies/TreeEditorCookieImpl.java
@@ -591,7 +591,7 @@ public class TreeEditorCookieImpl implements TreeEditorCookie, UpdateDocumentCoo
             if (editor == null) {
                 return prepareEditor();
             } else {
-                TreeEditorCookieImpl cached = (TreeEditorCookieImpl) editor.get();
+                TreeEditorCookieImpl cached = editor.get();
                 if (cached == null) {
                     return prepareEditor();
                 } else {

--- a/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
+++ b/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
@@ -450,7 +450,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
 
             // Finally we add xsl namespace elements with other prefixes than the first one
             for (int prefixInd = 1; prefixInd < prefixList.size(); prefixInd++) {
-                String curPrefix = (String)prefixList.get(prefixInd) + ":"; // NOI18N
+                String curPrefix = prefixList.get(prefixInd) + ":"; // NOI18N
                 Node curNode = el;
                 String curName = null;
                 while(curNode != null && null != (curName = curNode.getNodeName()) && !curName.startsWith(curPrefix)) {
@@ -496,8 +496,8 @@ public final class XSLGrammarQuery implements GrammarQuery{
 
         String curXslPrefix = null;
         for (int ind = 0; ind < prefixList.size(); ind++) {
-            if (elTagName.startsWith((String)prefixList.get(ind) + ":")){ // NOI18N
-                curXslPrefix = (String)prefixList.get(ind) + ":"; // NOI18N
+            if (elTagName.startsWith(prefixList.get(ind) + ":")){ // NOI18N
+                curXslPrefix = prefixList.get(ind) + ":"; // NOI18N
                 break;
             }
         }
@@ -512,7 +512,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
             if (prefixList.size() > 0) {
                 Iterator it = getResultElementAttr().iterator();
                 while ( it.hasNext()) {
-                    possibleAttributes.add((String)prefixList.get(0) + ":" + (String) it.next()); // NOI18N
+                    possibleAttributes.add(prefixList.get(0) + ":" + (String) it.next()); // NOI18N
                 }
             }
         }
@@ -874,7 +874,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
 
         boolean outputFound = false;
         if (prefixList.size() > 0) {
-            String outputElName = (String)prefixList.get(0) + ":output"; // NOI18N
+            String outputElName = prefixList.get(0) + ":output"; // NOI18N
             Node childOfRoot = rootNode.getFirstChild();
             while (childOfRoot != null) {
                 String childNodeName = childOfRoot.getNodeName();

--- a/java/ant.grammar/src/org/netbeans/modules/ant/grammar/AntGrammarQueryProvider.java
+++ b/java/ant.grammar/src/org/netbeans/modules/ant/grammar/AntGrammarQueryProvider.java
@@ -45,7 +45,7 @@ public final class AntGrammarQueryProvider extends GrammarQueryManager {
         }
         Enumeration<Node> en = ctx.getDocumentChildren();
         while (en.hasMoreElements()) {
-            Node next = (Node) en.nextElement();
+            Node next = en.nextElement();
             if (next.getNodeType() == Node.ELEMENT_NODE) {
                 Element root = (Element) next;                
                 if ("project".equals(root.getNodeName())) { // NOI18N

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/TableElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/TableElementImpl.java
@@ -564,7 +564,7 @@ public class TableElementImpl extends DBElementImpl implements TableElement.Impl
                     if (bridge != null) {
                         rset = bridge.getDriverSpecification().getRow();
                         keySeq = rset.get(new Integer(5));
-                        colName = (String) rset.get(new Integer(4));
+                        colName = rset.get(new Integer(4));
                         rset.clear();
                     } else {
                         keySeq = rs.getObject("KEY_SEQ"); //NOI18N

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaTablesPanel.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaTablesPanel.java
@@ -344,7 +344,7 @@ public class DBSchemaTablesPanel extends JPanel implements ListDataListener {
         int i;
         
         for (i = start; i < handlers.size(); i++) {
-            Handler h = (Handler)handlers.get(i);
+            Handler h = handlers.get(i);
             if (!h.isRunnable()) {
                 if (LOG) {
                     LOGGER.log(Level.FINE, "Skipping " + h);

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/RecaptureSchema.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/RecaptureSchema.java
@@ -62,7 +62,7 @@ public class RecaptureSchema {
     }
     
     public void start() throws ClassNotFoundException, SQLException {
-        final DBschemaDataObject dobj = (DBschemaDataObject)dbSchemaNode.getCookie(DBschemaDataObject.class);
+        final DBschemaDataObject dobj = dbSchemaNode.getCookie(DBschemaDataObject.class);
         final SchemaElement elem = dobj.getSchema();
         //elem.
         //ConnectionProvider cp = new ConnectionProvider(elem.getDriver(), elem.getUrl(), elem.getUsername(), null);

--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/SourceRootsUi.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/SourceRootsUi.java
@@ -461,7 +461,7 @@ out:        for( int i = 0; i < files.length; i++ ) {
             ListSelectionModel selectionModel = this.rootsList.getSelectionModel();
             selectionModel.clearSelection();
             for( int i = si.length -1 ; i >= 0 ; i-- ) {
-                Vector item = (Vector)rootsModel.getDataVector().elementAt(si[i]);
+                Vector item = rootsModel.getDataVector().elementAt(si[i]);
                 int newIndex = si[i] + 1;
                 rootsModel.removeRow( si[i] );
                 rootsModel.insertRow( newIndex, item );

--- a/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/UnusedDetector.java
+++ b/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/UnusedDetector.java
@@ -653,7 +653,7 @@ public class UnusedDetector {
         @Override
         public Void visitLiteral(LiteralTree node, Void p) {
             if (node.getKind() == Kind.STRING_LITERAL) {
-                allStringLiterals.add((String) ((LiteralTree) node).getValue());
+                allStringLiterals.add((String)node.getValue());
             }
             return super.visitLiteral(node, p);
         }

--- a/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBParserFactory.java
+++ b/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBParserFactory.java
@@ -157,7 +157,7 @@ public class NBParserFactory extends ParserFactory {
             if (result instanceof JCEnhancedForLoop) {
                 JCEnhancedForLoop tree = (JCEnhancedForLoop) result;
                 if (getEndPos(tree.var) == Position.NOPOS) {
-                    endPosTable.storeEnd(tree.var, getEndPos(((JCVariableDecl) tree.var).vartype));
+                    endPosTable.storeEnd(tree.var, getEndPos(tree.var.vartype));
                 }
             }
             return result;

--- a/java/maven/src/org/netbeans/modules/maven/ModuleInfoSupport.java
+++ b/java/maven/src/org/netbeans/modules/maven/ModuleInfoSupport.java
@@ -235,7 +235,7 @@ public class ModuleInfoSupport {
                 src.runModificationTask((WorkingCopy copy) -> {
                     copy.toPhase(JavaSource.Phase.RESOLVED);
                     TreeMaker tm = copy.getTreeMaker();
-                    ModuleTree modle = (ModuleTree) copy.getCompilationUnit().getModule();
+                    ModuleTree modle = copy.getCompilationUnit().getModule();
                     ModuleTree newModle = modle;
                     for (String mName : mNames) {
                         newModle = tm.addModuleDirective(newModle, tm.Requires(false, false, tm.QualIdent(mName)));

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/Block.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/Block.java
@@ -46,7 +46,7 @@ public class Block extends Statement {
     }
 
     public Block(int start, int end, List<Statement> statements, boolean isCurly) {
-        this(start, end, statements == null ? new Statement[0] : (Statement[]) statements.toArray(new Statement[0]), isCurly);
+        this(start, end, statements == null ? new Statement[0] : statements.toArray(new Statement[0]), isCurly);
     }
 
     public Block(int start, int end, List<Statement> statements) {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/FunctionDeclaration.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/FunctionDeclaration.java
@@ -61,7 +61,7 @@ public class FunctionDeclaration extends Statement implements Attributed {
     }
 
     private FunctionDeclaration(int start, int end, Identifier functionName, List<FormalParameter> formalParameters, Expression returnType, Block body, boolean isReference, List<Attribute> attributes) {
-        this(start, end, functionName, (FormalParameter[]) formalParameters.toArray(new FormalParameter[0]), returnType, body, isReference, attributes);
+        this(start, end, functionName, formalParameters.toArray(new FormalParameter[0]), returnType, body, isReference, attributes);
     }
 
     public FunctionDeclaration(int start, int end, Identifier functionName, List<FormalParameter> formalParameters, Expression returnType, Block body, boolean isReference) {

--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/ButtonPopupSwitcher.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/ButtonPopupSwitcher.java
@@ -341,7 +341,7 @@ final class ButtonPopupSwitcher implements MouseInputListener, AWTEventListener,
                 }
                 break;
             case KeyEvent.VK_DELETE: {
-                final Item item = ( Item ) pTable.getSelectedItem();
+                final Item item = pTable.getSelectedItem();
                 if (item != null) {
                     TabData tab = item.getTabData();
                     int tabIndex = controller.getTabModel().indexOf( tab );


### PR DESCRIPTION
Reduce redundant cast warnings. These happen as a side result of code cleanup..

Reduce warnings that look like this:

   [repeat] /home/bwalker/src/netbeans/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/LogManager.java:271: warning: [cast] redundant cast to LogViewer
   [repeat]         contextLog = (LogViewer)contextLogViewers.get(moduleID);
   [repeat]                      ^Cleanup redundant casts. These are a side effect of work done doing code cleanup.
