### PR TITLE
[#5439] - Manage JumpTo/GoTo settings from the file search dialog

### DIFF
--- a/ide/jumpto/src/org/netbeans/modules/jumpto/file/Bundle.properties
+++ b/ide/jumpto/src/org/netbeans/modules/jumpto/file/Bundle.properties
@@ -22,11 +22,13 @@ editor-popup-CTL_FileSearchAction=File...
 CTL_Open=&OK
 CTL_SelectInProjects=&Select in Projects
 CTL_Close=&Close
+CTL_Save=&Save
 # {0} = project name
 MSG_FileSearchDlgTitle=Go to File
 CTL_FileName=File &Name (prefix, wildcards: "?" "*"):
 CTL_MatchingFiles=&Matching Files
 CTL_CaseSensitive=&Case Sensitive
+CTL_Manage=Mana&ge...
 
 LBL_Location=&Location\:
 
@@ -59,3 +61,5 @@ AD_SearchText=Search text
 
 AN_FileSearchDialog=Go To File
 AD_FileSearchDialog=Go To File
+
+MSG_SettingsDlgTitle="Go To Settings"

--- a/ide/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchAction.java
+++ b/ide/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchAction.java
@@ -22,7 +22,6 @@
 
 package org.netbeans.modules.jumpto.file;
 
-import org.netbeans.modules.jumpto.common.CurrentSearch;
 import java.awt.Dialog;
 import java.awt.Dimension;
 import java.awt.Rectangle;
@@ -58,8 +57,8 @@ import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.editor.JumpList;
-import org.netbeans.modules.jumpto.EntityComparator;
 import org.netbeans.modules.jumpto.common.AbstractModelFilter;
+import org.netbeans.modules.jumpto.common.CurrentSearch;
 import org.netbeans.modules.jumpto.common.ItemRenderer;
 import org.netbeans.modules.jumpto.common.Models;
 import org.netbeans.modules.jumpto.common.Utils;
@@ -179,7 +178,7 @@ public class FileSearchAction extends AbstractAction implements FileSearchPanel.
 
 
     @Override
-    public boolean setListModel(final FileSearchPanel panel, String text ) {
+    public boolean setListModel(final FileSearchPanel panel, String text, boolean force) {
         enableOK(false);
 
         cancel();
@@ -218,7 +217,7 @@ public class FileSearchAction extends AbstractAction implements FileSearchPanel.
         // Compute in other thread
         synchronized(this) {
             final SearchType searchType = Utils.toSearchType(nameKind);
-            if (currentSearch.isNarrowing(searchType, text, getSearchScope(panel), true)) {
+            if (!force && currentSearch.isNarrowing(searchType, text, getSearchScope(panel), true)) {
                 itemsComparator.setUsePreferred(panel.isPreferedProject());
                 itemsComparator.setText(text);
                 filterFactory.setLineNumber(lineNr);
@@ -383,6 +382,7 @@ public class FileSearchAction extends AbstractAction implements FileSearchPanel.
         // Set size
         d.setPreferredSize( new Dimension(  FileSearchOptions.getWidth(),
                                                  FileSearchOptions.getHeight() ) );
+        d.setMinimumSize(new Dimension(FileSearchOptions.MIN_WIDTH, FileSearchOptions.MIN_HEIGHT));
 
         // Center the dialog after the size changed.
         Rectangle r = Utilities.getUsableScreenBounds();

--- a/ide/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchOptions.java
+++ b/ide/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchOptions.java
@@ -29,10 +29,13 @@ import org.openide.util.NbPreferences;
  * @author Andrei Badea, Petr Hrebejk
  */
 public class FileSearchOptions  {
-        
+
+    public static final int MIN_HEIGHT = 350;
+    public static final int MIN_WIDTH = 650;
+
     private static final String CASE_SENSITIVE = "caseSensitive"; // NOI18N
-    private static final String SHOW_HIDDEN_FILES = "showHiddenFiles"; // NOI18N 
-    private static final String PREFER_MAIN_PROJECT = "preferMainProject"; // NOI18N    
+    private static final String SHOW_HIDDEN_FILES = "showHiddenFiles"; // NOI18N
+    private static final String PREFER_MAIN_PROJECT = "preferMainProject"; // NOI18N
     private static final String SEARCH_BY_FOLDERS = "searchByFolders"; // NOI18N
     private static final String WIDTH = "width"; // NOI18N
     private static final String HEIGHT = "height"; // NOI18N
@@ -46,7 +49,7 @@ public class FileSearchOptions  {
     public static void setCaseSensitive( boolean caseSensitive) {
         getNode().putBoolean(CASE_SENSITIVE, caseSensitive);
     }
-    
+
     public static boolean getShowHiddenFiles() {
         return getNode().getBoolean(SHOW_HIDDEN_FILES, false);
     }
@@ -62,7 +65,7 @@ public class FileSearchOptions  {
     public static void setPreferMainProject( boolean preferMainProject) {
         getNode().putBoolean(PREFER_MAIN_PROJECT, preferMainProject);
     }
-    
+
     public static void setSearchByFolders(boolean preferMainProject) {
         getNode().putBoolean(SEARCH_BY_FOLDERS, preferMainProject);
     }
@@ -95,12 +98,12 @@ public class FileSearchOptions  {
             Exceptions.printStackTrace(ex);
         }
     }
-    
+
     private static synchronized Preferences getNode() {
-        if ( node == null ) {                
+        if ( node == null ) {
             node = NbPreferences.forModule(FileSearchOptions.class);
         }
         return node;
     }
-    
+
 }

--- a/ide/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchPanel.form
+++ b/ide/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchPanel.form
@@ -29,7 +29,7 @@
       </Border>
     </Property>
     <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-      <Dimension value="[540, 280]"/>
+      <Dimension value="[575, 280]"/>
     </Property>
   </Properties>
   <AuxValues>
@@ -40,7 +40,7 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,-124,0,0,2,85"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,-124,0,0,2,103"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
@@ -117,7 +117,7 @@
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="0" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="8" insetsRight="0" anchor="10" weightX="0.0" weightY="1.0"/>
+          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="0" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="8" insetsRight="0" anchor="10" weightX="1.0" weightY="1.0"/>
         </Constraint>
       </Constraints>
 
@@ -191,7 +191,7 @@
       </AccessibilityProperties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="4" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -213,7 +213,7 @@
       </AccessibilityProperties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="8" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="4" insetsLeft="8" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -235,7 +235,7 @@
       </AccessibilityProperties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="8" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="4" insetsLeft="8" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -250,7 +250,28 @@
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="0" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="8" insetsBottom="0" insetsRight="0" anchor="18" weightX="1.0" weightY="0.0"/>
+          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="4" insetsLeft="8" insetsBottom="0" insetsRight="0" anchor="18" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+    <Component class="javax.swing.JButton" name="gotoSettingsBtn">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/jumpto/file/Bundle.properties" key="CTL_Manage" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+        <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
+          <Insets value="[2, 10, 2, 10]"/>
+        </Property>
+        <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[80, 24]"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="gotoSettingsBtnActionPerformed"/>
+      </Events>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="0" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="8" insetsBottom="0" insetsRight="0" anchor="13" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -273,7 +294,7 @@
       </AccessibilityProperties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="0" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="8" insetsLeft="0" insetsBottom="4" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="0" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="8" insetsLeft="0" insetsBottom="4" insetsRight="0" anchor="17" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>

--- a/ide/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchPanel.java
+++ b/ide/jumpto/src/org/netbeans/modules/jumpto/file/FileSearchPanel.java
@@ -20,9 +20,12 @@
 package org.netbeans.modules.jumpto.file;
 
 import java.awt.Color;
+import java.awt.Dialog;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
@@ -34,6 +37,7 @@ import javax.swing.BorderFactory;
 import javax.swing.ButtonModel;
 import javax.swing.Icon;
 import javax.swing.InputMap;
+import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JList;
@@ -56,8 +60,15 @@ import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.modules.jumpto.SearchHistory;
 import org.netbeans.modules.jumpto.common.UiUtils;
+import org.netbeans.modules.jumpto.settings.JumpToOptionsPanelController;
 import org.netbeans.spi.jumpto.file.FileDescriptor;
+import org.netbeans.spi.options.OptionsPanelController;
+import org.openide.DialogDescriptor;
+import org.openide.DialogDisplayer;
+import org.openide.awt.Mnemonics;
+import org.openide.util.HelpCtx;
 import org.openide.util.ImageUtilities;
+import org.openide.util.Lookup;
 import org.openide.util.Mutex;
 import org.openide.util.NbBundle;
 import org.openide.util.NbCollections;
@@ -81,7 +92,7 @@ public class FileSearchPanel extends javax.swing.JPanel implements ActionListene
     private final ContentProvider contentProvider;
     private final Project currentProject;
     private boolean containsScrollPane;
-    private JLabel messageLabel;
+    private final JLabel messageLabel;
     private List<?> selectedItems;
     /* package */ long time;
 
@@ -113,7 +124,7 @@ public class FileSearchPanel extends javax.swing.JPanel implements ActionListene
         messageLabel.setEnabled(true);
         messageLabel.setText(NbBundle.getMessage(FileSearchPanel.class, "TXT_NoTypesFound")); // NOI18N
         messageLabel.setFont(resultList.getFont());
-        
+
         caseSensitiveCheckBox.setSelected(FileSearchOptions.getCaseSensitive());
         hiddenFilesCheckBox.setSelected(FileSearchOptions.getShowHiddenFiles());
         mainProjectCheckBox.setSelected(FileSearchOptions.getPreferMainProject());
@@ -128,13 +139,13 @@ public class FileSearchPanel extends javax.swing.JPanel implements ActionListene
                 "FMT_CurrentProjectLabel",
                 ProjectUtils.getInformation(currentProject).getDisplayName()));
         }
-        
+
         mainProjectCheckBox.addActionListener(this);
         caseSensitiveCheckBox.addActionListener(this);
         hiddenFilesCheckBox.addActionListener(this);
         hiddenFilesCheckBox.setVisible(false);
 	searchByFolders.addActionListener(this);
-        
+
         resultList.setCellRenderer( contentProvider.getListCellRenderer(
                 resultList,
                 fileNameTextField.getDocument(),
@@ -151,17 +162,17 @@ public class FileSearchPanel extends javax.swing.JPanel implements ActionListene
                     selectedItems);
             }
         });
-        contentProvider.setListModel( this, null );
-                
+        contentProvider.setListModel(this, null, false);
+
         fileNameTextField.getDocument().addDocumentListener(new DocumentListener() {
             public void changedUpdate(DocumentEvent e) {
                 update();
             }
-            
+
             public void insertUpdate(DocumentEvent e) {
                 update();
             }
-            
+
             public void removeUpdate(DocumentEvent e) {
                 // handling http://netbeans.org/bugzilla/show_bug.cgi?id=203119
                 if (pastedFromClipboard) {
@@ -280,9 +291,9 @@ public class FileSearchPanel extends javax.swing.JPanel implements ActionListene
            containsScrollPane = true;
            revalidate();
            repaint();
-        }        
-        else if ( message != null ) { 
-           jTextFieldLocation.setText(""); 
+        }
+        else if ( message != null ) {
+           jTextFieldLocation.setText("");
            messageLabel.setText(message);
            messageLabel.setIcon( waitIcon ? WAIT_ICON : null);
            if ( containsScrollPane ) {
@@ -292,29 +303,34 @@ public class FileSearchPanel extends javax.swing.JPanel implements ActionListene
            }
            revalidate();
            repaint();
-       }                
+       }
     }
-    
+
     public boolean isShowHiddenFiles() {
         return hiddenFilesCheckBox.isSelected();
     }
-    
+
     public boolean isPreferedProject() {
         return mainProjectCheckBox.isSelected();
     }
-    
+
     public boolean isCaseSensitive() {
         return caseSensitiveCheckBox.isSelected();
     }
-    
+
     public boolean isSearchByFolders() {
         return searchByFolders.isSelected();
     }
 
     private void update() {
+        update(false);
+    }
+
+    // Forcing a refresh is costly, but reloads the configuration settings
+    private void update(boolean forceRefresh) {
         time = System.currentTimeMillis();
         final String text = getText();
-        if (contentProvider.setListModel(this, text)) {
+        if (contentProvider.setListModel(this, text, forceRefresh)) {
             setListPanelContent(NbBundle.getMessage(FileSearchPanel.class, "TXT_Searching"),true);
         }
     }
@@ -351,11 +367,12 @@ public class FileSearchPanel extends javax.swing.JPanel implements ActionListene
         hiddenFilesCheckBox = new javax.swing.JCheckBox();
         mainProjectCheckBox = new javax.swing.JCheckBox();
         searchByFolders = new javax.swing.JCheckBox();
+        gotoSettingsBtn = new javax.swing.JButton();
         jLabelLocation = new javax.swing.JLabel();
         jTextFieldLocation = new javax.swing.JTextField();
 
         setBorder(javax.swing.BorderFactory.createEmptyBorder(8, 8, 8, 8));
-        setPreferredSize(new java.awt.Dimension(540, 280));
+        setPreferredSize(new java.awt.Dimension(575, 280));
         setLayout(new java.awt.GridBagLayout());
 
         fileNameLabel.setFont(fileNameLabel.getFont());
@@ -421,6 +438,7 @@ public class FileSearchPanel extends javax.swing.JPanel implements ActionListene
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridwidth = java.awt.GridBagConstraints.REMAINDER;
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 8, 0);
         add(listPanel, gridBagConstraints);
@@ -429,6 +447,7 @@ public class FileSearchPanel extends javax.swing.JPanel implements ActionListene
         caseSensitiveCheckBox.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.insets = new java.awt.Insets(4, 0, 0, 0);
         add(caseSensitiveCheckBox, gridBagConstraints);
         caseSensitiveCheckBox.getAccessibleContext().setAccessibleDescription(org.openide.util.NbBundle.getMessage(FileSearchPanel.class, "AD_CaseSensitive")); // NOI18N
 
@@ -436,7 +455,7 @@ public class FileSearchPanel extends javax.swing.JPanel implements ActionListene
         hiddenFilesCheckBox.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
-        gridBagConstraints.insets = new java.awt.Insets(0, 8, 0, 0);
+        gridBagConstraints.insets = new java.awt.Insets(4, 8, 0, 0);
         add(hiddenFilesCheckBox, gridBagConstraints);
         hiddenFilesCheckBox.getAccessibleContext().setAccessibleDescription(org.openide.util.NbBundle.getMessage(FileSearchPanel.class, "AD_HiddenFiles")); // NOI18N
 
@@ -444,24 +463,36 @@ public class FileSearchPanel extends javax.swing.JPanel implements ActionListene
         mainProjectCheckBox.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
-        gridBagConstraints.insets = new java.awt.Insets(0, 8, 0, 0);
+        gridBagConstraints.insets = new java.awt.Insets(4, 8, 0, 0);
         add(mainProjectCheckBox, gridBagConstraints);
         mainProjectCheckBox.getAccessibleContext().setAccessibleDescription(org.openide.util.NbBundle.getMessage(FileSearchPanel.class, "AD_PreferMainProject")); // NOI18N
 
         org.openide.awt.Mnemonics.setLocalizedText(searchByFolders, "Search by Folders");
         searchByFolders.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
         gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridwidth = java.awt.GridBagConstraints.REMAINDER;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
-        gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.insets = new java.awt.Insets(0, 8, 0, 0);
+        gridBagConstraints.insets = new java.awt.Insets(4, 8, 0, 0);
         add(searchByFolders, gridBagConstraints);
+
+        org.openide.awt.Mnemonics.setLocalizedText(gotoSettingsBtn, org.openide.util.NbBundle.getMessage(FileSearchPanel.class, "CTL_Manage")); // NOI18N
+        gotoSettingsBtn.setMargin(new java.awt.Insets(2, 10, 2, 10));
+        gotoSettingsBtn.setMaximumSize(new java.awt.Dimension(80, 24));
+        gotoSettingsBtn.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                gotoSettingsBtnActionPerformed(evt);
+            }
+        });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridwidth = java.awt.GridBagConstraints.REMAINDER;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.EAST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 8, 0, 0);
+        add(gotoSettingsBtn, gridBagConstraints);
 
         jLabelLocation.setLabelFor(jTextFieldLocation);
         org.openide.awt.Mnemonics.setLocalizedText(jLabelLocation, org.openide.util.NbBundle.getMessage(FileSearchPanel.class, "LBL_Location")); // NOI18N
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridwidth = java.awt.GridBagConstraints.REMAINDER;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(8, 0, 4, 0);
         add(jLabelLocation, gridBagConstraints);
@@ -525,8 +556,6 @@ private void resultListValueChanged(javax.swing.event.ListSelectionEvent evt) {/
             "selectPreviousRowExtendSelection".equals(actionKey) || // NOI18N
             "selectNextRow".equals(actionKey) || // NOI18N
             "selectNextRowExtendSelection".equals(actionKey) || // NOI18N
-            // "selectFirstRow".equals(action) || // NOI18N
-            // "selectLastRow".equals(action) || // NOI18N
             "scrollUp".equals(actionKey) || // NOI18N
             "scrollUpExtendSelection".equals(actionKey) || // NOI18N
             "scrollDown".equals(actionKey) || // NOI18N
@@ -579,11 +608,58 @@ private void resultListValueChanged(javax.swing.event.ListSelectionEvent evt) {/
             }
         }
     }//GEN-LAST:event_fileNameTextFieldKeyPressed
-    
+
+    private void gotoSettingsBtnActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_gotoSettingsBtnActionPerformed
+        JumpToOptionsPanelController jumpToController = new JumpToOptionsPanelController();
+        jumpToController.update();
+
+        JButton saveSettingsBtn = new JButton();
+        Mnemonics.setLocalizedText(saveSettingsBtn, NbBundle.getMessage(FileSearchPanel.class, "CTL_Save"));
+        saveSettingsBtn.getAccessibleContext().setAccessibleDescription(saveSettingsBtn.getText());
+        saveSettingsBtn.setEnabled(false);
+
+        jumpToController.addPropertyChangeListener(pcEvt -> {
+            if (OptionsPanelController.PROP_CHANGED.equals(pcEvt.getPropertyName())) {
+                saveSettingsBtn.setEnabled(true);
+            }
+        });
+
+        saveSettingsBtn.addActionListener(ae -> {
+            jumpToController.applyChanges();
+
+            update(true);
+        });
+
+        Object[] buttons = new Object[] { saveSettingsBtn, DialogDescriptor.CANCEL_OPTION };
+
+        DialogDescriptor dialogDescriptor = new DialogDescriptor(
+                jumpToController.getComponent(Lookup.EMPTY),
+                NbBundle.getMessage(FileSearchPanel.class, "MSG_SettingsDlgTitle"),
+                true,
+                buttons,
+                null,
+                DialogDescriptor.DEFAULT_ALIGN,
+                HelpCtx.DEFAULT_HELP,
+                null);
+        dialogDescriptor.setClosingOptions(buttons);
+
+        final Dialog settingsDialog = DialogDisplayer.getDefault().createDialog(dialogDescriptor);
+
+        settingsDialog.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosed(WindowEvent e) {
+                settingsDialog.dispose();
+            }
+        });
+
+        settingsDialog.setVisible(true);
+    }//GEN-LAST:event_gotoSettingsBtnActionPerformed
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JCheckBox caseSensitiveCheckBox;
     private javax.swing.JLabel fileNameLabel;
     private javax.swing.JTextField fileNameTextField;
+    private javax.swing.JButton gotoSettingsBtn;
     private javax.swing.JCheckBox hiddenFilesCheckBox;
     private javax.swing.JLabel jLabelLocation;
     private javax.swing.JLabel jLabelWarningMessage;
@@ -595,16 +671,17 @@ private void resultListValueChanged(javax.swing.event.ListSelectionEvent evt) {/
     private javax.swing.JScrollPane resultScrollPane;
     private javax.swing.JCheckBox searchByFolders;
     // End of variables declaration//GEN-END:variables
-    
+
+    @Override
     public void actionPerformed(ActionEvent e) {
         if ( e.getSource() == caseSensitiveCheckBox ) {
             FileSearchOptions.setCaseSensitive(caseSensitiveCheckBox.isSelected());
         }
         else if ( e.getSource() == hiddenFilesCheckBox ) {
-            FileSearchOptions.setShowHiddenFiles(hiddenFilesCheckBox.isSelected());            
+            FileSearchOptions.setShowHiddenFiles(hiddenFilesCheckBox.isSelected());
         }
-        else if ( e.getSource() == mainProjectCheckBox ) {            
-            FileSearchOptions.setPreferMainProject(isPreferedProject());            
+        else if ( e.getSource() == mainProjectCheckBox ) {
+            FileSearchOptions.setPreferMainProject(isPreferedProject());
         }
         else if ( e.getSource() == searchByFolders ) {
             FileSearchOptions.setSearchByFolders(searchByFolders.isSelected());
@@ -612,7 +689,7 @@ private void resultListValueChanged(javax.swing.event.ListSelectionEvent evt) {/
 
         update();
     }
-    
+
     /** Sets the initial text to find in case the user did not start typing yet. */
     public void setInitialText( final String text ) {
         SwingUtilities.invokeLater( new Runnable() {
@@ -640,8 +717,8 @@ private void resultListValueChanged(javax.swing.event.ListSelectionEvent evt) {/
 
     private int getFontSize () {
         return this.resultLabel.getFont().getSize();
-    }        
-    
+    }
+
     public void setSelectedFile() {
         List<FileDescriptor> list = NbCollections.checkedListByCopy(Arrays.asList(resultList.getSelectedValues()), FileDescriptor.class, true);
         selectedFile = list.toArray(new FileDescriptor[0]);
@@ -655,18 +732,6 @@ private void resultListValueChanged(javax.swing.event.ListSelectionEvent evt) {/
        return currentProject;
    }
 
-//    public boolean accept(Object obj) {
-//        if ( obj instanceof FileDescription ) {
-//            FileDescription fd = (FileDescription)obj;
-//            return isShowHiddenFiles() ? true : fd.isVisible();
-//        }
-//        return true;
-//    }
-//
-//    public void scheduleUpdate(Runnable run) {
-//        SwingUtilities.invokeLater( run );
-//    }
-
     public static interface ContentProvider {
 
         public ListCellRenderer getListCellRenderer(
@@ -676,7 +741,7 @@ private void resultListValueChanged(javax.swing.event.ListSelectionEvent evt) {/
                 @NonNull ButtonModel colorPrefered,
                 @NonNull ButtonModel searchFolders);
 
-        public boolean setListModel( FileSearchPanel panel, String text );
+        public boolean setListModel(FileSearchPanel panel, String text, boolean forceRefresh);
 
         public void closeDialog();
 


### PR DESCRIPTION
With reference to #5439, this changes proposes following the convention of a "Manage..." behavior, allowing quick access to the relevant settings associated with the feature.

Reason for this proposal is the detached nature of the configuration at current.  The [answer](https://github.com/apache/netbeans/issues/5439#issuecomment-1510208863) should have been the immediate response.

The alternative to this proposed change (or something similar) is to change the default configuration for the Jump To feature, but it does not resolve the issue of being unaware of the available settings.