### PR TITLE
Fix extraction of annotation processor classpath for maven

### DIFF
--- a/java/maven/apichanges.xml
+++ b/java/maven/apichanges.xml
@@ -83,6 +83,27 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="pluginconfigpathparams-pathitem-name-null">
+            <api name="general"/>
+            <summary>Enable using PluginConfigPathParams with null valued pathItemName</summary>
+            <version major="2" minor="164"/>
+            <date day="10" month="8" year="2024"/>
+            <author login="matthiasblaesing"/>
+            <compatibility addition="yes" semantic="compatible"/>
+            <description>
+                Maven <a href="https://maven.apache.org/guides/mini/guide-configuring-plugins.html#mapping-collections-and-arrays"
+                >documentation for plugin configuration</a> declares, that for
+                list and array typed configuration plugins, the name of the
+                single entry element does not matter, only the name of the
+                wrapping element is relevant. This change modifies
+                <pre>PluginPropertyUtils.PluginConfigPathParams</pre> to always
+                report <pre>null</pre> for <pre>pathItemName</pre> and adds a
+                constructor without that parameter, deprecating the original
+                constructor.
+            </description>
+            <class package="org.netbeans.modules.maven.api" name="PluginPropertyUtils"/>
+            <issue number="GITHUB-7658" />
+        </change>
         <change id="partial-maven-project">
             <api name="general"/>
             <summary>Support for partially loaded projects</summary>

--- a/java/maven/src/org/netbeans/modules/maven/api/PluginPropertyUtils.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/PluginPropertyUtils.java
@@ -194,7 +194,7 @@ public class PluginPropertyUtils {
         T build(Xpp3Dom configRoot, ExpressionEvaluator eval);
     }
     
-    private static ExpressionEvaluator DUMMY_EVALUATOR = new ExpressionEvaluator() {
+    static ExpressionEvaluator DUMMY_EVALUATOR = new ExpressionEvaluator() {
 
         @Override
         public Object evaluate(String string) throws ExpressionEvaluationException {
@@ -610,18 +610,14 @@ public class PluginPropertyUtils {
         private static final String PROP_VERSION = "version"; // NOI18N
         private static final String PROP_SCOPE = "scope"; // NOI18N
         
-        private final MavenProject mvnProject;
         private final String multiPropertyName;
-        private final String propertyItemName;
         private final String filterType;
-        
-        public DependencyListBuilder(MavenProject mvnProject, String multiPropertyName, String propertyItemName, String filterType) {
-            this.mvnProject = mvnProject;
+
+        public DependencyListBuilder(String multiPropertyName, String filterType) {
             this.multiPropertyName = multiPropertyName;
-            this.propertyItemName = propertyItemName;
             this.filterType = filterType;
         }
-        
+
         @Override
         public List<Dependency> build(Xpp3Dom configRoot, ExpressionEvaluator eval) {
             if (configRoot == null) {
@@ -632,7 +628,7 @@ public class PluginPropertyUtils {
             if (source == null) {
                 return null;
             }
-            for (Xpp3Dom ch : source.getChildren(propertyItemName)) {
+            for (Xpp3Dom ch : source.getChildren()) {
                 Xpp3Dom a = ch.getChild(PROP_ARTIFACT_ID);
                 Xpp3Dom g = ch.getChild(PROP_GROUP_ID);
                 Xpp3Dom v = ch.getChild(PROP_VERSION);
@@ -693,16 +689,31 @@ public class PluginPropertyUtils {
 
         /**
          * Creates a query instance with mandatory parameters
+         *
          * @param pluginGroupId plugin's group ID
          * @param pluginArtifactId plugin's artifact ID
-         * @param pathProperty name of the property (the property should contain a list of items)
-         * @param pathItemName name of the single item's element
+         * @param pathProperty name of the property (the property should contain
+         * a list of items)
          */
-        public PluginConfigPathParams(String pluginGroupId, String pluginArtifactId, String pathProperty, String pathItemName) {
+        public PluginConfigPathParams(String pluginGroupId, String pluginArtifactId, String pathProperty) {
             this.pluginGroupId = pluginGroupId;
             this.pluginArtifactId = pluginArtifactId;
             this.pathProperty = pathProperty;
-            this.pathItemName = pathItemName;
+            this.pathItemName = null;
+        }
+
+        /**
+         * Creates a query instance with mandatory parameters
+         * 
+         * @deprecated List items can have arbitrary names, use {@link #PluginConfigPathParams(java.lang.String, java.lang.String, java.lang.String)} instead.
+         * @param pluginGroupId plugin's group ID
+         * @param pluginArtifactId plugin's artifact ID
+         * @param pathProperty name of the property (the property should contain a list of items)
+         * @param pathItemName name of the single item's element (ignored)
+         */
+        @Deprecated
+        public PluginConfigPathParams(String pluginGroupId, String pluginArtifactId, String pathProperty, String pathItemName) {
+            this(pluginGroupId, pluginArtifactId, pathProperty);
         }
 
         /**
@@ -741,6 +752,10 @@ public class PluginPropertyUtils {
             return pathProperty;
         }
 
+        /**
+         * Returns null.
+         */
+        @Deprecated
         public String getPathItemName() {
             return pathItemName;
         }
@@ -777,7 +792,7 @@ public class PluginPropertyUtils {
         }
         
         MavenProject mavenProject = projectImpl.getOriginalMavenProject();
-        DependencyListBuilder bld = new DependencyListBuilder(mavenProject, query.getPathProperty(), query.getPathItemName(), query.getArtifactType());
+        DependencyListBuilder bld = new DependencyListBuilder(query.getPathProperty(), query.getArtifactType());
         List<Dependency> coordinates = PluginPropertyUtils.getPluginPropertyBuildable(mavenProject, query.getPluginGroupId(), query.getPluginArtifactId(), query.getGoal(), bld);
         if (coordinates == null) {
             return null;

--- a/java/maven/src/org/netbeans/modules/maven/classpath/AnnotationProcClassPathImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/classpath/AnnotationProcClassPathImpl.java
@@ -50,7 +50,6 @@ final class AnnotationProcClassPathImpl extends AbstractProjectClassPathImpl imp
     private static final String GOAL_COMPILE = "compile"; // NOI18N
     private static final String GOAL_TEST_COMPILE = "testCompile"; // NOI18N
     private static final String PROPERTY_PATH = "annotationProcessorPaths"; // NOI18N
-    private static final String PROPERTY_ITEM = "path"; // NOI18N
     
     private final boolean mainCompile;
     
@@ -84,14 +83,12 @@ final class AnnotationProcClassPathImpl extends AbstractProjectClassPathImpl imp
     }
 
     static boolean getCompileArtifacts(NbMavenProjectImpl prjImpl, String goal, MavenProject mavenProject, List<URI> lst) {
-        PluginConfigPathParams query = new PluginConfigPathParams(COMPILER_GROUP_ID, COMPILER_ARTIFACT_ID, 
-                PROPERTY_PATH, PROPERTY_ITEM);
+        PluginConfigPathParams query = new PluginConfigPathParams(COMPILER_GROUP_ID, COMPILER_ARTIFACT_ID, PROPERTY_PATH);
         query.setDefaultScope(Artifact.SCOPE_RUNTIME);
         query.setGoal(goal);
         List<ArtifactResolutionException> errorList = new ArrayList<>();
-        List<Artifact> arts = Collections.emptyList();
-        
-        arts = PluginPropertyUtils.getPluginPathProperty(prjImpl, query, true, errorList);
+
+        List<Artifact> arts = PluginPropertyUtils.getPluginPathProperty(prjImpl, query, true, errorList);
         if (arts == null) {
             return false;
         }


### PR DESCRIPTION
It was reported that this configuration snippet:

```xml
    <build>
        <plugins>
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
                <version>3.13.0</version>
                <configuration>
                    <parameters>true</parameters>
                    <annotationProcessorPaths>
                        <annotationProcessorPath>
                            <groupId>org.mapstruct</groupId>
                            <artifactId>mapstruct-processor</artifactId>
                            <version>1.5.5.Final</version>
                        </annotationProcessorPath>
                        <annotationProcessorPath>
                            <groupId>io.soabase.record-builder</groupId>
                            <artifactId>record-builder-processor</artifactId>
                            <version>42</version>
                        </annotationProcessorPath>
                    </annotationProcessorPaths>
                </configuration>
            </plugin>
        </plugins>
    </build>
```

works for maven, but not for NetBeans. Indeed the documentation for maven-compiler says, that the child element for annotationProcessorPaths is named path. But that is ignored by maven.

Maven documentation for plugin configuration [1] declares, that for list and array typed configuration plugins, the name of the single entry element does not matter, only the name of the wrapping element is relevant. This change implements handling of `null` values for `pathItemName`, by considering all children of `pathProperty` in that case.

[1] https://maven.apache.org/guides/mini/guide-configuring-plugins.html#mapping-collections-and-arrays


Closes: #7658
Closes: #7661