### PR TITLE
Update FlatLaf from 3.3 to 3.5

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-C816DFDF2AC7BD55512597E4605FFCCFF840040D com.formdev:flatlaf:3.3
+5BA0BA8CA4A1942BFFF4A2771565F125C07A56A6 com.formdev:flatlaf:3.5

--- a/platform/libs.flatlaf/external/flatlaf-3.5-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-3.5-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 3.3
-Files: flatlaf-3.3.jar
+Version: 3.5
+Files: flatlaf-3.5.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/manifest.mf
+++ b/platform/libs.flatlaf/manifest.mf
@@ -4,4 +4,4 @@ OpenIDE-Module: org.netbeans.libs.flatlaf/1
 OpenIDE-Module-Install: org/netbeans/libs/flatlaf/Installer.class
 OpenIDE-Module-Specification-Version: 1.19
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Implementation-Version: 3.3
+OpenIDE-Module-Implementation-Version: 3.5

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.release=8
 nbm.target.cluster=platform
 
 spec.version.base.fatal.warning=false
@@ -31,17 +31,17 @@ spec.version.base.fatal.warning=false
 #
 # So when FlatLaf is updated, the OpenIDE-Module-Implementation-Version entry
 # in manifest.mf needs to be updated to match the new FlatLaf version.
-release.external/flatlaf-3.3.jar=modules/ext/flatlaf-3.3.jar
+release.external/flatlaf-3.5.jar=modules/ext/flatlaf-3.5.jar
 # com.formdev.flatlaf.ui intentionally ommitted.
 # rest is equivalent to the "public" packages for friend dependencies as declared in project.xml
 sigtest.public.packages=com.formdev.flatlaf,com.formdev.flatlaf.themes,com.formdev.flatlaf.util
 
-release.external/flatlaf-3.3.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
-release.external/flatlaf-3.3.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll
-release.external/flatlaf-3.3.jar!/com/formdev/flatlaf/natives/flatlaf-windows-arm64.dll=modules/lib/flatlaf-windows-arm64.dll
-release.external/flatlaf-3.3.jar!/com/formdev/flatlaf/natives/libflatlaf-macos-arm64.dylib=modules/lib/libflatlaf-macos-arm64.dylib
-release.external/flatlaf-3.3.jar!/com/formdev/flatlaf/natives/libflatlaf-macos-x86_64.dylib=modules/lib/libflatlaf-macos-x86_64.dylib
-release.external/flatlaf-3.3.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-x86_64.so=modules/lib/libflatlaf-linux-x86_64.so
+release.external/flatlaf-3.5.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
+release.external/flatlaf-3.5.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll
+release.external/flatlaf-3.5.jar!/com/formdev/flatlaf/natives/flatlaf-windows-arm64.dll=modules/lib/flatlaf-windows-arm64.dll
+release.external/flatlaf-3.5.jar!/com/formdev/flatlaf/natives/libflatlaf-macos-arm64.dylib=modules/lib/libflatlaf-macos-arm64.dylib
+release.external/flatlaf-3.5.jar!/com/formdev/flatlaf/natives/libflatlaf-macos-x86_64.dylib=modules/lib/libflatlaf-macos-x86_64.dylib
+release.external/flatlaf-3.5.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-x86_64.so=modules/lib/libflatlaf-linux-x86_64.so
 jnlp.verify.excludes=\
     modules/lib/flatlaf-windows-x86.dll,\
     modules/lib/flatlaf-windows-x86_64.dll,\

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -49,8 +49,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-3.3.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-3.3.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-3.5.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-3.5.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Bundle.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Bundle.properties
@@ -34,7 +34,7 @@ FlatLafOptionsPanel.unifiedTitleBarCheckBox.text=&Unified window title bar
 FlatLafOptionsPanel.menuBarEmbeddedCheckBox.text=&Embedded menu bar
 FlatLafOptionsPanel.underlineMenuSelectionCheckBox.text=Use underline menu &selection
 FlatLafOptionsPanel.alwaysShowMnemonicsCheckBox.text=Always show &mnemonics
-FlatLafOptionsPanel.showFileChooserFavoritesCheckBox.text=Show favorites in file chooser (experimental)
+FlatLafOptionsPanel.showFileChooserFavoritesCheckBox.text=Show favorites in file chooser
 
 LookAndFeel.Config.displayName=Look and Feel
 FlatLafOptionsPanel.Advanced.title=Advanced


### PR DESCRIPTION
changes since last update:
- https://github.com/JFormDesigner/FlatLaf/releases/tag/3.5
  - https://github.com/JFormDesigner/FlatLaf/issues/828 allows us to remove the "experimental" tag from https://github.com/apache/netbeans/pull/7164
- https://github.com/JFormDesigner/FlatLaf/releases/tag/3.4.1
- https://github.com/JFormDesigner/FlatLaf/releases/tag/3.4

this is mostly to check if it helps with https://github.com/apache/netbeans/issues/7560