### PR TITLE
Fix java completion sort for not-imported items.

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItem.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItem.java
@@ -1522,7 +1522,7 @@ public abstract class JavaCompletionItem implements CompletionItem {
         public String toString() {
             return (typeName != null ? typeName + " " : "") + varName; //NOI18N
         }
-   }
+    }
 
     static class FieldItem extends WhiteListJavaCompletionItem<VariableElement> {
 
@@ -1545,6 +1545,7 @@ public abstract class JavaCompletionItem implements CompletionItem {
         private String typeName;
         private String leftText;
         private String rightText;
+        private CharSequence sortText;
         private boolean autoImportEnclosingType;
         private CharSequence enclSortText;
         private int castEndOffset;
@@ -1597,7 +1598,10 @@ public abstract class JavaCompletionItem implements CompletionItem {
 
         @Override
         public CharSequence getSortText() {
-            return simpleName + "#" + enclSortText; //NOI18N
+            if (sortText == null) {
+                sortText = LazySortText.link(simpleName, enclSortText);
+            }
+            return sortText;
         }
 
         @Override
@@ -1827,7 +1831,7 @@ public abstract class JavaCompletionItem implements CompletionItem {
         protected List<ParamDesc> params;
         private String typeName;
         private boolean addSemicolon;
-        private String sortText;
+        private CharSequence sortText;
         private String leftText;
         private String rightText;
         private boolean autoImportEnclosingType;
@@ -1910,7 +1914,7 @@ public abstract class JavaCompletionItem implements CompletionItem {
                     cnt++;
                 }
                 sortParams.append(')');
-                sortText = simpleName + "#" + enclSortText + "#" + ((cnt < 10 ? "0" : "") + cnt) + "#" + sortParams.toString(); //NOI18N
+                sortText = LazySortText.link(simpleName, enclSortText, ((cnt < 10 ? "0" : "") + cnt) + "#" + sortParams.toString()); //NOI18N
             }
             return sortText;
         }


### PR DESCRIPTION
`LazySortText` implements `CharSequence` but misses a `toString()` method.

Without it, it would use `Object#toString()`, and since it is used as comparator input, it would lead to undesired results.

This was the case with 'List.of' for example. ('List' must not have an import yet)

before
![completion-sort-issue_before](https://github.com/user-attachments/assets/fbbcce90-4522-4239-b2da-0d546f7e82dc)

after
![completion-sort-issue_fixed](https://github.com/user-attachments/assets/908f14e5-e38b-401a-ac61-7565865bab2a)

test
```java
public class Mavenproject1 {
    public static void main(String[] args) {
        // use completion after 'of'
        java.util.Set.of; // sort works
        List.of;          // sort fails
    }
}
```

- - -

assignment (`enclSortText` can be of type `String` or `LazySortText`):
https://github.com/apache/netbeans/blob/03aa32d15aba53f980e095b1a8efa6700c515331/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItem.java#L1564-L1568

search token:
https://github.com/apache/netbeans/blob/03aa32d15aba53f980e095b1a8efa6700c515331/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItem.java#L1913

comparator:
https://github.com/apache/netbeans/blob/03aa32d15aba53f980e095b1a8efa6700c515331/ide/editor.completion/src/org/netbeans/modules/editor/completion/CompletionItemComparator.java#L59-L60
