### PR TITLE
Java LSP server: Associate a single source file with an available workspace with no client workspace folders in order to obtain the configured options

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/singlesourcefile/SingleFileOptionsQueryImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/singlesourcefile/SingleFileOptionsQueryImpl.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.java.lsp.server.singlesourcefile;
 import java.io.File;
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -67,6 +68,15 @@ public abstract class SingleFileOptionsQueryImpl implements SingleFileOptionsQue
                     }
                 }
 
+                for (Workspace w : workspaces) {
+                    // Since this is a single source file, associate it with
+                    // any workspace which has no client workspace folders.
+                    final List<FileObject> clientWorkspaceFolders = w.getClientWorkspaceFolders();
+                    if (clientWorkspaceFolders == null || clientWorkspaceFolders.isEmpty()) {
+                        final FileObject folder = file.isFolder() ? file : file.getParent();
+                        return getResult(w, folder == null ? file : folder);
+                    }
+                }
                 return null;
             }
         }


### PR DESCRIPTION
Java LSP server: Associate a single source file with an available workspace with no client workspace folders in order to obtain the configured options

# Issue
1. When a single-source file is opened in a workspace with no workspace folders, the global workspace options need to be made available to the operations done on that file.
    - In #7382, `SingleFileOptionsQueryImpl` introduced search for a single source file's parent in open workspaces' folders.
    - However, when `setConfiguration()` is invoked with `null` `workDirectory`, the options for the workspace are not made available to single-source files which are outside any workspace folders.
2. The netbeans IDE works around this by inserting 2 entries in the *attributes.xml*, one for the file and subsequently another one for its parent.
    - Example *~/Library/Application\ Support/NetBeans/dev/var/attributes.xml* 
    ```xml
    <?xml version="1.0" encoding="UTF-8"?>
    <!DOCTYPE attributes PUBLIC "-//NetBeans//DTD DefaultAttributes 1.0//EN" "http://www.netbeans.org/dtds/attributes-1_0.dtd">
    <attributes version="1.0">
        <fileobject name="|path|to|single|file">
            <attr name="single_file_vm_options" stringvalue="--enable-preview --source 23"/>
        </fileobject>
        <fileobject name="|path|to|single|file|Test.java">
            <attr name="single_file_vm_options" stringvalue="--enable-preview --source 23"/>
        </fileobject>
    </attributes>
    ```
4. However, the Java VS Code extension cannot achieve the same since the Java LSP server cannot apply this.

## Effect
Errors such as those resolved by vmOptions such as `--enable-preview` or a `--source <version>` continue to be flagged even when the single-source file can be run successfully.
-  Example *Test.java*:
    ```java
    public static void main(String... args) {
        System.out.println("Hello");
    }
    ```
- This can be reproduced in the IDE as well if the artificial entry added for the file's parent is removed from the *attributes.xml* as below:
    ```xml
    <?xml version="1.0" encoding="UTF-8"?>
    <!DOCTYPE attributes PUBLIC "-//NetBeans//DTD DefaultAttributes 1.0//EN" "http://www.netbeans.org/dtds/attributes-1_0.dtd">
    <attributes version="1.0">
        <fileobject name="|path|to|single|file|Test.java">
            <attr name="single_file_vm_options" stringvalue="--enable-preview --source 23"/>
        </fileobject>
    </attributes>
    ```
    - Visible error in the editor even though the file runs successfully:
    <img width="858" alt="Screenshot 2024-07-24 at 6 46 23 PM" src="https://github.com/user-attachments/assets/a67f53b1-db15-452c-b72f-a2a6b7459eca">

# Fix
1. Fixed `SingleFileOptionsQueryImpl.optionsFor()`:
    - to: associate a single-source file's parent with a workspace having no client workspace folders,
    - when: it has no associated workspace folder.
2. Updated the associated unit tests in `SingleFileOptionsQueryImplTest`.