### PR TITLE
Fix error when registering TomEE 10

### DIFF
--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/TomcatFactory.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/TomcatFactory.java
@@ -465,6 +465,8 @@ public final class TomcatFactory implements DeploymentFactory {
             return TomcatManager.TomEEVersion.TOMEE_80;
         } else if (version.startsWith("9.")) { // NOI18N
             return TomcatManager.TomEEVersion.TOMEE_90;
+        } else if (version.startsWith("10.")) { // NOI18N
+            return TomcatManager.TomEEVersion.TOMEE_100;
         }
         return defaultVersion;
     }

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManager.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/deploy/TomcatManager.java
@@ -520,11 +520,11 @@ public class TomcatManager implements DeploymentManager {
     }
 
     public boolean isJpa31() {
-        return false;
+        return isTomEE10();
     }
     
     public boolean isJpa32() {
-        return isTomEE10();
+        return false;
     }
 
     public boolean isJpa22() {

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
@@ -465,7 +465,7 @@ public class TomcatPlatformImpl extends J2eePlatformImpl2 {
             if (manager.getTomEEType().ordinal() >= 3 ) {
                 switch (manager.getTomEEVersion()) {
                     case TOMEE_100:
-                        profiles.add(Profile.JAKARTA_EE_11_FULL);
+                        profiles.add(Profile.JAKARTA_EE_10_FULL);
                     case TOMEE_90:
                         profiles.add(Profile.JAKARTA_EE_9_1_FULL);
                         break;
@@ -481,7 +481,7 @@ public class TomcatPlatformImpl extends J2eePlatformImpl2 {
             }
             switch (manager.getTomEEVersion()) {
                 case TOMEE_100:
-                    profiles.add(Profile.JAKARTA_EE_11_WEB);
+                    profiles.add(Profile.JAKARTA_EE_10_WEB);
                 case TOMEE_90:
                     profiles.add(Profile.JAKARTA_EE_9_1_WEB);
                     break;


### PR DESCRIPTION
- TomcatFactory does not return correct TomEE version when registering TomEE 10
- TomEE 10 support Jakarta EE 10
- TomEE 10 support JPA 3.1

NetBeans Testing:

- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Verify Sigtests
- Verify successful execution of unit tests for module `tomcat5`
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Successfully register TomEE 10 and run a Jakarta EE 10 Web App