### PR TITLE
Enterprise: Fix multiple places where null values could be encountered and are not protected

### DIFF
--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/dd/EjbJarXmlWizardIterator.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/dd/EjbJarXmlWizardIterator.java
@@ -94,15 +94,17 @@ public final class EjbJarXmlWizardIterator implements WizardDescriptor.Instantia
             String resource;
             // see #213631 - caused by fact that EJB DD schemas have different numbering than WEB DD schemas
             //   (so Java EE6 Web-DD is of the version 3.0, but Ejb-DD is of the version 3.1)
-            if (j2eeProfile.isAtLeast(Profile.JAKARTA_EE_9_WEB)) {
+            if (j2eeProfile != null && j2eeProfile.isAtLeast(Profile.JAKARTA_EE_9_WEB)) {
                 resource = "org-netbeans-modules-j2ee-ejbjarproject/ejb-jar-4.0.xml";
-            } else if (j2eeProfile.isAtLeast(Profile.JAVA_EE_7_WEB)) {
+            } else if (j2eeProfile != null && j2eeProfile.isAtLeast(Profile.JAVA_EE_7_WEB)) {
                 resource = "org-netbeans-modules-j2ee-ejbjarproject/ejb-jar-3.2.xml";
-            } else if (j2eeProfile.isAtLeast(Profile.JAVA_EE_6_WEB)) {
+            } else if (j2eeProfile != null && j2eeProfile.isAtLeast(Profile.JAVA_EE_6_WEB)) {
                 // ee6 web module is of the version 3.0 but the ee6 deployment descriptor schema should be of version 3.1
                 resource = "org-netbeans-modules-j2ee-ejbjarproject/ejb-jar-3.1.xml";
-            } else {
+            } else if (j2eeModule != null) {
                 resource = "org-netbeans-modules-j2ee-ejbjarproject/ejb-jar-" + j2eeModule.getModuleVersion() + ".xml";
+            } else {
+                return Collections.EMPTY_SET;
             }
             FileObject source = FileUtil.getConfigFile(resource);
             if (source == null) {

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/jaxws/EjbProjectJAXWSClientSupport.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/jaxws/EjbProjectJAXWSClientSupport.java
@@ -86,7 +86,7 @@ public class EjbProjectJAXWSClientSupport extends ProjectJAXWSClientSupport/* im
     @Override
     protected String getProjectJavaEEVersion() {
         EjbJar ejbModule = EjbJar.getEjbJar(project.getProjectDirectory());
-        if (ejbModule != null) {
+        if (ejbModule != null && ejbModule.getJ2eeProfile() != null) {
             switch (ejbModule.getJ2eeProfile()) {
                 case JAVA_EE_6_WEB:
                 case JAVA_EE_6_FULL:

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/jaxws/EjbProjectJAXWSSupport.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/jaxws/EjbProjectJAXWSSupport.java
@@ -157,7 +157,7 @@ public String addService(String name, String serviceImpl, String wsdlUrl, String
     @Override
     protected String getProjectJavaEEVersion() {
         EjbJar ejbModule = EjbJar.getEjbJar(project.getProjectDirectory());
-        if (ejbModule != null) {
+        if (ejbModule != null && ejbModule.getJ2eeProfile() != null) {
             switch (ejbModule.getJ2eeProfile()) {
                 case JAVA_EE_6_WEB:
                 case JAVA_EE_6_FULL:

--- a/enterprise/j2ee.ejbverification/src/org/netbeans/modules/j2ee/ejbverification/rules/PersistentTimerInEjbLite.java
+++ b/enterprise/j2ee.ejbverification/src/org/netbeans/modules/j2ee/ejbverification/rules/PersistentTimerInEjbLite.java
@@ -84,9 +84,9 @@ public final class PersistentTimerInEjbLite {
         final EJBProblemContext ctx = HintsUtils.getOrCacheContext(hintContext);
         if (ctx != null && ctx.getEjb() instanceof Session) {
             final Profile profile = ctx.getEjbModule().getJ2eeProfile();
-            boolean ee9lite = profile.isAtLeast(Profile.JAKARTA_EE_9_WEB);
-            boolean ee7lite = profile.isAtLeast(Profile.JAVA_EE_7_WEB);
-            boolean ee6lite = (profile == Profile.JAVA_EE_6_WEB);
+            boolean ee9lite = profile != null && profile.isAtLeast(Profile.JAKARTA_EE_9_WEB);
+            boolean ee7lite = profile != null && profile.isAtLeast(Profile.JAVA_EE_7_WEB);
+            boolean ee6lite = profile == Profile.JAVA_EE_6_WEB;
             J2eePlatform platform = ProjectUtil.getPlatform(ctx.getProject());
             if ((ee6lite || ee7lite || ee9lite) && nonEeFullServer(platform)) {
                 for (Element element : ctx.getClazz().getEnclosedElements()) {

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/api/WebProjectUtilities.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/api/WebProjectUtilities.java
@@ -836,7 +836,7 @@ public class WebProjectUtilities {
 
     public static void upgradeJ2EEProfile(WebProject project){
         Profile profile = project.getAPIEjbJar().getJ2eeProfile();
-        if (profile.isWebProfile() && profile.isAtLeast(Profile.JAVA_EE_6_WEB)) {
+        if (profile != null && profile.isWebProfile() && profile.isAtLeast(Profile.JAVA_EE_6_WEB)) {
             //check the J2EE 6/7 Full profile specific functionality
             Boolean isFullRequired = Boolean.FALSE;
             try{

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/jaxws/WebProjectJAXWSClientSupport.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/jaxws/WebProjectJAXWSClientSupport.java
@@ -109,7 +109,7 @@ public class WebProjectJAXWSClientSupport extends ProjectJAXWSClientSupport /*im
     @Override
     protected String getProjectJavaEEVersion() {
         WebModule webModule = WebModule.getWebModule(project.getProjectDirectory());
-        if (webModule != null) {
+        if (webModule != null && webModule.getJ2eeProfile() != null) {
             switch (webModule.getJ2eeProfile()) {
                 case JAVA_EE_6_WEB:
                 case JAVA_EE_6_FULL:

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/jaxws/WebProjectJAXWSSupport.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/jaxws/WebProjectJAXWSSupport.java
@@ -594,7 +594,7 @@ public class WebProjectJAXWSSupport extends ProjectJAXWSSupport /*implements JAX
     @Override
     protected String getProjectJavaEEVersion() {
         WebModule webModule = WebModule.getWebModule(project.getProjectDirectory());
-        if (webModule != null) {
+        if (webModule != null && webModule.getJ2eeProfile() != null) {
             switch (webModule.getJ2eeProfile()) {
                 case JAVA_EE_6_WEB:
                 case JAVA_EE_6_FULL:

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/ui/customizer/WebProjectProperties.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/ui/customizer/WebProjectProperties.java
@@ -375,30 +375,32 @@ public final class WebProjectProperties {
         PLATFORM_LIST_RENDERER = PlatformUiSupport.createPlatformListCellRenderer();
         SpecificationVersion minimalSourceLevel = null;
         Profile profile = Profile.fromPropertiesString(evaluator.getProperty(J2EE_PLATFORM));
-        switch (profile) {
-            case JAKARTA_EE_11_FULL:
-                minimalSourceLevel = new SpecificationVersion("21");
-                break;
-            case JAKARTA_EE_10_FULL:
-            case JAKARTA_EE_9_1_FULL:
-                minimalSourceLevel = new SpecificationVersion("11");
-                break;
-            case JAKARTA_EE_9_FULL:
-            case JAKARTA_EE_8_FULL:
-            case JAVA_EE_8_FULL:
-                minimalSourceLevel = new SpecificationVersion("1.8");
-                break;
-            case JAVA_EE_7_FULL:
-                minimalSourceLevel = new SpecificationVersion("1.7");
-                break;
-            case JAVA_EE_6_FULL:
-                minimalSourceLevel = new SpecificationVersion("1.6");
-                break;
-            case JAVA_EE_5:
-                minimalSourceLevel = new SpecificationVersion("1.5");
-                break;
-            default:
-                break;
+        if (profile != null) {
+            switch (profile) {
+                case JAKARTA_EE_11_FULL:
+                    minimalSourceLevel = new SpecificationVersion("21");
+                    break;
+                case JAKARTA_EE_10_FULL:
+                case JAKARTA_EE_9_1_FULL:
+                    minimalSourceLevel = new SpecificationVersion("11");
+                    break;
+                case JAKARTA_EE_9_FULL:
+                case JAKARTA_EE_8_FULL:
+                case JAVA_EE_8_FULL:
+                    minimalSourceLevel = new SpecificationVersion("1.8");
+                    break;
+                case JAVA_EE_7_FULL:
+                    minimalSourceLevel = new SpecificationVersion("1.7");
+                    break;
+                case JAVA_EE_6_FULL:
+                    minimalSourceLevel = new SpecificationVersion("1.6");
+                    break;
+                case JAVA_EE_5:
+                    minimalSourceLevel = new SpecificationVersion("1.5");
+                    break;
+                default:
+                    break;
+            }
         }
         JAVAC_SOURCE_MODEL = PlatformUiSupport.createSourceLevelComboBoxModel (PLATFORM_MODEL, evaluator.getProperty(JAVAC_SOURCE), evaluator.getProperty(JAVAC_TARGET), minimalSourceLevel);
         JAVAC_SOURCE_RENDERER = PlatformUiSupport.createSourceLevelListCellRenderer ();

--- a/enterprise/websocket/src/org/netbeans/modules/websocket/editor/WebSocketMethodsTask.java
+++ b/enterprise/websocket/src/org/netbeans/modules/websocket/editor/WebSocketMethodsTask.java
@@ -124,7 +124,7 @@ public class WebSocketMethodsTask implements CancellableTask<CompilationInfo> {
             return false;
         }
         Profile profile = webModule.getJ2eeProfile();
-        if (profile.isAtMost(Profile.JAVA_EE_6_FULL)) {
+        if (profile != null && profile.isAtMost(Profile.JAVA_EE_6_FULL)) {
             return false;
         }
         return true;

--- a/enterprise/websocket/src/org/netbeans/modules/websocket/wizard/WebSocketPanel.java
+++ b/enterprise/websocket/src/org/netbeans/modules/websocket/wizard/WebSocketPanel.java
@@ -78,7 +78,7 @@ class WebSocketPanel implements Panel<WizardDescriptor> {
         WebModule webModule = WebModule.getWebModule(project.getProjectDirectory());
         if (webModule != null) {
             Profile profile = webModule.getJ2eeProfile();
-            if (profile.isAtMost(Profile.JAVA_EE_6_FULL)) {
+            if (profile != null && profile.isAtMost(Profile.JAVA_EE_6_FULL)) {
                 setErrorMessage(NbBundle.getMessage(WebSocketPanel.class,
                         "MSG_NoJEE7Profile"));          // NOI18N
                 return false;

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/editor/AsyncConverter.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/editor/AsyncConverter.java
@@ -95,7 +95,7 @@ abstract class AsyncConverter {
             return false;
         }
         Profile profile = webModule.getJ2eeProfile();
-        if (profile.isAtMost(Profile.JAVA_EE_6_FULL)) {
+        if (profile != null && profile.isAtMost(Profile.JAVA_EE_6_FULL)) {
             return false;
         }
         return true;

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/wizard/InterceptorPanel.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/wizard/InterceptorPanel.java
@@ -80,7 +80,7 @@ public class InterceptorPanel implements Panel<WizardDescriptor> {
         WebModule webModule = WebModule.getWebModule(project.getProjectDirectory());
         if (webModule != null) {
             Profile profile = webModule.getJ2eeProfile();
-            if (profile.isAtMost(Profile.JAVA_EE_6_FULL)) {
+            if (profile != null && profile.isAtMost(Profile.JAVA_EE_6_FULL)) {
                 setErrorMessage(NbBundle.getMessage(InterceptorPanel.class,
                         "MSG_NoJEE7Profile"));          // NOI18N
                 return false;

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/wizard/JaxRsFilterPanel.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/wizard/JaxRsFilterPanel.java
@@ -89,7 +89,7 @@ class JaxRsFilterPanel implements Panel<WizardDescriptor> {
         WebModule webModule = WebModule.getWebModule(project.getProjectDirectory());
         if (webModule != null) {
             Profile profile = webModule.getJ2eeProfile();
-            if (profile.isAtMost(Profile.JAVA_EE_6_FULL)) {
+            if (profile != null && profile.isAtMost(Profile.JAVA_EE_6_FULL)) {
                 setErrorMessage(NbBundle.getMessage(JaxRsFilterPanel.class,
                         "MSG_NoJEE7Profile"));          // NOI18N
                 return false;

--- a/enterprise/websvc.restapi/src/org/netbeans/modules/websvc/rest/spi/RestSupport.java
+++ b/enterprise/websvc.restapi/src/org/netbeans/modules/websvc/rest/spi/RestSupport.java
@@ -495,7 +495,8 @@ public abstract class RestSupport {
         boolean isJee6 = Profile.JAVA_EE_6_WEB.equals(profile) ||
                 Profile.JAVA_EE_6_FULL.equals(profile);
         // Fix for BZ#216345: JAVA_EE_6_WEB profile doesn't contain JAX-RS API
-        return (isJee6 && MiscPrivateUtilities.supportsTargetProfile(project, Profile.JAVA_EE_6_FULL)) || profile.isAtLeast(Profile.JAVA_EE_7_WEB);
+        return (isJee6 && MiscPrivateUtilities.supportsTargetProfile(project, Profile.JAVA_EE_6_FULL)) 
+                || (profile != null && profile.isAtLeast(Profile.JAVA_EE_7_WEB));
     }
 
     /**


### PR DESCRIPTION
Observed exception:

```
java.lang.NullPointerException: Cannot invoke "org.netbeans.api.j2ee.core.Profile.isAtMost(org.netbeans.api.j2ee.core.Profile)" because "profile" is null
    at org.netbeans.modules.websvc.rest.editor.AsyncConverter.isApplicable(AsyncConverter.java:98)
    at org.netbeans.modules.websvc.rest.editor.AsyncConverterTask.run(AsyncConverterTask.java:61)
    at org.netbeans.modules.websvc.rest.editor.AsyncConverterTask.run(AsyncConverterTask.java:52)
[catch] at org.netbeans.modules.java.source.JavaSourceAccessor$CancelableTaskWrapper.run(JavaSourceAccessor.java:273)
    at org.netbeans.modules.parsing.impl.TaskProcessor.callParserResultTask(TaskProcessor.java:561)
    at org.netbeans.modules.parsing.impl.TaskProcessor$RequestPerformer.run(TaskProcessor.java:786)
    at org.openide.util.lookup.Lookups.executeWith(Lookups.java:288)
    at org.netbeans.modules.parsing.impl.TaskProcessor$RequestPerformer.execute(TaskProcessor.java:702)
    at org.netbeans.modules.parsing.impl.TaskProcessor$CompilationJob.run(TaskProcessor.java:663)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
    at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1403)
    at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
    at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
    at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2018)
```