### PR TITLE
Copy public ip command on compute instance node, run ssh session

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCINode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCINode.java
@@ -124,7 +124,8 @@ public class OCINode extends AbstractNode {
     private final class RefreshListener implements PropertyChangeListener {
         @Override
         public void propertyChange(PropertyChangeEvent evt) {
-            if ("referenceName".equals(evt.getPropertyName())) {
+            if ("referenceName".equals(evt.getPropertyName()) //NOI18N
+                    || "publicIp".equals(evt.getPropertyName())) { //NOI18N
                 fireDisplayNameChange("", getDisplayName());
             } else {
                 refresh();

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/compute/ComputeInstanceNode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/compute/ComputeInstanceNode.java
@@ -35,7 +35,7 @@ import org.openide.util.NbBundle;
  * @author Jan Horvath
  */
 @NbBundle.Messages({
-    "CoputeInstanceDesc=Compute Instance: {0}"
+    "CoputeInstanceDesc=Compute Instance: {0}\nPublic IP: {1}"
 })
 public class ComputeInstanceNode extends OCINode {
     private static final String COMPUTE_INSTANCE_ICON = "org/netbeans/modules/cloud/oracle/resources/computeinstance.svg"; // NOI18N
@@ -45,7 +45,7 @@ public class ComputeInstanceNode extends OCINode {
         setName(instance.getName());
         setDisplayName(instance.getName());
         setIconBaseWithExtension(COMPUTE_INSTANCE_ICON);
-        setShortDescription(Bundle.CoputeInstanceDesc(instance.getName()));
+        setShortDescription(Bundle.CoputeInstanceDesc(instance.getName(), instance.getPublicIp()));
     }
 
     public static NodeProvider<ComputeInstanceItem> createNode() {

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/items/OCIItem.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/items/OCIItem.java
@@ -121,6 +121,10 @@ public abstract class OCIItem {
     public void removeChangeListener(PropertyChangeListener listener) {
         changeSupport.removePropertyChangeListener(listener);
     }
+    
+    protected void firePropertyChange(String propertyName, Object oldValue, Object newValue) {
+        changeSupport.firePropertyChange(propertyName, oldValue, newValue);
+    }
 
     public int maxInProject() {
         return 1;

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspAssetsDecorationProvider.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspAssetsDecorationProvider.java
@@ -24,6 +24,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.modules.cloud.oracle.assets.CloudAssets;
 import org.netbeans.modules.cloud.oracle.bucket.BucketItem;
+import org.netbeans.modules.cloud.oracle.compute.ComputeInstanceItem;
 import org.netbeans.modules.cloud.oracle.database.DatabaseItem;
 import org.netbeans.modules.cloud.oracle.items.OCIItem;
 import static org.netbeans.modules.java.lsp.server.explorer.DefaultDecorationsImpl.COOKIES_EXT;
@@ -45,6 +46,7 @@ public class LspAssetsDecorationProvider implements TreeDataProvider.Factory {
     private static final Logger LOG = Logger.getLogger(LspAssetsDecorationProvider.class.getName());
     
     public static final String CTXVALUE_CAP_REFERENCE_NAME = "cap:refName"; // NOI18N
+    public static final String CTXVALUE_CAP_PUBLIC_IP = "cap:publicIp"; // NOI18N
     public static final String CTXVALUE_PREFIX_REFERENCE_NAME = "cloudAssetsReferenceName:"; // NOI18N
 
     void readFiles(FileObject parent, List<String> lines) {
@@ -83,6 +85,10 @@ public class LspAssetsDecorationProvider implements TreeDataProvider.Factory {
             }
             if (refName != null) {
                 d.addContextValues(CTXVALUE_PREFIX_REFERENCE_NAME + refName);
+                set = true;
+            }
+            if (item instanceof ComputeInstanceItem && ((ComputeInstanceItem) item).getPublicIp() != null) {
+                d.addContextValues(CTXVALUE_CAP_PUBLIC_IP);
                 set = true;
             }
             if (item instanceof BucketItem 

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/OCIDCommand.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/commands/OCIDCommand.java
@@ -19,12 +19,15 @@
 package org.netbeans.modules.nbcode.integration.commands;
 
 import com.google.gson.JsonPrimitive;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.netbeans.modules.cloud.oracle.compute.ComputeInstanceItem;
 import org.netbeans.modules.cloud.oracle.items.OCIItem;
 import org.netbeans.modules.java.lsp.server.explorer.TreeNodeRegistry;
 import org.netbeans.modules.java.lsp.server.explorer.TreeViewProvider;
@@ -43,13 +46,19 @@ public class OCIDCommand implements CommandProvider {
     private static final Logger LOG = Logger.getLogger(OCIDCommand.class.getName());
 
     private static final String COMMAND_CLOUD_OCID_GET = "nbls.cloud.ocid.get"; // NOI18N
+    private static final String COMMAND_CLOUD_PUBLIC_IP_GET = "nbls.cloud.publicIp.get"; // NOI18N
+    
+    private static final Set COMMANDS = new HashSet<>(Arrays.asList(
+            COMMAND_CLOUD_OCID_GET,
+            COMMAND_CLOUD_PUBLIC_IP_GET
+    ));
 
     public OCIDCommand() {
     }
 
     @Override
     public Set<String> getCommands() {
-        return Collections.singleton(COMMAND_CLOUD_OCID_GET);
+        return COMMANDS;
     }
 
     @Override
@@ -74,7 +83,14 @@ public class OCIDCommand implements CommandProvider {
         }
         OCIItem item = node.getLookup().lookup(OCIItem.class);
         if (item != null) {
-            return CompletableFuture.completedFuture(item.getKey().getValue());
+            switch(command) {
+                case COMMAND_CLOUD_OCID_GET: 
+                    return CompletableFuture.completedFuture(item.getKey().getValue());
+                case COMMAND_CLOUD_PUBLIC_IP_GET:
+                    if (item instanceof ComputeInstanceItem) {
+                        return CompletableFuture.completedFuture(((ComputeInstanceItem) item).getPublicIp());
+                    } 
+            }
         }
         return CompletableFuture.completedFuture(null);
     }

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -474,6 +474,15 @@
 				"title": "Copy OCID"
 			},
 			{
+				"command": "nbls.cloud.publicIp.copy",
+				"title": "Copy the public IP address"
+			},
+			{
+				"command": "nbls.cloud.computeInstance.ssh",
+				"title": "Start SSH session",
+                                "icon": "$(terminal)"
+			},
+			{
 				"command": "nbls.workspace.compile",
 				"title": "Compile Workspace",
 				"category": "Java"
@@ -774,6 +783,14 @@
 					"when": "false"
 				},
 				{
+					"command": "nbls.cloud.publicIp.copy",
+					"when": "false"
+				},
+				{
+					"command": "nbls.cloud.computeInstance.ssh",
+					"when": "false"
+				},
+				{
 					"command": "nbls:Database:netbeans.db.explorer.action.Connect",
 					"when": "false"
 				},
@@ -991,6 +1008,16 @@
 					"command": "nbls.cloud.ocid.copy",
 					"when": "viewItem =~ /class:oracle.items.OCIItem/ && viewItem =~ /^(?!.*Suggested).*/",
 					"group": "oci@1000"
+				},
+				{
+					"command": "nbls.cloud.publicIp.copy",
+					"when": "viewItem =~ /cap:publicIp/",
+					"group": "oci@1000"
+				},
+				{
+					"command": "nbls.cloud.computeInstance.ssh",
+					"when": "viewItem =~ /cap:publicIp/",
+					"group": "inline@10"
 				},
 				{
 					"command": "nbls:Tools:org.netbeans.modules.cloud.oracle.actions.AddRepository",

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -821,6 +821,20 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
         }
     ));
 
+    context.subscriptions.push(commands.registerCommand(COMMAND_PREFIX + '.cloud.publicIp.copy',
+        async (node) => {
+            const publicIp : string = await commands.executeCommand(COMMAND_PREFIX + '.cloud.publicIp.get', node.id);
+            vscode.env.clipboard.writeText(publicIp);
+        }
+    ));
+
+    context.subscriptions.push(commands.registerCommand(COMMAND_PREFIX + '.cloud.computeInstance.ssh',
+        async (node) => {
+            const publicIp : string = await commands.executeCommand(COMMAND_PREFIX + '.cloud.publicIp.get', node.id);
+            openSSHSession("opc", publicIp);
+        }
+    ));
+
     const archiveFileProvider = <vscode.TextDocumentContentProvider> {
         provideTextDocumentContent: async (uri: vscode.Uri, token: vscode.CancellationToken): Promise<string> => {
             return await commands.executeCommand('nbls.get.archive.file.content', uri.toString());
@@ -896,6 +910,11 @@ function activateWithJDK(specifiedJDK: string | null, context: ExtensionContext,
     }
 }
 
+function openSSHSession(username: string, host: string) {
+    const terminal = vscode.window.createTerminal(`SSH: ${username}@${host}`);
+    terminal.sendText(`ssh ${username}@${host}`);
+    terminal.show();
+}
 
 function killNbProcess(notifyKill : boolean, log : vscode.OutputChannel, specProcess?: ChildProcess) : Promise<void> {
     const p = nbProcess;


### PR DESCRIPTION
This pull request introduces two new commands to enhance the functionality of managing compute instances:
**Copy Public IP Address:**
Added a command to copy the public IP address of a compute instance, if available.
**Start SSH Session:**
Added a command to initiate an SSH session to a compute instance directly from the interface.