### PR TITLE
Maven project reload implementation

### DIFF
--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/reload/Reloader.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/reload/Reloader.java
@@ -556,6 +556,11 @@ public final class Reloader {
     }
 
     private CompletableFuture<ProjectReload.ProjectState> loadStepDone(ProjectStateData<?> state, LoadContextImpl fd, Throwable t) {
+        loadStepDone1(state, fd, t);
+        return processOne();
+    }
+
+    private void loadStepDone1(ProjectStateData<?> state, LoadContextImpl fd, Throwable t) {
         // record the returned data for subsequent rounds:
         if (t != null) {
             fd.reloadError = t;
@@ -571,7 +576,6 @@ public final class Reloader {
         LOG.log(Level.FINE, "{0} {1} loaded {2} with load-private data {3}", new Object[]{this, fd.impl, state, fd.contextData});
         currentStage = null;
         currentStageContext = null;
-        return processOne();
     }
 
     /**
@@ -656,6 +660,7 @@ public final class Reloader {
                 LOG.log(Level.FINE, "{0}: {1} rejected by {2}", new Object[]{this, d.loadedData, d.impl});
                 break;
             }
+            loadStepDone1(d.loadedData, d, null);
         }
         final LoadContextImpl fd = d;
         try {

--- a/java/maven/nbproject/project.xml
+++ b/java/maven/nbproject/project.xml
@@ -608,6 +608,10 @@
                     <test-dependency>
                         <code-name-base>org.netbeans.api.maven</code-name-base>
                     </test-dependency>
+                    <test-dependency>
+                        <!-- Because otherwise data systems and their services will not materialize -->
+                        <code-name-base>org.netbeans.modules.settings</code-name-base>
+                    </test-dependency>
                 </test-type>
             </test-dependencies>
             <friend-packages>

--- a/java/maven/src/org/netbeans/modules/maven/NbArtifactFixer.java
+++ b/java/maven/src/org/netbeans/modules/maven/NbArtifactFixer.java
@@ -108,7 +108,7 @@ public class NbArtifactFixer implements ArtifactFixer {
             //instead of workarounds down the road, we set the artifact's file here.
             // some stacktraces to maven/aether do set it after querying our code, but some don't for reasons unknown to me.
             artifact.setFile(f);
-            Set<Artifact> s = CAPTURE_FAKE_ARTIFACTS.get();
+            Set<Artifact> s = CAPTURE_PLACEHOLDER_ARTIFACTS.get();
             if (s != null) {
                 String c = artifact.getProperty("nbResolvingArtifact.classifier", null);
                 String e = artifact.getProperty("nbResolvingArtifact.extension", null);
@@ -194,10 +194,10 @@ public class NbArtifactFixer implements ArtifactFixer {
     }        
     
     /**
-     * Collects faked artifacts, which would be otherwise hidden in maven infrastructure. The value is only valid during {@link #collectFallbackArtifacts}, which
+     * Collects placeholder artifacts, which would be otherwise hidden in maven infrastructure. The value is only valid during {@link #collectPlaceholderArtifacts}, which
      * can be invoked recursively.
      */
-    private static ThreadLocal<Set<Artifact>> CAPTURE_FAKE_ARTIFACTS = new ThreadLocal<Set<Artifact>>();
+    private static final ThreadLocal<Set<Artifact>> CAPTURE_PLACEHOLDER_ARTIFACTS = new ThreadLocal<Set<Artifact>>();
 
     /**
      * Performs an operation and collects forged artifacts created during that operation. The invocation can be nested; each invocation gets only artifacts from its own 'level',
@@ -210,10 +210,10 @@ public class NbArtifactFixer implements ArtifactFixer {
      * @return
      * @throws E 
      */
-    public static <T, E extends Throwable> T collectFallbackArtifacts(ExceptionCallable<T, E> code, Consumer<Set<Artifact>> collector) throws E {
-        Set<Artifact> save = CAPTURE_FAKE_ARTIFACTS.get();
+    public static <T, E extends Throwable> T collectPlaceholderArtifacts(ExceptionCallable<T, E> code, Consumer<Set<Artifact>> collector) throws E {
+        Set<Artifact> save = CAPTURE_PLACEHOLDER_ARTIFACTS.get();
         try {
-            CAPTURE_FAKE_ARTIFACTS.set(new HashSet<>());
+            CAPTURE_PLACEHOLDER_ARTIFACTS.set(new HashSet<>());
             return code.call();
         } catch (Error | RuntimeException r) {
             throw r;
@@ -223,9 +223,9 @@ public class NbArtifactFixer implements ArtifactFixer {
             throw new Error(); 
         } finally {
             if (collector != null) {
-                collector.accept(CAPTURE_FAKE_ARTIFACTS.get());
+                collector.accept(CAPTURE_PLACEHOLDER_ARTIFACTS.get());
             }
-            CAPTURE_FAKE_ARTIFACTS.set(save);
+            CAPTURE_PLACEHOLDER_ARTIFACTS.set(save);
         }
     }
 }

--- a/java/maven/src/org/netbeans/modules/maven/api/NbMavenProject.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/NbMavenProject.java
@@ -203,6 +203,14 @@ public final class NbMavenProject {
         return MavenProjectCache.isFallbackproject(getMavenProject());
     }
     
+    /**
+     * Returns timestamp of project (metadata) load. Returns negative number,
+     * if the timestamp is not known or project is not loaded.
+     * @return timestamp.
+     */
+    public long getLoadTimestamp() {
+        return project.getLoadTimestamp();
+    }
 
     @Messages({
         "Progress_Download=Downloading Maven dependencies", 

--- a/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
@@ -370,7 +370,8 @@ public class MavenCommandLineExecutor extends AbstractMavenExecutor {
                 final Project prj = clonedConfig.getProject();
                 if (prj != null) {
                     NbMavenProjectImpl impl = prj.getLookup().lookup(NbMavenProjectImpl.class);
-                    if (impl != null) {
+                    // magic number -10 seems to be a cancelled process.
+                    if (impl != null && executionresult != -10) {
                         // this reload must not wait for blockers.
                         RequestProcessor.Task reloadTask = impl.fireProjectReload();
                         reloadTask.waitFinished();

--- a/java/maven/src/org/netbeans/modules/maven/problems/MavenModelProblemsProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/problems/MavenModelProblemsProvider.java
@@ -365,25 +365,25 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
         List<Artifact> missingJars = new ArrayList<Artifact>();
         List<Artifact> artifactsToCheck = new ArrayList<>(project.getArtifacts());
         MavenProject partial = MavenProjectCache.getPartialProject(project);
-        Collection<Artifact> fakes = (Collection<Artifact>)project.getContextValue("NB_FakedArtifacts");
+        Collection<Artifact> placeholders = MavenProjectCache.getPlaceholderArtifacts(project);
         if (LOG.isLoggable(Level.FINER)) {
             LOG.log(Level.FINER, "Checking artifacts: {0}", artifactsToCheck);
             if (partial != null && partial != project) {
-                Collection<Artifact> partialFakes = (Collection<Artifact>)partial.getContextValue("NB_FakedArtifacts");
-                LOG.log(Level.FINER, "Partial project for {0}@{1} is: {2}@{3}, fake artifacts: {4}", new Object[] { 
-                    project, System.identityHashCode(project), partial, System.identityHashCode(partial), partialFakes
+                Collection<Artifact> partialPlaceholders = MavenProjectCache.getPlaceholderArtifacts(partial);
+                LOG.log(Level.FINER, "Partial project for {0}@{1} is: {2}@{3}, placeholder artifacts: {4}", new Object[] { 
+                    project, System.identityHashCode(project), partial, System.identityHashCode(partial), partialPlaceholders
                 });
             }
-            LOG.log(Level.FINER, "Fake artifacts for {0}@{1}: {2}", new Object[] { 
-                project, System.identityHashCode(project), fakes
+            LOG.log(Level.FINER, "Placeholder artifacts for {0}@{1}: {2}", new Object[] { 
+                project, System.identityHashCode(project), placeholders
             });
         }
         
         Collection<Artifact> toCheck = new HashSet<>(project.getArtifacts());
-        if (fakes != null) {
-            // the fake artifacts are typically without a scope, so ignore scope when merging with other reported pieces.
+        if (placeholders != null) {
+            // the placeholder artifacts are typically without a scope, so ignore scope when merging with other reported pieces.
             Set<String> ids = toCheck.stream().map(MavenModelProblemsProvider::artifactId).collect(Collectors.toSet());
-            fakes.stream().filter(a -> !ids.contains(artifactId(a))).forEach(toCheck::add);
+            placeholders.stream().filter(a -> !ids.contains(artifactId(a))).forEach(toCheck::add);
         }
         
         for (Artifact art : toCheck) {

--- a/java/maven/src/org/netbeans/modules/maven/problems/MavenModelProblemsProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/problems/MavenModelProblemsProvider.java
@@ -25,6 +25,8 @@ import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -36,7 +38,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.function.Predicate;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -75,6 +77,7 @@ import org.openide.util.RequestProcessor;
 import org.openide.util.lookup.Lookups;
 import org.netbeans.modules.maven.InternalActionDelegate;
 import org.netbeans.modules.maven.problems.SanityBuildAction.SanityBuildNeededChecker;
+import org.openide.util.Cancellable;
 import org.openide.util.Pair;
 
 /**
@@ -555,6 +558,34 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
         return primingProvider;
     }
     
+    /**
+     * Finds a suitable Consumer for cancellable in the action context Lookup.
+     * I didn't want to provide yet another public interface, so this code checks for a Consumer,
+     * whose implementation class specializes the T type to org.openide.Cancellable
+     * If the context lookup can accept a Cancellable implementation, we provide one, that can cancel 
+     * the running process.
+     * @param context action context
+     * @param primingHandle future capable of cancelling the priming build
+     * @return true, if attached.
+     */
+    private boolean attachCancellable(Lookup context, CompletableFuture primingHandle) {
+        Consumer<Cancellable> c = context.lookup(Consumer.class);
+        if (c != null) {
+            int index = 0;
+            Class[] interfaces = c.getClass().getInterfaces();
+            for (Type t  : c.getClass().getGenericInterfaces()) {
+                if (interfaces[index].getName().equals(Consumer.class.getName())) {
+                    if (((ParameterizedType)t).getActualTypeArguments()[0].getTypeName().equals(Cancellable.class.getName())) {
+                        c.accept(() -> primingHandle.cancel(true));
+                        return true;
+                    }
+                }
+                index++;
+            }
+        }
+        return false;
+    }
+    
     private class PrimingActionProvider implements ActionProvider {
         @Override
         public String[] getSupportedActions() {
@@ -576,8 +607,9 @@ public class MavenModelProblemsProvider implements ProjectProblemsProvider, Inte
                 listener.finished(true);
             } else {
                 LOG.log(Level.FINE, "Resolving sanity build action");
-                CompletableFuture<ProjectProblemsProvider.Result> r = saba.resolve(context);
-                r.whenComplete((a, e) -> {
+                CompletableFuture<ProjectProblemsProvider.Result> primingHandle = saba.resolve(context);
+                attachCancellable(context, primingHandle);
+                primingHandle.whenComplete((a, e) -> {
                    listener.finished(e == null); 
                 });
             }

--- a/java/maven/src/org/netbeans/modules/maven/queries/MavenPrimingReloadImplementation.java
+++ b/java/maven/src/org/netbeans/modules/maven/queries/MavenPrimingReloadImplementation.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.queries;
+
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.project.MavenProject;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectUtils;
+import org.netbeans.modules.maven.api.NbMavenProject;
+import org.netbeans.modules.maven.modelcache.MavenProjectCache;
+import org.netbeans.modules.project.dependency.ProjectOperationException;
+import org.netbeans.modules.project.dependency.ProjectReload;
+import org.netbeans.modules.project.dependency.spi.ProjectReloadImplementation;
+import org.netbeans.spi.project.ActionProgress;
+import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.LookupProvider;
+import org.netbeans.spi.project.ProjectServiceProvider;
+import org.openide.util.Cancellable;
+import org.openide.util.Lookup;
+import org.openide.util.NbBundle;
+import org.openide.util.lookup.Lookups;
+
+/**
+ * This class steps in, if the requested quality is higher than LOAD and the 
+ * MavenProject loaded by the base implementation contains fake artifacts.
+ * If RESOLVED is requested, the implementation runs a priming build and then restarts the reload
+ * operation, so that base maven impl will re-read the project.
+ * To avoid reloading loops, the faked artifacts are stored between reloads. If the reported fake artifacts
+ * are all already known - that is,they were not resolved by the priming build, the implementation ends
+ * with an error, the project is not correctable.
+ * @author sdedic
+ */
+@ProjectServiceProvider(service = ProjectReloadImplementation.class, projectTypes = {
+    @LookupProvider.Registration.ProjectType(id = NbMavenProject.TYPE, position = 11000)
+    
+})
+public class MavenPrimingReloadImplementation implements ProjectReloadImplementation {
+    /**
+     * Names of artifacts that were faked. It's not productive to run a priming build to fix this known set of artifacts,
+     * unless "force" is in effect - they are unlikely to be retrieved, since they already failed.
+     */
+    // @GuardedBy(this)
+    private Set<String> fakeArtifactNames = new HashSet<>();
+
+    
+    private Reference<ProjectStateData> lastData = new WeakReference<>(null);
+    
+    static class LC {
+        boolean firstRun = true;
+    }
+    
+    /**
+     * Holds the MavenProject instance. MavenProject instance is already published
+     * as data by base reload implementation.
+     */
+    private static class ModelHolder {
+        final MavenProject p;
+
+        public ModelHolder(MavenProject p) {
+            this.p = p;
+        }
+    }
+
+    private ProjectReload.Quality getProjectQuality(MavenProject mp) {
+        if (MavenProjectCache.isFallbackproject(mp)) {
+            // could not load at all.
+            MavenProject fallback = MavenProjectCache.getPartialProject(mp);
+            return fallback != null ? 
+                    ProjectReload.Quality.BROKEN:
+                    ProjectReload.Quality.NONE;
+        }
+        if (!MavenProjectCache.getFakedArtifacts(mp).isEmpty()) {
+            return ProjectReload.Quality.LOADED;
+        }
+        return ProjectReload.Quality.RESOLVED;
+    }
+    
+    
+    private ProjectStateData createStateData(MavenProject mp) {
+        synchronized (this) {
+            ProjectStateData<ModelHolder> d2 = lastData.get();
+            if (d2 != null) {
+                ModelHolder h = d2.getProjectData();
+                if (h != null && h.p == mp) {
+                    return d2;
+                }
+            }
+        }
+        ProjectStateData d;
+        
+        ProjectStateBuilder builder = ProjectStateData.builder(getProjectQuality(mp)).
+                timestamp(MavenProjectCache.getLoadTimestamp(mp));
+        builder.data(new ModelHolder(mp));
+        builder.attachLookup(Lookups.fixed(mp));
+        d = builder.build();
+        synchronized (this) {
+            ProjectStateData d2 = lastData.get();
+            if (d2 != null) {
+                if (d2.getProjectData() == mp) {
+                    return d2;
+                }
+                d2.fireChanged(true, false);
+            }
+            lastData = new WeakReference<>(d);
+        }
+        return d;
+    }
+
+    static boolean checkForMissingArtifacts(MavenProject p) {       
+        return p == null || !MavenProjectCache.isIncompleteProject(p) ||
+               MavenProjectCache.getFakedArtifacts(p).isEmpty();
+    }
+
+    static String artifactGav(Artifact a) {
+        return String.format("%s:%s:%s:%s", a.getGroupId(), a.getArtifactId(), a.getVersion(), a.getClassifier());
+    }
+
+    @NbBundle.Messages({
+        "# {0} - project name",
+        "ERR_PrimingBuildFailed=Priming build of {0} failed."
+    })
+    @Override
+    public CompletableFuture reload(Project project, ProjectReload.StateRequest request, LoadContext context) {
+        MavenProject p = context.stateLookup().lookup(MavenProject.class);
+        
+        LC lc = (LC)context.ensureLoadContext(LC.class, LC::new);
+        
+        boolean ok = checkForMissingArtifacts(p);
+        if (ok) {
+            synchronized (this) {
+                fakeArtifactNames.clear();
+            }
+            context.saveLoadContext(this);
+            return CompletableFuture.completedFuture(null);
+        } 
+        
+        ActionProvider ap = project.getLookup().lookup(ActionProvider.class);
+        if (!ap.isActionEnabled(ActionProvider.COMMAND_PRIME, Lookup.EMPTY)) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        Collection<Artifact> faked = MavenProjectCache.getFakedArtifacts(p);
+        Set<String> gavs = new HashSet<>();
+        faked.forEach(a -> gavs.add(artifactGav(a)));
+        String parentGav = artifactGav(p.getParentArtifact());
+        
+        CompletableFuture<ProjectStateData> future = new CompletableFuture<>();
+        if (gavs.contains(parentGav)) {
+            if (request.getMinQuality().isWorseThan(ProjectReload.Quality.BROKEN)) {
+                future.complete(createStateData(p));
+            } else if (request.isOfflineOperation()) {
+                PartialLoadException ex = new PartialLoadException(createStateData(p),
+                     Bundle.ERR_ParentPomMissing(ProjectUtils.getInformation(project).getDisplayName(), parentGav), 
+                    new ProjectOperationException(project, ProjectOperationException.State.OFFLINE, 
+                    Bundle.ERR_UnprimedInOfflineMode(ProjectUtils.getInformation(project).getDisplayName()))
+                );
+                future.completeExceptionally(ex);
+                return future;
+            }
+        }
+        if (request.getMinQuality().isWorseThan(ProjectReload.Quality.RESOLVED)) {
+            future.complete(createStateData(p));
+            return future;
+        } else if (request.isOfflineOperation()) {
+            PartialLoadException ex = new PartialLoadException(createStateData(p),
+                 Bundle.ERR_ParentPomMissing(ProjectUtils.getInformation(project).getDisplayName(), parentGav), 
+                new ProjectOperationException(project, ProjectOperationException.State.OFFLINE, 
+                    Bundle.ERR_UnprimedInOfflineMode(ProjectUtils.getInformation(project).getDisplayName()))
+            );
+            future.completeExceptionally(ex);
+            return future;
+        }
+        
+        synchronized (this) {
+            if (!lc.firstRun && fakeArtifactNames.containsAll(gavs) && !request.isForceReload()) {
+                // no point in running priming build again, when the artifacts are known to be broken.
+                future.complete(createStateData(p));
+                return future;
+            }
+            fakeArtifactNames = gavs;
+        }
+
+        lc.firstRun = false;
+
+        /**
+         * Action looks for Consumer&lt;Cancellable> in the context lookup and gives it
+         * its {@link Cancellable} capable to abort the priming build. The class will receive
+         * the Cancellable during priming build initialization.
+         */
+        class CancelSignalDelegator implements Consumer<Cancellable>, Cancellable {
+            private final AtomicReference<Cancellable> ref = new AtomicReference<>();
+            
+            @Override
+            public void accept(Cancellable other) {
+                ref.set(other);
+            }
+            @Override
+            public boolean cancel() {
+                Cancellable other = ref.get();
+                return other != null && other.cancel();
+            }
+        }
+        Cancellable csd = new CancelSignalDelegator();
+        context.setCancellable(csd);
+        
+        // PENDING: report progress through progress API, use request.getReason().
+        ActionProgress prg = new ActionProgress() {
+            @Override
+            protected void started() {
+            }
+
+            @Override
+            public void finished(boolean success) {
+                if (success) {
+                    context.retryReload();
+                    future.complete(null);
+                } else if (context.isCancelled()) {
+                    future.completeExceptionally(context.getCancelled());
+                } else {
+                    String n = ProjectUtils.getInformation(project).getDisplayName();
+                    ProjectOperationException cause = new ProjectOperationException(project, ProjectOperationException.State.BROKEN, Bundle.ERR_PrimingBuildFailed(n));
+                    ProjectStateData partialdata = createStateData(p);
+                    // allow the project operation to complete, with degraded quality:
+                    PartialLoadException ex = new PartialLoadException(partialdata, Bundle.ERR_PrimingBuildFailed(n), cause);
+                    future.completeExceptionally(ex);
+                }
+            }
+        };
+        if (context.isCancelled()) {
+            future.cancel(true);
+            return future;
+        }
+        ap.invokeAction(ActionProvider.COMMAND_PRIME, Lookups.fixed(prg, csd));
+        return future;
+    }
+}

--- a/java/maven/src/org/netbeans/modules/maven/queries/MavenReloadImplementation.java
+++ b/java/maven/src/org/netbeans/modules/maven/queries/MavenReloadImplementation.java
@@ -159,7 +159,7 @@ public class MavenReloadImplementation implements ProjectReloadImplementation, P
                     ProjectReload.Quality.BROKEN:
                     ProjectReload.Quality.NONE;
         }
-        if (!MavenProjectCache.getFakedArtifacts(mp).isEmpty()) {
+        if (!MavenProjectCache.getPlaceholderArtifacts(mp).isEmpty()) {
             return ProjectReload.Quality.LOADED;
         }
         return ProjectReload.Quality.RESOLVED;

--- a/java/maven/src/org/netbeans/modules/maven/queries/MavenReloadImplementation.java
+++ b/java/maven/src/org/netbeans/modules/maven/queries/MavenReloadImplementation.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.queries;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.project.MavenProject;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.maven.NbMavenProjectImpl;
+import org.netbeans.modules.maven.api.NbMavenProject;
+import org.netbeans.modules.maven.embedder.EmbedderFactory;
+import org.netbeans.modules.maven.modelcache.MavenProjectCache;
+import org.netbeans.modules.project.dependency.ProjectReload;
+import org.netbeans.modules.project.dependency.ProjectReload.StateRequest;
+import org.netbeans.modules.project.dependency.spi.ProjectReloadImplementation;
+import org.netbeans.spi.project.LookupProvider;
+import org.netbeans.spi.project.ProjectServiceProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.NbBundle;
+import org.openide.util.RequestProcessor;
+import org.openide.util.Task;
+import org.openide.util.TaskListener;
+import org.openide.util.WeakListeners;
+import org.openide.util.lookup.Lookups;
+
+/**
+ * Basic maven implementation. It uses Maven internal API to load or force-reload the project to
+ * get MavenProject instance. Hooks to PROP_PROJECT change event and invalidates last-known state.
+ * @author sdedic
+ */
+@ProjectServiceProvider(service = ProjectReloadImplementation.class, projectTypes = {
+    @LookupProvider.Registration.ProjectType(id = NbMavenProject.TYPE, position = 10000)
+    
+})
+public class MavenReloadImplementation implements ProjectReloadImplementation, PropertyChangeListener {
+    private final Project project;
+    private volatile Reference<ProjectStateData> lastData = new WeakReference<>(null);
+
+    
+    public MavenReloadImplementation(Project project) {
+        this.project = project;
+        NbMavenProject.addPropertyChangeListener(project, 
+                WeakListeners.propertyChange(this, project)
+        );
+    }
+    
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (evt.getPropertyName() == null) {
+            return;
+        }
+        ProjectStateData st = lastData.get();
+        if (st == null) {
+            return;
+        }
+        if (NbMavenProject.PROP_PROJECT.equals(evt.getPropertyName())) {
+            st.fireChanged(true, false);
+        }
+    }
+    
+    /**
+     * Returns project metadata files. If 'forReload' is false, it just returns project's
+     * pom.xml file. If the 'forReload' is true, it will return all the settings and 
+     * referenced parent project's files.
+     * 
+     * @param forReload
+     * @return 
+     */
+    public Set<FileObject> findProjectFiles() {
+        NbMavenProject p = project.getLookup().lookup(NbMavenProject.class);
+        return findProjectFiles0(p.getMavenProject());
+    }
+
+    Set<FileObject> findProjectFiles0(MavenProject mp) {
+        File pomFile = mp.getFile();
+        Set<FileObject> fileSet = new HashSet<>();
+        fileSet.add(FileUtil.toFileObject(pomFile));
+        
+        MavenExecutionRequest rq = EmbedderFactory.getProjectEmbedder().createMavenExecutionRequest();
+        File userSettings = rq.getUserSettingsFile();
+        File toolchains = rq.getGlobalToolchainsFile();
+        File globalSettings = rq.getGlobalSettingsFile();
+        if (userSettings != null && userSettings.exists()) {
+            fileSet.add(FileUtil.toFileObject(userSettings));
+        }
+        if (toolchains != null && toolchains.exists()) {
+            fileSet.add(FileUtil.toFileObject(toolchains));
+        }
+        if (globalSettings != null && globalSettings.exists()) {
+            fileSet.add(FileUtil.toFileObject(globalSettings));
+        }
+        
+        Set<Artifact> processed = new HashSet<>();
+        ArrayDeque<Artifact> toProcess = new ArrayDeque<>();
+        Artifact a = mp.getParentArtifact();
+        if (a != null) {
+            toProcess.add(a);
+        }
+        toProcess.addAll(mp.getArtifacts());
+        
+        while ((a = toProcess.poll()) != null) {
+            if (!processed.add(a)) {
+                continue;
+            }
+            File pom = MavenFileOwnerQueryImpl.getInstance().getOwnerPOM(a.getGroupId(), a.getArtifactId(), a.getVersion());
+            if (pom != null) {
+                Project parentOwner = FileOwnerQuery.getOwner(FileUtil.toFileObject(pom));
+                // can't call getProjectState, since that may block 
+                FileObject parentPom = parentOwner.getProjectDirectory().getFileObject("pom.xml");
+                if (parentPom != null) {
+                    fileSet.add(parentPom);
+                }
+                NbMavenProject p2 = project.getLookup().lookup(NbMavenProject.class);
+                a = p2.getMavenProject().getParentArtifact();
+                if (a != null) {
+                    toProcess.add(a);
+                }
+                toProcess.addAll(p2.getMavenProject().getArtifacts());
+            }
+        }
+        return fileSet;
+    }
+    
+    private static class CF extends CompletableFuture<ProjectStateData<MavenProject>> {}
+
+    static ProjectReload.Quality getProjectQuality(MavenProject mp) {
+        if (MavenProjectCache.isFallbackproject(mp)) {
+            // could not load at all.
+            MavenProject fallback = MavenProjectCache.getPartialProject(mp);
+            return fallback != null ? 
+                    ProjectReload.Quality.BROKEN:
+                    ProjectReload.Quality.NONE;
+        }
+        if (!MavenProjectCache.getFakedArtifacts(mp).isEmpty()) {
+            return ProjectReload.Quality.LOADED;
+        }
+        return ProjectReload.Quality.RESOLVED;
+    }
+    
+    private ProjectStateData createStateData(MavenProject mp) {
+        ProjectStateData d;
+        
+        ProjectStateBuilder builder = ProjectStateData.builder(getProjectQuality(mp)).
+                files(findProjectFiles()).
+                timestamp(MavenProjectCache.getLoadTimestamp(mp));
+        builder.data(mp);
+        builder.attachLookup(Lookups.fixed(mp));
+        d = builder.build();
+        synchronized (this) {
+            ProjectStateData d2 = lastData.get();
+            if (d2 != null) {
+                if (d2.getProjectData() == mp) {
+                    return d2;
+                }
+                d2.fireChanged(true, false);
+            }
+            lastData = new WeakReference<>(d);
+        }
+        return d;
+    }
+
+    @NbBundle.Messages({
+        "# {0} - project name",
+        "ERR_UnprimedInOfflineMode=Priming build for {0} is required, but offline operation was requested.",
+        "# {0} - project name",
+        "# {1} - parent gav",
+        "ERR_ParentPomMissing=Project {0} is missing its parent artifact ({1}) is missing and offline operation was requested"
+    })
+    @Override
+    public CompletableFuture reload(Project project, StateRequest request, LoadContext context) {
+        CF cf = new CF();
+        loadMavenProject(request, cf);
+        return cf;
+    }
+
+    private void loadMavenProject(StateRequest request, CF future) {
+        NbMavenProjectImpl nbImpl = project.getLookup().lookup(NbMavenProjectImpl.class);
+        if (!request.isForceReload()) {
+            if (request.isConsistent()) {
+                nbImpl.getFreshOriginalMavenProject().thenAccept((mp) ->loadMavenProject2(mp, request, future));
+            } else {
+                MavenProject mp = nbImpl.getOriginalMavenProjectOrNull();
+                if (mp != null) {
+                    loadMavenProject2(mp, request, future);
+                }
+            }
+            return;
+        }
+        loadMavenProject3(future);
+    }
+    
+    private void loadMavenProject2(MavenProject p, StateRequest request, CF future) {
+        if (p != null) {
+            ProjectReload.Quality q = getProjectQuality(p);
+            if (q.isAtLeast(request.getMinQuality())) {
+                if (!request.isConsistent()) {
+                    future.complete(createStateData(p));
+                    return;
+                }
+
+                // check that the project is consistent with known files:
+                long ts = MavenProjectCache.getLoadTimestamp(p);
+                Collection<FileObject> fos = findProjectFiles0(p);
+                boolean obsolete = false;
+                for (FileObject f : fos) {
+                    if (f.lastModified().getTime() > ts) {
+                        obsolete = true;
+                    }
+                }
+                if (!obsolete) {
+                    future.complete(createStateData(p));
+                    return;
+                }
+            }
+        }
+        loadMavenProject3(future);
+    }
+    
+    private void loadMavenProject3(CF future) {
+        NbMavenProjectImpl nbImpl = project.getLookup().lookup(NbMavenProjectImpl.class);
+        RequestProcessor.Task t = nbImpl.fireProjectReload(true);
+        t.addTaskListener(new TaskListener() {
+            @Override
+            public void taskFinished(Task task) {
+                task.removeTaskListener(this);
+                // retain initial = true for the first project load.
+                nbImpl.getFreshOriginalMavenProject().thenAccept((mp) -> {
+                    future.complete(createStateData(mp));
+                });
+            }
+        });
+    }
+}

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenReloadImplementationTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenReloadImplementationTest.java
@@ -1,0 +1,601 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.queries;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.text.Document;
+import org.apache.maven.project.MavenProject;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.api.project.ui.OpenProjects;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.maven.NbMavenProjectImpl;
+import org.netbeans.modules.maven.api.NbMavenProject;
+import org.netbeans.modules.maven.embedder.EmbedderFactory;
+import org.netbeans.modules.maven.modelcache.MavenProjectCache;
+import org.netbeans.modules.project.dependency.ProjectOperationException;
+import org.netbeans.modules.project.dependency.ProjectReload;
+import org.netbeans.modules.project.dependency.ProjectReload.ProjectState;
+import org.netbeans.modules.project.dependency.ProjectReload.Quality;
+import org.netbeans.modules.project.dependency.ProjectReload.StateRequest;
+import org.netbeans.modules.project.dependency.reload.ProjectReloadInternal;
+import org.netbeans.spi.project.ActionProgress;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.cookies.EditorCookie;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.modules.DummyInstalledFileLocator;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+import org.openide.windows.IOProvider;
+
+/**
+ *
+ * @author sdedic
+ */
+public class MavenReloadImplementationTest extends NbTestCase {
+    private FileObject d;
+    private File repo;
+    private FileObject repoFO;
+    private FileObject dataFO;
+
+    public MavenReloadImplementationTest(String name) {
+        super(name);
+    }
+    
+    private static File getTestNBDestDir() {
+        String destDir = System.getProperty("test.netbeans.dest.dir");
+        // set in project.properties as test-unit-sys-prop.test.netbeans.dest.dir
+        assertNotNull("test.netbeans.dest.dir property has to be set when running within binary distribution", destDir);
+        return new File(destDir);
+    }
+
+    protected @Override void setUp() throws Exception {
+        // this property could be eventually initialized by NB module system, as MavenCacheDisabler i @OnStart, but that's unreliable.
+        System.setProperty("maven.defaultProjectBuilder.disableGlobalModelCache", "true");
+        
+        clearWorkDir();
+        
+        // This is needed, otherwose the core window's startup code will redirect
+        // System.out/err to the IOProvider, and its Trivial implementation will redirect
+        // it back to System.err - loop is formed. Initialize IOProvider first, it gets
+        // the real System.err/out references.
+        IOProvider p = IOProvider.getDefault();
+        d = FileUtil.toFileObject(getWorkDir());
+        System.setProperty("test.reload.sync", "false");
+        repo = EmbedderFactory.getProjectEmbedder().getLocalRepositoryFile();
+        repoFO = FileUtil.toFileObject(repo);
+        dataFO = FileUtil.toFileObject(getDataDir());
+        
+        // Configure the DummyFilesLocator with NB harness dir
+        File destDirF = getTestNBDestDir();
+        DummyInstalledFileLocator.registerDestDir(destDirF);
+        
+        System.err.println("*** Running: " + getName());
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        OpenProjects.getDefault().close(OpenProjects.getDefault().getOpenProjects());
+        ProjectReloadInternal.getInstance().assertNoOperations();
+        super.tearDown(); 
+    }
+    
+    FileObject prjCopy;
+    Project root;
+    Project oci;
+    Project lib;
+    
+    void setupMicronautProject() throws Exception {
+        FileUtil.toFileObject(getWorkDir()).refresh();
+
+        FileObject testApp = dataFO.getFileObject("projects/multiproject/democa");
+        prjCopy = FileUtil.copyFile(testApp, FileUtil.toFileObject(getWorkDir()), "democa");
+        root = ProjectManager.getDefault().findProject(prjCopy);
+        oci = ProjectManager.getDefault().findProject(prjCopy.getFileObject("oci"));
+        lib =  ProjectManager.getDefault().findProject(prjCopy.getFileObject("lib"));
+        OpenProjects.getDefault().open(new Project[] { root, oci, lib }, false);
+        OpenProjects.getDefault().openProjects().get();
+    }
+    
+    private void primeProject() throws Exception {
+        CountDownLatch cdl = new CountDownLatch(1);
+        
+        ActionProvider ap = root.getLookup().lookup(ActionProvider.class);
+        if (!ap.isActionEnabled(ActionProvider.COMMAND_PRIME, Lookup.EMPTY)) {
+            return;
+        }
+
+        ActionProgress prg = new ActionProgress() {
+            @Override
+            protected void started() {
+            }
+
+            @Override
+            public void finished(boolean success) {
+                cdl.countDown();
+            }
+        };
+        ap.invokeAction(ActionProvider.COMMAND_PRIME, Lookups.fixed(prg));
+        cdl.await(100, TimeUnit.SECONDS);
+    }
+    
+    private Collection<FileObject> projectFiles(Collection<FileObject> fos, Project p) {
+        return fos.stream().filter(f -> FileOwnerQuery.getOwner(f) == p).toList();
+    }
+    
+    /**
+     * Checks that root POM is reported as project file.
+     * @throws Exception 
+     */
+    public void testSingleRootProject() throws Exception {
+        setupMicronautProject();
+        primeProject();
+        
+        Collection<FileObject> fos = projectFiles(ProjectReload.getProjectState(root, true).getLoadedFiles(), root);
+        assertEquals(1, fos.size());
+        assertSame(prjCopy.getFileObject("pom.xml"), fos.iterator().next());
+    }
+    
+    /**
+     * Checks that the root project just reports its own POM and the settings.
+     * @throws Exception 
+     */
+    public void testRootProjectReloadJustOnePom() throws Exception {
+        setupMicronautProject();
+        primeProject();
+        
+        Collection<FileObject> fos = ProjectReload.getProjectState(root, true).getLoadedFiles();
+        
+        assertEquals(2, fos.size());
+        assertTrue(fos.contains(prjCopy.getFileObject("pom.xml")));
+        assertTrue(fos.contains(FileUtil.toFileObject(new File(System.getProperty("user.home"))).getFileObject(".m2/settings.xml")));
+    }
+    
+    
+    /**
+     * Checks that project with dependencies and parent report both parent and the dependent projects
+     * in NB workspace (must be opened). 
+     * @throws Exception 
+     */
+    public void testReloadFilesDependentAndParent() throws Exception {
+        setupMicronautProject();
+        primeProject();
+        
+        Collection<FileObject> fos = ProjectReload.getProjectState(oci, true).getLoadedFiles();
+        
+        assertEquals(4, fos.size());
+        assertTrue(fos.contains(prjCopy.getFileObject("pom.xml")));
+        assertTrue(fos.contains(prjCopy.getFileObject("oci/pom.xml")));
+        assertTrue(fos.contains(prjCopy.getFileObject("lib/pom.xml")));
+        assertTrue(fos.contains(FileUtil.toFileObject(new File(System.getProperty("user.home"))).getFileObject(".m2/settings.xml")));
+    }
+
+    /**
+     * Checks that reload of a subproject fails if its parent-pom is modified.
+     * @throws Exception 
+     */
+    public void testReloadFailsWithParentPomModified() throws Exception {
+        setupMicronautProject();
+        
+        primeProject();
+        
+        FileObject rootPomFile = root.getProjectDirectory().getFileObject("pom.xml");
+        EditorCookie cake = rootPomFile.getLookup().lookup(EditorCookie.class);
+        Document doc = cake.openDocument();
+        doc.insertString(0, "aaa", null);
+        doc.remove(0, 3);
+        
+        try {
+            ProjectState p = ProjectReload.withProjectState(oci, 
+                    ProjectReload.StateRequest.refresh()).toCompletableFuture().get();
+            fail("Should fail as pom is modified in memory");
+        } catch (ExecutionException ex) {
+            assertTrue(ex.getCause() instanceof ProjectOperationException);
+            ProjectOperationException ex2 = (ProjectOperationException)ex.getCause();
+            // expected
+            assertEquals(ProjectOperationException.State.OUT_OF_SYNC, ex2.getState());
+        }
+    }
+    
+    /**
+     * Checks that the reload succeeds, if only submodule has been modified. The reload should
+     * succeed immediately as on-disk state is not modified after the project load.
+     * @throws Exception 
+     */
+    public void testReloadOKWithSubprojectModified() throws Exception {
+        setupMicronautProject();
+        primeProject();
+
+        FileObject ociPomFile = oci.getProjectDirectory().getFileObject("pom.xml");
+        EditorCookie cake = ociPomFile.getLookup().lookup(EditorCookie.class);
+        Document doc = cake.openDocument();
+        doc.insertString(0, "aaa", null);
+        doc.remove(0, 3);
+        
+        // ensure some project state is present
+        ProjectReload.getProjectState(lib, true);
+
+        CompletableFuture f;
+        synchronized (this) {
+            f = ProjectReload.withProjectState(lib, 
+                ProjectReload.StateRequest.refresh()).toCompletableFuture().thenAccept(p -> {
+                    synchronized (this) {
+                        // just block
+                    }
+                });
+            // the reload actually does not happen. The Future completes even before the withProjectState returns.
+            assertTrue(f.isDone());
+        }
+    }
+
+    /**
+     * Checks that the reload succeeds, if only submodule has been modified. The reload should
+     * succeed immediately as on-disk state is not modified after the project load.
+     * @throws Exception 
+     */
+    public void testInitialLoadOKWithSubprojectModified() throws Exception {
+        setupMicronautProject();
+        primeProject();
+
+        FileObject ociPomFile = oci.getProjectDirectory().getFileObject("pom.xml");
+        EditorCookie cake = ociPomFile.getLookup().lookup(EditorCookie.class);
+        Document doc = cake.openDocument();
+        doc.insertString(0, "aaa", null);
+        doc.remove(0, 3);
+        
+        CompletableFuture<ProjectState> f;
+        f = ProjectReload.withProjectState(lib, 
+            ProjectReload.StateRequest.refresh()).toCompletableFuture();
+        ProjectState ps = f.get();
+        assertTrue(ps.isConsistent());
+    }
+    
+    /**
+     * Checks that a reload succeeds immediately when the consistency check is disabled.
+     */
+    public void testReloadIgnoresModifications() throws Exception {
+        setupMicronautProject();
+        
+        // get the project model THEN mark file as modified:
+        FileObject rootPomFile = root.getProjectDirectory().getFileObject("pom.xml");   
+        
+        // ensure that some state is established, otherwise the withProjectState will attempt to load from NONE quality to better.
+        ProjectState ps = ProjectReload.withProjectState(root, 
+                    ProjectReload.StateRequest.load()).get();
+        
+        // and make some edits; must be done after setting timestamp to avoid "save file" dialog during tests.
+        EditorCookie cake = rootPomFile.getLookup().lookup(EditorCookie.class);
+        Document doc = cake.openDocument();
+        doc.insertString(0, "aaa", null);
+        doc.remove(0, 3);
+        
+        CompletableFuture f;
+        AtomicInteger n = new AtomicInteger();
+        synchronized (this) {
+            f = ProjectReload.withProjectState(root, 
+                    ProjectReload.StateRequest.refresh().consistent(false)).toCompletableFuture().thenAccept(p -> {
+                synchronized (this) {
+                    assertEquals(0, n.get());
+                    n.incrementAndGet();
+                }
+            });
+            n.incrementAndGet();
+            assertTrue(f.isDone());
+        }
+        f.get();
+    }
+    
+    /**
+     * Checks that a project, that desperately needs to download artifacts will fail to reach ready state in offline mode. For this, we 
+     * remove micronaut-parent parent POM that is referenced by the project.
+     */
+    public void testReloadFailsInOfflineMode() throws Exception {
+        // must remove artifacts from .m2 BEFORE the project is opened / scanned.
+        Path p = Paths.get(System.getProperty("user.home"), ".m2", "repository", "io", "micronaut", "platform", "micronaut-parent");
+        if (Files.exists(p)) {
+            Files.walk(p)
+                .sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(File::delete);
+        }
+        setupMicronautProject();
+        try {
+            ProjectReload.withProjectState(root, 
+                ProjectReload.StateRequest.refresh().toQuality(ProjectReload.Quality.RESOLVED).offline()).toCompletableFuture().get();
+            fail("Project has no parent POM, and offline is forced");
+        } catch (ExecutionException eex) {
+            assertTrue(eex.getCause() instanceof ProjectOperationException);
+            ProjectOperationException ex = (ProjectOperationException)eex.getCause();
+            assertEquals(ProjectOperationException.State.OFFLINE, ex.getState());
+        }
+    }
+
+    /**
+     * Checks that project reload fails, if the POM is modified.
+     */
+    public void testReloadFailsWithPomModified() throws Exception {
+        setupMicronautProject();
+        primeProject();
+        
+        FileObject libPomFile = lib.getProjectDirectory().getFileObject("pom.xml");
+        EditorCookie cake = libPomFile.getLookup().lookup(EditorCookie.class);
+        Document doc = cake.openDocument();
+        doc.insertString(0, "aaa", null);
+        doc.remove(0, 3);
+        
+        try {
+            ProjectState ps = ProjectReload.withProjectState(oci, 
+                    ProjectReload.StateRequest.refresh()).toCompletableFuture().get();
+            fail("Should fail as pom is modified in memory");
+        } catch (ExecutionException eex) {
+            assertTrue(eex.getCause() instanceof ProjectOperationException);
+            ProjectOperationException ex = (ProjectOperationException)eex.getCause();
+            // expected
+            assertEquals(ProjectOperationException.State.OUT_OF_SYNC, ex.getState());
+        }
+    }
+    
+    public void testProjectStatePresent() throws Exception {
+        setupMicronautProject();
+        primeProject();
+        
+        AtomicReference ref = new AtomicReference();
+        CountDownLatch cdl = new CountDownLatch(1);
+        
+        ProjectReload.withProjectState(oci, ProjectReload.StateRequest.refresh()).
+                thenAccept(ps -> {
+            MavenProject nbmp = ps.getLookup().lookup(MavenProject.class);
+            ref.set(nbmp);
+            cdl.countDown();
+        });
+        assertTrue(cdl.await(30, TimeUnit.SECONDS));
+        assertNotNull(ref.get());
+    }
+    
+    /**
+     * Check that a cancel on the CompletableFuture that represents the project reload will cancel the
+     * priming build.
+     * 
+     * @throws Exception 
+     */
+    public void testCancelStateRequest() throws Exception {
+        Path p = Paths.get(System.getProperty("user.home"), ".m2", "repository", "io", "micronaut", "platform", "micronaut-parent");
+        if (Files.exists(p)) {
+            Files.walk(p)
+                .sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(File::delete);
+        }
+        setupMicronautProject();
+
+        FileObject pomFile = root.getProjectDirectory().getFileObject("pom.xml");
+        // this will take a while, as there's a priming build to do.
+        CompletableFuture<ProjectState> f = ProjectReload.withProjectState(root, ProjectReload.StateRequest.refresh().toQuality(ProjectReload.Quality.RESOLVED));
+        Thread.sleep(3 * 100);
+        f.cancel(true);
+        
+        CountDownLatch l = new CountDownLatch(1);
+        
+        ProjectReloadInternal.getInstance().runProjectAction(root, () -> {
+            l.countDown();
+        });
+        l.await(10, TimeUnit.SECONDS);
+        
+        NbMavenProject nbmp = root.getLookup().lookup(NbMavenProject.class);
+        boolean inc = NbMavenProject.isIncomplete(nbmp.getMavenProject());
+        
+        assertTrue("Project must be still incomplete", inc);
+    }
+    
+    /**
+     * Checks that a ProjectState is invalidated when the Maven internally reloads its
+     * project bypassing this API
+     * @throws Exception 
+     */
+    public void testMavenInternalReloadFiresInvalid() throws Exception {
+        setupMicronautProject();
+        primeProject();
+        
+        FileObject pomFile = root.getProjectDirectory().getFileObject("pom.xml");
+        ProjectState st = ProjectReload.getProjectState(root, true);
+       
+        NbMavenProjectImpl nbmp = root.getLookup().lookup(NbMavenProjectImpl.class);
+        nbmp.fireProjectReload().waitFinished();
+        // hack: wait for the project reload to dispatch eventual events
+        ProjectReloadInternal.RELOAD_RP.post(()->{}, 300).waitFinished();
+        assertFalse(st.isValid());
+    }
+    
+    /**
+     * The reload API is asked to refresh the state, but the underlying MavenProject
+     * was already reloaded (through other means). The test checks that the project
+     * is not reloaded needlessly again.
+     * 
+     * @throws Exception 
+     */
+    public void testMavenDoesNotReloadCurrent() throws Exception {
+        setupMicronautProject();
+        primeProject();
+        
+        NbMavenProjectImpl nbmp = root.getLookup().lookup(NbMavenProjectImpl.class);
+        ProjectState initialState = ProjectReload.getProjectState(root, true);
+        MavenProject initialProject = nbmp.getOriginalMavenProject();
+        
+        assertEquals(Quality.RESOLVED, initialState.getQuality());
+        // wait, change timestamp, refresh the fileobject to make the state inconsistent.
+        Thread.sleep(2000);
+        FileObject pom = root.getProjectDirectory().getFileObject("pom.xml");
+        Path pomPath = FileUtil.toFile(pom).toPath();
+        Files.setLastModifiedTime(pomPath, FileTime.from(Instant.now()));
+        pom.refresh();
+        
+        assertFalse(initialState.isConsistent());
+        
+        // have maven project reload the project
+        nbmp.fireProjectReload().waitFinished();
+        MavenProject refreshedProject = nbmp.getOriginalMavenProject();
+        assertNotSame(refreshedProject, initialProject);
+
+        ProjectReload.withProjectState(root, StateRequest.load()).thenAccept(s -> {
+            MavenProject newMP = s.getLookup().lookup(MavenProject.class);
+            assertSame(newMP, refreshedProject);
+        }).get(10, TimeUnit.SECONDS);
+    }
+    
+    /**
+     * The reload API is asked to refresh the state, but the underlying MavenProject
+     * was already reloaded (through other means). Force flag will cause the reload
+     * to happen.
+     * 
+     * @throws Exception 
+     */
+    public void testForcedMavenDoesReloadCurrent() throws Exception {
+        setupMicronautProject();
+        primeProject();
+        
+        NbMavenProjectImpl nbmp = root.getLookup().lookup(NbMavenProjectImpl.class);
+        ProjectState initialState = ProjectReload.getProjectState(root, true);
+        MavenProject initialProject = nbmp.getOriginalMavenProject();
+        
+        assertEquals(Quality.RESOLVED, initialState.getQuality());
+        // wait, change timestamp, refresh the fileobject to make the state inconsistent.
+        Thread.sleep(2000);
+        FileObject pom = root.getProjectDirectory().getFileObject("pom.xml");
+        Path pomPath = FileUtil.toFile(pom).toPath();
+        Files.setLastModifiedTime(pomPath, FileTime.from(Instant.now()));
+        pom.refresh();
+        
+        assertFalse(initialState.isConsistent());
+        
+        // have maven project reload the project
+        nbmp.fireProjectReload().waitFinished();
+        MavenProject refreshedProject = nbmp.getOriginalMavenProject();
+        assertNotSame(refreshedProject, initialProject);
+
+        ProjectReload.withProjectState(root, StateRequest.reload()).thenAccept(s -> {
+            MavenProject newMP = s.getLookup().lookup(MavenProject.class);
+            assertNotSame(newMP, refreshedProject);
+        }).get();
+    }
+    
+    /**
+     * The reload API is asked to refresh the state, but the underlying MavenProject
+     * was already reloaded (through other means). A higher actual quality will
+     * force the load.
+     * 
+     * @throws Exception 
+     */
+    public void testMavenCurrentReplacedWithHigherQuality() throws Exception {
+        Path p = Paths.get(System.getProperty("user.home"), ".m2", "repository", "io", "micronaut", "platform", "micronaut-parent");
+        if (Files.exists(p)) {
+            Files.walk(p)
+                .sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(File::delete);
+        }
+        setupMicronautProject();
+
+        NbMavenProjectImpl impl = root.getLookup().lookup(NbMavenProjectImpl.class);        
+        
+        ProjectState s = ProjectReload.getProjectState(root, true);
+        MavenProject original = impl.getOriginalMavenProject();
+        assertTrue(s.getQuality().isWorseThan(Quality.RESOLVED));
+        assertTrue(s.isValid());
+        
+        impl.fireProjectReload().waitFinished();
+        MavenProject reloaded = impl.getOriginalMavenProject();
+        
+        assertNotSame(original, reloaded);
+        
+        ProjectState s2 = ProjectReload.getProjectState(root);
+        MavenProject s2Project = s2.getLookup().lookup(MavenProject.class);
+        
+        assertTrue(s2.getQuality().isWorseThan(Quality.RESOLVED));
+        assertSame(s, s2);
+        assertSame(original, s2Project);
+        assertFalse(s.isValid());
+        
+        ProjectState s3 = ProjectReload.withProjectState(root, StateRequest.refresh()).get();
+        MavenProject s3Project = s3.getLookup().lookup(MavenProject.class);
+        
+        assertNotSame(s3, s2);
+        assertSame(reloaded, s3Project);
+        assertFalse(s2.isValid());
+        // still bad
+        assertTrue(s3.getQuality().isWorseThan(Quality.RESOLVED));
+        
+        ProjectState s4 = ProjectReload.withProjectState(root, StateRequest.refresh().toQuality(Quality.RESOLVED)).get();
+        assertNotSame(s4, s3);
+        assertTrue(s4.getQuality().isAtLeast(Quality.RESOLVED));
+    }
+    
+    /**
+     * Checks that a new withProjectState will load a new project after internal
+     * refresh.
+     * @throws Exception 
+     */
+    public void testMavenLoadsNewProjectAfterInternalReload() throws Exception {
+        setupMicronautProject();
+        primeProject();
+        
+        NbMavenProjectImpl nbmp = root.getLookup().lookup(NbMavenProjectImpl.class);
+        ProjectState initialState = ProjectReload.getProjectState(root, true);
+        MavenProject initialProject = nbmp.getOriginalMavenProject();
+        
+        assertSame(initialProject, initialState.getLookup().lookup(MavenProject.class));
+        
+        ProjectReload.withProjectState(root, StateRequest.load()).thenAccept(s -> {
+            assertSame("Load should suceeed immediately, as the project was already read", initialState, s);
+        }).get();
+        
+        Thread.sleep(2000);
+        FileObject pom = root.getProjectDirectory().getFileObject("pom.xml");
+        Path pomPath = FileUtil.toFile(pom).toPath();
+        Files.setLastModifiedTime(pomPath, FileTime.from(Instant.now()));
+        pom.refresh();
+        
+
+        nbmp.fireProjectReload().waitFinished();
+        
+        ProjectReload.withProjectState(root, StateRequest.refresh()).thenAccept(s -> {
+            assertNotSame(initialState, s);
+        
+            MavenProject newProject = nbmp.getOriginalMavenProject();
+            assertSame(newProject, s.getLookup().lookup(MavenProject.class));
+            assertNotSame(newProject, initialProject);
+            long time = MavenProjectCache.getLoadTimestamp(newProject);
+            assertEquals(time, s.getTimestamp());
+        }).get();
+    }
+}


### PR DESCRIPTION
Followup to #7651, implementation for Maven. 
The implementation adapts maven internal project reloading to project reload SPI. It reports broken projects, project with missing dependencies and performs priming build to resolve the dependencies.
