### PR TITLE
Java Hints SPI module renovation

### DIFF
--- a/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintRegistryTest.java
+++ b/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintRegistryTest.java
@@ -48,7 +48,7 @@ public class DeclarativeHintRegistryTest extends NbTestCase {
 
         HintDescription hd = allHints.iterator().next().iterator().next();
 
-        assertEquals(new HashSet<>(Arrays.asList("java.lang.String")), hd.getAdditionalConstraints().requiredErasedTypes);
+        assertEquals(new HashSet<>(Arrays.asList("java.lang.String")), hd.getAdditionalConstraints().requiredErasedTypes());
     }
 
     public void testSuppressWarnings() {

--- a/java/spi.java.hints/nbproject/project.properties
+++ b/java/spi.java.hints/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.59.0
 requires.nb.javac=true

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/jackpot/spi/HintsRunner.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/jackpot/spi/HintsRunner.java
@@ -21,7 +21,7 @@ package org.netbeans.modules.java.hints.jackpot.spi;
 
 import org.netbeans.modules.java.hints.providers.spi.HintDescription;
 import com.sun.source.util.TreePath;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -39,7 +39,8 @@ public class HintsRunner {
 
     @CheckForNull
     public static Map<HintDescription, List<ErrorDescription>> computeErrors(CompilationInfo info, Iterable<? extends HintDescription> hints, AtomicBoolean cancel) {
-        return new HintsInvoker(HintsSettings.getSettingsFor(info.getFileObject()), cancel).computeHints(info, new TreePath(info.getCompilationUnit()), hints, new LinkedList<>());
+        return new HintsInvoker(HintsSettings.getSettingsFor(info.getFileObject()), cancel)
+                        .computeHints(info, new TreePath(info.getCompilationUnit()), hints, new ArrayList<>());
     }
 
 }

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/jackpot/spi/PatternConvertor.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/jackpot/spi/PatternConvertor.java
@@ -23,7 +23,8 @@ import org.netbeans.modules.java.hints.providers.spi.HintDescriptionFactory;
 import org.netbeans.spi.java.hints.HintContext;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.modules.java.hints.providers.spi.HintDescription.Worker;
@@ -67,7 +68,7 @@ public abstract class PatternConvertor {
         Collection<HintDescription> result = new ArrayList<>(patterns.size());
 
         for (String pattern : patterns) {
-            PatternDescription pd = PatternDescription.create(pattern, Collections.<String, String>emptyMap());
+            PatternDescription pd = PatternDescription.create(pattern, Map.of());
 
             HintDescription desc = HintDescriptionFactory.create()
     //                                                     .setDisplayName("Pattern Matches")
@@ -86,8 +87,7 @@ public abstract class PatternConvertor {
         @Override
         public Collection<? extends ErrorDescription> createErrors(HintContext ctx) {
             ErrorDescription ed = ErrorDescriptionFactory.forTree(ctx, ctx.getPath(), "Found pattern occurrence");
-
-            return Collections.singleton(ed);
+            return List.of(ed);
         }
         
     }

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/code/FSWrapper.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/code/FSWrapper.java
@@ -194,12 +194,7 @@ public class FSWrapper {
 
         String getConstantValue() {
             Object constantValue = folder.getAttribute("constantValue");
-
-            if (constantValue instanceof String) {
-                return (String) constantValue;
-            }
-
-            return null;
+            return constantValue instanceof String string ? string : null;
         }
     }
 

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/code/ReflectiveCustomizerProvider.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/code/ReflectiveCustomizerProvider.java
@@ -44,16 +44,7 @@ import org.openide.util.Exceptions;
  *
  * @author lahvac
  */
-public class ReflectiveCustomizerProvider implements CustomizerProvider {
-    private final String hintClassName;
-    private final String hintId;
-    private final List<OptionDescriptor> options;
-
-    public ReflectiveCustomizerProvider(String hintClassName, String hintId, List<OptionDescriptor> options) {
-        this.hintClassName = hintClassName;
-        this.hintId = hintId;
-        this.options = options;
-    }
+record ReflectiveCustomizerProvider(String hintClassName, String hintId, List<OptionDescriptor> options) implements CustomizerProvider {
 
     @Override
     public JComponent getCustomizer(Preferences prefs) {
@@ -92,9 +83,7 @@ public class ReflectiveCustomizerProvider implements CustomizerProvider {
                 constraints.weighty = 1;
 
                 add(new JPanel(), constraints);
-            } catch (IllegalArgumentException ex) {
-                Exceptions.printStackTrace(ex);
-            } catch (SecurityException ex) {
+            } catch (IllegalArgumentException | SecurityException ex) {
                 Exceptions.printStackTrace(ex);
             }
         }
@@ -118,7 +107,7 @@ public class ReflectiveCustomizerProvider implements CustomizerProvider {
             add(l, constraints);
             
             JComponent field;
-            int val = prefs.getInt(option.preferencesKey, ((Integer)option.defaultValue).intValue());
+            int val = prefs.getInt(option.preferencesKey, ((Integer)option.defaultValue));
             if (iopt.step() > 0) {
                 val = Math.min(iopt.maxValue(), Math.max(iopt.minValue(), val));
                 prefs.putInt(option.preferencesKey, val);
@@ -188,15 +177,7 @@ public class ReflectiveCustomizerProvider implements CustomizerProvider {
         }
                 
         
-        private static final class ActionListenerImpl implements ActionListener, ChangeListener {
-            private final String key;
-            private final Preferences prefs;
-
-            public ActionListenerImpl(String key, Preferences prefs) {
-                this.key = key;
-                this.prefs = prefs;
-            }
-
+        private record ActionListenerImpl(String key, Preferences prefs) implements ActionListener, ChangeListener {
             @Override
             public void actionPerformed(ActionEvent e) {
                 JCheckBox checkBox = ((JCheckBox)e.getSource());
@@ -208,33 +189,15 @@ public class ReflectiveCustomizerProvider implements CustomizerProvider {
                 Integer i = (Integer)((JSpinner)e.getSource()).getValue();
                 prefs.putInt(key, i);
             }
-
         }
         
     }
-
-    public static final class OptionDescriptor {
-        public final String preferencesKey;
-        public final Object defaultValue;
-        public final String displayName;
-        public final String tooltip;
-        /**
-         * The original Annotation object, type-specific parameters.
-         */
-        public final Object parameters;
-
-        public OptionDescriptor(
-                String preferencesKey, 
-                Object defaultValue, 
-                String displayName, String tooltip, 
-                Object parameters) {
-            this.preferencesKey = preferencesKey;
-            this.defaultValue = defaultValue;
-            this.displayName = displayName;
-            this.tooltip = tooltip;
-            this.parameters = parameters;
-        }
-
+    
+    /**
+     * @param parameters The original Annotation object, type-specific parameters.
+     */
+    public record OptionDescriptor(
+        String preferencesKey, Object defaultValue, String displayName, String tooltip, Object parameters) {
     }
 
 }

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/ElementBasedHintProvider.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/ElementBasedHintProvider.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.java.hints.providers.spi;
 
 import java.util.Collection;
 import org.netbeans.api.java.source.CompilationInfo;
-import org.netbeans.modules.java.hints.providers.spi.HintDescription;
 
 /**
  * XXX: this is an ugly hack!

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintDescription.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintDescription.java
@@ -31,27 +31,9 @@ import org.netbeans.spi.java.hints.HintContext;
  *
  * @author Jan Lahoda
  */
-public final class HintDescription {
-
-    private final HintMetadata metadata;
-    private final Trigger trigger;
-    private final Worker worker;
-    private final AdditionalQueryConstraints additionalConstraints;
-    private final String hintText;
-    private final Set<Options> options;
-
-    private HintDescription(HintMetadata metadata, Trigger trigger, Worker worker, AdditionalQueryConstraints additionalConstraints, String hintText, Set<Options> options) {
-        this.metadata = metadata;
-        this.trigger = trigger;
-        this.worker = worker;
-        this.additionalConstraints = additionalConstraints;
-        this.hintText = hintText;
-        this.options = options;
-    }
-
-    static HintDescription create(HintMetadata metadata, Trigger trigger, Worker worker, AdditionalQueryConstraints additionalConstraints, String hintText, Set<Options> options) {
-        return new HintDescription(metadata, trigger, worker, additionalConstraints, hintText, options);
-    }
+public record HintDescription(
+        HintMetadata metadata, Trigger trigger, Worker worker,
+        AdditionalQueryConstraints additionalConstraints, String hintText, Set<Options> options) {
 
     @Override
     public String toString() {
@@ -88,14 +70,13 @@ public final class HintDescription {
 
     }
 
-    public static final class AdditionalQueryConstraints {
-        public final Set<String> requiredErasedTypes;
+    public record AdditionalQueryConstraints(Set<String> requiredErasedTypes) {
 
         public AdditionalQueryConstraints(Set<String> requiredErasedTypes) {
             this.requiredErasedTypes = Collections.unmodifiableSet(new HashSet<>(requiredErasedTypes));
         }
 
-        private static final AdditionalQueryConstraints EMPTY = new AdditionalQueryConstraints(Collections.<String>emptySet());
+        private static final AdditionalQueryConstraints EMPTY = new AdditionalQueryConstraints(Set.of());
         public static AdditionalQueryConstraints empty() {
             return EMPTY;
         }

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintDescriptionFactory.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintDescriptionFactory.java
@@ -20,7 +20,6 @@
 package org.netbeans.modules.java.hints.providers.spi;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 import org.netbeans.api.annotations.common.NonNull;
@@ -40,7 +39,6 @@ public class HintDescriptionFactory {
     private       AdditionalQueryConstraints additionalConstraints;
     private       String hintText;
     private       Set<Options> options;
-    private       boolean finished;
 
     private HintDescriptionFactory() {
     }
@@ -103,7 +101,7 @@ public class HintDescriptionFactory {
         if (this.additionalConstraints == null) {
             this.additionalConstraints = AdditionalQueryConstraints.empty();
         }
-        return HintDescription.create(metadata, trigger, worker, additionalConstraints, hintText, options != null ? options : Collections.<Options>emptySet());
+        return new HintDescription(metadata, trigger, worker, additionalConstraints, hintText, options != null ? options : Set.of());
     }
     
 }

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintMetadata.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintMetadata.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.Set;
@@ -210,7 +209,7 @@ public class HintMetadata {
         HEAVY;
 
         public static Set<Options> fromHintOptions(Hint.Options... options) {
-            Set<Options> result = new HashSet<>();
+            Set<Options> result = EnumSet.noneOf(Options.class);
 
             for (Hint.Options opt : options) {
                 result.add(valueOf(opt.name()));

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintProvider.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintProvider.java
@@ -21,8 +21,6 @@ package org.netbeans.modules.java.hints.providers.spi;
 
 import java.util.Collection;
 import java.util.Map;
-import org.netbeans.modules.java.hints.providers.spi.HintDescription;
-import org.netbeans.modules.java.hints.providers.spi.HintMetadata;
 
 public interface HintProvider {
 

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/Trigger.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/Trigger.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.java.hints.providers.spi;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -35,7 +34,7 @@ import org.openide.util.Parameters;
 public abstract class Trigger {
     private static final String[] NO_OPTIONS = new String[0];
     
-    private Set<String> options = Collections.emptySet();
+    private Set<String> options = Set.of();
     
     Trigger() {}
     
@@ -45,14 +44,14 @@ public abstract class Trigger {
     
     public void setOptions(String[] opts) {
         if (opts == null || opts.length == 0) {
-            options = Collections.emptySet();
+            options = Set.of();
         } else {
             options = new HashSet<>(Arrays.asList(opts));
         }
     }
     
     public String[] getOptions() {
-        return options.isEmpty() ? NO_OPTIONS : options.toArray(new String[0]);
+        return options.isEmpty() ? NO_OPTIONS : options.toArray(String[]::new);
     }
 
     /**Invoke the given hint's worker on the specified {@link Tree.Kind}(s).

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/JavaFixImpl.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/JavaFixImpl.java
@@ -22,7 +22,6 @@ package org.netbeans.modules.java.hints.spiimpl;
 import com.sun.source.util.TreePath;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -67,7 +66,7 @@ public class JavaFixImpl implements Fix {
     public ChangeInfo implement() throws Exception {
         FileObject file = Accessor.INSTANCE.getFile(jf);
         
-        BatchUtilities.fixDependencies(file, Collections.singletonList(jf), new IdentityHashMap<>());
+        BatchUtilities.fixDependencies(file, List.of(jf), new IdentityHashMap<>());
 
         JavaSource js = JavaSource.forFileObject(file);
 
@@ -79,7 +78,7 @@ public class JavaFixImpl implements Fix {
             Accessor.INSTANCE.process(jf, wc, true, resourceContentChanges, /*Ignored in editor:*/new ArrayList<>());
             Map<FileObject, List<Difference>> resourceContentDiffs = new HashMap<>();
             BatchUtilities.addResourceContentChanges(resourceContentChanges, resourceContentDiffs);
-            JavaSourceAccessor.getINSTANCE().createModificationResult(resourceContentDiffs, Collections.<Object, int[]>emptyMap()).commit();
+            JavaSourceAccessor.getINSTANCE().createModificationResult(resourceContentDiffs, Map.of()).commit();
         });
 
         result.commit();
@@ -91,8 +90,8 @@ public class JavaFixImpl implements Fix {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof JavaFixImpl) {
-            return jf.equals(((JavaFixImpl)obj).jf);
+        if (obj instanceof JavaFixImpl javaFixImpl) {
+            return jf.equals(javaFixImpl.jf);
         }
         return super.equals(obj);
     }

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
@@ -63,7 +63,6 @@ import com.sun.tools.javac.comp.Todo;
 import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.parser.JavacParser;
 import com.sun.tools.javac.parser.Lexer;
-import com.sun.tools.javac.parser.Parser;
 import com.sun.tools.javac.parser.ParserFactory;
 import com.sun.tools.javac.parser.Scanner;
 import com.sun.tools.javac.parser.ScannerFactory;
@@ -257,22 +256,17 @@ public class Utilities {
     }
 
     public static boolean isPureMemberSelect(Tree mst, boolean allowVariables) {
-        switch (mst.getKind()) {
-            case IDENTIFIER: return allowVariables || ((IdentifierTree) mst).getName().charAt(0) != '$';
-            case MEMBER_SELECT: return isPureMemberSelect(((MemberSelectTree) mst).getExpression(), allowVariables);
-            default: return false;
-        }
+        return switch (mst.getKind()) {
+            case IDENTIFIER -> allowVariables || ((IdentifierTree) mst).getName().charAt(0) != '$';
+            case MEMBER_SELECT -> isPureMemberSelect(((MemberSelectTree) mst).getExpression(), allowVariables);
+            default -> false;
+        };
     }
 
     public static Map<String, Collection<HintDescription>> sortOutHints(Iterable<? extends HintDescription> hints, Map<String, Collection<HintDescription>> output) {
         for (HintDescription d : hints) {
-            Collection<HintDescription> h = output.get(d.getMetadata().displayName);
-
-            if (h == null) {
-                output.put(d.getMetadata().displayName, h = new LinkedList<>());
-            }
-
-            h.add(d);
+            output.computeIfAbsent(d.getMetadata().displayName, k -> new LinkedList<>())
+                  .add(d);
         }
 
         return output;
@@ -288,7 +282,7 @@ public class Utilities {
             }
         }
 
-        result.addAll(listClassPathHints(Collections.<ClassPath>emptySet(), cps));
+        result.addAll(listClassPathHints(Set.of(), cps));
 
         return result;
     }
@@ -311,9 +305,9 @@ public class Utilities {
 
         Set<ClassPath> cps = new HashSet<>(sourceCPs);
 
-        cps.add(ClassPathSupport.createClassPath(roots.toArray(new FileObject[0])));
+        cps.add(ClassPathSupport.createClassPath(roots.toArray(FileObject[]::new)));
 
-        ClassPath cp = ClassPathSupport.createProxyClassPath(cps.toArray(new ClassPath[0]));
+        ClassPath cp = ClassPathSupport.createProxyClassPath(cps.toArray(ClassPath[]::new));
 
         for (ClassPathBasedHintProvider p : Lookup.getDefault().lookupAll(ClassPathBasedHintProvider.class)) {
             result.addAll(p.computeHints(cp, new AtomicBoolean()));
@@ -350,6 +344,7 @@ public class Utilities {
         return parseAndAttribute(info, jti, pattern, scope, new SourcePositions[1], errors);
     }
 
+    @SuppressWarnings("NestedAssignment")
     private static Tree parseAndAttribute(CompilationInfo info, JavacTaskImpl jti, String pattern, Scope scope, SourcePositions[] sourcePositions, Collection<Diagnostic<? extends JavaFileObject>> errors) {
         Context c = jti.getContext();
         JavaCompiler.instance(c); //force reasonable initialization order
@@ -506,7 +501,7 @@ public class Utilities {
                 newMembers.add(make.ExpressionStatement(make.Identifier("$$1$")));
                 newMembers.addAll(members.subList(syntheticOffset, members.size()));
 
-                patternTree = make.Class(mt, "$", Collections.<TypeParameterTree>emptyList(), null, Collections.<Tree>emptyList(), newMembers);
+                patternTree = make.Class(mt, "$", List.of(), null, List.of(), newMembers);
             } else {
                 patternTree = members.get(0 + syntheticOffset);
             }
@@ -548,7 +543,7 @@ public class Utilities {
     }
 
     private static boolean isStatement(String pattern) {
-        return pattern.trim().endsWith(";");
+        return pattern.stripTrailing().endsWith(";");
     }
 
     private static boolean isErrorTree(Tree t) {
@@ -585,16 +580,14 @@ public class Utilities {
         };
         try {
             CharBuffer buf = CharBuffer.wrap((stmt+"\u0000").toCharArray(), 0, stmt.length());
-            ParserFactory factory = ParserFactory.instance(context);
+            NBParserFactory factory = (NBParserFactory) ParserFactory.instance(context);
             ScannerFactory scannerFactory = ScannerFactory.instance(context);
             Names names = Names.instance(context);
-            Parser parser = new JackpotJavacParser(context, (NBParserFactory) factory, scannerFactory.newScanner(buf, false), false, false, CancelService.instance(context), names);
-            if (parser instanceof JavacParser) {
-                if (pos != null)
-                    pos[0] = new ParserSourcePositions((JavacParser)parser);
-                return parser.parseStatement();
+            JavacParser parser = new JackpotJavacParser(context, factory, scannerFactory.newScanner(buf, false), false, false, CancelService.instance(context), names);
+            if (pos != null) {
+                pos[0] = new ParserSourcePositions(parser);
             }
-            return null;
+            return parser.parseStatement();
         } finally {
             compiler.log.useSource(prev);
             compiler.log.popDiagnosticHandler(discardHandler);
@@ -614,19 +607,18 @@ public class Utilities {
         };
         try {
             CharBuffer buf = CharBuffer.wrap((expr+"\u0000").toCharArray(), 0, expr.length());
-            ParserFactory factory = ParserFactory.instance(context);
+            NBParserFactory factory = (NBParserFactory) ParserFactory.instance(context);
             ScannerFactory scannerFactory = ScannerFactory.instance(context);
             Names names = Names.instance(context);
             Scanner scanner = scannerFactory.newScanner(buf, false);
-            Parser parser = new JackpotJavacParser(context, (NBParserFactory) factory, scanner, false, false, CancelService.instance(context), names);
-            if (parser instanceof JavacParser) {
-                if (pos != null)
-                    pos[0] = new ParserSourcePositions((JavacParser)parser);
-                JCExpression result = parser.parseExpression();
+            JavacParser parser = new JackpotJavacParser(context, factory, scanner, false, false, CancelService.instance(context), names);
+            if (pos != null) {
+                pos[0] = new ParserSourcePositions(parser);
+            }
+            JCExpression result = parser.parseExpression();
 
-                if (!onlyFullInput || scanner.token().kind == TokenKind.EOF) {
-                    return result;
-                }
+            if (!onlyFullInput || scanner.token().kind == TokenKind.EOF) {
+                return result;
             }
             return null;
         } finally {
@@ -705,7 +697,7 @@ public class Utilities {
     private static long inc;
 
     public static Scope constructScope(CompilationInfo info, Map<String, TypeMirror> constraints) {
-        return constructScope(info, constraints, Collections.<String>emptyList());
+        return constructScope(info, constraints, List.of());
     }
 
     public static Scope constructScope(CompilationInfo info, Map<String, TypeMirror> constraints, Iterable<? extends String> auxiliaryImports) {
@@ -822,42 +814,7 @@ public class Utilities {
 
     }
 
-    private static final class ScopeDescription {
-        private final Map<String, TypeMirror> constraints;
-        private final Iterable<? extends String> auxiliaryImports;
-
-        public ScopeDescription(Map<String, TypeMirror> constraints, Iterable<? extends String> auxiliaryImports) {
-            this.constraints = constraints;
-            this.auxiliaryImports = auxiliaryImports;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == null) {
-                return false;
-            }
-            if (getClass() != obj.getClass()) {
-                return false;
-            }
-            final ScopeDescription other = (ScopeDescription) obj;
-            if (this.constraints != other.constraints && (this.constraints == null || !this.constraints.equals(other.constraints))) {
-                return false;
-            }
-            if (this.auxiliaryImports != other.auxiliaryImports && (this.auxiliaryImports == null || !this.auxiliaryImports.equals(other.auxiliaryImports))) {
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public int hashCode() {
-            int hash = 7;
-            hash = 47 * hash + (this.constraints != null ? this.constraints.hashCode() : 0);
-            hash = 47 * hash + (this.auxiliaryImports != null ? this.auxiliaryImports.hashCode() : 0);
-            return hash;
-        }
-
-    }
+    private record ScopeDescription(Map<String, TypeMirror> constraints, Iterable<? extends String> auxiliaryImports) {}
 
 //    private static Scope constructScope2(CompilationInfo info, Map<String, TypeMirror> constraints) {
 //        JavacScope s = (JavacScope) info.getTrees().getScope(new TreePath(info.getCompilationUnit()));
@@ -909,15 +866,9 @@ public class Utilities {
             Tree leaf = path.getLeaf();
 
             switch (leaf.getKind()) {
-                case METHOD:
-                    handleSuppressWarnings(info, path, ((MethodTree) leaf).getModifiers(), keys);
-                    break;
-                case CLASS:
-                    handleSuppressWarnings(info, path, ((ClassTree) leaf).getModifiers(), keys);
-                    break;
-                case VARIABLE:
-                    handleSuppressWarnings(info, path, ((VariableTree) leaf).getModifiers(), keys);
-                    break;
+                case METHOD -> handleSuppressWarnings(info, path, ((MethodTree) leaf).getModifiers(), keys);
+                case CLASS -> handleSuppressWarnings(info, path, ((ClassTree) leaf).getModifiers(), keys);
+                case VARIABLE -> handleSuppressWarnings(info, path, ((VariableTree) leaf).getModifiers(), keys);
             }
 
             path = path.getParentPath();
@@ -1145,15 +1096,10 @@ public class Utilities {
             if (el.getModifiers().contains(Modifier.PRIVATE)) {
                 return true;
             }
-
-            switch (el.getKind()) {
-                case LOCAL_VARIABLE:
-                case EXCEPTION_PARAMETER:
-                case PARAMETER:
-                    return true;
-            }
-
-            return false;
+            return switch (el.getKind()) {
+                case LOCAL_VARIABLE, EXCEPTION_PARAMETER, PARAMETER -> true;
+                default -> false;
+            };
         }
 
         @Override
@@ -1188,7 +1134,7 @@ public class Utilities {
                 return null;
             }
 
-            NewClassTree nue = make.NewClass(node.getEnclosingExpression(), Collections.<ExpressionTree>singletonList(make.Identifier("$" + currentVariableIndex++ + "$")), make.Identifier("$" + currentVariableIndex++), Collections.<ExpressionTree>singletonList(make.Identifier("$" + currentVariableIndex++ + "$")), null);
+            NewClassTree nue = make.NewClass(node.getEnclosingExpression(), List.of(make.Identifier("$" + currentVariableIndex++ + "$")), make.Identifier("$" + currentVariableIndex++), List.of(make.Identifier("$" + currentVariableIndex++ + "$")), null);
 
             tree2Variable.put(node, nue);
 
@@ -1247,7 +1193,7 @@ public class Utilities {
 
         @Override
         public Set<? extends Element> getImports() {
-            return Collections.emptySet();
+            return Set.of();
         }
 
         @Override
@@ -1578,15 +1524,7 @@ public class Utilities {
         return wildcardTreeName.toString().startsWith("$$");
     }
 
-    private static final class OffsetSourcePositions implements SourcePositions {
-
-        private final SourcePositions delegate;
-        private final long offset;
-
-        public OffsetSourcePositions(SourcePositions delegate, long offset) {
-            this.delegate = delegate;
-            this.offset = offset;
-        }
+    private record OffsetSourcePositions(SourcePositions delegate, long offset) implements SourcePositions {
 
         @Override
         public long getStartPosition(CompilationUnitTree cut, Tree tree) {
@@ -1600,16 +1538,8 @@ public class Utilities {
 
     }
 
-    private static final class OffsetDiagnostic<S> implements Diagnostic<S> {
-        private final Diagnostic<? extends S> delegate;
-        private final SourcePositions sp;
-        private final long offset;
-
-        public OffsetDiagnostic(Diagnostic<? extends S> delegate, SourcePositions sp, long offset) {
-            this.delegate = delegate;
-            this.sp = sp;
-            this.offset = offset;
-        }
+    private record OffsetDiagnostic<S>(
+            Diagnostic<? extends S> delegate, SourcePositions sp, long offset) implements Diagnostic<S> {
 
         @Override
         public Diagnostic.Kind getKind() {
@@ -1633,9 +1563,7 @@ public class Utilities {
 
         @Override
         public long getEndPosition() {
-            if (delegate instanceof JCDiagnostic) {
-                JCDiagnostic dImpl = (JCDiagnostic) delegate;
-                
+            if (delegate instanceof JCDiagnostic dImpl) {
                 return dImpl.getDiagnosticPosition().getEndPosition(new EndPosTable() {
                     @Override public int getEndPos(JCTree tree) {
                         return (int) sp.getEndPosition(null, tree);
@@ -1673,13 +1601,7 @@ public class Utilities {
 
     }
 
-    private static class ParserSourcePositions implements SourcePositions {
-
-        private final JavacParser parser;
-
-        private ParserSourcePositions(JavacParser parser) {
-            this.parser = parser;
-        }
+    private record ParserSourcePositions(JavacParser parser) implements SourcePositions {
 
         @Override
         public long getStartPosition(CompilationUnitTree file, Tree tree) {

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/BatchSearch.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/BatchSearch.java
@@ -210,7 +210,7 @@ public class BatchSearch {
                 toRegisterSet.add(cpInfo.getClassPath(PathKind.SOURCE));
             }
 
-            toRegister = !toRegisterSet.isEmpty() ? toRegisterSet.toArray(new ClassPath[0]) : null;
+            toRegister = !toRegisterSet.isEmpty() ? toRegisterSet.toArray(ClassPath[]::new) : null;
 
             if (toRegister != null) {
                 GlobalPathRegistry.getDefault().register(ClassPath.SOURCE, toRegister);
@@ -359,8 +359,8 @@ public class BatchSearch {
             Folder[] result = new Folder[list.size()];
             int i=0;
             for (Object item:list) {
-                if (item instanceof FileObject)
-                    result[i] = new Folder((FileObject) item);
+                if (item instanceof FileObject fileObject)
+                    result[i] = new Folder(fileObject);
                 else 
                     result[i] = new Folder((NonRecursiveFolder) item);
                 i++;

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/ProgressHandleWrapper.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/ProgressHandleWrapper.java
@@ -180,11 +180,7 @@ public final class ProgressHandleWrapper {
 
     public static int[] prepareParts(int count) {
         int[] result = new int[count];
-
-        for (int cntr = 0; cntr < count; cntr++) {
-            result[cntr] = 1;
-        }
-
+        Arrays.fill(result, 1);
         return result;
     }
 
@@ -200,12 +196,7 @@ public final class ProgressHandleWrapper {
 
     }
 
-    private static final class ProgressHandleBasedProgressHandleAbstraction implements ProgressHandleAbstraction {
-        private final ProgressHandle delegate;
-        public ProgressHandleBasedProgressHandleAbstraction(ProgressHandle delegate) {
-            this.delegate = delegate;
-        }
-
+    private record ProgressHandleBasedProgressHandleAbstraction(ProgressHandle delegate) implements ProgressHandleAbstraction {
         @Override
         public void start(int totalWork) {
             delegate.start(totalWork);
@@ -227,12 +218,7 @@ public final class ProgressHandleWrapper {
         }
     }
 
-    private static final class AnalysisContextBasedProgressHandleAbstraction implements ProgressHandleAbstraction {
-        private final Context delegate;
-        AnalysisContextBasedProgressHandleAbstraction(Context delegate) {
-            this.delegate = delegate;
-        }
-
+    private record AnalysisContextBasedProgressHandleAbstraction(Context delegate) implements ProgressHandleAbstraction {
         @Override
         public void start(int totalWork) {
             delegate.start(totalWork);
@@ -254,12 +240,7 @@ public final class ProgressHandleWrapper {
         }
     }
 
-    private static final class ProgressHandleWrapperBasedProgressHandleAbstraction implements ProgressHandleAbstraction {
-        private final ProgressHandleWrapper delegate;
-        public ProgressHandleWrapperBasedProgressHandleAbstraction(ProgressHandleWrapper delegate) {
-            this.delegate = delegate;
-        }
-
+    private record ProgressHandleWrapperBasedProgressHandleAbstraction(ProgressHandleWrapper delegate) implements ProgressHandleAbstraction {
         @Override
         public void start(int totalWork) {
             delegate.startNextPart(totalWork);

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/Scopes.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/batch/Scopes.java
@@ -97,9 +97,7 @@ public class Scopes {
     public static MapIndices getDefaultIndicesMapper() {
         return (FileObject root, ProgressHandleWrapper progress, boolean recursive) -> {
             IndexEnquirer e = findIndexEnquirer(root, progress, recursive);
-            
-            if (e != null) return e;
-            else return new BatchSearch.FileSystemBasedIndexEnquirer(root, recursive);
+            return e != null ? e : new BatchSearch.FileSystemBasedIndexEnquirer(root, recursive);
         };
     }
     

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/hints/HintsInvoker.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/hints/HintsInvoker.java
@@ -31,15 +31,12 @@ import org.netbeans.api.java.source.support.CancellableTreePathScanner;
 import org.netbeans.editor.GuardedDocument;
 import org.netbeans.editor.MarkBlock;
 import org.netbeans.editor.MarkBlockChain;
-import org.openide.filesystems.FileObject;
-
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.TreePath;
 import com.sun.source.util.Trees;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
@@ -62,7 +59,6 @@ import org.netbeans.modules.java.hints.spiimpl.Hacks;
 import org.netbeans.spi.java.hints.HintContext;
 import org.netbeans.modules.java.hints.providers.spi.HintDescription;
 import org.netbeans.modules.java.hints.providers.spi.HintMetadata;
-import org.netbeans.modules.java.hints.providers.spi.Trigger;
 import org.netbeans.modules.java.hints.providers.spi.Trigger.Kinds;
 import org.netbeans.modules.java.hints.providers.spi.Trigger.PatternDescription;
 import org.netbeans.modules.java.hints.spiimpl.options.HintsSettings;
@@ -162,7 +158,7 @@ public class HintsInvoker {
             }
         }
 
-        List<ErrorDescription> errors = join(computeHints(info, startAt, descs, new LinkedList<>()));
+        List<ErrorDescription> errors = join(computeHints(info, startAt, descs, new ArrayList<>()));
 
         dumpTimeSpentInHints();
         
@@ -182,8 +178,6 @@ public class HintsInvoker {
         return join(computeHints(info, new TreePath(info.getCompilationUnit()), hints, problems));
     }
 
-    private static final Iterable<? extends Class<? extends Trigger>> TRIGGER_KINDS = Arrays.asList(Kinds.class, PatternDescription.class);
-    
     @CheckForNull
     public Map<HintDescription, List<ErrorDescription>> computeHints(CompilationInfo info,
                                         TreePath startAt,
@@ -198,34 +192,31 @@ public class HintsInvoker {
                                         boolean recursive,
                                         Iterable<? extends HintDescription> hints,
                                         Collection<? super MessageImpl> problems) {
-        Map<Class<?>, List<HintDescription>> triggerKind2Hints = new HashMap<>();
 
-        for (Class<? extends Trigger> c : TRIGGER_KINDS) {
-            triggerKind2Hints.put(c, new ArrayList<>());
-        }
+        Map<Class<?>, List<HintDescription>> triggerKind2Hints = Map.of(
+            Kinds.class, new ArrayList<>(),
+            PatternDescription.class, new ArrayList<>()
+        );
+
         SourceVersion srcVersion = info.getSourceVersion();
         for (HintDescription hd : hints) {
             SourceVersion hVersion = hd.getMetadata().sourceVersion;
-            if (hVersion != null &&
-                (srcVersion.compareTo(hVersion) < 0)) {
+            if (hVersion != null && srcVersion.compareTo(hVersion) < 0) {
                 continue;
             }
-            List<HintDescription> sorted = triggerKind2Hints.get(hd.getTrigger().getClass());
-
-            sorted.add(hd);
+            triggerKind2Hints.get(hd.getTrigger().getClass())
+                             .add(hd);
         }
 
         if (caret != -1) {
             TreePath tp = info.getTreeUtilities().pathFor(caret);
             return computeSuggestions(info, tp, true, triggerKind2Hints, problems);
+        } else if (from != -1 && to != -1) {
+            return computeHintsInSpan(info, triggerKind2Hints, problems);
+        } else if (!recursive) {
+            return computeSuggestions(info, startAt, false, triggerKind2Hints, problems);
         } else {
-            if (from != (-1) && to != (-1)) {
-                return computeHintsInSpan(info, triggerKind2Hints, problems);
-            } else if (!recursive) {
-                return computeSuggestions(info, startAt, false, triggerKind2Hints, problems);
-            } else {
-                return computeHintsImpl(info, startAt, triggerKind2Hints, problems);
-            }
+            return computeHintsImpl(info, startAt, triggerKind2Hints, problems);
         }
     }
 
@@ -241,7 +232,7 @@ public class HintsInvoker {
         if (!kindBasedHints.isEmpty()) {
             long kindStart = System.currentTimeMillis();
 
-            new ScannerImpl(info, cancel, sortByKinds(kindBasedHints), problems).scan(startAt, errors);
+            new ScannerImpl(info, cancel, sortByKinds(kindBasedHints)).scan(startAt, errors);
 
             long kindEnd = System.currentTimeMillis();
 
@@ -315,7 +306,7 @@ public class HintsInvoker {
         if (!kindBasedHints.isEmpty()) {
             long kindStart = System.currentTimeMillis();
 
-            new ScannerImpl(info, cancel, sortByKinds(kindBasedHints), problems).scan(path, errors);
+            new ScannerImpl(info, cancel, sortByKinds(kindBasedHints)).scan(path, errors);
 
             long kindEnd = System.currentTimeMillis();
 
@@ -381,7 +372,7 @@ public class HintsInvoker {
             TreePath proc = workOn;
 
             while (proc != null) {
-                new ScannerImpl(info, cancel, hints, problems).scanDoNotGoDeeper(proc, errors);
+                new ScannerImpl(info, cancel, hints).scanDoNotGoDeeper(proc, errors);
                 if (!up) break;
                 proc = proc.getParentPath();
             }
@@ -469,13 +460,7 @@ public class HintsInvoker {
 
         for (HintDescription hd : kindBasedHints) {
             for (Kind k : ((Kinds) hd.getTrigger()).getKinds()) {
-                List<HintDescription> hints = result.get(k);
-
-                if (hints == null) {
-                    result.put(k, hints = new ArrayList<>());
-                }
-
-                hints.add(hd);
+                result.computeIfAbsent(k, l -> new LinkedList<>()).add(hd);
             }
         }
 
@@ -486,13 +471,7 @@ public class HintsInvoker {
         Map<PatternDescription, List<HintDescription>> result = new HashMap<>();
 
         for (HintDescription hd : kindBasedHints) {
-            List<HintDescription> hints = result.get((PatternDescription) hd.getTrigger());
-
-            if (hints == null) {
-                result.put((PatternDescription) hd.getTrigger(), hints = new ArrayList<>());
-            }
-
-            hints.add(hd);
+            result.computeIfAbsent((PatternDescription) hd.getTrigger(), k -> new LinkedList<>()).add(hd);
         }
 
         return result;
@@ -502,11 +481,7 @@ public class HintsInvoker {
         Map<String, List<PatternDescription>> patternTests = new HashMap<>();
         for (Entry<PatternDescription, List<HintDescription>> e : patternHints.entrySet()) {
             String p = e.getKey().getPattern();
-            List<PatternDescription> descs = patternTests.get(p);
-            if (descs == null) {
-                patternTests.put(p, descs = new LinkedList<>());
-            }
-            descs.add(e.getKey());
+            patternTests.computeIfAbsent(p, k -> new LinkedList<>()).add(e.getKey());
         }
         return patternTests;
     }
@@ -572,36 +547,6 @@ public class HintsInvoker {
         return errors;
     }
 
-//    public static void computeHints(URI file, ProcessingEnvironment env, CompilationUnitTree cut, RulesManager m) {
-//        Map<Kind, HintDescription> hints = m.getKindBasedHints();
-//
-//        if (hints.isEmpty()) {
-//            return ;
-//        }
-//
-//        List<ErrorDescription> errors = new  LinkedList<ErrorDescription>();
-//
-//        File af = new File(file.getPath());
-//        FileObject f = FileUtil.toFileObject(af);
-//
-//        new ScannerImpl(f, env, hints).scan(cut, errors);
-//
-//        for (ErrorDescription ed : errors) {
-//            Diagnostic.Kind k;
-//
-//            switch (ed.getSeverity()) {
-//                case ERROR:
-//                    k = Diagnostic.Kind.ERROR;
-//                    break;
-//                default:
-//                    k = Diagnostic.Kind.WARNING;
-//                    break;
-//            }
-//
-//            env.getMessager().printMessage(k, ed.getDescription());
-//        }
-//    }
-
     public Map<String, Long> getTimeLog() {
         return timeLog;
     }
@@ -610,27 +555,14 @@ public class HintsInvoker {
 
         private final Deque<Set<String>> suppresWarnings = new ArrayDeque<>();
         private final CompilationInfo info;
-        private final FileObject file;
         private final ProcessingEnvironment env;
         private final Map<Kind, List<HintDescription>> hints;
-        private final Collection<? super MessageImpl> problems;
         
-        public ScannerImpl(CompilationInfo info, AtomicBoolean cancel, Map<Kind, List<HintDescription>> hints, Collection<? super MessageImpl> problems) {
+        public ScannerImpl(CompilationInfo info, AtomicBoolean cancel, Map<Kind, List<HintDescription>> hints) {
             super(cancel);
             this.info = info;
-            this.file = null;
             this.env  = null;
             this.hints = hints;
-            this.problems = problems;
-        }
-
-        public ScannerImpl(FileObject file, ProcessingEnvironment env, Map<Kind, List<HintDescription>> hints, Collection<? super MessageImpl> problems) {
-            super(new AtomicBoolean());
-            this.info = null;
-            this.file = file;
-            this.env = env;
-            this.hints = hints;
-            this.problems = problems;
         }
 
         private void runAndAdd(TreePath path, List<HintDescription> rules, Map<HintDescription, List<ErrorDescription>> d) {
@@ -711,34 +643,22 @@ public class HintsInvoker {
         }
 
         private boolean pushSuppressWarrnings(TreePath path) {
-            switch(path.getLeaf().getKind()) {
-                case ANNOTATION_TYPE:
-                case CLASS:
-                case ENUM:
-                case INTERFACE:
-                case METHOD:
-                case VARIABLE:
-                    Set<String> current = suppresWarnings.size() == 0 ? null : suppresWarnings.peek();
+            switch (path.getLeaf().getKind()) {
+                case ANNOTATION_TYPE, CLASS, ENUM, INTERFACE, METHOD, VARIABLE -> {
+                    Set<String> current = suppresWarnings.isEmpty() ? null : suppresWarnings.peek();
                     Set<String> nju = current == null ? new HashSet<>() : new HashSet<>(current);
 
                     Element e = getTrees().getElement(path);
 
-                    if ( e != null) {
+                    if (e != null) {
                         for (AnnotationMirror am : e.getAnnotationMirrors()) {
                             String name = ((TypeElement)am.getAnnotationType().asElement()).getQualifiedName().toString();
-                            if ( "java.lang.SuppressWarnings".equals(name) ) { // NOI18N
-                                Map<? extends ExecutableElement, ? extends AnnotationValue> elementValues = am.getElementValues();
-                                for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : elementValues.entrySet()) {
-                                    if( "value".equals(entry.getKey().getSimpleName().toString()) ) { // NOI18N
-                                        Object value = entry.getValue().getValue();
-                                        if ( value instanceof List) {
-                                            for (Object av : (List)value) {
-                                                if( av instanceof AnnotationValue ) {
-                                                    Object wname = ((AnnotationValue)av).getValue();
-                                                    if ( wname instanceof String ) {
-                                                        nju.add((String)wname);
-                                                    }
-                                                }
+                            if ("java.lang.SuppressWarnings".equals(name)) { // NOI18N
+                                for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : am.getElementValues().entrySet()) {
+                                    if ("value".equals(entry.getKey().getSimpleName().toString()) && entry.getValue().getValue() instanceof List list) { // NOI18N
+                                        for (Object obj : list) {
+                                            if (obj instanceof AnnotationValue av && av.getValue() instanceof String str) {
+                                                nju.add(str);
                                             }
                                         }
                                     }
@@ -746,9 +666,9 @@ public class HintsInvoker {
                             }
                         }
                     }
-
                     suppresWarnings.push(nju);
                     return true;
+                }
             }
             return false;
         }
@@ -766,11 +686,10 @@ public class HintsInvoker {
         try {
             Document doc = info.getDocument();
 
-            if (doc instanceof GuardedDocument) {
-                final int start = (int) info.getTrees().getSourcePositions().getStartPosition(info.getCompilationUnit(), tree.getLeaf());
-                final int end = (int) info.getTrees().getSourcePositions().getEndPosition(info.getCompilationUnit(), tree.getLeaf());
-                final GuardedDocument gdoc = (GuardedDocument) doc;
-                final boolean[] ret = { false };
+            if (doc instanceof GuardedDocument gdoc) {
+                int start = (int) info.getTrees().getSourcePositions().getStartPosition(info.getCompilationUnit(), tree.getLeaf());
+                int end = (int) info.getTrees().getSourcePositions().getEndPosition(info.getCompilationUnit(), tree.getLeaf());
+                boolean[] ret = { false };
                 gdoc.render(() -> {
                     // MarkBlockChain should only be accessed under doc's readlock to guarantee a stability of the offsets.
                     MarkBlockChain guardedBlockChain = gdoc.getGuardedBlockChain();
@@ -798,33 +717,19 @@ public class HintsInvoker {
         }
     }
 
-    public static <K, V> Map<K, List<V>> merge(Map<K, List<V>> to, K key, Collection<? extends V> value) {
-        List<V> toColl = to.get(key);
-
-        if (toColl == null) {
-            to.put(key, toColl = new LinkedList<>());
-        }
-
-        toColl.addAll(value);
-
-        return to;
+    private static <K, V> void merge(Map<K, List<V>> to, K key, Collection<? extends V> value) {
+        to.computeIfAbsent(key, k -> new LinkedList<>())
+          .addAll(value);
     }
 
-    public static <K, V> Map<K, List<V>> mergeAll(Map<K, List<V>> to, Map<? extends K, ? extends Collection<? extends V>> what) {
+    private static <K, V> void mergeAll(Map<K, List<V>> to, Map<? extends K, ? extends Collection<? extends V>> what) {
         for (Entry<? extends K, ? extends Collection<? extends V>> e : what.entrySet()) {
-            List<V> toColl = to.get(e.getKey());
-
-            if (toColl == null) {
-                to.put(e.getKey(), toColl = new LinkedList<>());
-            }
-
-            toColl.addAll(e.getValue());
+            to.computeIfAbsent(e.getKey(), k -> new LinkedList<>())
+              .addAll(e.getValue());
         }
-
-        return to;
     }
 
-    public static List<ErrorDescription> join(Map<?, ? extends List<? extends ErrorDescription>> errors) {
+    private static List<ErrorDescription> join(Map<?, ? extends List<? extends ErrorDescription>> errors) {
         if (errors == null) return null;
         
         List<ErrorDescription> result = new LinkedList<>();

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/hints/HintsTask.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/hints/HintsTask.java
@@ -41,7 +41,6 @@ import org.netbeans.api.java.source.JavaSourceTaskFactory;
 import org.netbeans.api.java.source.support.CaretAwareJavaSourceTaskFactory;
 import org.netbeans.api.java.source.support.EditorAwareJavaSourceTaskFactory;
 import org.netbeans.editor.BaseDocument;
-import org.netbeans.lib.editor.util.swing.DocumentUtilities;
 import org.netbeans.modules.java.hints.providers.spi.PositionRefresherHelper;
 import org.netbeans.modules.java.hints.providers.spi.PositionRefresherHelper.DocumentVersion;
 import org.netbeans.modules.java.hints.spiimpl.options.HintsSettings;
@@ -104,7 +103,6 @@ public class HintsTask implements CancellableTask<CompilationInfo> {
                 return;
             }
         }
-        long version = doc != null ? DocumentUtilities.getDocumentVersion(doc) : 0;
         long startTime = System.currentTimeMillis();
 
         int caret = CaretAwareJavaSourceTaskFactory.getLastPosition(info.getFileObject());
@@ -207,8 +205,8 @@ public class HintsTask implements CancellableTask<CompilationInfo> {
 
         private static void setVersion(Document doc) {
             for (PositionRefresherHelper<?> h : MimeLookup.getLookup("text/x-java").lookupAll(PositionRefresherHelper.class)) {
-                if (h instanceof HintPositionRefresherHelper) {
-                    ((HintPositionRefresherHelper) h).setVersion(doc, new DocumentVersion(doc));
+                if (h instanceof HintPositionRefresherHelper hp) {
+                    hp.setVersion(doc, new DocumentVersion(doc));
                 }
             }
         }
@@ -234,8 +232,8 @@ public class HintsTask implements CancellableTask<CompilationInfo> {
 
         private static void setVersion(Document doc, int caret) {
             for (PositionRefresherHelper<?> h : MimeLookup.getLookup("text/x-java").lookupAll(PositionRefresherHelper.class)) {
-                if (h instanceof SuggestionsPositionRefresherHelper) {
-                    ((SuggestionsPositionRefresherHelper) h).setVersion(doc, new SuggestionsDocumentVersion(doc, caret));
+                if (h instanceof SuggestionsPositionRefresherHelper sp) {
+                    sp.setVersion(doc, new SuggestionsDocumentVersion(doc, caret));
                 }
             }
         }

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/options/HintsSettings.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/options/HintsSettings.java
@@ -85,11 +85,12 @@ public abstract class HintsSettings {
 
             if (s == null) return overrideSeverity != null ? overrideSeverity : hint != null ? hint.severity : null;
 
-            if ("ERROR".equals(s)) return Severity.ERROR;
-            else if ("WARNING".equals(s)) return Severity.VERIFIER;
-            else if ("CURRENT_LINE_WARNING".equals(s)) return Severity.HINT;
-
-            return overrideSeverity != null ? overrideSeverity : hint != null ? hint.severity : null;
+            return switch (s) {
+                case "ERROR" -> Severity.ERROR;
+                case "WARNING" -> Severity.VERIFIER;
+                case "CURRENT_LINE_WARNING" -> Severity.HINT;
+                default -> overrideSeverity != null ? overrideSeverity : hint != null ? hint.severity : null;
+            };
         }
         
         @Override

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/NFA.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/pm/NFA.java
@@ -31,7 +31,6 @@ public class NFA<I, R> {
 
     /*XXX: private*/ final int stateCount;
     private final int startingState;
-    private final Set<I> inputs;
     private final Map<Key<I>, State> transitionTable;
     private final Map<Integer, R> finalStates;
 
@@ -40,11 +39,10 @@ public class NFA<I, R> {
     private NFA(int startingState, int stateCount, Set<I> inputs, Map<Key<I>, State> transitionTable, Map<Integer, R> finalStates) {
         this.startingState = startingState;
         this.stateCount = stateCount;
-        this.inputs = inputs;
         this.transitionTable = transitionTable;
         this.finalStates = finalStates;
 
-        startingStateObject = State.create().mutableOr(startingState);
+        startingStateObject = new State().mutableOr(startingState);
     }
 
     public State getStartingState() {
@@ -56,11 +54,11 @@ public class NFA<I, R> {
 
         for (int i : active) {
 //        for (int i = active.nextSetBit(0); i >= 0; i = active.nextSetBit(i+1)) {
-             State target = transitionTable.get(Key.create(i, input));
+             State target = transitionTable.get(new Key(i, input));
 
              if (target != null) {
                  if (result == null) {
-                     result = State.create();
+                     result = new State();
                  }
                  
                  result.mutableOr(target);
@@ -97,7 +95,7 @@ public class NFA<I, R> {
     }
 
     public State join(State s1, State s2) {
-        State bs = State.create();
+        State bs = new State();
 
         bs.mutableOr(s1);
         bs.mutableOr(s2);
@@ -105,59 +103,16 @@ public class NFA<I, R> {
         return bs;
     }
 
-    public static final class Key<I> {
-        private final int state;
-        private final I   input;
-
-        private Key(int state, I input) {
-            this.state = state;
-            this.input = input;
-        }
-
-        public static <I> Key<I> create(int state, I input) {
-            return new Key<>(state, input);
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == null) {
-                return false;
-            }
-            if (getClass() != obj.getClass()) {
-                return false;
-            }
-            final Key<?> other = (Key<?>) obj;
-            if (this.state != other.state) {
-                return false;
-            }
-            if (this.input != other.input && (this.input == null || !this.input.equals(other.input))) {
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public int hashCode() {
-            int hash = 3;
-            hash = 83 * hash + this.state;
-            hash = 83 * hash + (this.input != null ? this.input.hashCode() : 0);
-            return hash;
-        }
-
+    public record Key<I>(int state, I input) {
         @Override
         public String toString() {
             return "[" + state + ", " + input + "]";
         }
-
     }
 
     public static final class State extends HashSet<Integer> {
-        private State() {
+        public State() {
             super(4);
-        }
-
-        public static State create() {
-            return new State();
         }
 
         public State mutableOr(int state) {

--- a/java/spi.java.hints/src/org/netbeans/spi/java/hints/ErrorDescriptionFactory.java
+++ b/java/spi.java.hints/src/org/netbeans/spi/java/hints/ErrorDescriptionFactory.java
@@ -36,7 +36,6 @@ import com.sun.source.util.TreePath;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -52,11 +51,9 @@ import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.java.source.GeneratorUtilities;
 import org.netbeans.api.java.source.JavaSource;
 import org.netbeans.api.java.source.JavaSource.Phase;
-import org.netbeans.api.java.source.Task;
 import org.netbeans.api.java.source.TreePathHandle;
 import org.netbeans.api.java.source.WorkingCopy;
 import org.netbeans.api.lexer.TokenSequence;
-import org.netbeans.api.options.OptionsDisplayer;
 import org.netbeans.modules.analysis.api.CodeAnalysis;
 import org.netbeans.modules.analysis.spi.Analyzer.WarningDescription;
 import org.netbeans.modules.java.hints.providers.spi.HintMetadata;
@@ -86,10 +83,6 @@ public class ErrorDescriptionFactory {
     
     private ErrorDescriptionFactory() {
     }
-
-//    public static ErrorDescription forTree(HintContext context, String text, Fix... fixes) {
-//        return forTree(context, context.getContext(), text, fixes);
-//    }
 
     public static ErrorDescription forTree(HintContext context, TreePath tree, String text, Fix... fixes) {
         return forTree(context, tree.getLeaf(), text, fixes);
@@ -169,48 +162,50 @@ public class ErrorDescriptionFactory {
         return null;
     }
 
-    @SuppressWarnings("fallthrough")
     private static int[] computeNameSpan(Tree tree, HintContext context) {
+        CompilationInfo info = context.getInfo();
         switch (tree.getKind()) {
-            case LABELED_STATEMENT:
-                return context.getInfo().getTreeUtilities().findNameSpan((LabeledStatementTree) tree);
-            case METHOD:
-                return context.getInfo().getTreeUtilities().findNameSpan((MethodTree) tree);
-            case ANNOTATION_TYPE:
-            case CLASS:
-            case ENUM:
-            case INTERFACE:
-                return context.getInfo().getTreeUtilities().findNameSpan((ClassTree) tree);
-            case VARIABLE:
-                return context.getInfo().getTreeUtilities().findNameSpan((VariableTree) tree);
-            case MEMBER_SELECT:
+            case LABELED_STATEMENT -> {
+                return info.getTreeUtilities().findNameSpan((LabeledStatementTree) tree);
+            }
+            case METHOD -> {
+                return info.getTreeUtilities().findNameSpan((MethodTree) tree);
+            }
+            case ANNOTATION_TYPE, CLASS, ENUM, INTERFACE -> {
+                return info.getTreeUtilities().findNameSpan((ClassTree) tree);
+            }
+            case VARIABLE -> {
+                return info.getTreeUtilities().findNameSpan((VariableTree) tree);
+            }
+            case MEMBER_SELECT -> {
                 //XXX:
                 MemberSelectTree mst = (MemberSelectTree) tree;
-                int[] span = context.getInfo().getTreeUtilities().findNameSpan(mst);
+                int[] span = info.getTreeUtilities().findNameSpan(mst);
 
                 if (span == null) {
-                    int end = (int) context.getInfo().getTrees().getSourcePositions().getEndPosition(context.getInfo().getCompilationUnit(), tree);
+                    int end = (int) info.getTrees().getSourcePositions().getEndPosition(info.getCompilationUnit(), tree);
                     span = new int[] {end - mst.getIdentifier().length(), end};
                 }
                 return span;
-            case METHOD_INVOCATION:
+            }
+            case METHOD_INVOCATION -> {
                 return computeNameSpan(((MethodInvocationTree) tree).getMethodSelect(), context);
-            case BLOCK:
-                Collection<? extends TreePath> prefix = context.getMultiVariables().get("$$1$");
-                
-                if (prefix != null) {
-                    BlockTree bt = (BlockTree) tree;
-                    
-                    if (bt.getStatements().size() > prefix.size()) {
-                        return computeNameSpan(bt.getStatements().get(prefix.size()), context);
+            }
+            default -> {
+                if (tree.getKind() == Kind.BLOCK) {
+                    Collection<? extends TreePath> prefix = context.getMultiVariables().get("$$1$");
+                    if (prefix != null) {
+                        BlockTree bt = (BlockTree) tree;
+                        if (bt.getStatements().size() > prefix.size()) {
+                            return computeNameSpan(bt.getStatements().get(prefix.size()), context);
+                        }
                     }
                 }
-            default:
-                int start = (int) context.getInfo().getTrees().getSourcePositions().getStartPosition(context.getInfo().getCompilationUnit(), tree);
-                if (    StatementTree.class.isAssignableFrom(tree.getKind().asInterface())
-                    && tree.getKind() != Kind.EXPRESSION_STATEMENT
-                    && tree.getKind() != Kind.BLOCK) {
-                    TokenSequence<?> ts = context.getInfo().getTokenHierarchy().tokenSequence();
+                int start = (int) info.getTrees().getSourcePositions().getStartPosition(info.getCompilationUnit(), tree);
+                if (StatementTree.class.isAssignableFrom(tree.getKind().asInterface())
+                        && tree.getKind() != Kind.EXPRESSION_STATEMENT
+                        && tree.getKind() != Kind.BLOCK) {
+                    TokenSequence<?> ts = info.getTokenHierarchy().tokenSequence();
                     ts.move(start);
                     if (ts.moveNext()) {
                         return new int[] {ts.offset(), ts.offset() + ts.token().length()};
@@ -218,9 +213,11 @@ public class ErrorDescriptionFactory {
                 }
                 return new int[] {
                     start,
-                    Math.min((int) context.getInfo().getTrees().getSourcePositions().getEndPosition(context.getInfo().getCompilationUnit(), tree),
-                             findLineEnd(context.getInfo(), start)),
+                    Math.min((int) info.getTrees().getSourcePositions().getEndPosition(info.getCompilationUnit(), tree),
+                             findLineEnd(info, start)),
                 };
+            }
+
         }
     }
 
@@ -242,13 +239,12 @@ public class ErrorDescriptionFactory {
             Set<String> suppressWarningsKeys = new LinkedHashSet<>();
 
             for (String key : hm.suppressWarnings) {
-                if (key == null || key.length() == 0) {
+                if (key == null || key.isEmpty()) {
                     break;
                 }
 
                 suppressWarningsKeys.add(key);
             }
-
 
             auxiliaryFixes.add(new DisableConfigure(ctx.getInfo().getFileObject(), hm, true, SPIAccessor.getINSTANCE().getHintSettings(ctx)));
             auxiliaryFixes.add(new DisableConfigure(ctx.getInfo().getFileObject(), hm, false, null));
@@ -261,7 +257,7 @@ public class ErrorDescriptionFactory {
             }
             
             if (!suppressWarningsKeys.isEmpty()) {
-                auxiliaryFixes.addAll(createSuppressWarnings(ctx.getInfo(), ctx.getPath(), suppressWarningsKeys.toArray(new String[0])));
+                auxiliaryFixes.addAll(createSuppressWarnings(ctx.getInfo(), ctx.getPath(), suppressWarningsKeys.toArray(String[]::new)));
             }
 
             List<Fix> result = new LinkedList<>();
@@ -298,18 +294,10 @@ public class ErrorDescriptionFactory {
         @Override
         public String getText() {
             String displayName = metadata.displayName;
-            String key;
-            switch (metadata.kind) {
-                case INSPECTION:
-                    key = disable ? "FIX_DisableHint" : "FIX_ConfigureHint";
-                    break;
-                case ACTION:
-                    key = disable ? "FIX_DisableSuggestion" : "FIX_ConfigureSuggestion";
-                    break;
-                default:
-                    throw new IllegalStateException();
-            }
-
+            String key = switch (metadata.kind) {
+                case INSPECTION -> disable ? "FIX_DisableHint" : "FIX_ConfigureHint";
+                case ACTION -> disable ? "FIX_DisableSuggestion" : "FIX_ConfigureSuggestion";
+            };
             return NbBundle.getMessage(ErrorDescriptionFactory.class, key, displayName);
         }
 
@@ -367,14 +355,7 @@ public class ErrorDescriptionFactory {
         
     }
 
-    private static class InspectFix implements Fix, SyntheticFix {
-        private final @NonNull HintMetadata metadata;
-        private final boolean transform;
-
-        InspectFix(@NonNull HintMetadata metadata, boolean transform) {
-            this.metadata = metadata;
-            this.transform = transform;
-        }
+    private record InspectFix(@NonNull HintMetadata metadata, boolean transform) implements Fix, SyntheticFix {
 
         @Override
         @Messages({
@@ -403,33 +384,6 @@ public class ErrorDescriptionFactory {
             
             return null;
         }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == null) {
-                return false;
-            }
-            if (this.getClass() != obj.getClass()) {
-                return false;
-            }
-            final InspectFix other = (InspectFix) obj;
-            if (this.metadata != other.metadata && (this.metadata == null || !this.metadata.equals(other.metadata))) {
-                return false;
-            }
-            if (this.transform != other.transform) {
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public int hashCode() {
-            int hash = 7;
-            hash = 43 * hash + (this.metadata != null ? this.metadata.hashCode() : 0);
-            hash = 43 * hash + (this.transform ? 1 : 0);
-            return hash;
-        }
-
 
     }
     
@@ -487,12 +441,7 @@ public class ErrorDescriptionFactory {
         }
 
         Fix f = createSuppressWarningsFix(compilationInfo, treePath, keys);
-
-        if (f != null) {
-            return Collections.<Fix>singletonList(f);
-        } else {
-            return Collections.emptyList();
-        }
+        return f != null ? List.of(f) : List.of();
     }
 
     private static boolean isSuppressWarningsSupported(CompilationInfo info) {
@@ -507,9 +456,9 @@ public class ErrorDescriptionFactory {
 
     private static final class FixImpl implements Fix, SyntheticFix {
 
-        private String keys[];
-        private TreePathHandle handle;
-        private FileObject file;
+        private final String keys[];
+        private final TreePathHandle handle;
+        private final FileObject file;
 
         public FixImpl(TreePathHandle handle, FileObject file, String... keys) {
             this.keys = keys;
@@ -535,81 +484,72 @@ public class ErrorDescriptionFactory {
         public ChangeInfo implement() throws IOException {
             JavaSource js = JavaSource.forFileObject(file);
 
-            js.runModificationTask(new Task<WorkingCopy>() {
-                @Override
-                public void run(WorkingCopy copy) throws IOException {
-                    copy.toPhase(Phase.RESOLVED); //XXX: performance
-                    TreePath path = handle.resolve(copy);
+            js.runModificationTask((WorkingCopy copy) -> {
+                copy.toPhase(Phase.RESOLVED); //XXX: performance
+                TreePath path = handle.resolve(copy);
 
-                    while (path != null && path.getLeaf().getKind() != Kind.COMPILATION_UNIT && !DECLARATION.contains(path.getLeaf().getKind())) {
-                        path = path.getParentPath();
-                    }
+                while (path != null && path.getLeaf().getKind() != Kind.COMPILATION_UNIT && !DECLARATION.contains(path.getLeaf().getKind())) {
+                    path = path.getParentPath();
+                }
 
-                    if (path == null || path.getLeaf().getKind() == Kind.COMPILATION_UNIT) {
-                        return ;
-                    }
+                if (path == null || path.getLeaf().getKind() == Kind.COMPILATION_UNIT) {
+                    return ;
+                }
 
-                    Tree top = path.getLeaf();
-                    ModifiersTree modifiers = null;
-                    TreePath lambdaPath = null;
-                    
-                    switch (top.getKind()) {
-                        case ANNOTATION_TYPE:
-                        case CLASS:
-                        case ENUM:
-                        case INTERFACE:
-                            modifiers = ((ClassTree) top).getModifiers();
-                            break;
-                        case METHOD:
-                            modifiers = ((MethodTree) top).getModifiers();
-                            break;
-                        case VARIABLE: {
-                                if (path.getParentPath() != null && 
-                                    path.getParentPath().getLeaf().getKind() == Tree.Kind.LAMBDA_EXPRESSION) {
-                                    // check if the variable is an implict parameter. If so, it must be turned into explicit
-                                    TreePath typePath = TreePath.getPath(path.getParentPath(), ((VariableTree)top).getType());
-                                    if (copy.getTreeUtilities().isSynthetic(typePath)) {
-                                        lambdaPath = path.getParentPath();
-                                    }
-                                }
-                                modifiers = ((VariableTree) top).getModifiers();
-                            }
-                            break;
-                        default: assert false : "Unhandled Tree.Kind";  // NOI18N
-                    }
+                Tree top = path.getLeaf();
+                TreePath lambdaPath = null;
 
-                    if (modifiers == null) {
-                        return ;
-                    }
-
-                    TypeElement el = copy.getElements().getTypeElement("java.lang.SuppressWarnings");  // NOI18N
-
-                    if (el == null) {
-                        return ;
-                    }
-
-                    LiteralTree[] keyLiterals = new LiteralTree[keys.length];
-
-                    for (int i = 0; i < keys.length; i++) {
-                        keyLiterals[i] = copy.getTreeMaker().
-                                Literal(keys[i]);
-                    }
-
-                    if (lambdaPath != null) {
-                        LambdaExpressionTree let = (LambdaExpressionTree)lambdaPath.getLeaf();
-                        for (VariableTree var : let.getParameters()) {
-                            TreePath typePath = TreePath.getPath(lambdaPath, var.getType());
+                ModifiersTree modifiers = switch (top.getKind()) {
+                    case ANNOTATION_TYPE, CLASS, ENUM, INTERFACE -> ((ClassTree) top).getModifiers();
+                    case METHOD -> ((MethodTree) top).getModifiers();
+                    case VARIABLE -> {
+                        TreePath parent = path.getParentPath();
+                        if (parent != null && parent.getLeaf().getKind() == Tree.Kind.LAMBDA_EXPRESSION) {
+                            // check if the variable is an implict parameter. If so, it must be turned into explicit
+                            TreePath typePath = TreePath.getPath(parent, ((VariableTree)top).getType());
                             if (copy.getTreeUtilities().isSynthetic(typePath)) {
-                                Tree imported = copy.getTreeMaker().Type(copy.getTrees().getTypeMirror(typePath));
-                                copy.rewrite(var.getType(), imported);
+                                lambdaPath = parent;
                             }
                         }
+                        yield ((VariableTree) top).getModifiers();
                     }
-                    
-                    ModifiersTree nueMods = GeneratorUtilities.get(copy).appendToAnnotationValue(modifiers, el, "value", keyLiterals);
+                    default -> {
+                        assert false : "Unhandled Tree.Kind";  // NOI18N
+                        yield null;
+                    }
+                };
 
-                    copy.rewrite(modifiers, nueMods);
+                if (modifiers == null) {
+                    return ;
                 }
+
+                TypeElement el = copy.getElements().getTypeElement("java.lang.SuppressWarnings");  // NOI18N
+
+                if (el == null) {
+                    return ;
+                }
+
+                LiteralTree[] keyLiterals = new LiteralTree[keys.length];
+
+                for (int i = 0; i < keys.length; i++) {
+                    keyLiterals[i] = copy.getTreeMaker().
+                            Literal(keys[i]);
+                }
+
+                if (lambdaPath != null) {
+                    LambdaExpressionTree let = (LambdaExpressionTree)lambdaPath.getLeaf();
+                    for (VariableTree var : let.getParameters()) {
+                        TreePath typePath = TreePath.getPath(lambdaPath, var.getType());
+                        if (copy.getTreeUtilities().isSynthetic(typePath)) {
+                            Tree imported = copy.getTreeMaker().Type(copy.getTrees().getTypeMirror(typePath));
+                            copy.rewrite(var.getType(), imported);
+                        }
+                    }
+                }
+
+                ModifiersTree nueMods = GeneratorUtilities.get(copy).appendToAnnotationValue(modifiers, el, "value", keyLiterals);
+
+                copy.rewrite(modifiers, nueMods);
             }).commit();
 
             return null;

--- a/java/spi.java.hints/src/org/netbeans/spi/java/hints/HintSeverity.java
+++ b/java/spi.java.hints/src/org/netbeans/spi/java/hints/HintSeverity.java
@@ -34,15 +34,11 @@ public enum HintSeverity {
     CURRENT_LINE_WARNING;
 
     public Severity toEditorSeverity() {
-        switch ( this ) {
-            case ERROR:
-                return Severity.ERROR;
-            case WARNING:
-                return Severity.VERIFIER;
-            case CURRENT_LINE_WARNING:
-                return Severity.HINT;
-            default:
-                return null;
-        }
+        return switch (this) {
+            case ERROR -> Severity.ERROR;
+            case WARNING -> Severity.VERIFIER;
+            case CURRENT_LINE_WARNING -> Severity.HINT;
+            default -> null;
+        };
     }
 }

--- a/java/spi.java.hints/src/org/netbeans/spi/java/hints/JavaFixUtilities.java
+++ b/java/spi.java.hints/src/org/netbeans/spi/java/hints/JavaFixUtilities.java
@@ -1851,9 +1851,11 @@ public class JavaFixUtilities {
                                         if (tree == assignmentTree.getVariable()) {
                                             if (!info.getTreeUtilities().isExpressionStatement(assignmentTree.getExpression()) && canHaveSideEffects(assignmentTree.getExpression())) {
                                                 ret.set(false);
+                                                return null;
                                             }
                                         } else {
                                             ret.set(false);
+                                            return null;
                                         }
                                     }
                                     case AND_ASSIGNMENT, DIVIDE_ASSIGNMENT, LEFT_SHIFT_ASSIGNMENT, MINUS_ASSIGNMENT,
@@ -1863,13 +1865,16 @@ public class JavaFixUtilities {
                                         if (tree == compoundAssignmentTree.getVariable()) {
                                             if (!info.getTreeUtilities().isExpressionStatement(compoundAssignmentTree.getExpression()) && canHaveSideEffects(compoundAssignmentTree.getExpression())) {
                                                 ret.set(false);
+                                                return null;
                                             }
                                         } else {
                                             ret.set(false);
+                                            return null;
                                         }
                                     }
                                     default -> {
                                         ret.set(false);
+                                        return null;
                                     }
                                 }
                             }
@@ -1891,6 +1896,7 @@ public class JavaFixUtilities {
                             case METHOD_INVOCATION, NEW_CLASS, POSTFIX_DECREMENT, POSTFIX_INCREMENT,
                                  PREFIX_DECREMENT, PREFIX_INCREMENT -> {
                                 ret.set(true);
+                                return null;
                             }
                         }
                     }

--- a/java/spi.java.hints/src/org/netbeans/spi/java/hints/MatcherUtilities.java
+++ b/java/spi.java.hints/src/org/netbeans/spi/java/hints/MatcherUtilities.java
@@ -25,7 +25,6 @@ import com.sun.source.tree.StatementTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -52,20 +51,25 @@ public class MatcherUtilities {
 
     public static boolean matches(@NonNull HintContext ctx, @NonNull TreePath variable, @NonNull String pattern, boolean fillInVariablesHack) {
         return matches(ctx, variable, pattern, ctx.getVariables(), ctx.getMultiVariables(), ctx.getVariableNames(), 
-                fillInVariablesHack ? ctx.getConstraints() : Collections.<String, TypeMirror>emptyMap());
+                fillInVariablesHack ? ctx.getConstraints() : Map.of());
     }
 
     public static boolean matches(@NonNull HintContext ctx, @NonNull TreePath variable, @NonNull String pattern, Map<String, TreePath> outVariables, Map<String, Collection<? extends TreePath>> outMultiVariables, Map<String, String> outVariables2Names) {
-        return matches(ctx, variable, pattern, outVariables, outMultiVariables, outVariables2Names, Collections.<String, TypeMirror>emptyMap());
+        return matches(ctx, variable, pattern, outVariables, outMultiVariables, outVariables2Names, Map.of());
     }
 
     public static boolean matches(@NonNull HintContext ctx, @NonNull TreePath variable, @NonNull String pattern, Map<String, TreePath> outVariables, 
                         Map<String, Collection<? extends TreePath>> outMultiVariables, Map<String, String> outVariables2Names, Map<String, TypeMirror> variable2Type) {
-        Pattern p = PatternCompiler.compile(ctx.getInfo(), pattern, variable2Type, Collections.<String>emptyList());
+        Pattern p = PatternCompiler.compile(ctx.getInfo(), pattern, variable2Type, List.of());
         Map<String, TreePath> variables = new HashMap<>(ctx.getVariables());
         Map<String, Collection<? extends TreePath>> multiVariables = new HashMap<>(ctx.getMultiVariables());
         Map<String, String> variables2Names = new HashMap<>(ctx.getVariableNames());
-        Iterable<? extends Occurrence> occurrences = Matcher.create(ctx.getInfo()).setCancel(new AtomicBoolean()).setPresetVariable(variables, multiVariables, variables2Names).setSearchRoot(variable).setTreeTopSearch().match(p);
+        Iterable<? extends Occurrence> occurrences = Matcher.create(ctx.getInfo())
+                                                            .setCancel(new AtomicBoolean())
+                                                            .setPresetVariable(variables, multiVariables, variables2Names)
+                                                            .setSearchRoot(variable)
+                                                            .setTreeTopSearch()
+                                                            .match(p);
 
         if (occurrences.iterator().hasNext()) {
             Occurrence od = occurrences.iterator().next();
@@ -80,7 +84,7 @@ public class MatcherUtilities {
     }
 
     public static boolean matches(@NonNull HintContext ctx, @NonNull Collection<? extends TreePath> variable, @NonNull String pattern, Map<String, TreePath> outVariables, Map<String, Collection<? extends TreePath>> outMultiVariables, Map<String, String> outVariables2Names) {
-        Scope s = Utilities.constructScope(ctx.getInfo(), Collections.<String, TypeMirror>emptyMap());
+        Scope s = Utilities.constructScope(ctx.getInfo(), Map.of());
         Tree  patternTree = Utilities.parseAndAttribute(ctx.getInfo(), pattern, s);
         List<? extends Tree> patternTrees;
 
@@ -89,7 +93,7 @@ public class MatcherUtilities {
 
             patternTrees = statements.subList(1, statements.size() - 1);
         } else {
-            patternTrees = Collections.singletonList(patternTree);
+            patternTrees = List.of(patternTree);
         }
 
         if (variable.size() != patternTrees.size()) return false;
@@ -102,8 +106,13 @@ public class MatcherUtilities {
 
         while (variableIt.hasNext() && patternTreesIt.hasNext()) {
             TreePath patternTreePath = new TreePath(new TreePath(ctx.getInfo().getCompilationUnit()), patternTreesIt.next());
-            Pattern p = Pattern.createPatternWithFreeVariables(patternTreePath, Collections.<String, TypeMirror>emptyMap());
-            Iterable<? extends Occurrence> occurrences = Matcher.create(ctx.getInfo()).setCancel(new AtomicBoolean()).setPresetVariable(variables, multiVariables, variables2Names).setSearchRoot(variableIt.next()).setTreeTopSearch().match(p);
+            Pattern p = Pattern.createPatternWithFreeVariables(patternTreePath, Map.of());
+            Iterable<? extends Occurrence> occurrences = Matcher.create(ctx.getInfo())
+                                                                .setCancel(new AtomicBoolean())
+                                                                .setPresetVariable(variables, multiVariables, variables2Names)
+                                                                .setSearchRoot(variableIt.next())
+                                                                .setTreeTopSearch()
+                                                                .match(p);
 
             if (!occurrences.iterator().hasNext()) {
                 return false;

--- a/java/spi.java.hints/src/org/netbeans/spi/java/hints/support/TransformationSupport.java
+++ b/java/spi.java.hints/src/org/netbeans/spi/java/hints/support/TransformationSupport.java
@@ -60,8 +60,8 @@ import org.openide.util.Exceptions;
  */
 public final class TransformationSupport {
 
-    private String jackpotPattern;
-    private Transformer transformer;
+    private final String jackpotPattern;
+    private final Transformer transformer;
     private AtomicBoolean cancel = new AtomicBoolean();
 
     private TransformationSupport(String jackpotPattern, Transformer transformer) {
@@ -202,9 +202,12 @@ public final class TransformationSupport {
 
         for (HintDescription hd : PatternConvertor.create(inputJackpotPattern)) {
             final String triggerPattern = ((Trigger.PatternDescription) hd.getTrigger()).getPattern();
-            descriptions.add(HintDescriptionFactory.create().setTrigger(hd.getTrigger()).
-                    setTriggerOptions(hd.getTrigger().getOptions()).
-                setWorker((HintContext ctx) -> {
+            descriptions.add(
+                HintDescriptionFactory.create()
+                        .setTrigger(hd.getTrigger())
+                        .setTriggerOptions(hd.getTrigger()
+                        .getOptions())
+                        .setWorker((HintContext ctx) -> {
                     final Map<String, TypeMirrorHandle<?>> constraintsHandles = new HashMap<>();
 
                     for (Map.Entry<String, TypeMirror> c : ctx.getConstraints().entrySet()) {
@@ -232,8 +235,9 @@ public final class TransformationSupport {
                         }
                     }.toEditorFix();
                     
-                    return Collections.singletonList(ErrorDescriptionFactory.createErrorDescription(Severity.WARNING, "", Collections.singletonList(fix), ctx.getInfo().getFileObject(), 0, 0));
-            }).produce());
+                    return List.of(ErrorDescriptionFactory.createErrorDescription(Severity.WARNING, "", List.of(fix), ctx.getInfo().getFileObject(), 0, 0));
+                }).produce()
+            );
 
         }
         


### PR DESCRIPTION
3 commits: first (large) is cleanup, second improves hint metrics logging, third has some performance tweaks


Java Hints SPI module cleanup:

 - records, switch, instanceof
 - removed unused fields and code
 - collections
 - code simplifications
 - java 17 lang level
 

HintsInvoker logging improvements:

 - print metrics to regular logger ([`-Dorg.netbeans.modules.java.hints.spiimpl.hints.HintsInvoker.level=FINE`](https://github.com/apache/netbeans/pull/7563#issuecomment-2229562394))
 - add invocation count and cancelled state
 - sort by time spent before dump
 

Performance Improvements:

in CopyFinderBasedBulkSearch:

 - implemented matches method
 - extracted matcher from loop

in JavaFixUtilities:

 - fast path for JavaFixUtilities can-safely-remove scanners