### PR TITLE
Update manifest of core.output2 to separate the OpenIDE-Module-Provides values with comma

### DIFF
--- a/platform/core.output2/manifest.mf
+++ b/platform/core.output2/manifest.mf
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.core.output2/1
 OpenIDE-Module-Layer: org/netbeans/core/output2/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/core/output2/Bundle.properties
-OpenIDE-Module-Provides: org.openide.windows.IOProvider org.netbeans.spi.io.InputOutputProvider
+OpenIDE-Module-Provides: org.openide.windows.IOProvider, org.netbeans.spi.io.InputOutputProvider
 AutoUpdate-Essential-Module: true
 OpenIDE-Module-Specification-Version: 1.67
 


### PR DESCRIPTION
In a Netbeans application based on Maven, the `nbm-maven-plugin` is failing with the following message while both modules are explicitly part of the application.

```
[ERROR] Some tokens required by included modules are not provided by included modules. The application will fail starting up. The missing tokens are:
[ERROR]    org.openide.windows.IOProvider          ref: [org.netbeans.modules.css.visual]
```

Looking at the [ExamineManifest source code](https://github.com/apache/netbeans-mavenutils-nbm-maven-plugin/blob/601764a0c8342cf90f3dbc0a6c3e102d83d6d67c/nb-shared/src/main/java/org/apache/netbeans/nbm/utils/ExamineManifest.java#L196-L199) the `nbm-maven-plugin` is expecting to find comma separated values.

Looking at the other Manifest on Netbeans source code, it seems that other are comma separated already 
- [ide/xml.xdm/manifest.mf](https://github.com/apache/netbeans/blob/faabea09cba7ad3af5744813cfd1a6d7d52157a5/ide/xml.xdm/manifest.mf#L5)
- [ide/projectui/manifest.mf](https://github.com/apache/netbeans/blob/faabea09cba7ad3af5744813cfd1a6d7d52157a5/ide/projectui/manifest.mf#L6)
- [webcommon/libs.graaljs/manifest.mf](https://github.com/apache/netbeans/blob/faabea09cba7ad3af5744813cfd1a6d7d52157a5/webcommon/libs.graaljs/manifest.mf#L7)
- Etc.

Thus `core.output2` seems to have a typo addressed by this pull request.

