### PR TITLE
Update nb-javac to jdk-23+35.

### DIFF
--- a/java/libs.javacapi/external/binaries-list
+++ b/java/libs.javacapi/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-C251D126090F6362D805B1987372BF4963B3782C com.dukescript.nbjavac:nb-javac:jdk-23+30
-A9105543E5EB96B9705D338A4C42A3A89E25A19A com.dukescript.nbjavac:nb-javac:jdk-23+30:api
+1B70EC8A5230901C0EEE6EDF9829B43EAFAE9CC9 com.dukescript.nbjavac:nb-javac:jdk-23+35
+B3CB7A425EC7AAADA60754E6DF2E5E2D990E91AE com.dukescript.nbjavac:nb-javac:jdk-23+35:api

--- a/java/libs.javacapi/external/nb-javac-jdk-23+35-license.txt
+++ b/java/libs.javacapi/external/nb-javac-jdk-23+35-license.txt
@@ -1,7 +1,7 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Version: 23+30
-Files: nb-javac-jdk-23+30-api.jar nb-javac-jdk-23+30.jar
+Version: 23+35
+Files: nb-javac-jdk-23+35-api.jar nb-javac-jdk-23+35.jar
 License: GPL-2-CP
 Origin: OpenJDK (https://github.com/openjdk/jdk)
 Source: https://github.com/openjdk/jdk

--- a/java/libs.javacapi/nbproject/project.xml
+++ b/java/libs.javacapi/nbproject/project.xml
@@ -40,11 +40,11 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-jdk-23+30-api.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-23+35-api.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-jdk-23+30.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-23+35.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/libs.nbjavacapi/external/binaries-list
+++ b/java/libs.nbjavacapi/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-C251D126090F6362D805B1987372BF4963B3782C com.dukescript.nbjavac:nb-javac:jdk-23+30
-A9105543E5EB96B9705D338A4C42A3A89E25A19A com.dukescript.nbjavac:nb-javac:jdk-23+30:api
+1B70EC8A5230901C0EEE6EDF9829B43EAFAE9CC9 com.dukescript.nbjavac:nb-javac:jdk-23+35
+B3CB7A425EC7AAADA60754E6DF2E5E2D990E91AE com.dukescript.nbjavac:nb-javac:jdk-23+35:api

--- a/java/libs.nbjavacapi/external/nb-javac-jdk-23+35-license.txt
+++ b/java/libs.nbjavacapi/external/nb-javac-jdk-23+35-license.txt
@@ -1,7 +1,7 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Version: 23+30
-Files: nb-javac-jdk-23+30-api.jar nb-javac-jdk-23+30.jar
+Version: 23+35
+Files: nb-javac-jdk-23+35-api.jar nb-javac-jdk-23+35.jar
 License: GPL-2-CP
 Origin: OpenJDK (https://github.com/openjdk/jdk)
 Source: https://github.com/openjdk/jdk

--- a/java/libs.nbjavacapi/nbproject/project.properties
+++ b/java/libs.nbjavacapi/nbproject/project.properties
@@ -18,8 +18,8 @@
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 license.file.override=${nb_all}/nbbuild/licenses/GPL-2-CP
-release.external/nb-javac-jdk-23+30-api.jar=modules/ext/nb-javac-jdk-23-30-api.jar
-release.external/nb-javac-jdk-23+30.jar=modules/ext/nb-javac-jdk-23-30.jar
+release.external/nb-javac-jdk-23+35-api.jar=modules/ext/nb-javac-jdk-23-30-api.jar
+release.external/nb-javac-jdk-23+35.jar=modules/ext/nb-javac-jdk-23-30.jar
 
 # for tests
 requires.nb.javac=true

--- a/java/libs.nbjavacapi/nbproject/project.xml
+++ b/java/libs.nbjavacapi/nbproject/project.xml
@@ -46,11 +46,11 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>ext/nb-javac-jdk-23-30-api.jar</runtime-relative-path>
-                <binary-origin>external/nb-javac-jdk-23+30-api.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-23+35-api.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path>ext/nb-javac-jdk-23-30.jar</runtime-relative-path>
-                <binary-origin>external/nb-javac-jdk-23+30.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-23+35.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -96,8 +96,8 @@ nb/ide.launcher/external/launcher-external-binaries-1-94a19f0.zip platform/o.n.b
 nb/ide.launcher/external/launcher-external-binaries-1-94a19f0.zip harness/apisupport.harness/external/launcher-external-binaries-1-94a19f0.zip
 
 # only one is part of the product:
-java/libs.javacapi/external/nb-javac-jdk-23+30-api.jar java/libs.nbjavacapi/external/nb-javac-jdk-23+30-api.jar
-java/libs.javacapi/external/nb-javac-jdk-23+30.jar java/libs.nbjavacapi/external/nb-javac-jdk-23+30.jar
+java/libs.javacapi/external/nb-javac-jdk-23+35-api.jar java/libs.nbjavacapi/external/nb-javac-jdk-23+35-api.jar
+java/libs.javacapi/external/nb-javac-jdk-23+35.jar java/libs.nbjavacapi/external/nb-javac-jdk-23+35.jar
 
 # Used only in unittests for mysql db specific tests
 ide/db.metadata.model/external/mysql-connector-j-8.0.31.jar ide/db.mysql/external/mysql-connector-j-8.0.31.jar


### PR DESCRIPTION
- update from b30 to b35
- contains JDK-8336705, JDK-8336250 and JDK-8335926 ([changes](https://bugs.openjdk.org/issues/?jql=project%20%3D%20JDK%20AND%20status%20in%20(Resolved%2C%20Integrated%2C%20Completed)%20AND%20fixVersion%20in%20(23.0.1%2C%20%2223%22%2C%2023.0.2)%20AND%20component%20%3D%20tools%20AND%20%22Resolved%20In%20Build%22%20in%20(%22b31%22%2C%20%22b32%22%2C%20%22b33%22%2C%20%22b34%22%20%2C%20%22b35%22)%20AND%20Subcomponent%20in%20(javac%2C%20javac%2C%20javac%2C%20javac)))

~uses staged build atm~