### PR TITLE
Add support for Java SE 24 for Tomcat/TomEE and GlassFish

### DIFF
--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV8_0_0.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV8_0_0.xml
@@ -27,6 +27,7 @@
         <platform version="21"/>
         <platform version="22"/>
         <platform version="23"/>
+        <platform version="24"/>
     </java>
     <javaee version="11.0.0">
         <profile version="11.0.0" type="web"/>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/JavaSEPlatform.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/JavaSEPlatform.java
@@ -73,7 +73,9 @@ public enum JavaSEPlatform {
     /** JavaSE 22. */
     v22,
     /** JavaSE 23. */
-    v23;
+    v23,
+    /** JavaSE 24. */
+    v24;
 
     ////////////////////////////////////////////////////////////////////////////
     // Class attributes                                                       //

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
@@ -556,13 +556,11 @@ public class TomcatPlatformImpl extends J2eePlatformImpl2 {
         if (manager.isTomEE()) {
             switch (manager.getTomEEVersion()) {
                 case TOMEE_100:
-                    versions = versionRange(21, 23);
-                    break;
                 case TOMEE_90:
-                    versions = versionRange(11, 23);
+                    versions = versionRange(11, 24);
                     break;
                 case TOMEE_80:
-                    versions = versionRange(8, 23);
+                    versions = versionRange(8, 24);
                     break;
                 case TOMEE_71:
                 case TOMEE_70:
@@ -579,20 +577,20 @@ public class TomcatPlatformImpl extends J2eePlatformImpl2 {
         } else {
             switch (manager.getTomcatVersion()) {
                 case TOMCAT_110:
-                    versions = versionRange(21, 23);
+                    versions = versionRange(21, 24);
                     break;
                 case TOMCAT_101:
-                    versions = versionRange(11, 23);
+                    versions = versionRange(11, 24);
                     break;
                 case TOMCAT_100:
                 case TOMCAT_90:
-                    versions = versionRange(8, 23);
+                    versions = versionRange(8, 24);
                     break;
                 case TOMCAT_80:
-                    versions = versionRange(7, 23);
+                    versions = versionRange(7, 24);
                     break;
                 case TOMCAT_70:
-                    versions = versionRange(6, 23);
+                    versions = versionRange(6, 24);
                     break;
                 case TOMCAT_60:
                     versions = versionRange(5, 8);


### PR DESCRIPTION

- TomEE 10 supports Jakarta EE 9.1 which run on Java 11 or higher

NetBeans Testing:

- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Verify Sigtests
- Verify successful execution of unit tests for modules `tomcat5`, `glassfish.common`, `glassfish.eecommon`, `glassfish.javaee` and `glassfish.tooling`
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Successfully register Tomcat, TomEE, GlassFish with Java 24.