### PR TITLE
Fix unit tests

### DIFF
--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/functionGuessingFloatReturnType.php.testFunctionGuessingFloatReturnType_01.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/functionGuessingFloatReturnType.php.testFunctionGuessingFloatReturnType_01.html
@@ -1,7 +1,7 @@
 <html><body>
 <pre>Code completion result for source line:
 testFloatReturn|Type_01();
-(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
 METHOD     testFloatReturnType_01()        [PUBLIC]   functionGuessingFloatReturnType.php
 </pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>testFloatReturnType_01</b><br/><br/><br />
 <h3>Returns:</h3>

--- a/php/php.editor/test/unit/data/testfiles/completion/documentation/functionGuessingFloatReturnType.php.testFunctionGuessingFloatReturnType_02.html
+++ b/php/php.editor/test/unit/data/testfiles/completion/documentation/functionGuessingFloatReturnType.php.testFunctionGuessingFloatReturnType_02.html
@@ -1,7 +1,7 @@
 <html><body>
 <pre>Code completion result for source line:
 testFloatReturnTypeWithUnion|Type_01();
-(QueryType=COMPLETION, prefixSearch=false, caseSensitive=true)
+(QueryType=DOCUMENTATION, prefixSearch=false, caseSensitive=true)
 METHOD     testFloatReturnTypeWithUnionTy  [PUBLIC]   functionGuessingFloatReturnType.php
 </pre><h2>Documentation:</h2><div align="right"><font size=-1></font></div><b>testFloatReturnTypeWithUnionType_01</b><br/><br/><br />
 <h3>Returns:</h3>

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCCDocumentationTest.java
@@ -655,11 +655,11 @@ public class PHPCCDocumentationTest extends PHPCodeCompletionTestBase {
     }
 
     public void testFunctionGuessingFloatReturnType_01() throws Exception {
-        checkCompletionDocumentation("testfiles/completion/documentation/functionGuessingFloatReturnType.php", "testFloatReturn^Type_01();", false, "");
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/functionGuessingFloatReturnType.php", "testFloatReturn^Type_01();");
     }
 
     public void testFunctionGuessingFloatReturnType_02() throws Exception {
-        checkCompletionDocumentation("testfiles/completion/documentation/functionGuessingFloatReturnType.php", "testFloatReturnTypeWithUnion^Type_01();", false, "");
+        checkCompletionOnlyDocumentation("testfiles/completion/documentation/functionGuessingFloatReturnType.php", "testFloatReturnTypeWithUnion^Type_01();");
     }
 
     @Override


### PR DESCRIPTION
- Use `checkCompletionOnlyDocumentation` test method because there are functions that have the same prefix