### PR TITLE
binaries-list dependency checker workflow updates

### DIFF
--- a/.github/scripts/BinariesListUpdates.java
+++ b/.github/scripts/BinariesListUpdates.java
@@ -28,7 +28,6 @@ import org.apache.maven.search.backend.smo.SmoSearchBackend;
 import org.apache.maven.search.backend.smo.SmoSearchBackendFactory;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 
-import static java.util.FormatProcessor.FMT;
 import static org.apache.maven.search.api.MAVEN.ARTIFACT_ID;
 import static org.apache.maven.search.api.MAVEN.CLASSIFIER;
 import static org.apache.maven.search.api.MAVEN.GROUP_ID;
@@ -39,7 +38,9 @@ import static org.apache.maven.search.api.request.FieldQuery.fieldQuery;
 /**
  * Scans for binaries-list files and checks if newer versions of the declared dependencies exist.
  * 
- * <pre>org.apache.maven.indexer:search-backend-smo</pre> must be in classpath.
+ * dependencies:
+ * <pre>org.apache.maven.indexer:search-backend-smo</pre>
+ * <pre>org.apache.maven:maven-artifact</pre>
  * 
  * @author mbien
  */
@@ -49,7 +50,7 @@ public class BinariesListUpdates {
     private static final LongAdder checks = new LongAdder();
     private static final LongAdder skips = new LongAdder();
 
-    // java --enable-preview --source 22 --class-path "lib/*" BinariesListUpdates.java /path/to/netbeans/project
+    // java --class-path "lib/*" BinariesListUpdates.java /path/to/netbeans/project
     public static void main(String[] args) throws IOException, InterruptedException {
 
         if (args.length != 1 || Files.notExists(Path.of(args[0]).resolve("README.md"))) {
@@ -68,7 +69,7 @@ public class BinariesListUpdates {
             });
         }
 
-        System.out.println(STR."checked \{checks.sum()} dependencies, found \{updates.sum()} updates, skipped \{skips.sum()}." );
+        System.out.println("checked " + checks.sum() + " dependencies, found " + updates.sum() + " updates, skipped " + skips.sum() + "." );
     }
 
     private static void checkDependencies(Path path, SmoSearchBackend backend) throws IOException, InterruptedException {
@@ -98,7 +99,7 @@ public class BinariesListUpdates {
                             gac = String.join(":", gid, aid, classifier);
                         }
                         if (latest != null && !version.equals(latest)) {
-                            System.out.println(FMT."    %-50s\{gac} \{version} -> \{latest}");
+                            System.out.printf("    %-50s %s -> %s\n", gac, version, latest);
                             updates.increment();
                         }
                     } catch (IOException | InterruptedException ex) {
@@ -131,7 +132,7 @@ public class BinariesListUpdates {
             return backend.search(request).getPage().stream()
                     .map(r -> r.getValue(VERSION))
                     .filter(v -> !v.contains("alpha") && !v.contains("beta"))
-                    .filter(v -> !v.contains("M") && !v.contains("m") && !v.contains("B") && !v.contains("b") && !v.contains("ea"))
+                    .filter(v -> !v.contains("M") && !v.contains("m") && !v.contains("B") && !v.contains("b") && !v.contains("ea") && !v.contains("RC"))
                     .limit(5)
                     .max((v1, v2) -> new ComparableVersion(v1).compareTo(new ComparableVersion(v2)))
                     .orElse(null);

--- a/.github/workflows/dependency-checks.yml
+++ b/.github/workflows/dependency-checks.yml
@@ -48,11 +48,9 @@ jobs:
 
       - name: Check Dependencies
         run: |
-          mvn -q dependency:copy -Dartifact=org.apache.maven.indexer:search-backend-smo:7.1.1 -DoutputDirectory=./lib
-          mvn -q dependency:copy -Dartifact=org.apache.maven.indexer:search-api:7.1.1         -DoutputDirectory=./lib
-          mvn -q dependency:copy -Dartifact=com.google.code.gson:gson:2.10.1                  -DoutputDirectory=./lib
-          mvn -q dependency:copy -Dartifact=org.apache.maven:maven-artifact:3.9.6             -DoutputDirectory=./lib
+          DEPS=org.apache.maven:maven-artifact:3.9.8,org.apache.maven.indexer:search-backend-smo:7.1.4
+          mvn eu.maveniverse.maven.plugins:toolbox:gav-copy-transitive -Dgav=$DEPS -DsinkSpec="flat(./lib)"
           echo "<pre>" >> $GITHUB_STEP_SUMMARY
-          $JAVA_HOME_21_X64/bin/java --enable-preview --source 21 -cp "lib/*" .github/scripts/BinariesListUpdates.java ./ | tee -a $GITHUB_STEP_SUMMARY
+          $JAVA_HOME_21_X64/bin/java -cp "lib/*" .github/scripts/BinariesListUpdates.java ./ | tee -a $GITHUB_STEP_SUMMARY
           echo "</pre>" >> $GITHUB_STEP_SUMMARY
           rm -Rf lib


### PR DESCRIPTION
 - removed string templates to make the script more portable
 - use single [maveniverse/toolbox](https://github.com/maveniverse/toolbox) `toolbox:gav-copy-transitive`, instead of multiple sequential `dependency:copy` calls
 - filter out release candidates
 - bump dependencies
