### PR TITLE
Opt-in to use ErrorProviderBridge

### DIFF
--- a/ide/api.lsp/apichanges.xml
+++ b/ide/api.lsp/apichanges.xml
@@ -51,6 +51,20 @@
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
 <changes>
+    <change id="ErrorProvider-hintsLayerNameFor">
+        <api name="LSP_API"/>
+        <summary>ErrorProvider.hintsLayerNameFor()</summary>
+        <version major="1" minor="29"/>
+        <date day="12" month="8" year="2024"/>
+        <author login="jtulach"/>
+        <compatibility binary="compatible" source="compatible" addition="yes" deletion="no" />
+        <description>
+            Control when <code>ErrorProvider</code> results should be used in
+            the NetBeans IDE by overriding <code>hintsLayerNameFor</code>
+            and returning non-<code>null</code> value.
+        </description>
+        <class package="org.netbeans.spi.lsp" name="ErrorProvider"/>
+    </change>
     <change id="CodeActionProvider.getSupportedCodeActionKinds">
         <api name="LSP_API"/>
         <summary>Adding CodeActionProvider.getSupportedCodeActionKinds method</summary>

--- a/ide/api.lsp/manifest.mf
+++ b/ide/api.lsp/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.api.lsp/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/api/lsp/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.28
+OpenIDE-Module-Specification-Version: 1.29
 AutoUpdate-Show-In-Client: false

--- a/ide/api.lsp/src/org/netbeans/spi/lsp/ErrorProvider.java
+++ b/ide/api.lsp/src/org/netbeans/spi/lsp/ErrorProvider.java
@@ -41,6 +41,29 @@ public interface ErrorProvider {
      */
     public List<? extends Diagnostic> computeErrors(Context context);
 
+    /** The default hints layer name. Since version 1.29 of this module it
+     * is possible to display <b>hints</b> in NetBeans IDE (not only in
+     * NetBeans VSCode extension). However one has to <b>opt-in</b> to do so.
+     * Override this method to return non-{@code null} values:
+     * <pre>
+     * @Override
+     * public String hintsLayerNameFor(Kind kind) {
+     *   return switch (kind) {
+     *     case ERRORS -> "lsp:errors";
+     *     case HINTS -> "lsp:hints";
+     *   };
+     * }
+     * </pre>
+     *
+     * @param kind errors or hints
+     * @return non-{@code null} value if you want these errors or hints be visible
+     *   in the NetBeans IDE
+     * @since 1.29
+     */
+    public default String hintsLayerNameFor(Kind kind) {
+        return null;
+    }
+
     /**
      * The context for the error provider.
      */

--- a/ide/lsp.client/nbproject/project.xml
+++ b/ide/lsp.client/nbproject/project.xml
@@ -64,7 +64,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.28</specification-version>
+                        <specification-version>1.29</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/ErrorProviderBridge.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/ErrorProviderBridge.java
@@ -60,12 +60,16 @@ class ErrorProviderBridge implements Runnable, DocumentListener {
     @Override
     public final void run() {
         for (ErrorProvider p : errorProviders) {
-            computeHints(ErrorProvider.Kind.ERRORS, p, "lsp:errors");
-            computeHints(ErrorProvider.Kind.HINTS, p, "lsp:hints");
+            computeHints(ErrorProvider.Kind.ERRORS, p);
+            computeHints(ErrorProvider.Kind.HINTS, p);
         }
     }
 
-    private void computeHints(final ErrorProvider.Kind type, ErrorProvider p, final String prefix) {
+    private void computeHints(final ErrorProvider.Kind type, ErrorProvider p) {
+        final String prefix = p.hintsLayerNameFor(type);
+        if (prefix == null) {
+            return;
+        }
         List<ErrorDescription> arr = new ArrayList<>();
         ErrorProvider.Context errorCtx = new ErrorProvider.Context(file, type);
         List<? extends Diagnostic> errors = p.computeErrors(errorCtx);

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/TextDocumentSyncServerCapabilityHandler.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/TextDocumentSyncServerCapabilityHandler.java
@@ -20,7 +20,6 @@ package org.netbeans.modules.lsp.client.bindings;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
@@ -49,16 +48,11 @@ import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.netbeans.api.editor.EditorRegistry;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
-import org.netbeans.api.lsp.Diagnostic;
 import org.netbeans.editor.BaseDocumentEvent;
 import org.netbeans.lib.editor.util.swing.DocumentUtilities;
 import org.netbeans.modules.editor.*;
 import org.netbeans.modules.lsp.client.LSPBindings;
 import org.netbeans.modules.lsp.client.Utils;
-import org.netbeans.spi.editor.hints.ErrorDescription;
-import org.netbeans.spi.editor.hints.ErrorDescriptionFactory;
-import org.netbeans.spi.editor.hints.HintsController;
-import org.netbeans.spi.editor.hints.Severity;
 import org.netbeans.spi.lsp.ErrorProvider;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -333,7 +327,14 @@ public class TextDocumentSyncServerCapabilityHandler {
 
             if (server == null) {
                 Lookup lkp = MimeLookup.getLookup(file.getMIMEType());
-                Collection<? extends ErrorProvider> errorProviders = lkp.lookupAll(ErrorProvider.class);
+                ArrayList<ErrorProvider> errorProviders = new ArrayList<>();
+                for (ErrorProvider ep : lkp.lookupAll(ErrorProvider.class)) {
+                    boolean errors = ep.hintsLayerNameFor(ErrorProvider.Kind.ERRORS) != null;
+                    boolean hints = ep.hintsLayerNameFor(ErrorProvider.Kind.HINTS) != null;
+                    if (errors || hints) {
+                        errorProviders.add(ep);
+                    }
+                }
                 if (!errorProviders.isEmpty()) {
                     ErrorProviderBridge b = new ErrorProviderBridge(doc, file, errorProviders, WORKER);
                     b.start();

--- a/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/bindings/ErrorProviderBridgeTest.java
+++ b/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/bindings/ErrorProviderBridgeTest.java
@@ -109,6 +109,18 @@ public class ErrorProviderBridgeTest {
         }
 
         @Override
+        public String hintsLayerNameFor(Kind kind) {
+            switch (kind) {
+                case ERRORS:
+                    return "lsp:errors";
+                case HINTS:
+                    return "lsp:hints";
+                default:
+                    throw new IllegalStateException();
+            }
+        }
+
+        @Override
         public List<? extends Diagnostic> computeErrors(Context context) {
             List<Diagnostic> arr = new ArrayList<>();
             JTextComponent tmp = c.get();


### PR DESCRIPTION
Fixes #7647 by designing an **opt-in** API for providers of `ErrorProvider` implementations to enable bridging of their errors into NetBeans IDE as hints.

The existing `ErrorProvider` subclasses (that don't override this new method) will only be _used in the VSCode extension_.

New providers are encouraged (by the Javadoc) to override the `hintsLayerNameFor` method to return non-`null` value. E.g. to **opt-in** into the delegation as provided by

- #7579

This **opt-in** gives us so much needed compatibility for previously written modules and also easy path for new implementations of `ErrorProvider` to be used in NetBeans IDE.