### PR TITLE
fix javadoc task source properties + javadoc typo

### DIFF
--- a/ide/api.lsp/src/org/netbeans/api/lsp/WorkspaceEdit.java
+++ b/ide/api.lsp/src/org/netbeans/api/lsp/WorkspaceEdit.java
@@ -60,7 +60,7 @@ public class WorkspaceEdit {
      * a {@link WorkspaceEdit} with {@link TextDocumentEdit}s that have empty set of changes. 
      * The implementation must apply edits so they result in the same result as if the contents
      * of the WorkspaceEdit are applied in the order.
-     * <p/>
+     *
      * Upon failure, the returned Future completes with {@link ResourceModificationException}. 
      * Completed WorkspaceEdits, the failed one and the index of a failed operation within it should be reported.
      * If any resource was saved before the failure, it should be reported as saved.

--- a/nbbuild/javadoctools/template.xml
+++ b/nbbuild/javadoctools/template.xml
@@ -134,6 +134,12 @@ cause it to fail.
         <condition property="javadoc.reference.generated" >
             <isset property="javadoc.docs.${javadoc.name}" />
         </condition>
+        <!-- generate a javac.source for javadoc task that prioritize javac.release over javac.source -->
+        <condition property="javac.sourcerelease" value="${javac.release}" else="${javac.source}" >
+            <not>
+                <equals arg1="${javac.release}" arg2="" trim="true"/>
+            </not>
+        </condition>
     </target>
 
     <target name="javadoc-generate-references" depends="javadoc-init" unless="javadoc.reference.generated" >
@@ -288,7 +294,7 @@ cause it to fail.
     
     <target name="javadoc-exec-packages" depends="javadoc-init,javadoc-generate-references,javadoc-generate-overview,javadoc-exec-condition,javadoc-check-timestamps,javadoc-make-plain-title,javadoc-make-hyperlinked-title,javadoc-exec-condition,-javadoc-set-footer" unless="javadoc.exec.packages">
         <!-- -->
-        <javadoc source="${javac.source}" failonerror="${apidoc.check}" failonwarning="false" author="false" destdir="${javadoc.out.dir}" packagenames="${javadoc.packages}" stylesheetfile="${javadoc.css.main}" windowtitle="${javadoc.title}" overview="${javadoc.overview}" splitindex="true" use="true" version="false" useexternalfile="true" encoding="UTF-8">
+        <javadoc source="${javac.sourcerelease}" failonerror="${apidoc.check}" failonwarning="false" author="false" destdir="${javadoc.out.dir}" packagenames="${javadoc.packages}" stylesheetfile="${javadoc.css.main}" windowtitle="${javadoc.title}" overview="${javadoc.overview}" splitindex="true" use="true" version="false" useexternalfile="true" encoding="UTF-8">
             <sourcepath>
                 <pathelement location="${javadoc.docfiles}"/>
                 <pathelement location="${javadoc.src}"/>
@@ -321,7 +327,7 @@ cause it to fail.
     </target>
     
     <target name="javadoc-exec-files" depends="javadoc-init,javadoc-generate-references,javadoc-generate-overview,javadoc-exec-condition,javadoc-check-timestamps,javadoc-make-plain-title,javadoc-make-hyperlinked-title" if="javadoc.files.provided,-javadoc-set-footer" unless="javadoc.up.to.date">
-        <javadoc source="${javac.source}" author="false" destdir="${javadoc.out.dir}" packagenames="${javadoc.packages}" stylesheetfile="${javadoc.css.main}" windowtitle="${javadoc.title}" overview="${javadoc.overview}" splitindex="true" use="true" version="false" useexternalfile="true" encoding="UTF-8">
+        <javadoc source="${javac.sourcerelease}" author="false" destdir="${javadoc.out.dir}" packagenames="${javadoc.packages}" stylesheetfile="${javadoc.css.main}" windowtitle="${javadoc.title}" overview="${javadoc.overview}" splitindex="true" use="true" version="false" useexternalfile="true" encoding="UTF-8">
             <fileset dir="${javadoc.docfiles}"/>
             <fileset dir="${javadoc.src}" >
                 <and>

--- a/platform/openide.dialogs/src/org/openide/NotifyDescriptor.java
+++ b/platform/openide.dialogs/src/org/openide/NotifyDescriptor.java
@@ -1038,7 +1038,7 @@ public class NotifyDescriptor extends Object {
         /**
          * Property whose value is the input text, an event is fired
          * when the input text's value changes,
-         * if enabled using {@link #setInputTextEventsEnabled(boolean) }.
+         * if enabled using {@link #setInputTextEventEnabled(boolean) }.
          *
          * @since 7.70
          */


### PR DESCRIPTION
javadoc task was not prepared to use javac.release and default to 1.7 and leads to some javadoc (java.source) missing.

Find 2 typo in api.lsp and openide.dialogs and apidoc is back on track.

Tested with jdk22 maybe the jsonfile need and upgrade "jdktoolapidoc" : "jdk_22_latest", but