### PR TITLE
Fix possible InaccessibleObjectExceptions during debugging session

### DIFF
--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/VariableMirrorTranslator.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/VariableMirrorTranslator.java
@@ -49,7 +49,7 @@ import java.beans.PropertyVetoException;
 import java.io.InvalidObjectException;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.InaccessibleObjectException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -250,7 +250,12 @@ public class VariableMirrorTranslator {
                 logger.log(Level.CONFIG, "No Such Field({0}) of class {1}", new Object[]{name, clazz});
                 return null;
             }
-            field.setAccessible(true);
+            try {
+                field.setAccessible(true);
+            } catch(InaccessibleObjectException ex) {
+                logger.log(Level.CONFIG, "InaccessibleObjectException({0}) of field {1}", new Object[]{ex.getLocalizedMessage(), field});
+                return null;
+            }
             Value v = fieldValues.get(f);
             try {
                 if (v == null) {


### PR DESCRIPTION
Opening the popup table during a breakpoint for a variable can cause reflection exceptions due to JDK module encapsulation.

e.g for a java.util.Date field:
![image](https://github.com/user-attachments/assets/5a8b2418-ae4f-4b41-bc1d-547835cb8d2c)
click on the `>` symbol

```
java.lang.reflect.InaccessibleObjectException: Unable to make field long sun.util.calendar.BaseCalendar$Date.cachedFixedDateJan1 accessible: module java.base does not "opens sun.util.calendar" to unnamed module @493e76e4
	at java.base/java.lang.reflect.AccessibleObject.throwInaccessibleObjectException(AccessibleObject.java:388)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:364)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:312)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:183)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:177)
	at org.netbeans.modules.debugger.jpda.models.VariableMirrorTranslator.setFieldsValues(VariableMirrorTranslator.java:253)
	at org.netbeans.modules.debugger.jpda.models.VariableMirrorTranslator.createMirrorObject(VariableMirrorTranslator.java:239)
	at org.netbeans.modules.debugger.jpda.models.VariableMirrorTranslator.createMirrorObject(VariableMirrorTranslator.java:114)
	at org.netbeans.modules.debugger.jpda.models.VariableMirrorTranslator.setFieldsValues(VariableMirrorTranslator.java:261)
	at org.netbeans.modules.debugger.jpda.models.VariableMirrorTranslator.createMirrorObject(VariableMirrorTranslator.java:239)
	at org.netbeans.modules.debugger.jpda.models.VariableMirrorTranslator.createMirrorObject(VariableMirrorTranslator.java:114)
	at org.netbeans.modules.debugger.jpda.models.VariableMirrorTranslator.createMirrorObject(VariableMirrorTranslator.java:95)
	at org.netbeans.modules.debugger.jpda.models.AbstractVariable.createMirrorObject(AbstractVariable.java:463)
	at org.netbeans.modules.debugger.jpda.ui.models.VariablesTableModel.getValueOf(VariablesTableModel.java:193)
	at org.netbeans.modules.debugger.jpda.ui.models.VariablesTableModel.getValueAt(VariablesTableModel.java:158)
	at org.netbeans.spi.viewmodel.Models$DelegatingTableModel.getValueAt(Models.java:2249)
	at org.netbeans.modules.debugger.jpda.ui.models.NumericDisplayFilter.getValueAt(NumericDisplayFilter.java:112)
	at org.netbeans.spi.viewmodel.Models$CompoundTableModel.getValueAt(Models.java:1439)
	at org.netbeans.modules.debugger.jpda.ui.models.VariablesTreeModelFilter.getValueAt(VariablesTreeModelFilter.java:530)
	at org.netbeans.spi.viewmodel.Models$CompoundTableModel.getValueAt(Models.java:1439)
	at org.netbeans.spi.viewmodel.Models$CompoundTableModel.getValueAt(Models.java:1441)
	at org.netbeans.spi.viewmodel.Models$CompoundTableModel.getValueAt(Models.java:1441)
	at org.netbeans.spi.viewmodel.Models$CompoundModel.getValueAt(Models.java:4563)
[catch] at org.netbeans.modules.viewmodel.TreeModelNode$MyProperty.run(TreeModelNode.java:1883)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1403)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2018)

```