### PR TITLE
Cleanup warnings that are related to the use of a Result raw type..

### DIFF
--- a/enterprise/websvc.clientapi/src/org/netbeans/modules/websvc/api/client/WebServicesClientSupport.java
+++ b/enterprise/websvc.clientapi/src/org/netbeans/modules/websvc/api/client/WebServicesClientSupport.java
@@ -38,6 +38,7 @@ import org.openide.util.Lookup;
 import org.netbeans.modules.websvc.spi.client.WebServicesClientSupportImpl;
 import org.netbeans.modules.websvc.spi.client.WebServicesClientSupportProvider;
 import org.netbeans.modules.websvc.client.WebServicesClientSupportAccessor;
+import org.netbeans.modules.websvc.spi.client.WebServicesClientViewProvider;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.util.NbBundle;
@@ -56,7 +57,7 @@ public final class WebServicesClientSupport {
     public static final String WSCLIENTUPTODATE_CLASSPATH = "wsclientuptodate.classpath";
 
     private WebServicesClientSupportImpl impl;
-    private static final Lookup.Result implementations =
+    private static final Lookup.Result<WebServicesClientSupportProvider> implementations =
         Lookup.getDefault().lookupResult(WebServicesClientSupportProvider.class);
 
     static  {

--- a/enterprise/websvc.clientapi/src/org/netbeans/modules/websvc/api/client/WebServicesClientView.java
+++ b/enterprise/websvc.clientapi/src/org/netbeans/modules/websvc/api/client/WebServicesClientView.java
@@ -41,7 +41,7 @@ import org.netbeans.modules.websvc.client.WebServicesClientViewAccessor;
 public final class WebServicesClientView {
 
 	private WebServicesClientViewImpl impl;
-	private static final Lookup.Result implementations =
+	private static final Lookup.Result<WebServicesClientViewProvider> implementations =
 		Lookup.getDefault().lookupResult(WebServicesClientViewProvider.class);
 
 	static  {

--- a/enterprise/websvc.clientapi/src/org/netbeans/modules/websvc/api/jaxws/client/JAXWSClientSupport.java
+++ b/enterprise/websvc.clientapi/src/org/netbeans/modules/websvc/api/jaxws/client/JAXWSClientSupport.java
@@ -44,7 +44,7 @@ import org.openide.nodes.Node;
 public final class JAXWSClientSupport {
     
     private JAXWSClientSupportImpl impl;
-    private static final Lookup.Result implementations =
+    private static final Lookup.Result<WebServicesClientSupportProvider> implementations =
         Lookup.getDefault().lookupResult(WebServicesClientSupportProvider.class);
 
     static  {

--- a/enterprise/websvc.clientapi/src/org/netbeans/modules/websvc/api/jaxws/client/JAXWSClientView.java
+++ b/enterprise/websvc.clientapi/src/org/netbeans/modules/websvc/api/jaxws/client/JAXWSClientView.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.websvc.api.jaxws.client;
 
 import java.util.Iterator;
 import org.netbeans.modules.websvc.jaxws.client.JAXWSClientViewAccessor;
+import org.netbeans.modules.websvc.spi.client.WebServicesClientViewProvider;
 import org.netbeans.modules.websvc.spi.jaxws.client.JAXWSClientViewImpl;
 import org.netbeans.modules.websvc.spi.jaxws.client.JAXWSClientViewProvider;
 import org.openide.util.Lookup;
@@ -39,7 +40,7 @@ import org.netbeans.api.project.Project;
 public final class JAXWSClientView {
 
 	private JAXWSClientViewImpl impl;
-	private static final Lookup.Result implementations =
+	private static final Lookup.Result<JAXWSClientViewProvider> implementations =
 		Lookup.getDefault().lookupResult(JAXWSClientViewProvider.class);
 
 	static  {

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/projects/ProjectTestRestServicesAction.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/projects/ProjectTestRestServicesAction.java
@@ -53,7 +53,7 @@ public class ProjectTestRestServicesAction extends AbstractAction implements Pre
     private JMenuItem menuPresenter;
     private Lookup lookup;
     private Class<?>[] watch;
-    private Lookup.Result results[];
+    private Lookup.Result<?>[] results;
     private boolean needsRefresh = true;
     private boolean initialized = false;
     private boolean refreshing = false;

--- a/ide/css.visual/src/org/netbeans/modules/css/visual/CssStylesTCController.java
+++ b/ide/css.visual/src/org/netbeans/modules/css/visual/CssStylesTCController.java
@@ -172,7 +172,7 @@ public class CssStylesTCController implements PropertyChangeListener, LookupList
     public final void resultChanged(LookupEvent ev) {
         PageInspector pageInspector = PageInspector.getDefault();
         if (pageInspector != null) {
-            Lookup.Result lookupResult = (Lookup.Result) ev.getSource();
+            Lookup.Result<?> lookupResult = (Lookup.Result<?>) ev.getSource();
             lookupResult.removeLookupListener(this);
             pageInspector.addPropertyChangeListener(this);
         }

--- a/ide/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldViewFactory.java
+++ b/ide/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldViewFactory.java
@@ -104,7 +104,7 @@ public final class FoldViewFactory extends EditorViewFactory implements FoldHier
     /**
      * Lookup results for color settings, being listened for changes.
      */
-    private Lookup.Result       colorSource;
+    private Lookup.Result<FontColorSettings>    colorSource;
     
     private Preferences         prefs;
     

--- a/ide/xml.core/src/org/netbeans/modules/xml/api/model/GrammarQueryManager.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/api/model/GrammarQueryManager.java
@@ -108,7 +108,7 @@ public abstract class GrammarQueryManager {
 
         private static final String FOLDER = "Plugins/XML/GrammarQueryManagers";// NOI18N
         
-        private Lookup.Result registrations;
+        private Lookup.Result<GrammarQueryManager> registrations;
         
         private static ThreadLocal<GrammarQueryManager> transaction =
                 new ThreadLocal<GrammarQueryManager>();
@@ -145,8 +145,9 @@ public abstract class GrammarQueryManager {
             }
         }
         
+        @Override
         public Enumeration enabled(GrammarEnvironment ctx) {
-            Iterator<GrammarQueryManager> it = getRegistrations();
+            Iterator<? extends GrammarQueryManager> it = getRegistrations();
             transaction.set(null);
             List list = new ArrayList<>(5);
             {
@@ -172,7 +173,7 @@ public abstract class GrammarQueryManager {
             return null;
         }
         
-        private synchronized Iterator getRegistrations() {
+        private synchronized Iterator<? extends GrammarQueryManager> getRegistrations() {
             if (registrations != null) {
                 return registrations.allInstances().iterator();
             }

--- a/platform/openide.explorer/src/org/openide/explorer/DefaultEMLookup.java
+++ b/platform/openide.explorer/src/org/openide/explorer/DefaultEMLookup.java
@@ -47,7 +47,7 @@ final class DefaultEMLookup extends ProxyLookup implements LookupListener, Prope
     private LookupListener listener;
 
     /** Map of (Node -> node Lookup.Result) the above lookup listener is attached to */
-    private Map<Lookup, Lookup.Result> attachedTo;
+    private Map<Lookup, Lookup.Result<?>> attachedTo;
 
     /** action map for the top component */
     private Lookup actionMap;
@@ -78,7 +78,7 @@ final class DefaultEMLookup extends ProxyLookup implements LookupListener, Prope
 
         Lookup[] lookups = new Lookup[arr.length];
 
-        Map<Lookup, Lookup.Result> copy;
+        Map<Lookup, Lookup.Result<?>> copy;
 
         synchronized (this) {
             if (attachedTo == null) {
@@ -97,8 +97,8 @@ final class DefaultEMLookup extends ProxyLookup implements LookupListener, Prope
             }
         }
 
-        for (Iterator<Lookup.Result> it = copy.values().iterator(); it.hasNext();) {
-            Lookup.Result res = it.next();
+        for (Iterator<Lookup.Result<?>> it = copy.values().iterator(); it.hasNext();) {
+            Lookup.Result<?> res = it.next();
             res.removeLookupListener(listener);
         }
 
@@ -126,10 +126,10 @@ final class DefaultEMLookup extends ProxyLookup implements LookupListener, Prope
         if ((attachedTo == null) && isNodeQuery(t.getType())) {
             Lookup[] arr = getLookups();
 
-            attachedTo = new WeakHashMap<Lookup, Lookup.Result>(arr.length * 2);
+            attachedTo = new WeakHashMap<>(arr.length * 2);
 
             for (int i = 0; i < (arr.length - 2); i++) {
-                Lookup.Result res = arr[i].lookup(t);
+                Lookup.Result<?> res = arr[i].lookup(t);
                 res.addLookupListener(listener);
                 attachedTo.put(arr[i], res);
             }

--- a/platform/openide.loaders/src/org/openide/loaders/InstanceDataObject.java
+++ b/platform/openide.loaders/src/org/openide/loaders/InstanceDataObject.java
@@ -671,8 +671,8 @@ public class InstanceDataObject extends MultiDataObject implements InstanceCooki
         }
     }
 
-    private Lookup.Result cookieResult = null;
-    private Lookup.Result nodeResult = null;
+    private Lookup.Result<Node.Cookie> cookieResult = null;
+    private Lookup.Result<InstanceCookie> nodeResult = null;
     private Lookup cookiesLkp = null;
     private LookupListener cookiesLsnr = null;
     private LookupListener nodeLsnr = null;

--- a/platform/openide.loaders/src/org/openide/loaders/XMLDataObjectInfoParser.java
+++ b/platform/openide.loaders/src/org/openide/loaders/XMLDataObjectInfoParser.java
@@ -95,7 +95,7 @@ implements FileChangeListener, LexicalHandler, LookupListener {
     private Reference<XMLDataObject> xml;
     private String parsedId;
     private Lookup lookup;
-    private Lookup.Result result;
+    private Lookup.Result<Node.Cookie> result;
     private ThreadLocal<Class<?>> QUERY = new ThreadLocal<Class<?>>();
 
     XMLDataObjectInfoParser(XMLDataObject xml) {
@@ -151,7 +151,7 @@ implements FileChangeListener, LexicalHandler, LookupListener {
                     break;
                 }
             }
-            Lookup.Result r = result;
+            Lookup.Result<Node.Cookie> r = result;
             if (r != null) {
                 if (XMLDataObject.ERR.isLoggable(Level.FINE)) {
                     XMLDataObject.ERR.fine("Querying the result: " + r);
@@ -327,7 +327,7 @@ implements FileChangeListener, LexicalHandler, LookupListener {
             }
         }
         synchronized (this) {
-            Lookup.Result prevRes = result;
+            Lookup.Result<Node.Cookie> prevRes = result;
             lookup = newLookup;
             if (XMLDataObject.ERR.isLoggable(Level.FINE)) {
                 XMLDataObject.ERR.fine("Shared lookup updated: " + lookup + " for " + realXML);

--- a/platform/openide.util.lookup/src/org/openide/util/lookup/ProxyLookup.java
+++ b/platform/openide.util.lookup/src/org/openide/util/lookup/ProxyLookup.java
@@ -197,8 +197,8 @@ public class ProxyLookup extends Lookup {
         Set<Lookup> current;
         Lookup[] old;
 
-        Map<Result,LookupListener> toRemove = new IdentityHashMap<Lookup.Result, LookupListener>();
-        Map<Result,LookupListener> toAdd = new IdentityHashMap<Lookup.Result, LookupListener>();
+        Map<Result<?>,LookupListener> toRemove = new IdentityHashMap<>();
+        Map<Result<?>,LookupListener> toAdd = new IdentityHashMap<>();
 
         ImmutableInternalData orig;
         synchronized (ProxyLookup.this) {
@@ -211,16 +211,16 @@ public class ProxyLookup extends Lookup {
         }
 
         // better to do this later than in synchronized block
-        for (Map.Entry<Result, LookupListener> e : toRemove.entrySet()) {
+        for (Map.Entry<Result<?>, LookupListener> e : toRemove.entrySet()) {
             e.getKey().removeLookupListener(e.getValue());
         }
-        for (Map.Entry<Result, LookupListener> e : toAdd.entrySet()) {
+        for (Map.Entry<Result<?>, LookupListener> e : toAdd.entrySet()) {
             e.getKey().addLookupListener(e.getValue());
         }
 
 
         // this cannot be done from the synchronized block
-        final ArrayList<Object> evAndListeners = new ArrayList<Object>();
+        final List<Object> evAndListeners = new ArrayList<>();
         for (Reference<R> ref : arr) {
             R<?> r = ref.get();
             if (r != null) {
@@ -340,7 +340,7 @@ public class ProxyLookup extends Lookup {
 
     private Collection<Reference<R>> setData(
         ImmutableInternalData newData, Lookup[] current,
-        Map<Result,LookupListener> toAdd, Map<Result,LookupListener> toRemove
+        Map<Result<?>,LookupListener> toAdd, Map<Result<?>,LookupListener> toRemove
     ) {
         assert Thread.holdsLock(ProxyLookup.this);
         assert newData != null;
@@ -487,7 +487,7 @@ public class ProxyLookup extends Lookup {
         final void lookupChange(
             ImmutableInternalData newData, Lookup[] current, ImmutableInternalData oldData,
             Set<Lookup> added, Set<Lookup> removed,
-            Map<Result,LookupListener> toAdd, Map<Result,LookupListener> toRemove
+            Map<Result<?>,LookupListener> toAdd, Map<Result<?>,LookupListener> toRemove
         ) {
             if (weakL.getResults() == null) {
                 // not computed yet, do not need to do anything
@@ -497,7 +497,7 @@ public class ProxyLookup extends Lookup {
             Lookup[] old = oldData.getLookups(false);
 
             // map (Lookup, Lookup.Result)
-            Map<Lookup,Result<T>> map = new IdentityHashMap<Lookup,Result<T>>(old.length * 2);
+            Map<Lookup, Result<T>> map = new IdentityHashMap<>(old.length * 2);
 
             for (int i = 0; i < old.length; i++) {
                 if (removed.contains(old[i])) {
@@ -609,7 +609,7 @@ public class ProxyLookup extends Lookup {
                 }
             }
             // if caches exist, wait for finished
-            Lookup.Result[] arr = myBeforeLookup(callBeforeLookup, cachedResult != null);
+            Lookup.Result<T>[] arr = myBeforeLookup(callBeforeLookup, cachedResult != null);
             // use caches, if they exist
             Collection[] cc;
             synchronized (proxy()) {
@@ -1117,7 +1117,7 @@ public class ProxyLookup extends Lookup {
         private final Object[] cc;
         private final int indexToCache;
         private final boolean callBeforeLookup;
-        private final Lookup.Result[] arr;
+        private final Lookup.Result<?>[] arr;
         /** GuardedBy("this") */
         private final Collection[] computed;
         /** GuardedBy("this") */


### PR DESCRIPTION
Cleanup warnings that are related to the use of a Result raw type..

Warnings like this:

   [repeat] /home/bwalker/src/netbeans/ide/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldViewFactory.java:107: warning: [rawtypes] found raw type: Result
   [repeat]     private Lookup.Result       colorSource;
   [repeat]                   ^
   [repeat]   missing type arguments for generic class Result<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in class Result

This pull request reduces many of those warnings.





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
