### PR TITLE
Fix Maven annotation processor path list query.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/api/PluginPropertyUtils.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/PluginPropertyUtils.java
@@ -612,16 +612,14 @@ public class PluginPropertyUtils {
         
         private final MavenProject mvnProject;
         private final String multiPropertyName;
-        private final String propertyItemName;
         private final String filterType;
-        
-        public DependencyListBuilder(MavenProject mvnProject, String multiPropertyName, String propertyItemName, String filterType) {
+
+        public DependencyListBuilder(MavenProject mvnProject, String multiPropertyName, String filterType) {
             this.mvnProject = mvnProject;
             this.multiPropertyName = multiPropertyName;
-            this.propertyItemName = propertyItemName;
             this.filterType = filterType;
         }
-        
+
         @Override
         public List<Dependency> build(Xpp3Dom configRoot, ExpressionEvaluator eval) {
             if (configRoot == null) {
@@ -632,7 +630,7 @@ public class PluginPropertyUtils {
             if (source == null) {
                 return null;
             }
-            for (Xpp3Dom ch : source.getChildren(propertyItemName)) {
+            for (Xpp3Dom ch : source.getChildren()) {
                 Xpp3Dom a = ch.getChild(PROP_ARTIFACT_ID);
                 Xpp3Dom g = ch.getChild(PROP_GROUP_ID);
                 Xpp3Dom v = ch.getChild(PROP_VERSION);
@@ -696,13 +694,26 @@ public class PluginPropertyUtils {
          * @param pluginGroupId plugin's group ID
          * @param pluginArtifactId plugin's artifact ID
          * @param pathProperty name of the property (the property should contain a list of items)
-         * @param pathItemName name of the single item's element
          */
-        public PluginConfigPathParams(String pluginGroupId, String pluginArtifactId, String pathProperty, String pathItemName) {
+        public PluginConfigPathParams(String pluginGroupId, String pluginArtifactId, String pathProperty) {
             this.pluginGroupId = pluginGroupId;
             this.pluginArtifactId = pluginArtifactId;
             this.pathProperty = pathProperty;
-            this.pathItemName = pathItemName;
+            this.pathItemName = null;
+        }
+
+        /**
+         * Creates a query instance with mandatory parameters
+         * 
+         * @deprecated List items can have arbitrary names, use {@link #PluginConfigPathParams(java.lang.String, java.lang.String, java.lang.String)} instead.
+         * @param pluginGroupId plugin's group ID
+         * @param pluginArtifactId plugin's artifact ID
+         * @param pathProperty name of the property (the property should contain a list of items)
+         * @param pathItemName name of the single item's element
+         */
+        @Deprecated
+        public PluginConfigPathParams(String pluginGroupId, String pluginArtifactId, String pathProperty, String pathItemName) {
+            this(pluginGroupId, pluginArtifactId, pathProperty);
         }
 
         /**
@@ -741,6 +752,10 @@ public class PluginPropertyUtils {
             return pathProperty;
         }
 
+        /**
+         * Returns null.
+         */
+        @Deprecated
         public String getPathItemName() {
             return pathItemName;
         }
@@ -777,7 +792,7 @@ public class PluginPropertyUtils {
         }
         
         MavenProject mavenProject = projectImpl.getOriginalMavenProject();
-        DependencyListBuilder bld = new DependencyListBuilder(mavenProject, query.getPathProperty(), query.getPathItemName(), query.getArtifactType());
+        DependencyListBuilder bld = new DependencyListBuilder(mavenProject, query.getPathProperty(), query.getArtifactType());
         List<Dependency> coordinates = PluginPropertyUtils.getPluginPropertyBuildable(mavenProject, query.getPluginGroupId(), query.getPluginArtifactId(), query.getGoal(), bld);
         if (coordinates == null) {
             return null;

--- a/java/maven/src/org/netbeans/modules/maven/classpath/AnnotationProcClassPathImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/classpath/AnnotationProcClassPathImpl.java
@@ -49,8 +49,7 @@ final class AnnotationProcClassPathImpl extends AbstractProjectClassPathImpl imp
     private static final String COMPILER_GROUP_ID = "org.apache.maven.plugins"; // NOI18N
     private static final String GOAL_COMPILE = "compile"; // NOI18N
     private static final String GOAL_TEST_COMPILE = "testCompile"; // NOI18N
-    private static final String PROPERTY_PATH = "annotationProcessorPaths"; // NOI18N
-    private static final String PROPERTY_ITEM = "path"; // NOI18N
+    private static final String PROPERTY_PATHS = "annotationProcessorPaths"; // NOI18N
     
     private final boolean mainCompile;
     
@@ -84,8 +83,7 @@ final class AnnotationProcClassPathImpl extends AbstractProjectClassPathImpl imp
     }
 
     static boolean getCompileArtifacts(NbMavenProjectImpl prjImpl, String goal, MavenProject mavenProject, List<URI> lst) {
-        PluginConfigPathParams query = new PluginConfigPathParams(COMPILER_GROUP_ID, COMPILER_ARTIFACT_ID, 
-                PROPERTY_PATH, PROPERTY_ITEM);
+        PluginConfigPathParams query = new PluginConfigPathParams(COMPILER_GROUP_ID, COMPILER_ARTIFACT_ID, PROPERTY_PATHS);
         query.setDefaultScope(Artifact.SCOPE_RUNTIME);
         query.setGoal(goal);
         List<ArtifactResolutionException> errorList = new ArrayList<>();


### PR DESCRIPTION
Maven Lists can often have arbitrary item names. NetBeans did only look for elements named `<path>`, this patch will update the logic to iterate over all elements.

fixes #7658