### PR TITLE
Lazy init SMO backend and increase timeout

### DIFF
--- a/java/maven.indexer/nbproject/project.properties
+++ b/java/maven.indexer/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 test.config.stableBTD.includes=**/*Test.class
 is.autoload=true
-javac.release=11
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 release.external/indexer-core-7.1.4.jar=modules/ext/maven/indexer-core-7.1.4.jar
 release.external/search-api-7.1.4.jar=modules/ext/maven/search-api-7.1.4.jar

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/CompositeResult.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/CompositeResult.java
@@ -19,7 +19,6 @@
 package org.netbeans.modules.maven.indexer;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import org.netbeans.modules.maven.indexer.spi.ResultImplementation;
 
 /**
@@ -27,13 +26,7 @@ import org.netbeans.modules.maven.indexer.spi.ResultImplementation;
  * 
  * @author mbien
  */
-final class CompositeResult<T> implements ResultImplementation<T> {
-
-    private final List<ResultImplementation<T>> results;
-
-    public CompositeResult(List<ResultImplementation<T>> results) {
-        this.results = results;
-    }
+record CompositeResult<T>(List<ResultImplementation<T>> results) implements ResultImplementation<T> {
 
     public CompositeResult(ResultImplementation<T> first, ResultImplementation<T> second) {
         this(List.of(first, second));
@@ -62,7 +55,7 @@ final class CompositeResult<T> implements ResultImplementation<T> {
                       .flatMap(r -> r.getResults().stream())
                       .sorted()
                       .distinct()
-                      .collect(Collectors.toList());
+                      .toList();
     }
 
     @Override

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/OnStop.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/OnStop.java
@@ -46,8 +46,8 @@ public class OnStop implements Runnable {
             }
         }
         for (RepositoryIndexerImplementation rii : Lookup.getDefault().lookupAll(RepositoryIndexerImplementation.class)) {
-            if (rii instanceof NexusRepositoryIndexerImpl) {
-                ((NexusRepositoryIndexerImpl)rii).shutdownAll();
+            if (rii instanceof NexusRepositoryIndexerImpl impl) {
+                impl.shutdownAll();
             }
         }
     }

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/api/PluginIndexManager.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/api/PluginIndexManager.java
@@ -24,7 +24,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -265,7 +264,7 @@ public class PluginIndexManager {
         qf.setValue(prefix);
         qf.setOccur(QueryField.OCCUR_MUST);
         qf.setMatch(QueryField.MATCH_EXACT);
-        for (NBVersionInfo v : RepositoryQueries.findResult(Collections.singletonList(qf), null).getResults()) {
+        for (NBVersionInfo v : RepositoryQueries.findResult(List.of(qf), null).getResults()) {
             result.add(v.getGroupId() + '|' + v.getArtifactId() + '|' + v.getVersion());
         }
         // This is more complete but much too slow:

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryQueries.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryQueries.java
@@ -225,12 +225,8 @@ public final class RepositoryQueries {
         for (RepositoryInfo repo : repos) {
             for (RepositoryIndexQueryProvider idx : idxs) {
                 if(idx.handlesRepository(repo)) {
-                    List<RepositoryInfo> mappedRepos = qp2Repo.get(idx);
-                    if(mappedRepos == null) {
-                        mappedRepos = new LinkedList<>();
-                        qp2Repo.put(idx, mappedRepos);
-                    }
-                    mappedRepos.add(repo);
+                    qp2Repo.computeIfAbsent(idx, k -> new LinkedList<>())
+                           .add(repo);
                     break;
                 }
             }


### PR DESCRIPTION
 - initialize SMO backend only when needed
 - bump request timeout to 15s, since the response time is fairly unpredictable
 - small java 17 renovation: instanceof, records, Stream/Colleciton API


So I noticed since https://github.com/apache/netbeans/pull/7569 this exception when NB is started and closed _before_ the maven indexer is initialized:

```
INFO [org.netbeans.NetigsoModule]: Can't load com.google.gson.JsonElement in package com.google.gson
java.lang.IllegalStateException: Bundle "reference:file:ide/modules/com-google-gson.jar" has been uninstalled
	at org.eclipse.osgi.framework.internal.core.AbstractBundle.checkValid(AbstractBundle.java:1175)
	at org.eclipse.osgi.framework.internal.core.BundleHost.checkLoader(BundleHost.java:183)
	at org.eclipse.osgi.framework.internal.core.BundleHost.loadClass(BundleHost.java:225)
	at org.eclipse.osgi.framework.internal.core.AbstractBundle.loadClass(AbstractBundle.java:1212)
	at org.netbeans.core.netigso.NetigsoLoader.doLoadClass(NetigsoLoader.java:89)
[catch] at org.netbeans.NetigsoModule$DelegateCL.doLoadClass(NetigsoModule.java:236)
	at org.netbeans.ProxyClassLoader.selfLoadClass(ProxyClassLoader.java:260)
	at org.netbeans.ProxyClassLoader.doFindClass(ProxyClassLoader.java:189)
	at org.netbeans.ProxyClassLoader.loadClass(ProxyClassLoader.java:140)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:528)
	at org.apache.maven.search.backend.smo.SmoSearchBackendFactory.create(SmoSearchBackendFactory.java:48)
	at org.apache.maven.search.backend.smo.SmoSearchBackendFactory.createDefault(SmoSearchBackendFactory.java:41)
	at org.netbeans.modules.maven.indexer.NexusRepositoryIndexerImpl.<init>(NexusRepositoryIndexerImpl.java:185)
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:501)
	at java.base/java.lang.reflect.ReflectAccess.newInstance(ReflectAccess.java:132)
	at java.base/jdk.internal.reflect.ReflectionFactory.newInstance(ReflectionFactory.java:259)
	at java.base/java.lang.Class.newInstance(Class.java:804)
	at org.openide.util.lookup.implspi.SharedClassObjectBridge.newInstance(SharedClassObjectBridge.java:41)
	at org.openide.util.lookup.MetaInfServicesLookup$Item.getInstance(MetaInfServicesLookup.java:490)
	at org.openide.util.lookup.AbstractLookup$R.allInstances(AbstractLookup.java:1033)
	at org.openide.util.lookup.AbstractLookup$R.allInstances(AbstractLookup.java:1013)
	at org.openide.util.lookup.ProxyLookup$LazyCollection.computeSingleResult(ProxyLookup.java:1348)
	at org.openide.util.lookup.ProxyLookup$LazyCollection.computeDelegate(ProxyLookup.java:1186)
	at org.openide.util.lookup.ProxyLookup$LazyCollection.access$900(ProxyLookup.java:1114)
	at org.openide.util.lookup.ProxyLookup$LazyCollection$1.hasNext(ProxyLookup.java:1314)
	at org.netbeans.modules.maven.indexer.OnStop.run(OnStop.java:48)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1403)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2018)
```

I am not completely sure why this happens. The gson wrapper can be found just fine when `NexusRepositoryIndexerImpl` is initialized normally, but when it is loaded from for the first time
https://github.com/apache/netbeans/blob/1b31400eaaa7d118ebb7c2b053f0b96c95f987e3/java/maven.indexer/src/org/netbeans/modules/maven/indexer/OnStop.java#L48-L52
it causes the exception. Lazy loading SMO fixes it.