### PR TITLE
Fix Command Prefixing Issue in Source Action

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ConstructorGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ConstructorGenerator.java
@@ -188,7 +188,7 @@ public final class ConstructorGenerator extends CodeActionsProvider {
         data.put(OFFSET, startOffset);
         data.put(CONSTRUCTORS, constructors);
         data.put(FIELDS, fields);
-        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateConstructor(), isSource ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, null, "nbls.generate.code", GENERATE_CONSTRUCTOR, data));
+        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateConstructor(), isSource ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, null, "nbls.generate.code", Utils.encodeCommand(GENERATE_CONSTRUCTOR, client.getNbCodeCapabilities()), data));
     }
 
     @Override

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/DelegateMethodGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/DelegateMethodGenerator.java
@@ -137,7 +137,7 @@ public final class DelegateMethodGenerator extends CodeActionsProvider {
         data.put(OFFSET, offset);
         data.put(TYPE, typeItem);
         data.put(FIELDS, fields);
-        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateDelegateMethod(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_DELEGATE_METHOD, data));
+        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateDelegateMethod(), CODE_GENERATOR_KIND, null, "nbls.generate.code", Utils.encodeCommand(GENERATE_DELEGATE_METHOD, client.getNbCodeCapabilities()), data));
     }
 
     @Override

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/EqualsHashCodeGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/EqualsHashCodeGenerator.java
@@ -115,11 +115,11 @@ public final class EqualsHashCodeGenerator extends CodeActionsProvider {
         String uri = Utils.toUri(info.getFileObject());
         if (equalsHashCode[0] == null) {
             if (equalsHashCode[1] == null) {
-                return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateEqualsHashCode(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_EQUALS_HASHCODE, data(0, uri, offset, fields)));
+                return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateEqualsHashCode(), CODE_GENERATOR_KIND, null, "nbls.generate.code", Utils.encodeCommand(GENERATE_EQUALS_HASHCODE, client.getNbCodeCapabilities()), data(0, uri, offset, fields)));
             }
-            return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateEquals(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_EQUALS_HASHCODE, data(EQUALS_ONLY, uri, offset, fields)));
+            return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateEquals(), CODE_GENERATOR_KIND, null, "nbls.generate.code", Utils.encodeCommand(GENERATE_EQUALS_HASHCODE, client.getNbCodeCapabilities()), data(EQUALS_ONLY, uri, offset, fields)));
         }
-        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateHashCode(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_EQUALS_HASHCODE, data(HASH_CODE_ONLY, uri, offset, fields)));
+        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateHashCode(), CODE_GENERATOR_KIND, null, "nbls.generate.code", Utils.encodeCommand(GENERATE_EQUALS_HASHCODE, client.getNbCodeCapabilities()), data(HASH_CODE_ONLY, uri, offset, fields)));
     }
 
     @Override

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/GetterSetterGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/GetterSetterGenerator.java
@@ -103,7 +103,7 @@ public final class GetterSetterGenerator extends CodeActionsProvider {
         List<CodeAction> result = new ArrayList<>();
         if (missingGetters) {
             String name = pair.first().size() == 1 ? Bundle.DN_GenerateGetterFor(pair.first().iterator().next().getSimpleName().toString()) : Bundle.DN_GenerateGetters();
-            result.add(createCodeAction(client, name, all ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, null, "nbls.generate.code", GENERATE_GETTER_SETTER, data(GeneratorUtils.GETTERS_ONLY, uri, offset, all, pair.first().stream().map(variableElement -> {
+            result.add(createCodeAction(client, name, all ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, null, "nbls.generate.code", Utils.encodeCommand(GENERATE_GETTER_SETTER, client.getNbCodeCapabilities()), data(GeneratorUtils.GETTERS_ONLY, uri, offset, all, pair.first().stream().map(variableElement -> {
                 QuickPickItem item = new QuickPickItem(createLabel(info, variableElement));
                 item.setUserData(new ElementData(variableElement));
                 return item;
@@ -111,7 +111,7 @@ public final class GetterSetterGenerator extends CodeActionsProvider {
         }
         if (missingSetters) {
             String name = pair.second().size() == 1 ? Bundle.DN_GenerateSetterFor(pair.second().iterator().next().getSimpleName().toString()) : Bundle.DN_GenerateSetters();
-            result.add(createCodeAction(client, name, all ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, null, "nbls.generate.code", GENERATE_GETTER_SETTER, data(GeneratorUtils.SETTERS_ONLY, uri, offset, all, pair.second().stream().map(variableElement -> {
+            result.add(createCodeAction(client, name, all ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, null, "nbls.generate.code", Utils.encodeCommand(GENERATE_GETTER_SETTER, client.getNbCodeCapabilities()), data(GeneratorUtils.SETTERS_ONLY, uri, offset, all, pair.second().stream().map(variableElement -> {
                 QuickPickItem item = new QuickPickItem(createLabel(info, variableElement));
                 item.setUserData(new ElementData(variableElement));
                 return item;
@@ -120,7 +120,7 @@ public final class GetterSetterGenerator extends CodeActionsProvider {
         if (missingGetters && missingSetters) {
             pair.first().retainAll(pair.second());
             String name = pair.first().size() == 1 ? Bundle.DN_GenerateGetterSetterFor(pair.first().iterator().next().getSimpleName().toString()) : Bundle.DN_GenerateGettersSetters();
-            result.add(createCodeAction(client, name, all ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, null, "nbls.generate.code", GENERATE_GETTER_SETTER, data(0, uri, offset, all, pair.first().stream().map(variableElement -> {
+            result.add(createCodeAction(client, name, all ? CODE_GENERATOR_KIND : CodeActionKind.QuickFix, null, "nbls.generate.code", Utils.encodeCommand(GENERATE_GETTER_SETTER, client.getNbCodeCapabilities()), data(0, uri, offset, all, pair.first().stream().map(variableElement -> {
                 QuickPickItem item = new QuickPickItem(createLabel(info, variableElement));
                 item.setUserData(new ElementData(variableElement));
                 return item;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ImplementOverrideMethodGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ImplementOverrideMethodGenerator.java
@@ -109,7 +109,7 @@ public final class ImplementOverrideMethodGenerator extends CodeActionsProvider 
                 implementMethods.add(new QuickPickItem(createLabel(info, method), enclosingTypeName, null, mustImplement, new ElementData(method)));
             }
             if (!implementMethods.isEmpty()) {
-                result.add(createCodeAction(client, Bundle.DN_GenerateImplementMethod(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_IMPLEMENT_OVERRIDE, data(uri, offset, true, implementMethods)));
+                result.add(createCodeAction(client, Bundle.DN_GenerateImplementMethod(), CODE_GENERATOR_KIND, null, "nbls.generate.code", Utils.encodeCommand(GENERATE_IMPLEMENT_OVERRIDE, client.getNbCodeCapabilities()), data(uri, offset, true, implementMethods)));
             }
         }
         if (typeElement.getKind().isClass() || typeElement.getKind().isInterface()) {
@@ -125,7 +125,7 @@ public final class ImplementOverrideMethodGenerator extends CodeActionsProvider 
                 overrideMethods.add(item);
             }
             if (!overrideMethods.isEmpty()) {
-                result.add(createCodeAction(client, Bundle.DN_GenerateOverrideMethod(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_IMPLEMENT_OVERRIDE, data(uri, offset, false, overrideMethods)));
+                result.add(createCodeAction(client, Bundle.DN_GenerateOverrideMethod(), CODE_GENERATOR_KIND, null, "nbls.generate.code", Utils.encodeCommand(GENERATE_IMPLEMENT_OVERRIDE, client.getNbCodeCapabilities()), data(uri, offset, false, overrideMethods)));
             }
         }
         return result;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LoggerGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LoggerGenerator.java
@@ -108,7 +108,7 @@ public final class LoggerGenerator extends CodeActionsProvider {
         Map<String, Object> data = new HashMap<>();
         data.put(URI, uri);
         data.put(OFFSET, offset);
-        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateLogger(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_LOGGER, data));
+        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateLogger(), CODE_GENERATOR_KIND, null, "nbls.generate.code", Utils.encodeCommand(GENERATE_LOGGER, client.getNbCodeCapabilities()), data));
     }
 
     @Override

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ToStringGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ToStringGenerator.java
@@ -116,7 +116,7 @@ public final class ToStringGenerator extends CodeActionsProvider {
         data.put(URI, uri);
         data.put(OFFSET, offset);
         data.put(FIELDS, fields);
-        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateToString(), CODE_GENERATOR_KIND, null, "nbls.generate.code", GENERATE_TO_STRING, data));
+        return Collections.singletonList(createCodeAction(client, Bundle.DN_GenerateToString(), CODE_GENERATOR_KIND, null, "nbls.generate.code", Utils.encodeCommand(GENERATE_TO_STRING, client.getNbCodeCapabilities()), data));
     }
 
     @Override


### PR DESCRIPTION
In [PR #6990](https://github.com/apache/netbeans/pull/6990), some refactoring was done on the source actions to incorporate VSCode changes. During this process, the command arguments for the required source action were hardcoded with the nbls prefix without checking the NBCode extended capabilities prefix flag. This introduced a regression for extensions other than the Apache Java extension that use the NetBeans LSP, causing the source action menu to stop working.

This fix ensures that the source action commands are properly prefixed, respecting the NBCode extended capabilities prefix flag, and restores functionality for all relevant extensions.

For more info: https://github.com/oracle/javavscode/issues/214 and https://github.com/oracle/javavscode/issues/215