### PR TITLE
truffle.RemoteServices should parse the java version correctly

### DIFF
--- a/java/debugger.jpda.truffle/nbproject/project.properties
+++ b/java/debugger.jpda.truffle/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.release=11
 javadoc.arch=${basedir}/arch.xml
 nbm.module.author=Martin Entlicher
 requires.nb.javac=true

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/RemoteServices.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/RemoteServices.java
@@ -180,11 +180,7 @@ public final class RemoteServices {
     
     private static int getTargetMajorVersion(VirtualMachine vm) throws InternalExceptionWrapper, VMDisconnectedExceptionWrapper {
         String version = VirtualMachineWrapper.version(vm);
-        int dot = version.indexOf(".");
-        if (dot < 0) {
-            dot = version.length();
-        }
-        return Integer.parseInt(version.substring(0, dot));
+        return Runtime.Version.parse(version).feature();
     }
 
     public static ClassObjectReference uploadBasicClasses(JPDAThreadImpl t, String basicClassName) throws InvalidTypeException, ClassNotLoadedException, IncompatibleThreadStateException, InvocationException, IOException, PropertyVetoException, InternalExceptionWrapper, VMDisconnectedExceptionWrapper, ObjectCollectedExceptionWrapper, UnsupportedOperationExceptionWrapper, ClassNotPreparedExceptionWrapper {


### PR DESCRIPTION
I ran NB in a debug session on JDK 23 build 35 and got an exception in NB 22.

It is reproducible with:
 - clean nbbuild/testuserdir/ 
 - debug NB (right click on any module and debug)
 - create new maven project

this exception should appear after clicking finish on the wizard. I am not sure why this code path runs at all tbh, I couldn't find a simpler way to reproduce it unfortunately.

```
java.lang.NumberFormatException: For input string: "23-ea"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
	at java.base/java.lang.Integer.parseInt(Integer.java:588)
	at java.base/java.lang.Integer.parseInt(Integer.java:685)
	at org.netbeans.modules.debugger.jpda.truffle.RemoteServices.getTargetMajorVersion(RemoteServices.java:187)
	at org.netbeans.modules.debugger.jpda.truffle.RemoteServices.doUpload(RemoteServices.java:243)
	at org.netbeans.modules.debugger.jpda.truffle.RemoteServices.uploadBasicClasses(RemoteServices.java:212)
	at org.netbeans.modules.debugger.jpda.truffle.DebugManagerHandler.doInitDebuggerRemoteService(DebugManagerHandler.java:180)
	at org.netbeans.modules.debugger.jpda.truffle.DebugManagerHandler.initDebuggerRemoteService(DebugManagerHandler.java:166)
	at org.netbeans.modules.debugger.jpda.truffle.TruffleDebugManager$1.breakpointReached(TruffleDebugManager.java:167)
	at org.netbeans.api.debugger.jpda.JPDABreakpoint.fireJPDABreakpointChange(JPDABreakpoint.java:275)
	at org.netbeans.api.debugger.jpda.JPDADebugger.fireBreakpointEvent(JPDADebugger.java:466)
	at org.netbeans.modules.debugger.jpda.JPDADebuggerImpl.fireBreakpointEvent(JPDADebuggerImpl.java:646)
	at org.netbeans.modules.debugger.jpda.breakpoints.BreakpointImpl.perform(BreakpointImpl.java:535)
	at org.netbeans.modules.debugger.jpda.breakpoints.MethodBreakpointImpl.exec(MethodBreakpointImpl.java:253)
[catch] at org.netbeans.modules.debugger.jpda.util.Operator.processEvents(Operator.java:518)
	at org.netbeans.modules.debugger.jpda.util.Operator.access$800(Operator.java:96)
	at org.netbeans.modules.debugger.jpda.util.Operator$1.run(Operator.java:228)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
	at org.netbeans.modules.debugger.jpda.util.Operator$2.run(Operator.java:260)
	at java.base/java.lang.Thread.run(Thread.java:1570)
```


