### PR TITLE
LoadOptions introduced to control project loading.

### DIFF
--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -83,6 +83,29 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="load-options-lookup">
+            <api name="general"/>
+            <summary>LoadOptions object replaces growing number of argumetns to project load APIs. Access to current Lookup added.</summary>
+            <version major="2" minor="43"/>
+            <date day="9" month="8" year="2024"/>
+            <author login="sdedic"/>
+            <compatibility semantic="compatible" addition="yes" deprecation="yes"/>
+            <description>
+                <p>
+                    To avoid growing number of parameters to <a href="@TOP@/org/netbeans/modules/gradle/api/NbGradleProject.html#toQuality-java.lang.String-org.netbeans.modules.gradle.api.NbGradleProject.Quality-boolean-">toQuality()</a>, 
+                    a <a href="@TOP@/org/netbeans/modules/gradle/api/NbGradleProject.LoadOptions.html">LoadOptions</a> structure was created that can be used to provide details on
+                    how the project should be loaded.
+                </p>
+                <p>
+                    The time the project data was actually loaded is now available using <a href="@TOP@/org/netbeans/modules/gradle/api/NbGradleProject.html#getEvaluateTime--">NbGradleProject.getEvaluateTime()</a>.
+                    The time can be used for timestamp checking against project files.
+                </p>
+                <p>
+                    Access to the current metadata information/services snapshot is newly available from <a href="@TOP@/org/netbeans/modules/gradle/api/NbGradleProject.html#curretLookup--">NbGradleProject.currentLookup()</a>.
+                </p>
+            </description>
+            <class package="org.netbeans.modules.gradle.api" name="NbGradleProject"/>
+        </change>
         <change id="gradle-init-javaversion">
             <api name="general"/>
             <summary>Gradle InitOperation now Supports  --java-version and --comments flags</summary>

--- a/extide/gradle/manifest.mf
+++ b/extide/gradle/manifest.mf
@@ -4,4 +4,4 @@ OpenIDE-Module: org.netbeans.modules.gradle/2
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/Bundle.properties
 OpenIDE-Module-Java-Dependencies: Java > 17
-OpenIDE-Module-Specification-Version: 2.42
+OpenIDE-Module-Specification-Version: 2.43

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectLoader.java
@@ -18,13 +18,12 @@
  */
 package org.netbeans.modules.gradle;
 
-import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.api.NbGradleProject.LoadOptions;
 
 /**
  *
  * @author lkishalmi
  */
 public interface GradleProjectLoader {
-
-    GradleProject loadProject(NbGradleProject.Quality aim, String descriptionOpt, boolean ignoreCache, boolean interactive, String... args);
+    public GradleProject loadProject(LoadOptions options, String... args);
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -28,6 +28,8 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.nio.file.Files;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -65,6 +67,7 @@ import org.netbeans.api.annotations.common.SuppressWarnings;
 import org.netbeans.api.project.ui.ProjectProblems;
 import org.netbeans.modules.gradle.api.GradleBaseProject;
 import org.netbeans.modules.gradle.api.GradleReport;
+import org.netbeans.modules.gradle.api.NbGradleProject.LoadOptions;
 import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
 import org.netbeans.spi.project.CacheDirectoryProvider;
 import org.netbeans.spi.project.support.LookupProviderSupport;
@@ -106,6 +109,8 @@ public final class NbGradleProjectImpl implements Project {
     private volatile GradleProject project;
     // @GuardedBy(this)
     private Quality attemptedQuality;
+    // @GuardedBy(this)
+    private Instant timeLoaded;
 
     static {
         // invokes static initializer of ModelHandle.class
@@ -258,6 +263,19 @@ public final class NbGradleProjectImpl implements Project {
     }
     
     /**
+     * Time when the gradle project was evaluated.
+     * @return evaluation time.
+     */
+    public long getEvaluationTime() {
+        GradleProject gp = this.project;
+        if (gp == null) {
+            return -1;
+        } else {
+            return gp.getEvaluationTime();
+        }
+    }
+    
+    /**
      * Obtains a project attempting at least the defined quality, without setting
      * that quality level for subsequent loads. Same as {@link #projectWithQualityTask}
      * but synchronous (runs in this thread).
@@ -308,23 +326,55 @@ public final class NbGradleProjectImpl implements Project {
      * @param force to force load even though the quality does not change.
      * @return project instance
      */
+    @Deprecated
     public CompletableFuture<GradleProject> projectWithQualityTask(String desc, Quality aim, boolean interactive, boolean force) {
+        return projectWithQualityTask(NbGradleProject.loadOptions(aim).
+                setDescription(desc).
+                setInteractive(interactive).
+                setForce(force)
+        );
+    }
+    
+    /**
+     * Obtains a project attempting at least the defined quality, without setting
+     * that quality level for subsequent loads. Note that the returned project's quality
+     * must be checked. If the currently loaded project declares the desired quality,
+     * no load is performed.
+     * <p>
+     * This method should be used in preference to {@link #loadProject()} or {@link #loadOWnProject},
+     * unless it's desired to force refresh the project contents to the current disk state.
+     * <div class="nonnormative">
+     * Implementation note: project reload events are dispatched <b>synchronously</b>
+     * in the calling thread.
+     * </div>
+     * @param options requirements and optiosn for the load operation
+     * @return Future that completes with the project instance
+     */
+    public CompletableFuture<GradleProject> projectWithQualityTask(LoadOptions options) {
+        boolean force = options.isForce();
         synchronized (this) {
             GradleProject c = project;
-            if (c != null) {
-                if (!force && c.getQuality().atLeast(aim)) {
+            if (options.isCheckFiles()) {
+                Instant newest = newestProjectFiletime();
+                if (newest.isAfter(Instant.ofEpochMilli(c.getEvaluationTime()))) {
+                    force = true;
+                }
+            }
+            if (!force && c != null) {
+                if (c.getQuality().atLeast(options.getAim())) {
                     return CompletableFuture.completedFuture(c);
                 }
-                if (!force && attemptedQuality.atLeast(aim)) {
+                if (attemptedQuality.atLeast(options.getAim())) {
                     return CompletableFuture.completedFuture(c);
                 }
             }
         }
         CompletableFuture<GradleProject> toRet = new CompletableFuture<>();
+        final boolean ff = force;
         RELOAD_RP.post(() -> 
-            loadOwnProject0(desc, false, interactive, aim, false, force)
+            loadOwnProject0(options.setForce(ff), false)
                 .handle((p, e) -> {
-                   if (e == null) {
+                       if (e == null) {
                        toRet.complete(p);
                    } else {
                        toRet.completeExceptionally(e);
@@ -388,26 +438,22 @@ public final class NbGradleProjectImpl implements Project {
     private LoadingCF loading;
     
     private static class LoadingCF extends CompletableFuture<GradleProject> {
-        private final Quality aim;
-        private final boolean ignoreCache;
-        private final boolean interactive;
+        private final LoadOptions options;
         private final boolean sync;
         private final List<String> args;
         private ThreadLocal<GradleProject> ownThreadCompletion = new ThreadLocal<>();
 
-        public LoadingCF(Quality aim, boolean ignoreCache, boolean interactive, boolean sync, List<String> args) {
-            this.aim = aim;
-            this.ignoreCache = ignoreCache;
-            this.interactive = interactive;
+        public LoadingCF(LoadOptions options, boolean sync, List<String> args) {
+            this.options = options;
             this.sync = sync;
             this.args = args;
         }
      
         public boolean satisifes(LoadingCF other) {
-            if (aim.worseThan(other.aim)) {
+            if (options.getAim().worseThan(other.options.getAim())) {
                 return false;
             }
-            if (ignoreCache != other.ignoreCache || interactive != other.interactive || sync != other.sync) {
+            if (options.isIgnoreCache() != other.options.isIgnoreCache() || options.isInteractive() != other.options.isInteractive() || sync != other.sync) {
                 return false;
             }
             return args.equals(other.args);
@@ -438,6 +484,17 @@ public final class NbGradleProjectImpl implements Project {
         }
     }
     
+    Instant newestProjectFiletime() {
+        return getGradleFiles().getProjectFiles().stream().map(f -> {
+            try {
+                return Files.getLastModifiedTime(f.toPath()).toInstant();
+            } catch (IOException ex) {
+                // no op
+                return Instant.now();
+            }
+        }).reduce((a, b) -> a.isAfter(b) ? a : b).orElse(Instant.now());
+    }
+    
     /**
      * Loads a project. After load, dispatches reload events. If "sync" is false (= asynchronous), dispatches events
      * and does possible fixups in {@link #RELOAD_RP}. The returned future completes only after all the event
@@ -455,16 +512,29 @@ public final class NbGradleProjectImpl implements Project {
      * @return Future for the new GradleProject state. See notes about sync/async differences.
      */
     /* nonprivate: tests only */CompletableFuture<GradleProject> loadOwnProject0(String desc, boolean ignoreCache, boolean interactive, Quality aim, boolean sync, boolean force, String... args) {
+        return loadOwnProject0(NbGradleProject.loadOptions(aim).
+                setDescription(desc).
+                setIgnoreCache(ignoreCache).
+                setInteractive(interactive).
+                setForce(force), 
+            sync, args
+        );
+    }
+    
+    // NOTE: the optional arguments are only used by ActionProviderImpl, to reload project before / after a project action. If there are more users,
+    // consider to expose the args... in the LoadOptions. Somehow need to solve the effect of different args to the project loaded data, as they may
+    // differ significantly and replace other-argumented state in the disk cache etc.
+    CompletableFuture<GradleProject> loadOwnProject0(LoadOptions options, boolean sync, String... args) {
         GradleProjectLoader loader = getLookup().lookup(GradleProjectLoader.class);
         if (loader == null) {
             throw new IllegalStateException("No loader implementation is present!");
         }
-        LoadingCF f = new LoadingCF(aim, ignoreCache, interactive, sync, Arrays.asList(args));
+        LoadingCF f = new LoadingCF(options, sync, Arrays.asList(args));
         synchronized (this) {
             if (this.loading != null && this.loading.satisifes(f)) {
-                if (!force) {
+                if (!options.isForce()) {
                     LOG.log(Level.FINER, "Project {2} is already loading to quality {0}, now attempted {1}, returning existing handle", new 
-                            Object[] { this.loading.aim, aim, this });
+                            Object[] { this.loading.options.getAim(), options.getAim(), this });
                     return loading;
                 }
             }
@@ -472,8 +542,11 @@ public final class NbGradleProjectImpl implements Project {
         }
         int s = currentSerial.incrementAndGet();
         // do not block during project load.
-        LOG.log(Level.FINER, "Starting project {2} load, serial {0}, attempted quality {1}", new Object[] { s, aim, this });
-        GradleProject prj = loader.loadProject(aim, desc, ignoreCache, interactive, args);
+        LOG.log(Level.FINER, "Starting project {2} load, serial {0}, attempted quality {1}", new Object[] { s, options.getAim(), this });
+        if (options.isForce()) {
+            options.setIgnoreCache(true);
+        }
+        GradleProject prj = loader.loadProject(options, args);
         synchronized (this) {
             if (loadedProjectSerial > s && project != null) {
                 // the load started LATER than this one: return that project, and do not replace anything as this.project is newer
@@ -481,9 +554,9 @@ public final class NbGradleProjectImpl implements Project {
                 return CompletableFuture.completedFuture(this.project);
             }
             loadedProjectSerial = s;
-            this.attemptedQuality = aim;
+            this.attemptedQuality = options.getAim();
             
-            boolean replace = project == null || force;
+            boolean replace = project == null || options.isForce();
             if (project != null) {
                 if (prj.getQuality().betterThan(project.getQuality())) {
                     replace = true;
@@ -497,7 +570,7 @@ public final class NbGradleProjectImpl implements Project {
             }
             if (!replace) {
                 // avoid replacing a project when nothing has changed.
-                LOG.log(Level.FINER, "Current project {1} sufficient for attempted quality {0}", new Object[] { this.project, aim });
+                LOG.log(Level.FINER, "Current project {1} sufficient for attempted quality {0}", new Object[] { this.project, options.getAim() });
                 return CompletableFuture.completedFuture(this.project);
             }
             LOG.log(Level.FINER, "Replacing {0} with {1}, attempted quality {2}", new Object[] { this.project, prj, attemptedQuality });
@@ -562,11 +635,7 @@ public final class NbGradleProjectImpl implements Project {
      * @return Task representing the reloading process
      */
     RequestProcessor.Task forceReloadProject(String reloadReason, boolean interactive, final Quality aim, final String... args) {
-        return reloadProject(reloadReason, true, interactive, aim, args);
-    }
-    
-    private RequestProcessor.Task reloadProject(String desc, final boolean ignoreCache, final boolean interactive, final Quality aim, final String... args) {
-        return RELOAD_RP.post(() -> loadOwnProject(desc, ignoreCache, interactive, aim, args));
+        return RELOAD_RP.post(() -> loadOwnProject(reloadReason, true, interactive, aim, args));
     }
 
     @Override

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/NbGradleProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/NbGradleProject.java
@@ -201,6 +201,15 @@ public final class NbGradleProject {
         this.project = project;
         support = new PropertyChangeSupport(project);
     }
+    
+    /**
+     * Provides full lookup of the currently loaded project state. This Lookup does NOT refreshes
+     * as project is reload, the client must eventually watch {@link #PROP_PROJECT_INFO} property change and obtain a fresh lookup.
+     * @return Lookup that contains the current metadata for the project.
+     */
+    public Lookup curretLookup() {
+        return project.getGradleProject().getLookup();
+    }
 
     public <T> T projectLookup(Class<T> clazz) {
         return project.getGradleProject().getLookup().lookup(clazz);
@@ -257,6 +266,15 @@ public final class NbGradleProject {
     }
     
     /**
+     * Returns the time the project was evaluated. If the project has not been loaded at least in its
+     * 'fallback' state, it returns a negative value.
+     * @return evaluation time of the project.
+     */
+    public long getEvaluateTime() {
+        return project.getEvaluationTime();
+    }
+    
+    /**
      * Attempts to refresh the project to at least the desired quality. The project information
      * may be reloaded, if the project is currently loaded with lower {@link Quality} than {@code q}.
      * If {@code forceLoad} is true, the project reloads even if the {@code q} is worse quality than
@@ -277,7 +295,160 @@ public final class NbGradleProject {
      * @since 2.11
      */
     public @NonNull CompletionStage<NbGradleProject> toQuality(@NullAllowed String reason, @NonNull Quality q, boolean forceLoad) {
-        return project.projectWithQualityTask(reason, q, false, forceLoad).thenApply(p -> this);
+        return project.projectWithQualityTask(loadOptions(q).setDescription(reason).setForce(forceLoad)).thenApply(p -> this);
+    }
+    
+    /**
+     * Creates a {@link LoadOptions} object to be used with {@link #toQuality(org.netbeans.modules.gradle.api.NbGradleProject.LoadOptions)}.
+     * @param aim the target quality
+     * @return options object.
+     * @since 2.43
+     */
+    public static LoadOptions loadOptions(Quality aim) {
+        return new LoadOptions(aim);
+    }
+    
+    /**
+     * Describes options for loading a Gradle project.
+     * @since 2.43
+     */
+    public static final class LoadOptions {
+        private final Quality aim;
+        private boolean force;
+        private String description;
+        private boolean ignoreCache;
+        private boolean interactive;
+        private boolean offline;
+        private boolean checkFiles;
+
+        LoadOptions(Quality aim) {
+            this.aim = aim;
+        }
+        
+        /**
+         * Instructs to check file timestamps against project loading time when deciding whether to use current data. The default is {@code false}.
+         * @param b true to check file timestamps.
+         * @return this options object.
+         */
+        public LoadOptions setCheckFiles(boolean b) {
+            this.checkFiles = b;
+            return this;
+        }
+        
+        /**
+         * Forces offline operation. The default is {@code false}.
+         * @param b true, if the operation must be offline
+         * @return this options object
+         */
+        public LoadOptions setOffline(boolean b) {
+            this.offline = b;
+            return this;
+        }
+        
+        /**
+         * Sets an interactive flag. If interactive, the implementation is allowed to ask for confirmation
+         * or other questions. False means that questions will fail as if cancelled, other prompts will resolve to
+         * their default options. The default is {@code false}.
+         * @param b true, if interactive process
+         * @return this options object
+         */
+        public LoadOptions setInteractive(boolean b) {
+            this.interactive = b;
+            return this;
+        }
+
+        /**
+         * Sets description of the operation. The description serves as part of a message to the user about project being
+         * loaded or a progress status indicator. The text should describe the operation that requires a load, e.g. "Creating classpath".
+         * There's no default description.
+         * @param desc description
+         * @return this options object
+         */
+        public LoadOptions setDescription(String desc) {
+            this.description = desc;
+            return this;
+        }
+        
+        /**
+         * Forces the load to bypass the on-disk cache. If set, cached data will be ignored. If false, the implementation
+         * is allowed to satisfy the load from the cache, if the cached quality is sufficient. The default is {@code false}.
+         * @param b true to bypass caches
+         * @return this options object
+         */
+        public LoadOptions setIgnoreCache(boolean b) {
+            this.ignoreCache = b;
+            return this;
+        }
+        
+        /**
+         * Forces the load, even though the quality of current project is OK and no files have been modified. The default is {@code false}.
+         * @param b true to force load the project.
+         * @return this options object
+         */
+        public LoadOptions setForce(boolean b) {
+            this.force = b;
+            return this;
+        }
+
+        /**
+         * @return true to force the load regardless of consistency and quality
+         */
+        public boolean isForce() {
+            return force;
+        }
+
+        /**
+         * @return the desired quality level
+         */
+        public NbGradleProject.Quality getAim() {
+            return aim;
+        }
+
+        /**
+         * @return description of the operation that initiated the load
+         */
+        public String getDescription() {
+            return description;
+        }
+
+        /**
+         * @return true to ignore netbeans caches
+         */
+        public boolean isIgnoreCache() {
+            return ignoreCache;
+        }
+
+        /**
+         * @return true, if the process is interactive
+         */
+        public boolean isInteractive() {
+            return interactive;
+        }
+
+        /**
+         * @return true, if the load must not use online resources.
+         */
+        public boolean isOffline() {
+            return offline;
+        }
+
+        /**
+         * @return true to check timestamps of gradle files
+         */
+        public boolean isCheckFiles() {
+            return checkFiles;
+        }
+    }
+
+    /**
+     * Unlike {@link #toQuality}, this method loads the project, if the project files have changed since the last load. If project definition
+     * files did not change, 
+     * @param options load options and requiremens.
+     * @return Future with the result project.
+     * @since 2.43
+     */
+    public @NonNull CompletionStage<NbGradleProject> toQuality(LoadOptions options) {
+        return project.projectWithQualityTask(options).thenApply(p -> this);
     }
 
     public Preferences getPreferences(boolean shared) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
@@ -215,14 +215,20 @@ public final class ProjectInfoDiskCache extends AbstractDiskCache<GradleFiles, Q
         private final Set<String> problems;
         private final Set<Report> reports;
         private final String gradleException;
+        private final long timestamp;
 
-        public QualifiedProjectInfo(Quality quality, NbProjectInfo pinfo) {
+        public QualifiedProjectInfo(Quality quality, NbProjectInfo pinfo, long timestamp) {
             this.quality = quality;
             info = new TreeMap<>(pinfo.getInfo());
             ext = new TreeMap<>(pinfo.getExt());
             problems = new LinkedHashSet<>(pinfo.getProblems());
             gradleException = pinfo.getGradleException();
             reports = makeReports(pinfo.getReports());
+            this.timestamp = timestamp;
+        }
+
+        public long getTimestamp() {
+            return timestamp;
         }
 
         @Override

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
@@ -29,6 +29,7 @@ import org.netbeans.modules.gradle.NbGradleProjectImpl;
 import org.netbeans.modules.gradle.api.GradleBaseProject;
 import org.netbeans.modules.gradle.api.GradleReport;
 import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.api.NbGradleProject.LoadOptions;
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.EVALUATED;
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FALLBACK;
 import org.netbeans.modules.gradle.tooling.internal.NbProjectInfo.Report;
@@ -62,19 +63,20 @@ public abstract class AbstractProjectLoader {
     }
     
     static final class ReloadContext {
-
+        final LoadOptions options;
         final NbGradleProjectImpl project;
         final GradleProject previous;
-        final NbGradleProject.Quality aim;
         final GradleCommandLine cmd;
-        final String description;
 
-        public ReloadContext(NbGradleProjectImpl project, NbGradleProject.Quality aim, GradleCommandLine cmd, String description) {
+        public ReloadContext(NbGradleProjectImpl project, LoadOptions options, GradleCommandLine cmd) {
             this.project = project;
             this.previous = project.isGradleProjectLoaded() ? project.projectWithQuality(null, FALLBACK, false, false) : FallbackProjectLoader.createFallbackProject(project.getGradleFiles());
-            this.aim = aim;
+            this.options = options;
             this.cmd = cmd;
-            this.description = description;
+        }
+        
+        public String getDescription() {
+            return options.getDescription();
         }
 
         public GradleProject getPrevious() {
@@ -82,7 +84,11 @@ public abstract class AbstractProjectLoader {
         }
 
         public NbGradleProject.Quality getAim() {
-            return aim;
+            return options.getAim();
+        }
+
+        public LoadOptions getOptions() {
+            return options;
         }
     }
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
@@ -57,7 +57,7 @@ public class DiskCacheProjectLoader extends AbstractProjectLoader {
 
     @Override
     boolean isEnabled() {
-        return ctx.aim.betterThan(FALLBACK) && !GradleExperimentalSettings.getDefault().isCacheDisabled();
+        return ctx.getAim().betterThan(FALLBACK) && !GradleExperimentalSettings.getDefault().isCacheDisabled();
     }
 
     @Override

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
@@ -26,7 +26,7 @@ import org.netbeans.api.project.Project;
 import org.netbeans.modules.gradle.GradleProject;
 import org.netbeans.modules.gradle.GradleProjectLoader;
 import org.netbeans.modules.gradle.NbGradleProjectImpl;
-import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.api.NbGradleProject.LoadOptions;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
 import org.netbeans.modules.gradle.api.execute.RunUtils;
 import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
@@ -49,15 +49,15 @@ public class GradleProjectLoaderImpl implements GradleProjectLoader {
     @NbBundle.Messages({
         "ERR_ProjectNotTrusted=Gradle execution is not trusted on this project."
     })
-    public GradleProject loadProject(NbGradleProject.Quality aim, String descriptionOpt, boolean ignoreCache, boolean interactive, String... args) {
-        LOGGER.info("Load aiming " +aim + " for "+ project);
+    public GradleProject loadProject(LoadOptions options, String... args) {
+        LOGGER.info("Load aiming " +options.getAim() + " for "+ project);
         GradleCommandLine cmd = new GradleCommandLine(args);
-        AbstractProjectLoader.ReloadContext ctx = new AbstractProjectLoader.ReloadContext((NbGradleProjectImpl) project, aim, cmd, descriptionOpt);
+        AbstractProjectLoader.ReloadContext ctx = new AbstractProjectLoader.ReloadContext((NbGradleProjectImpl) project, options, cmd);
         LOGGER.log(Level.FINER, "Load context: project = {0}, prev = {1}, aim = {2}, args = {3}", new Object[] { 
-            project, ctx.previous, aim, cmd});
+            project, ctx.previous, options.getAim(), cmd});
         List<AbstractProjectLoader> loaders = new LinkedList<>();
 
-        if (!ignoreCache) loaders.add(new DiskCacheProjectLoader(ctx));
+        if (!options.isIgnoreCache()) loaders.add(new DiskCacheProjectLoader(ctx));
         if (GradleExperimentalSettings.getDefault().isBundledLoading()) {
             loaders.add(new BundleProjectLoader(ctx));
             loaders.add(new DiskCacheProjectLoader(ctx));
@@ -73,7 +73,7 @@ public class GradleProjectLoaderImpl implements GradleProjectLoader {
             if (loader.isEnabled()) {
                 if (loader.needsTrust()) {
                     if (trust == null) {
-                        trust = RunUtils.isProjectTrusted(ctx.project, interactive);
+                        trust = RunUtils.isProjectTrusted(ctx.project, options.isInteractive());
                     }
                     if (trust) {
                         ret = loader.load();
@@ -93,7 +93,7 @@ public class GradleProjectLoaderImpl implements GradleProjectLoader {
                     if (best == null || best.getQuality().notBetterThan(ret.getQuality())) {
                         best = ret;
                     }
-                    if (ret.getQuality().atLeast(aim)) {
+                    if (ret.getQuality().atLeast(options.getAim())) {
                         // We have the quality we are looking for, let's be happy with that
                         break;
                     }

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/NbProjectInfoCachingDescriptor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/NbProjectInfoCachingDescriptor.java
@@ -59,7 +59,7 @@ public final class NbProjectInfoCachingDescriptor implements ModelCachingDescrip
     @Override
     public void onLoad(String target, NbProjectInfo model) {
         Quality quality = model.hasException() ? SIMPLE : FULL_ONLINE;
-        ProjectInfoDiskCache.QualifiedProjectInfo qinfo = new ProjectInfoDiskCache.QualifiedProjectInfo(quality, model);
+        ProjectInfoDiskCache.QualifiedProjectInfo qinfo = new ProjectInfoDiskCache.QualifiedProjectInfo(quality, model, System.currentTimeMillis());
         GradleFiles gf = new GradleFiles(structure.getProjectDir(target), true);
         ProjectInfoDiskCache.get(gf).storeData(qinfo);
     }

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
@@ -58,6 +58,8 @@ import org.netbeans.api.project.ProjectManager;
 import org.netbeans.modules.gradle.GradleProjectLoader;
 import org.netbeans.modules.gradle.ProjectTrust;
 import org.netbeans.modules.gradle.api.GradleProjects;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.api.NbGradleProject.LoadOptions;
 import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
 import org.netbeans.modules.gradle.execute.EscapeProcessingOutputStream;
 import org.netbeans.modules.gradle.execute.GradlePlainEscapeProcessor;
@@ -526,7 +528,7 @@ public final class TemplateOperation implements Runnable {
                             //Just load the project into the cache.
                             GradleProjectLoader loader = nbProject.getLookup().lookup(GradleProjectLoader.class);
                             if (loader != null) {
-                                loader.loadProject(Quality.FULL_ONLINE, null, true, false);
+                                loader.loadProject(NbGradleProject.loadOptions(Quality.FULL_ONLINE).setIgnoreCache(true));
                             }
                         }
                         Set<FileObject> ret = new LinkedHashSet<>();


### PR DESCRIPTION
The motivation for the change was introduction of an additional flag "offline" for loading, since `LegacyProjectLoader` did not allow for authoritative ban on online operations - it reads settings and decides on its own, mostly doing ON_DEMAND operation - but in some cases it is desired not to go online explicitly even though the option permit that for the default/standard operation.

I have decided to export a `LoadOptions` object that is passed into the loading infrastructures and replaces a number of parameters passed down from NbGradleProjectImpl to loaders etc.

Two minor additional API additions are in this PR:
- `NbGradleProject` exposes timestamp of the metadata load. The motivation is to be able to compare the metadata timestamp against GradleFiles timestamps to check if project reload should be done or not
- `NbGradleProject` exposes full current Lookup, that can be used to get the instances of GradleBaseProject, GradleJavaProject - essentially the snapshot of data loaded by the loading infrastructure. Though GradleJavaProject.get(prj) can be used, it always works against 'most recent' load, while the Lookup allows consistency between BaseProject, JavaProject even if another reload happens.
- 