### PR TITLE
Group application properties by type for Create External Config Properties command

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/assets/ApplicationPropertiesGenerator.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/assets/ApplicationPropertiesGenerator.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.cloud.oracle.assets;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ *
+ * @author Dusan Petrovic
+ */
+public class ApplicationPropertiesGenerator {
+
+    private static final String COMMENT_START = "# "; //NOI18N
+    private static final String NEW_LINE = "\n"; //NOI18N
+
+    final PropertiesGenerator propertiesGenerator;
+
+    public ApplicationPropertiesGenerator(PropertiesGenerator propertiesGenerator) {
+        this.propertiesGenerator = propertiesGenerator;
+    }
+
+    public String getApplicationPropertiesString() {
+        StringBuilder sb = new StringBuilder();
+        appendApplicationProperties(sb);
+        separatePropertiesSections(sb);
+        appendBootstrapProperties(sb);
+        return sb.toString();
+    }
+
+    private void separatePropertiesSections(StringBuilder sb) {
+        if (!this.propertiesGenerator.getApplication().isEmpty()) {
+            sb.append(NEW_LINE);
+        }
+    }
+
+    private void appendApplicationProperties(StringBuilder sb) {
+        appendComments(sb,
+                "Generated application.properties", //NOI18N
+                "Uncomment following line when running inside Oracle Cloud", //NOI18N
+                "oci.config.instance-principal.enabled=true" //NOI18N
+                );
+        appendDateComment(sb);
+        appendProperties(sb, new TreeMap<>(this.propertiesGenerator.getApplication()));
+    }
+
+    private void appendBootstrapProperties(StringBuilder sb) {
+        appendComments(sb, "Generated bootstrap.properties"); //NOI18N
+        appendProperties(sb, new TreeMap<>(this.propertiesGenerator.getBootstrap()));
+    }
+
+    private void appendComments(StringBuilder sb, String ...comments) {
+        for (String comment : comments) {
+            sb.append(COMMENT_START)
+                    .append(comment)
+                    .append(NEW_LINE);
+        }
+    }
+
+    private void appendDateComment(StringBuilder sb) {
+        sb.append(COMMENT_START)
+                .append(new Date())
+                .append(NEW_LINE);
+    }
+
+    private void appendProperties(StringBuilder sb, Map<String, String> sortedProperties) {
+        String groupName = null;
+        for (Map.Entry<String, String> entry : sortedProperties.entrySet()) {
+            if (entry.getKey() == null) continue;
+
+            String currentGroupName = getCurrentPropertyGroupName(entry);
+            if (!currentGroupName.equals(groupName)) {
+                groupName = currentGroupName;
+                sb.append(NEW_LINE);
+            }
+
+            sb.append(entry.getKey())
+                    .append("=")  //NOI18N
+                    .append(entry.getValue())
+                    .append(NEW_LINE);
+        }
+    }
+
+    private String getCurrentPropertyGroupName(Map.Entry<String, String> entry) {
+        int dotIndex = entry.getKey().indexOf('.'); //NOI18N
+        return dotIndex > -1 ? entry.getKey().substring(0, dotIndex) : entry.getKey();
+    }
+}

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/assets/CreatePoliciesCommand.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/assets/CreatePoliciesCommand.java
@@ -18,13 +18,10 @@
  */
 package org.netbeans.modules.cloud.oracle.assets;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.netbeans.modules.cloud.oracle.policy.PolicyGenerator;
@@ -73,19 +70,10 @@ public class CreatePoliciesCommand implements CommandProvider {
                 });
             return future;
         } else if (COMMAND_CREATE_CONFIG.equals(command)) {
-            StringWriter writer = new StringWriter();
-            Properties dbProps = new Properties();
             PropertiesGenerator propGen = new PropertiesGenerator(false);
-            dbProps.putAll(propGen.getApplication());
-            dbProps.putAll(propGen.getBootstrap());
-            try {
-                dbProps.store(writer, "Generated application.properties\n" //NOI18N
-                    + "Uncomment following line when running inside Oracle Cloud\n" //NOI18N
-                    + "oci.config.instance-principal.enabled=true"); //NOI18N
-                future.complete(writer.toString());
-            } catch (IOException ex) {
-                future.completeExceptionally(ex);
-            }
+            ApplicationPropertiesGenerator appPropGen = new ApplicationPropertiesGenerator(propGen);
+            String toWrite = appPropGen.getApplicationPropertiesString();
+            future.complete(toWrite);
         } else if (COMMAND_CLOUD_ASSETS_REFRESH.equals(command)) {
             CloudAssets.getDefault().update();
         }


### PR DESCRIPTION
In the Cloud Assets window, the properties lines are not grouped by type after using the Create External Config Properties command, causing disorganization and difficulty when reading them. 