### PR TITLE
Java LSP server: Associate a single source file with an available workspace with no client workspace folders in order to obtain the configured options

### DIFF
--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/singlesourcefile/SingleFileOptionsQueryImplTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/singlesourcefile/SingleFileOptionsQueryImplTest.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.java.lsp.server.singlesourcefile;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.netbeans.junit.NbTestCase;
@@ -58,6 +59,17 @@ public class SingleFileOptionsQueryImplTest extends NbTestCase {
         assertEquals(workspace2, SingleFileOptionsQueryImpl.findWorkspaceFolder(workspace, source2));
         assertEquals(workspace2, SingleFileOptionsQueryImpl.findWorkspaceFolder(workspace, source2.getParent()));
         assertEquals(workspace2, SingleFileOptionsQueryImpl.findWorkspaceFolder(workspace, source2.getParent().getParent()));
+
+        FileObject singleSourceDir = FileUtil.createFolder(wd, "standalone");
+        FileObject singleSourceFile = FileUtil.createData(singleSourceDir, "Test.java");
+
+        assertNull(SingleFileOptionsQueryImpl.findWorkspaceFolder(workspace, singleSourceFile));
+        assertNull(SingleFileOptionsQueryImpl.findWorkspaceFolder(workspace, singleSourceDir));
+
+        Workspace emptyWorkspace = new WorkspaceImpl(Collections.emptyList());
+
+        assertNull(SingleFileOptionsQueryImpl.findWorkspaceFolder(emptyWorkspace, singleSourceFile));
+        assertNull(SingleFileOptionsQueryImpl.findWorkspaceFolder(emptyWorkspace, singleSourceDir));
     }
 
     public void testWorkspaceOptions() throws Exception {
@@ -83,6 +95,17 @@ public class SingleFileOptionsQueryImplTest extends NbTestCase {
             assertEquals(workspace2.toURI(), query.optionsFor(source2).getWorkDirectory());
             assertEquals("-Dtest=test", query.optionsFor(source2.getParent()).getOptions());
             assertEquals(workspace2.toURI(), query.optionsFor(source2.getParent()).getWorkDirectory());
+
+            assertNotNull(query.optionsFor(source3));
+            assertEquals("-Dtest=test", query.optionsFor(source3).getOptions());
+            assertEquals(source3.getParent().toURI(), query.optionsFor(source3).getWorkDirectory());
+
+            assertNotNull(query.optionsFor(source3.getParent()));
+            assertEquals("-Dtest=test", query.optionsFor(source3.getParent()).getOptions());
+            assertEquals(source3.getParent().toURI(), query.optionsFor(source3.getParent()).getWorkDirectory());
+
+            assertEquals(query.optionsFor(source3), query.optionsFor(source3.getParent()));
+            assertNull(query.optionsFor(wd));
 
             AtomicInteger changeCount = new AtomicInteger();
 
@@ -148,6 +171,24 @@ public class SingleFileOptionsQueryImplTest extends NbTestCase {
         assertEquals(workspace2.toURI(), query.optionsFor(source2).getWorkDirectory());
         assertEquals("-Dtest=test2", query.optionsFor(source2.getParent()).getOptions());
         assertEquals(workspace2.toURI(), query.optionsFor(source2.getParent()).getWorkDirectory());
+
+        assertNotNull(query.optionsFor(source3));
+        assertEquals("-Dtest=test2", query.optionsFor(source3).getOptions());
+        assertEquals(source3.getParent().toURI(), query.optionsFor(source3).getWorkDirectory());
+        assertNotNull(query.optionsFor(source3.getParent()));
+        assertEquals("-Dtest=test2", query.optionsFor(source3.getParent()).getOptions());
+        assertEquals(source3.getParent().toURI(), query.optionsFor(source3.getParent()).getWorkDirectory());
+        assertEquals(query.optionsFor(source3), query.optionsFor(source3.getParent()));
+
+        // with multiple open workspaces:
+        Workspace emptyWorkspace = new WorkspaceImpl(Collections.emptyList());
+        query.setConfiguration(emptyWorkspace, "-Dtest=empty", null);
+
+        assertEquals("-Dtest=test2", query.optionsFor(source1).getOptions());
+        assertEquals(workspace1.toURI(), query.optionsFor(source1).getWorkDirectory());
+
+        assertEquals("-Dtest=test2", query.optionsFor(source2).getOptions());
+        assertEquals(workspace2.toURI(), query.optionsFor(source2).getWorkDirectory());
 
         assertNull(query.optionsFor(source3));
         assertNull(query.optionsFor(source3.getParent()));


### PR DESCRIPTION
Java LSP server: Associate a single source file with an available workspace with no client workspace folders in order to obtain the configured options

# Issue
1. When a single-source file is opened in a workspace with no workspace folders, the global workspace options need to be made available to the operations done on that file.
    - In #7382, `SingleFileOptionsQueryImpl` introduced search for a single source file's parent in open workspaces' folders.
    - However, when `setConfiguration()` is invoked with `null` `workDirectory`, the options for the workspace are not made available to single-source files which are outside any workspace folders.
2. The netbeans IDE works around this by inserting 2 entries in the *attributes.xml*, one for the file and subsequently another one for its parent.
    - Example *~/Library/Application Support/NetBeans/dev/var/attributes.xml* 
    ```xml
    <?xml version="1.0" encoding="UTF-8"?>
    <!DOCTYPE attributes PUBLIC "-//NetBeans//DTD DefaultAttributes 1.0//EN" "http://www.netbeans.org/dtds/attributes-1_0.dtd">
    <attributes version="1.0">
        <fileobject name="|path|to|single|file">
            <attr name="single_file_vm_options" stringvalue="--enable-preview --source 23"/>
        </fileobject>
        <fileobject name="|path|to|single|file|Test.java">
            <attr name="single_file_vm_options" stringvalue="--enable-preview --source 23"/>
        </fileobject>
    </attributes>
    ```
4. However, the Java VS Code extension cannot achieve the same since the Java LSP server cannot apply this.

## Effect
Errors such as those resolved by vmOptions such as `--enable-preview` or a `--source <version>` continue to be flagged even when the single-source file can be run successfully.
-  Example *Test.java*:
    ```java
    public static void main(String... args) {
        System.out.println("Hello");
    }
    ```
- This can be reproduced in the IDE as well if the artificial entry added for the file's parent is removed from the *attributes.xml* as below:
    ```xml
    <?xml version="1.0" encoding="UTF-8"?>
    <!DOCTYPE attributes PUBLIC "-//NetBeans//DTD DefaultAttributes 1.0//EN" "http://www.netbeans.org/dtds/attributes-1_0.dtd">
    <attributes version="1.0">
        <fileobject name="|path|to|single|file|Test.java">
            <attr name="single_file_vm_options" stringvalue="--enable-preview --source 23"/>
        </fileobject>
    </attributes>
    ```
    - Visible error in the editor even though the file runs successfully:
    <img width="858" alt="Screenshot 2024-07-24 at 6 46 23 PM" src="https://github.com/user-attachments/assets/a67f53b1-db15-452c-b72f-a2a6b7459eca">

# Fix
1. Fixed `SingleFileOptionsQueryImpl.optionsFor()`:
    - to: associate a single-source file's parent with a workspace having no client workspace folders,
    - when: it has no associated workspace folder.
2. Updated the associated unit tests in `SingleFileOptionsQueryImplTest`.