### PR TITLE
Fix use-instanceof-pattern hint messages

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToPatternInstanceOf.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToPatternInstanceOf.java
@@ -23,7 +23,6 @@ import com.sun.source.tree.IfTree;
 import com.sun.source.tree.InstanceOfTree;
 import com.sun.source.tree.ParenthesizedTree;
 import com.sun.source.tree.StatementTree;
-import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.TypeCastTree;
 import com.sun.source.tree.VariableTree;
@@ -59,10 +58,10 @@ import org.openide.util.NbBundle;
  * @author sdedic
  */
 @NbBundle.Messages({
-    "DN_ConvertToPatternInstanceOf=Convert to instanceof <pattern>",
-    "DESC_ConvertToPatternInstanceOf=Convert to instanceof <pattern>",
-    "ERR_ConvertToPatternInstanceOf=instanceof <pattern> can be used here",
-    "FIX_ConvertToPatternInstanceOf=Use instanceof <pattern>"
+    "DN_ConvertToPatternInstanceOf=Convert to instanceof pattern",
+    "DESC_ConvertToPatternInstanceOf=Convert to instanceof pattern",
+    "ERR_ConvertToPatternInstanceOf=instanceof pattern can be used here",
+    "FIX_ConvertToPatternInstanceOf=Use instanceof pattern"
 })
 @Hint(displayName="#DN_ConvertToPatternInstanceOf", description="#DESC_ConvertToPatternInstanceOf", category="rules15",
         minSourceVersion = "14")

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToPatternInstanceOfTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToPatternInstanceOfTest.java
@@ -20,7 +20,6 @@ package org.netbeans.modules.java.hints.jdk;
 
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.java.hints.test.api.HintTest;
-import javax.lang.model.SourceVersion;
 
 /**
  *


### PR DESCRIPTION
Some components render as html which made the text inside the angle brackets disappear. This caused confusing "use instanceof" hints, marking lines which already used `instanceof`. 

Now it reads "use instanceof pattern" as it was intended.

![image](https://github.com/user-attachments/assets/af6b8314-f4ad-438a-8353-47343594ee09)
