### PR TITLE
Minor NBM wizard pom generation fixes and plugin version bumps

### DIFF
--- a/apisupport/maven.apisupport/test/unit/src/org/netbeans/modules/maven/apisupport/NBMNativeMWITest.java
+++ b/apisupport/maven.apisupport/test/unit/src/org/netbeans/modules/maven/apisupport/NBMNativeMWITest.java
@@ -38,6 +38,8 @@ import org.openide.util.lookup.ServiceProvider;
 
 public class NBMNativeMWITest extends NbTestCase {
 
+    private static final String EXPECTED_JAVAC_PLUGIN_VERSION = "3.13.0";
+
     private FileObject wd;
 
     public NBMNativeMWITest(String testName) {
@@ -64,7 +66,7 @@ public class NBMNativeMWITest extends NbTestCase {
         assertEquals("nbm-maven-plugin", model.getBuild().getPlugins().get(0).getArtifactId());
         assertEquals(MavenNbModuleImpl.getLatestNbmPluginVersion(), model.getBuild().getPlugins().get(0).getVersion());
         assertEquals("maven-compiler-plugin", model.getBuild().getPlugins().get(1).getArtifactId());
-        assertEquals("3.11.0", model.getBuild().getPlugins().get(1).getVersion());
+        assertEquals(EXPECTED_JAVAC_PLUGIN_VERSION, model.getBuild().getPlugins().get(1).getVersion());
         assertEquals(0, model.getRepositories().size());
     }
 
@@ -82,7 +84,7 @@ public class NBMNativeMWITest extends NbTestCase {
         assertEquals("nbm-maven-plugin", model.getBuild().getPlugins().get(0).getArtifactId());
         assertEquals(MavenNbModuleImpl.getLatestNbmPluginVersion(), model.getBuild().getPlugins().get(0).getVersion());
         assertEquals("maven-compiler-plugin", model.getBuild().getPlugins().get(1).getArtifactId());
-        assertEquals("3.11.0", model.getBuild().getPlugins().get(1).getVersion());
+        assertEquals(EXPECTED_JAVAC_PLUGIN_VERSION, model.getBuild().getPlugins().get(1).getVersion());
         assertEquals(1, model.getRepositories().size());
     }
 
@@ -109,7 +111,7 @@ public class NBMNativeMWITest extends NbTestCase {
         assertEquals("nbm-maven-plugin", model.getBuild().getPlugins().get(0).getArtifactId());
         assertEquals(MavenNbModuleImpl.getLatestNbmPluginVersion(), model.getBuild().getPlugins().get(0).getVersion());
         assertEquals("maven-compiler-plugin", model.getBuild().getPlugins().get(1).getArtifactId());
-        assertEquals("3.11.0", model.getBuild().getPlugins().get(1).getVersion());
+        assertEquals(EXPECTED_JAVAC_PLUGIN_VERSION, model.getBuild().getPlugins().get(1).getVersion());
         assertEquals(0, model.getRepositories().size());
     }
 
@@ -135,7 +137,7 @@ public class NBMNativeMWITest extends NbTestCase {
         assertEquals("nbm-maven-plugin", model.getBuild().getPlugins().get(0).getArtifactId());
         assertEquals(MavenNbModuleImpl.getLatestNbmPluginVersion(), model.getBuild().getPlugins().get(0).getVersion());
         assertEquals("maven-compiler-plugin", model.getBuild().getPlugins().get(1).getArtifactId());
-        assertEquals("3.11.0", model.getBuild().getPlugins().get(1).getVersion());
+        assertEquals(EXPECTED_JAVAC_PLUGIN_VERSION, model.getBuild().getPlugins().get(1).getVersion());
         assertEquals(1, model.getRepositories().size());
     }
 
@@ -190,7 +192,7 @@ public class NBMNativeMWITest extends NbTestCase {
         assertEquals("nbm-maven-plugin", modeloutput.getBuild().getPlugins().get(0).getArtifactId());
         assertEquals(MavenNbModuleImpl.getLatestNbmPluginVersion(), modeloutput.getBuild().getPlugins().get(0).getVersion());
         assertEquals("maven-compiler-plugin", modeloutput.getBuild().getPlugins().get(1).getArtifactId());
-        assertEquals("3.11.0", modeloutput.getBuild().getPlugins().get(1).getVersion());
+        assertEquals(EXPECTED_JAVAC_PLUGIN_VERSION, modeloutput.getBuild().getPlugins().get(1).getVersion());
         assertEquals(0, model.getRepositories().size());
     }
 

--- a/java/maven/src/org/netbeans/modules/maven/options/MavenVersionSettings.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/MavenVersionSettings.java
@@ -44,11 +44,12 @@ public final class MavenVersionSettings {
 
     static {
         // TODO update periodically - modifications might require unit test adjustments
-        String nb_version = "RELEASE220";
-        String nb_utilities_version = "14.1";
+        String nb_version = "RELEASE230";
+        String nb_utilities_version = "14.2";
         fallback = Map.ofEntries(
             entry(key("org.netbeans.api", "org-netbeans-modules-editor"), nb_version), // represents all other nb artifacts
             entry(key(Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_COMPILER), "3.13.0"),
+            entry(key(Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_JAR), "3.4.2"),
             entry(key(Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_RESOURCES), "3.3.1"),
             entry(key(Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_FAILSAFE), "3.3.1"),
             entry(key(Constants.GROUP_APACHE_PLUGINS, Constants.PLUGIN_SUREFIRE), "3.3.1"),
@@ -57,8 +58,8 @@ public final class MavenVersionSettings {
             entry(key("org.apache.netbeans.utilities", "nbm-shared"), nb_utilities_version),
             entry(key("org.apache.netbeans.utilities", "nbm-repository-plugin"), nb_utilities_version),
             entry(key("org.apache.netbeans.utilities", "nbm-maven-plugin"), nb_utilities_version),
-            entry(key("org.apache.netbeans.archetypes", "nbm-archetype"), "1.18"),
-            entry(key("org.apache.netbeans.archetypes", "netbeans-platform-app-archetype"), "1.23")
+            entry(key("org.apache.netbeans.archetypes", "nbm-archetype"), "1.19"),
+            entry(key("org.apache.netbeans.archetypes", "netbeans-platform-app-archetype"), "1.24")
         );
     }
 


### PR DESCRIPTION
 - maven wizard iterator needed some updates to work better with the new archetypes
 - bumped the version fallbacks of MavenVersionSettings analog to https://github.com/apache/netbeans/pull/7357

While testing `nbm-maven-plugin` 14.2, I noticed that the wizard would generate redundant compiler plugins for child poms and it also missed out on some version bumps.

This reminded me that the `nbm-archetype` isn't used for anything right now (but this won't fix this).

To test this, `nbm-maven-plugin` v14.2 and `netbeans-platform-app-archetype` v1.24 should be put into the local repo first since they aren't released yet.