### PR TITLE
Add the `Error` class and the `Throwable` interface as completion items for exceptions [GH-7594]

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
@@ -273,6 +273,8 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
     private static final List<String> INHERITANCE_KEYWORDS =
             Arrays.asList(new String[]{"extends", "implements"}); //NOI18N
     private static final String EXCEPTION_CLASS_NAME = "\\Exception"; // NOI18N
+    private static final String ERROR_CLASS_NAME = "\\Error"; // NOI18N
+    private static final String THROWABLE_INTERFACE_NAME = "\\Throwable"; // NOI18N
     private static final List<PHPTokenId> VALID_UNION_TYPE_TOKENS = Arrays.asList(
             PHPTokenId.WHITESPACE, PHPTokenId.PHP_STRING, PHPTokenId.PHP_NS_SEPARATOR,
             PHPTokenId.PHP_TYPE_BOOL, PHPTokenId.PHP_TYPE_FLOAT, PHPTokenId.PHP_TYPE_INT, PHPTokenId.PHP_TYPE_STRING, PHPTokenId.PHP_TYPE_VOID,
@@ -891,7 +893,8 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
             if (CancelSupport.getDefault().isCancelled()) {
                 return;
             }
-            if (isExceptionClass(classElement)) {
+            if (isExceptionClass(classElement)
+                    || isErrorClass(classElement)) {
                 completionResult.add(new PHPCompletionItem.ClassItem(classElement, request, false, null));
                 if (withConstructors) {
                     constructorClassNames.add(classElement.getFullyQualifiedName());
@@ -904,7 +907,8 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
                     if (CancelSupport.getDefault().isCancelled()) {
                         return;
                     }
-                    if (isExceptionClass(inheritedClass)) {
+                    if (isExceptionClass(inheritedClass)
+                            || isErrorClass(inheritedClass)) {
                         completionResult.add(new PHPCompletionItem.ClassItem(classElement, request, false, null));
                         if (withConstructors) {
                             constructorClassNames.add(classElement.getFullyQualifiedName());
@@ -912,6 +916,13 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
                         break;
                     }
                 }
+            }
+        }
+        final Set<InterfaceElement> interfaces = request.index.getInterfaces(nameQuery);
+        for (InterfaceElement interfaceElement : interfaces) {
+            if (isThrowableInterface(interfaceElement)) {
+                completionResult.add(new PHPCompletionItem.InterfaceItem(interfaceElement, request, false));
+                break;
             }
         }
         for (QualifiedName qualifiedName : constructorClassNames) {
@@ -924,6 +935,14 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
 
     private boolean isExceptionClass(ClassElement classElement) {
         return classElement.getFullyQualifiedName().toString().equals(EXCEPTION_CLASS_NAME);
+    }
+
+    private boolean isErrorClass(ClassElement classElement) {
+        return classElement.getFullyQualifiedName().toString().equals(ERROR_CLASS_NAME);
+    }
+
+    private boolean isThrowableInterface(InterfaceElement interfaceElement) {
+        return interfaceElement.getFullyQualifiedName().toString().equals(THROWABLE_INTERFACE_NAME);
     }
 
     private void autoCompleteClassNames(final PHPCompletionResult completionResult,

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/gh7594.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/gh7594.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+try {
+
+} catch(Thr) {
+
+}
+
+try {
+
+} catch(\Thr) {
+
+}
+
+try {
+
+} catch(Err) {
+
+}
+
+try {
+
+} catch(\Err) {
+
+}
+
+try {
+
+} catch(TypeE) {
+
+}
+
+try {
+
+} catch(\TypeE) {
+
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/gh7594.php.testGH7594_01a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/gh7594.php.testGH7594_01a.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+} catch(Thr|) {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      Throwable                       [PUBLIC]   stub.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/gh7594.php.testGH7594_01b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/gh7594.php.testGH7594_01b.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+} catch(\Thr|) {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      Throwable                       [PUBLIC]   stub.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/gh7594.php.testGH7594_02a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/gh7594.php.testGH7594_02a.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+} catch(Err|) {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      Error                           [PUBLIC]   stub.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/gh7594.php.testGH7594_02b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/gh7594.php.testGH7594_02b.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+} catch(\Err|) {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      Error                           [PUBLIC]   stub.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/gh7594.php.testGH7594_03a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/gh7594.php.testGH7594_03a.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+} catch(TypeE|) {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      TypeError                       [PUBLIC]   stub.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/gh7594.php.testGH7594_03b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/gh7594.php.testGH7594_03b.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+} catch(\TypeE|) {
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      TypeError                       [PUBLIC]   stub.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/stub.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/gh7594/stub.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+interface Throwable extends Stringable {}
+
+class Error implements \Throwable {}
+
+class TypeError extends \Error {}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionGH7594Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionGH7594Test.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class PHPCodeCompletionGH7594Test extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionGH7594Test(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected FileObject[] createSourceClassPathsForTest() {
+        return new FileObject[]{FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/gh7594/"))};
+    }
+
+    public void testGH7594_01a() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh7594/gh7594.php", "} catch(Thr^) {", false);
+    }
+
+    public void testGH7594_01b() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh7594/gh7594.php", "} catch(\\Thr^) {", false);
+    }
+
+    public void testGH7594_02a() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh7594/gh7594.php", "} catch(Err^) {", false);
+    }
+
+    public void testGH7594_02b() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh7594/gh7594.php", "} catch(\\Err^) {", false);
+    }
+
+    public void testGH7594_03a() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh7594/gh7594.php", "} catch(TypeE^) {", false);
+    }
+
+    public void testGH7594_03b() throws Exception {
+        checkCompletion("testfiles/completion/lib/gh7594/gh7594.php", "} catch(\\TypeE^) {", false);
+    }
+}


### PR DESCRIPTION
- https://github.com/apache/netbeans/issues/7594
- https://www.php.net/manual/en/language.errors.php7.php
- https://www.php.net/manual/en/class.error.php
- https://www.php.net/manual/en/class.throwable.php

Example:
```php
<?php
try {
} catch (Thro^) { // here, ^ is the caret position
}
```

Before:

![nb-php-gh-7594-before](https://github.com/user-attachments/assets/f30becc8-16ff-4244-ab4b-18f6653a01b6)

After:

![nb-php-gh-7594-after](https://github.com/user-attachments/assets/a5972c90-74a8-4017-bcfb-3bfd28dbacd3)
