### PR TITLE
CodeGenerator should be able to generate basic code for records

### DIFF
--- a/java/java.source/src/org/netbeans/modules/java/classfile/CodeGenerator.java
+++ b/java/java.source/src/org/netbeans/modules/java/classfile/CodeGenerator.java
@@ -393,6 +393,9 @@ public class CodeGenerator {
                 List<Tree> members = new LinkedList<Tree>();
 
                 for (Element m : e.getEnclosedElements()) {
+                    if (m.getKind() == ElementKind.RECORD_COMPONENT) {
+                        continue; // TODO update to 'extend AbstractElementVisitor14'; visiting record components causes UnknownElementException
+                    }
                     Tree member = visit(m);
 
                     if (member != null)
@@ -408,6 +411,10 @@ public class CodeGenerator {
                         return addDeprecated(e, make.Interface(mods, e.getSimpleName(), constructTypeParams(e.getTypeParameters()), computeSuper(e.getInterfaces()), members));
                     case ENUM:
                         return addDeprecated(e, make.Enum(mods, e.getSimpleName(), computeSuper(e.getInterfaces()), members));
+                    case RECORD:
+                        // TODO generates final class atm
+                        return addDeprecated(e, make.Class(mods, e.getSimpleName(), constructTypeParams(e.getTypeParameters()), null, computeSuper(e.getInterfaces()), members));
+//                        return addDeprecated(e, make.Record(mods, e.getSimpleName(), computeSuper(e.getInterfaces()), members));
                     case ANNOTATION_TYPE:
                         return addDeprecated(e, make.AnnotationType(mods, e.getSimpleName(), members));
                     default:
@@ -782,6 +789,8 @@ public class CodeGenerator {
         IMPLICIT_MODIFIERS = new HashMap<List<ElementKind>, Set<Modifier>>();
 
         IMPLICIT_MODIFIERS.put(Arrays.asList(ElementKind.ENUM), EnumSet.of(Modifier.STATIC, Modifier.ABSTRACT, Modifier.FINAL));
+        // TODO implement record support
+//        IMPLICIT_MODIFIERS.put(Arrays.asList(ElementKind.RECORD), EnumSet.of(Modifier.STATIC, Modifier.ABSTRACT, Modifier.FINAL));
         IMPLICIT_MODIFIERS.put(Arrays.asList(ElementKind.ANNOTATION_TYPE), EnumSet.of(Modifier.STATIC, Modifier.ABSTRACT));
         IMPLICIT_MODIFIERS.put(Arrays.asList(ElementKind.METHOD, ElementKind.ANNOTATION_TYPE), EnumSet.of(Modifier.ABSTRACT));
         IMPLICIT_MODIFIERS.put(Arrays.asList(ElementKind.METHOD, ElementKind.INTERFACE), EnumSet.of(Modifier.ABSTRACT));


### PR DESCRIPTION
generates a final class as workaround instead of throwing an exception

fixes https://github.com/apache/netbeans/issues/7570 (see for reproducer)


So i tried to implement this properly at first, but there is some magic behind the scenes in the javac impl which kept generating final classes even though everything seemed to be correct. I had this in `TreeFactory` which works analog to `Enum`:
```java
    public ClassTree Record(ModifiersTree modifiers, 
             CharSequence simpleName,
             List<? extends Tree> implementsClauses,
             List<? extends Tree> memberDecls) {
        long flags = getBitFlags(modifiers.getFlags()) | Flags.RECORD;
        return Class(flags, (com.sun.tools.javac.util.List<JCAnnotation>) modifiers.getAnnotations(), simpleName, Collections.<TypeParameterTree>emptyList(), null, implementsClauses, memberDecls);
    }
```

since this had no effect, I decided to change this back to a minimal impact quickfix which simply calls `make.Class` right away, without introducing public API changes. This would also have to be updated to extend `AbstractElementVisitor14` as the todo indicates.

Edit: I might give this a second attempt to implement it properly