### PR TITLE
Gradle implementation of Project (re)load API

### DIFF
--- a/extide/gradle/manifest.mf
+++ b/extide/gradle/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: true
 OpenIDE-Module: org.netbeans.modules.gradle/2
+OpenIDE-Module-Implementation-Version: 1
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/Bundle.properties
 OpenIDE-Module-Java-Dependencies: Java > 17
-OpenIDE-Module-Specification-Version: 2.43

--- a/extide/gradle/nbproject/project.properties
+++ b/extide/gradle/nbproject/project.properties
@@ -25,6 +25,7 @@ javadoc.apichanges=${basedir}/apichanges.xml
 nbm.module.author=Laszlo Kishalmi
 source.reference.netbeans-gradle-tooling.jar=netbeans-gradle-tooling/src/main/groovy
 
+spec.version.base=2.43.0
 test-unit-sys-prop.test.netbeans.dest.dir=${netbeans.dest.dir}
 test-unit-sys-prop.java.awt.headless=true
 

--- a/extide/gradle/nbproject/project.xml
+++ b/extide/gradle/nbproject/project.xml
@@ -301,6 +301,7 @@
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
                         <compile-dependency/>
+                        <test/>
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.projectui</code-name-base>

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectReload.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectReload.java
@@ -173,7 +173,7 @@ public final class ProjectReload {
             return ProjectReloadInternal.getInstance().getProjectState0(p, Lookup.EMPTY, false).second();
         }
         try {
-            return withProjectState(p, StateRequest.load().toQuality(Quality.NONE).tryQuality(Quality.SIMPLE).consistent(false)).get();
+            return withProjectState(p, StateRequest.load().toQuality(Quality.NONE).tryQuality(Quality.SIMPLE).consistent(false).offline()).get();
         } catch (ExecutionException ex) {
             if (ex.getCause() instanceof ProjectOperationException) {
                 throw (ProjectOperationException)ex.getCause();
@@ -611,7 +611,7 @@ public final class ProjectReload {
          */
         public StateRequest tryQuality(Quality q) {
             this.tryQuality = q;
-            if (this.minQuality.isWorseThan(q)) {
+            if (q.isWorseThan(minQuality)) {
                 this.minQuality = q;
             }
             return this;

--- a/ide/projectapi.nb/nbproject/project.xml
+++ b/ide/projectapi.nb/nbproject/project.xml
@@ -107,6 +107,10 @@
                         <compile-dependency/>
                         <test/>
                     </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.openide.loaders</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
                 </test-type>
             </test-dependencies>
             <public-packages/>

--- a/ide/projectapi.nb/test/unit/src/org/netbeans/api/project/test/ProjectTestUtils.java
+++ b/ide/projectapi.nb/test/unit/src/org/netbeans/api/project/test/ProjectTestUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.api.project.test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CompletableFuture;
+import static junit.framework.Assert.fail;
+import org.netbeans.api.project.Project;
+import org.openide.loaders.FolderInstance;
+import org.openide.loaders.FolderLookup;
+import org.openide.util.Lookup;
+import org.openide.util.RequestProcessor;
+
+/**
+ * Collected project testing utilities.
+ * 
+ * @author sdedic
+ */
+public final class ProjectTestUtils {
+    private static final String FOLDER_PROXY_LOOKUP_NAME = "org.openide.loaders.FolderLookup$ProxyLkp"; // NOI18N
+    
+    /**
+     * After the project is loaded, reloaded or opened, wait for the Lookup stabilization.
+     * Projects use extensively FolderLookups that initialize asynchronously and fire their events
+     * also asynchronously to the proxy wrappers. The implementation relies on details
+     * from openide.loaders, as no API is available to wait for the process to finish/stabilize.
+     * 
+     * @param p the project
+     * @return promise with the Lookup
+     */
+    public static CompletableFuture<Lookup> waitProjectLookup(Project p) {
+        Class instClass = FolderInstance.class;
+        Class fldLookupClass = FolderLookup.class;
+        Class fldPrxClass;
+        CompletableFuture<Lookup> f = new CompletableFuture<>();
+        try {
+            Field processor = instClass.getDeclaredField("PROCESSOR");
+            fldPrxClass = fldLookupClass.getClassLoader().loadClass(fldLookupClass.getName() + "$Dispatch");
+            Field dispatch = fldPrxClass.getDeclaredField("DISPATCH");
+            
+            processor.setAccessible(true);
+            dispatch.setAccessible(true);
+            
+            // participants in the project lookup first initialize themselves in the PROCESSOR thread
+            // then the partial Lookups themselves broadcast changes in DISPATCH thread, which provokes
+            // ProxyLookup event flood. We need to wait first for PROCESSORs to complete, then
+            // DISPATCH thread to complete.
+            RequestProcessor.Task dispatchTask = ((RequestProcessor)dispatch.get(null)).create(()->{});
+            dispatchTask.addTaskListener((e) -> {
+                f.complete(p.getLookup());
+            });
+            ((RequestProcessor)processor.get(null)).post(() -> {
+                dispatchTask.schedule(0);
+            });
+        } catch (ReflectiveOperationException | SecurityException ex) {
+            fail("Error accessing DataSystems internals");
+            // should not happen
+            f.completeExceptionally(new IllegalStateException());
+        }
+        return f;
+    }
+}

--- a/java/gradle.dependencies/nbproject/project.properties
+++ b/java/gradle.dependencies/nbproject/project.properties
@@ -21,3 +21,5 @@ spec.version.base=1.3.0
 
 test-unit-sys-prop.test.netbeans.dest.dir=${netbeans.dest.dir}
 test-unit-sys-prop.java.awt.headless=true
+#test-unit-sys-prop.netbeans.debug.gradle.info.action=true
+#test-unit-sys-prop.org.netbeans.modules.gradle.dependencies

--- a/java/gradle.dependencies/nbproject/project.xml
+++ b/java/gradle.dependencies/nbproject/project.xml
@@ -48,7 +48,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.38</specification-version>
+                        <implementation-version/>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/gradle.dependencies/src/org/netbeans/modules/gradle/reload/GradleReloadImplementation.java
+++ b/java/gradle.dependencies/src/org/netbeans/modules/gradle/reload/GradleReloadImplementation.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.reload;
+
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectUtils;
+import org.netbeans.modules.gradle.GradleProject;
+import org.netbeans.modules.gradle.NbGradleProjectImpl;
+import org.netbeans.modules.gradle.ProjectTrust;
+import org.netbeans.modules.gradle.api.GradleBaseProject;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.spi.GradleFiles;
+import org.netbeans.modules.project.dependency.ProjectOperationException;
+import org.netbeans.modules.project.dependency.ProjectReload.Quality;
+import static org.netbeans.modules.project.dependency.ProjectReload.Quality.CONSISTENT;
+import org.netbeans.modules.project.dependency.ProjectReload.StateRequest;
+import org.netbeans.modules.project.dependency.spi.ProjectReloadImplementation;
+import org.netbeans.spi.project.ProjectServiceProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.NbBundle;
+import org.openide.util.WeakListeners;
+
+/**
+ * Implementation of Project State + Reload API for Gradle projects.
+ * @author sdedic
+ */
+@ProjectServiceProvider(service = ProjectReloadImplementation.class, projectType = NbGradleProject.GRADLE_PROJECT_TYPE)
+public class GradleReloadImplementation implements ProjectReloadImplementation {
+    private static final Logger LOG = Logger.getLogger(GradleReloadImplementation.class.getName());
+    
+    private final Project project;
+    private final PropertyChangeListener reloadL;
+
+    private Reference<ProjectStateData> last = new WeakReference<>(null);
+
+    
+    public GradleReloadImplementation(Project project) {
+        this.project = project;
+        this.reloadL = (pch) -> {
+            if (NbGradleProject.PROP_PROJECT_INFO.equals(pch.getPropertyName())) {
+                LOG.log(Level.FINE, "Project {0} reloaded", project);
+            }
+        };
+        NbGradleProject gp = NbGradleProject.get(project);
+        gp.addPropertyChangeListener(WeakListeners.propertyChange(reloadL, gp));
+    }
+    
+    private static void includeFile(File f, Collection<FileObject> into) {
+        if (f == null) {
+            return;
+        }
+        FileObject fo = FileUtil.toFileObject(f);
+        if (fo == null) {
+            return;
+        }
+        into.add(fo);
+    }
+
+    private Set<FileObject> findProjectFiles(boolean forReload) {
+        NbGradleProject nbgp = NbGradleProject.get(project);
+        GradleFiles gf = nbgp.getGradleFiles();
+        Set<FileObject> files = new HashSet<>();
+        
+        if (forReload) {
+            gf.getProjectFiles().forEach(f -> includeFile(f, files));
+            includeFile(gf.getFile(GradleFiles.Kind.ROOT_PROPERTIES), files);
+            includeFile(gf.getFile(GradleFiles.Kind.USER_PROPERTIES), files);
+            includeFile(gf.getFile(GradleFiles.Kind.ROOT_SCRIPT), files);
+        } else {
+            File f = gf.getSettingsScript();
+            if (gf.isRootProject() || f.getParentFile().equals(gf.getProjectDir())) {
+                includeFile(gf.getSettingsScript(), files);
+            }
+            includeFile(gf.getBuildScript(), files);
+        }
+        includeFile(gf.getFile(GradleFiles.Kind.PROJECT_PROPERTIES), files);
+        return files;
+    }
+
+    public ProjectStateData getProjectData() {
+        NbGradleProject nbgp = NbGradleProject.get(project);
+        long time = nbgp.getEvaluateTime();
+        
+        synchronized (this) {
+            ProjectStateData d = last.get();
+            if (d != null && d.getTimestamp() == time) {
+                return d;
+            }
+        }
+        
+        // PENDING: should also watch out for files that do not exist, but Gradle still looks for them.
+        // For example, buildscript may be initially missing, but can be created which should make to ProjectState inconsistent.
+        Collection<FileObject> files = findProjectFiles(true);
+        NbGradleProject.Quality pq = nbgp.getQuality();
+        Quality q;
+        
+        switch (pq) {
+            case FALLBACK:
+                q = Quality.FALLBACK;
+                if (ProjectTrust.getDefault().isTrusted(project)) {
+                    q = Quality.FALLBACK;
+                } else {
+                    q = Quality.UNTRUSTED;
+                }
+                break;
+            case EVALUATED:
+                q = Quality.BROKEN;
+                break;
+            case SIMPLE:
+                q = Quality.SIMPLE;
+                break;
+            case FULL:
+                q = Quality.LOADED;
+                break;
+            case FULL_ONLINE:
+                q = Quality.RESOLVED;
+                break;
+            default:
+                q = Quality.BROKEN;
+                break;
+        }
+        ProjectStateData sd = ProjectStateData.builder(q).
+                files(files).
+                attachLookup(NbGradleProject.get(project).curretLookup()).
+                build();
+        /*
+        ProjectStateControl track = new ProjectStateControl(
+                "gradle", null, files, pq == NbGradleProject.Quality.FALLBACK || pq.betterThan(NbGradleProject.Quality.EVALUATED), 
+                q, time, NbGradleProject.get(project).projectDataLookup()
+        );
+        */
+        synchronized (this) {
+//            states.add(new WeakReference<>(track));
+            last = new WeakReference<>(sd);
+        }
+        return sd;
+    }
+    
+    /**
+     * Exception classes known to be thrown if an artifact cannot be downloaded. For Plugins, the resolution against
+     * local repository fails, so we have to guess from the quality + "unknown plugin" information.
+     */
+    private static final String[] OFFLINE_EXCEPTION_CLASSES = {
+        "org.gradle.api.plugins.UnknownPluginException",    // NOI18N
+        "org.netbeans.modules.gradle.tooling.NeedOnlineModeException"   // NOI18N
+    };
+    
+    /**
+     * Process the known exception classes into match pattern at startup.
+     */
+    private static final Pattern OFFLINE_EXCEPTIONS_PATTERN = Pattern.compile(String.join("|", OFFLINE_EXCEPTION_CLASSES));
+    
+    @NbBundle.Messages({
+        "# {0} - number of files",
+        "ERROR_Project_Out_Of_Sync=Project files ({0}) are not saved",
+        "# {0} - project name",
+        "TEXT_RefreshProject=Reloading project {0}",
+        "# {0} - project name",
+        "# {1} - error message",
+        "ERRROR_ProjectNotLoadable=Project {0} cannot be loaded: {1}",
+        "# {0} - project name",
+        "ERROR_NeedOnlineOperation=Could not resolve project {0} in offline mode."
+    })
+    @Override
+    public CompletableFuture reload(Project project, StateRequest stateRequest, LoadContext context) {
+        if (!(project instanceof NbGradleProjectImpl)) {
+            return null;
+        }
+        NbGradleProjectImpl nbgp = (NbGradleProjectImpl)project;
+        NbGradleProject.Quality aimQuality;
+        CompletionStage<GradleProject> loadFuture;
+        boolean offline = false;
+        switch (stateRequest.getMinQuality()) {
+            case NONE:
+                // at least try :)
+                if (stateRequest.getTargetQuality().isAtLeast(Quality.SIMPLE)) {
+                    aimQuality = NbGradleProject.Quality.FALLBACK;
+                    offline = true;
+                    break;
+                } else {
+                    return CompletableFuture.completedFuture(getProjectData());
+                }
+            case FALLBACK:
+                aimQuality = NbGradleProject.Quality.FALLBACK;
+                break;
+            case BROKEN:
+                aimQuality = NbGradleProject.Quality.EVALUATED;
+                break;
+            case SIMPLE:
+                aimQuality = NbGradleProject.Quality.SIMPLE;
+                break;
+            case LOADED:
+                aimQuality = NbGradleProject.Quality.FULL;
+                break;
+            case CONSISTENT:
+            case RESOLVED:
+                aimQuality = stateRequest.isOfflineOperation() ? NbGradleProject.Quality.FULL : NbGradleProject.Quality.FULL_ONLINE;
+                break;
+            default:
+                throw new AssertionError(stateRequest.getMinQuality().name());
+            
+        }
+        if (stateRequest.isGrantTrust()) {
+            ProjectTrust.getDefault().isTrustedPermanently(project);
+        }
+        LOG.log(Level.FINE, "Request to reload {0}: aimedQuality={1}, force={2}", new Object[] { project, aimQuality, stateRequest.isForceReload() });
+        CompletableFuture<ProjectStateData> content = new CompletableFuture<>();
+        
+        loadFuture = nbgp.projectWithQualityTask(NbGradleProject.loadOptions(aimQuality).
+            setDescription(stateRequest.getReason()).
+            setForce(stateRequest.isForceReload()).
+            setCheckFiles(stateRequest.isConsistent()).
+            setOffline(stateRequest.isOfflineOperation() || offline)
+        );
+        loadFuture.thenAccept((p) -> {
+            NbGradleProject gp = NbGradleProject.get(project);
+            LOG.log(Level.FINE, "Project {0} reload complete, quality: {1}, time: {2}", new Object[] { project, gp.getQuality(), gp.getEvaluateTime() });
+            boolean failed = gp.getQuality().worseThan(aimQuality);
+            if (stateRequest.getMinQuality() == Quality.RESOLVED && gp.getQuality().atLeast(NbGradleProject.Quality.FULL)) {
+                failed = false;
+            }
+            if (failed) {
+                GradleBaseProject gbp = GradleBaseProject.get(project);
+                boolean offlineError = gbp.getProblems().stream().anyMatch(prb -> OFFLINE_EXCEPTIONS_PATTERN.matcher(prb.getErrorClass()).find());
+                
+                // handle online error specially:
+                if (offlineError) {
+                    PartialLoadException partialLoad = new PartialLoadException(getProjectData(), Bundle.ERROR_NeedOnlineOperation(ProjectUtils.getInformation(project).getDisplayName()), 
+                            new ProjectOperationException(project, ProjectOperationException.State.OFFLINE, Bundle.ERROR_NeedOnlineOperation(ProjectUtils.getInformation(project).getDisplayName())
+                    ));
+                    content.completeExceptionally(partialLoad);
+                    return;
+                }
+            }
+            content.complete(getProjectData());
+        });
+        
+        return content;
+    }
+}

--- a/java/gradle.dependencies/test/unit/data/projects/multi/app/src/main/java/com/example/Application.java
+++ b/java/gradle.dependencies/test/unit/data/projects/multi/app/src/main/java/com/example/Application.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+    public static void main(String[] args) {
+        Micronaut.run(Application.class, args);
+    }
+}

--- a/java/gradle.dependencies/test/unit/data/projects/multi/app/src/main/java/com/example/Something.java
+++ b/java/gradle.dependencies/test/unit/data/projects/multi/app/src/main/java/com/example/Something.java
@@ -1,0 +1,1 @@
+public class Something {}

--- a/java/gradle.dependencies/test/unit/data/projects/multi/app/src/main/resources/logback.xml
+++ b/java/gradle.dependencies/test/unit/data/projects/multi/app/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/java/gradle.dependencies/test/unit/data/projects/multi/app/src/test/java/com/example/DemoTest.java
+++ b/java/gradle.dependencies/test/unit/data/projects/multi/app/src/test/java/com/example/DemoTest.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import io.micronaut.runtime.EmbeddedApplication;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+import jakarta.inject.Inject;
+
+@MicronautTest
+class DemoTest {
+
+    @Inject
+    EmbeddedApplication<?> application;
+
+    @Test
+    void testItWorks() {
+        Assertions.assertTrue(application.isRunning());
+    }
+
+}

--- a/java/gradle.dependencies/test/unit/data/projects/multi/gradle.properties
+++ b/java/gradle.dependencies/test/unit/data/projects/multi/gradle.properties
@@ -1,0 +1,1 @@
+micronautVersion=3.10.2

--- a/java/gradle.dependencies/test/unit/data/projects/multi/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle.dependencies/test/unit/data/projects/multi/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/java/gradle.dependencies/test/unit/data/projects/multi/oci/build.gradle
+++ b/java/gradle.dependencies/test/unit/data/projects/multi/oci/build.gradle
@@ -1,0 +1,49 @@
+plugins {
+    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("io.micronaut.application") version "3.7.10"
+}
+
+version = "0.1"
+group = "com.example"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    annotationProcessor("io.micronaut:micronaut-http-validation")
+    implementation("io.micronaut:micronaut-http-client")
+    implementation("io.micronaut:micronaut-jackson-databind")
+    implementation("jakarta.annotation:jakarta.annotation-api")
+    runtimeOnly("ch.qos.logback:logback-classic")
+    implementation(project(":app"))
+    implementation("io.micronaut:micronaut-validation")
+
+}
+
+
+application {
+    mainClass.set("com.example.Application")
+}
+java {
+    sourceCompatibility = JavaVersion.toVersion("11")
+    targetCompatibility = JavaVersion.toVersion("11")
+}
+
+task testJar(type: Jar) {
+    classifier = 'tests'
+    from sourceSets.test.output
+}
+
+graalvmNative.toolchainDetection = false
+micronaut {
+    runtime("netty")
+    testRuntime("junit5")
+    processing {
+        incremental(true)
+        annotations("com.example.*")
+    }
+}
+
+
+

--- a/java/gradle.dependencies/test/unit/data/projects/multi/oci/src/main/java/com/example/Application.java
+++ b/java/gradle.dependencies/test/unit/data/projects/multi/oci/src/main/java/com/example/Application.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+    public static void main(String[] args) {
+        Micronaut.run(Application.class, args);
+    }
+}

--- a/java/gradle.dependencies/test/unit/data/projects/multi/settings.gradle
+++ b/java/gradle.dependencies/test/unit/data/projects/multi/settings.gradle
@@ -1,0 +1,6 @@
+
+rootProject.name="demo"
+
+include("app")
+include("aws")
+include("oci")

--- a/java/gradle.dependencies/test/unit/src/org/netbeans/modules/gradle/reload/GradleReloadImplementationTest.java
+++ b/java/gradle.dependencies/test/unit/src/org/netbeans/modules/gradle/reload/GradleReloadImplementationTest.java
@@ -1,0 +1,599 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.reload;
+
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.text.Document;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.fail;
+import org.gradle.tooling.internal.consumer.ConnectorServices;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.gradle.ProjectTrust;
+import org.netbeans.modules.gradle.api.GradleBaseProject;
+import org.netbeans.modules.gradle.api.GradleDependency;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
+import org.netbeans.modules.project.dependency.ProjectOperationException;
+import org.netbeans.modules.project.dependency.ProjectReload;
+import org.netbeans.modules.project.dependency.ProjectReload.ProjectState;
+import org.netbeans.modules.project.dependency.ProjectReload.StateRequest;
+import org.openide.DialogDescriptor;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
+import org.openide.cookies.EditorCookie;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.modules.DummyInstalledFileLocator;
+import org.openide.util.test.MockLookup;
+import org.openide.windows.IOProvider;
+
+/**
+ *
+ * @author sdedic
+ */
+public class GradleReloadImplementationTest extends NbTestCase {
+    
+    public GradleReloadImplementationTest(String name) {
+        super(name);
+    }
+    
+    FileObject workDir;
+    FileObject dataDir;
+
+    FileObject prjDir;
+    FileObject libDir;
+    FileObject ociDir;
+    
+    Project project;
+    Project libProject;
+    Project ociProject;
+    
+    private static File getTestNBDestDir() {
+        String destDir = System.getProperty("test.netbeans.dest.dir");
+        // set in project.properties as test-unit-sys-prop.test.netbeans.dest.dir
+        assertNotNull("test.netbeans.dest.dir property has to be set when running within binary distribution", destDir);
+        return new File(destDir);
+    }
+    
+    static class DDImpl extends DialogDisplayer {
+        List<NotifyDescriptor>   displayedDescriptors = new ArrayList<>();
+        
+        volatile Delegate delegate;
+
+        interface Delegate {
+            public CompletableFuture<NotifyDescriptor> notify(NotifyDescriptor d);
+        }
+        
+        @Override
+        public Object notify(NotifyDescriptor descriptor) {
+            throw new UnsupportedOperationException("Should not happen during the test.");
+        }
+
+        @Override
+        public Dialog createDialog(DialogDescriptor descriptor) {
+            throw new UnsupportedOperationException("Should not happen during the test.");
+        }
+
+        @Override
+        public Dialog createDialog(DialogDescriptor descriptor, Frame parent) {
+            throw new UnsupportedOperationException("Should not happen during the test.");
+        }
+
+        @Override
+        public <T extends NotifyDescriptor> CompletableFuture<T> notifyFuture(T descriptor) {
+            displayedDescriptors.add(descriptor);
+            if (delegate != null) {
+                return (CompletableFuture<T>)delegate.notify(descriptor);
+            } else {
+                descriptor.setValue(NotifyDescriptor.CANCEL_OPTION);
+                CompletableFuture<T> f = new CompletableFuture<>();
+                f.completeExceptionally(new CancellationException());
+                return f;
+            }
+        }
+
+        @Override
+        public void notifyLater(NotifyDescriptor descriptor) {
+            if (delegate != null) {
+                delegate.notify(descriptor);
+            } else {
+                descriptor.setValue(NotifyDescriptor.CANCEL_OPTION);
+            }
+        }
+    }
+    
+    DDImpl dialogImpl = new DDImpl();
+    
+    private List<Logger> loggers = new ArrayList<>();
+    
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        
+        
+        MockLookup.setLayersAndInstances(dialogImpl);
+        
+        // if an user-level gradle.properties does not exist, create it with empty content
+        Path up = Paths.get(System.getProperty("user.home"), ".gradle", "gradle.properties");
+        if (!Files.exists(up)) {
+            Files.write(up, Arrays.asList());
+        }
+        
+        clearWorkDir();
+        workDir = FileUtil.toFileObject(getWorkDir());
+        dataDir = FileUtil.toFileObject(getDataDir());
+
+        IOProvider.getDefault();
+
+        File destDirF = getTestNBDestDir();
+    
+        DummyInstalledFileLocator.registerDestDir(destDirF);
+        GradleExperimentalSettings.getDefault().setOpenLazy(false);
+        
+        setLoggers(Level.FINER, 
+                org.netbeans.modules.gradle.reload.GradleReloadImplementation.class.getName(), 
+                "org.netbeans.modules.project.dependency.ProjectReload");
+    }
+    
+    void setLoggers(Level level, String... names) {
+        for (String n : names) {
+            Logger l = Logger.getLogger(n);
+            loggers.add(l);
+            l.setLevel(level);
+        }
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        MockLookup.setLayersAndInstances();
+        super.tearDown(); 
+    }
+    
+    private void setupSimpleProject2() throws Exception {
+        FileObject mp = dataDir.getFileObject("projects/micronaut");
+        prjDir = FileUtil.copyFile(mp, workDir, mp.getName());
+        }
+    
+    private void setupSimpleProject3() throws Exception {
+        project = ProjectManager.getDefault().findProject(prjDir);
+        ProjectTrust.getDefault().trustProject(project);
+    }
+    
+    private void setupSimpleProject() throws Exception {
+        setupSimpleProject2();
+        setupSimpleProject3();
+        NbGradleProject.get(project).toQuality("", NbGradleProject.Quality.FULL_ONLINE, false).toCompletableFuture().get();
+        NbGradleProject.get(project).toQuality("", NbGradleProject.Quality.FULL_ONLINE, false).toCompletableFuture().get();
+}
+    
+    private void setupComplexProject() throws Exception {
+        FileObject mp = dataDir.getFileObject("projects/multi");
+        prjDir = FileUtil.copyFile(mp, workDir, mp.getName());
+        libDir = prjDir.getFileObject("app");
+        ociDir = prjDir.getFileObject("oci");
+        project = ProjectManager.getDefault().findProject(prjDir);
+        libProject = ProjectManager.getDefault().findProject(libDir);
+        ociProject = ProjectManager.getDefault().findProject(ociDir);
+        
+        ProjectTrust.getDefault().trustProject(project);
+        ProjectTrust.getDefault().trustProject(libProject);
+        ProjectTrust.getDefault().trustProject(ociProject);
+        
+        NbGradleProject.get(project).toQuality("", NbGradleProject.Quality.FULL_ONLINE, false).toCompletableFuture().get();
+        NbGradleProject.get(libProject).toQuality("", NbGradleProject.Quality.FULL_ONLINE, false).toCompletableFuture().get();
+        NbGradleProject.get(ociProject).toQuality("", NbGradleProject.Quality.FULL_ONLINE, false).toCompletableFuture().get();
+    }
+    
+    /**
+     * Checks that the root project just reports its own POM and the settings.
+     * @throws Exception 
+     */
+    public void testRootProjectReloadJustRoot() throws Exception {
+        setupComplexProject();
+        
+        Collection<FileObject> fos = ProjectReload.getProjectState(project, true).getLoadedFiles();
+        
+        assertEquals(3, fos.size());
+        assertTrue(fos.contains(prjDir.getFileObject("settings.gradle")));
+        assertTrue(fos.contains(prjDir.getFileObject("gradle.properties")));
+        assertTrue(fos.contains(FileUtil.toFileObject(new File(System.getProperty("user.home"))).getFileObject(".gradle/gradle.properties")));
+    }
+    
+    /**
+     * Checks that project reports parent.
+     * @throws Exception 
+     */
+    public void testReloadFilesReportsParent() throws Exception {
+        setupComplexProject();
+        
+        Collection<FileObject> fos = ProjectReload.getProjectState(project, true).getLoadedFiles();
+        
+        assertEquals(3, fos.size());
+        assertTrue(fos.contains(prjDir.getFileObject("settings.gradle")));
+        assertTrue(fos.contains(prjDir.getFileObject("gradle.properties")));
+        assertTrue(fos.contains(FileUtil.toFileObject(new File(System.getProperty("user.home"))).getFileObject(".gradle/gradle.properties")));
+    }
+
+    /**
+     * Checks that reload of a subproject fails if its parent-pom is modified.
+     * @throws Exception 
+     */
+    public void testReloadFailsWithRootProject() throws Exception {
+        setupComplexProject();
+        
+        FileObject rootPomFile = prjDir.getFileObject("settings.gradle");
+        EditorCookie cake = rootPomFile.getLookup().lookup(EditorCookie.class);
+        Document doc = cake.openDocument();
+        doc.insertString(0, "aaa", null);
+        doc.remove(0, 3);
+        
+        try {
+            ProjectState p = ProjectReload.withProjectState(ociProject, 
+                    StateRequest.refresh()).toCompletableFuture().get();
+            fail("Should fail as pom is modified in memory");
+        } catch (ExecutionException ex) {
+            assertSame(ProjectOperationException.class, ex.getCause().getClass());
+            ProjectOperationException t = (ProjectOperationException)ex.getCause();
+            // expected
+            assertEquals(ProjectOperationException.State.OUT_OF_SYNC, t.getState());
+        }
+    }
+    
+    private AtomicReference<NotifyDescriptor> dialogDisplayed = new AtomicReference<>();
+
+    /**
+     * Checks that reload of a subproject fails if its parent-pom is modified.
+     * @throws Exception 
+     */
+    public void testReloadSavesRootProject() throws Exception {
+        setupComplexProject();
+        
+        FileObject rootPomFile = prjDir.getFileObject("settings.gradle");
+        EditorCookie cake = rootPomFile.getLookup().lookup(EditorCookie.class);
+        Document doc = cake.openDocument();
+        doc.insertString(0, "aaa", null);
+        doc.remove(0, 3);
+        
+        dialogImpl.delegate = (nd) -> {
+            assertNull(dialogDisplayed.getAndSet(nd));
+            nd.setValue(NotifyDescriptor.OK_OPTION);
+            return CompletableFuture.completedFuture(nd);
+        };
+        
+        ProjectState ps = ProjectReload.withProjectState(ociProject, 
+                StateRequest.refresh().saveModifications()).toCompletableFuture().get();
+        assertNotNull(ps);
+        assertTrue(ps.isConsistent());
+    }
+    
+    /**
+     * Checks that the reload succeeds, if only submodule has been modified. The reload should
+     * succeed immediately as on-disk state is not modified after the project load.
+     * @throws Exception 
+     */
+    public void testReloadOKWithSubprojectModified() throws Exception {
+        setupComplexProject();
+        
+        // need to establish some state, so the check has a baseline
+        ProjectState baseline = ProjectReload.getProjectState(libProject, true);
+        
+        FileObject ociPomFile = ociProject.getProjectDirectory().getFileObject("build.gradle");
+        EditorCookie cake = ociPomFile.getLookup().lookup(EditorCookie.class);
+        Document doc = cake.openDocument();
+        doc.insertString(0, "aaa", null);
+        doc.remove(0, 3);
+
+        CompletableFuture f;
+        synchronized (this) {
+            f = ProjectReload.withProjectState(libProject, 
+                StateRequest.refresh()).toCompletableFuture().thenAccept(p -> {
+                    synchronized (this) {
+                        // just block
+                    }
+                });
+            // the reload actually does not happen. The Future completes even before the withProjectState returns.
+            assertTrue(f.isDone());
+        }
+    }
+    
+    /**
+     * Requests an inconsistent state, which ignores on-disk modifications.
+     */
+    public void testReloadIgnoresModifications() throws Exception {
+        setupSimpleProject();
+        
+        // need to establish some state, so the check has a baseline
+        ProjectState baseline = ProjectReload.getProjectState(project, true);
+
+        FileObject rootPomFile = prjDir.getFileObject("settings.gradle");
+        EditorCookie cake = rootPomFile.getLookup().lookup(EditorCookie.class);
+        Document doc = cake.openDocument();
+        doc.insertString(0, "aaa", null);
+        doc.remove(0, 3);
+        
+        Thread.sleep(2000);
+        // let's touch the root's pom.xml file to be formally newer than the loaded
+        // project
+        Files.setLastModifiedTime(Paths.get(rootPomFile.toURI()), FileTime.fromMillis(System.currentTimeMillis()));
+        
+        CompletableFuture f;
+        AtomicInteger n = new AtomicInteger();
+        synchronized (this) {
+            f = ProjectReload.withProjectState(project, 
+                    StateRequest.refresh().consistent(false)).toCompletableFuture().thenAccept(p -> {
+                // must complete synchronously.
+                synchronized (this) {
+                    assertEquals(0, n.get());
+                }
+            });
+            // the Future must not complete synchronously - a good signt that the project is actually being reloaded.
+            assertTrue(f.isDone());
+        }
+    }
+    
+    private void setupSimpleProjectWithMissingArtifacts() throws Exception {
+        ConnectorServices.reset();
+        setupSimpleProject2();
+        Path p = Paths.get(System.getProperty("user.home"), ".gradle", "caches", "modules-2", "files-2.1", "io.micronaut", "micronaut-http-validation");
+        int exit = new ProcessBuilder("gradle", "--stop").start().waitFor();
+        assertEquals("Could not kill gradle daemons", 0, exit);
+        if (Files.exists(p)) {
+            Files.walk(p)
+                .sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(File::delete);
+        }
+        setupSimpleProject3();
+        NbGradleProject.get(project).toQuality("", NbGradleProject.Quality.EVALUATED, false).toCompletableFuture().get();
+    }
+    
+    /**
+     * Checks that a project, that desperately needs to download artifacts will fail to reach ready state in offline mode. For this, we 
+     * remove micronaut-parent parent POM that is referenced by the project.
+     */
+    public void testReloadFailsInOfflineMode() throws Exception {
+        // must remove artifacts from .m2 BEFORE the project is opened / scanned.
+        setupSimpleProjectWithMissingArtifacts();
+        
+        try {
+            ProjectReload.withProjectState(project, 
+                StateRequest.refresh().toQuality(ProjectReload.Quality.RESOLVED).offline()).toCompletableFuture().get();
+            fail("Dependencies are missing, and offline is forced");
+        } catch (ExecutionException ex) {
+            assertTrue(ex.getCause() instanceof ProjectOperationException);
+            ProjectOperationException x2 = (ProjectOperationException)ex.getCause();
+            assertEquals(ProjectOperationException.State.OFFLINE, x2.getState());
+        }
+    }
+
+    /**
+     * Checks that refresh while all project files are up-to-date does nothing
+     * and completes immediately.
+     */
+    public void testRefreshWhileCurrent() throws Exception {
+        setupSimpleProject();
+
+        // need to establish some state, so the check has a baseline
+        ProjectReload.getProjectState(project, true);
+
+        // block the possibly completed future from entering the mutex ... if it runs in a separate thread,
+        // which it would do, if the project is reloaded.
+        AtomicInteger i = new AtomicInteger(1);
+        synchronized (this) {
+            ProjectReload.withProjectState(project, StateRequest.refresh()).thenApply(p -> {
+                synchronized (this) {
+                    i.incrementAndGet();
+                }
+                return p;
+            });
+            
+            assertEquals("Up-to-date project reload should complete synchronously", 2, i.get());
+        }
+    }
+    
+    /**
+     * Checks that a project whose files have changed will be reloaded.
+     * @throws Exception 
+     */
+    public void testRefreshStaleProject() throws Exception {
+        setupSimpleProject();
+
+        // need to establish some state, so the check has a baseline
+        ProjectState baseline = ProjectReload.getProjectState(project, true);
+
+        GradleBaseProject gbp = GradleBaseProject.get(project);
+        Collection<? extends GradleDependency> origDeps = gbp.getConfigurations().get("implementation").getConfiguredDependencies();
+        FileObject buildFile = prjDir.getFileObject("build.gradle");
+        List<String> fileLines = new ArrayList<>(buildFile.asLines());
+        int idx = fileLines.indexOf(fileLines.stream().filter(s -> s.contains("dependencies {")).findAny().get());
+        fileLines.add(idx + 1, "implementation(\"org.reactivestreams:reactive-streams\")");
+        // wait, since sometimes timestamps have 2-sec granularity
+        Thread.sleep(2000);
+        // overwrite, adding a dependency
+        Files.write(Paths.get(buildFile.toURI()), fileLines);
+        // force events
+        buildFile.refresh();
+        gbp = GradleBaseProject.get(project);
+        
+        AtomicInteger i = new AtomicInteger(1);
+
+        CompletableFuture<ProjectState> f;
+        
+        synchronized (this) {
+            f = ProjectReload.withProjectState(project, StateRequest.refresh()).toCompletableFuture().thenApply(p -> {
+                synchronized (this) {
+                    i.incrementAndGet();
+                }
+                return p;
+            });
+            assertEquals("Loading should fork to a separate thread", 1, i.get());
+        }
+        f.get();
+        gbp = GradleBaseProject.get(project);
+        Collection<? extends GradleDependency> afterRefreshDeps = new ArrayList<>(gbp.getConfigurations().get("implementation").getConfiguredDependencies());
+        afterRefreshDeps.removeAll(origDeps);
+        assertEquals("One more dependency should appear", 1, afterRefreshDeps.size());
+    }
+    
+    /**
+     * Checks that a project that is up-to-date will be still reloaded, if the load is forced.
+     * @throws Exception 
+     */
+    public void testForceRefreshCurrent() throws Exception {
+        setupSimpleProject();
+
+        GradleBaseProject gbp = GradleBaseProject.get(project);
+        CompletableFuture<ProjectState> f;
+        
+        AtomicInteger i = new AtomicInteger(1);
+        synchronized (this) {
+            f = ProjectReload.withProjectState(project, StateRequest.reload()).toCompletableFuture().thenApply(p -> {
+                synchronized (this) {
+                    i.incrementAndGet();
+                }
+                return p;
+            });
+            assertEquals("Loading should fork to a separate thread", 1, i.get());
+        }
+        f.get();
+    }
+    
+    /**
+     * Check that a project load will fail, if the project files are modified in the memory.
+     * @throws Exception 
+     */
+    public void testFailWithModifiedFiles() throws Exception {
+        setupSimpleProject();
+
+        // need to establish some state, so the check has a baseline
+        ProjectState baseline = ProjectReload.getProjectState(project, true);
+
+        FileObject build = prjDir.getFileObject("build.gradle");
+        Document doc = build.getLookup().lookup(EditorCookie.class).openDocument();
+        doc.insertString(0, "/* comment */", null);
+        try {
+            ProjectState f = ProjectReload.withProjectState(project, StateRequest.refresh()).toCompletableFuture().get();
+            fail("Should fail with ProjectOperationException");
+        } catch (ExecutionException ee) {
+            assertTrue(ee.getCause() instanceof ProjectOperationException);
+            ProjectOperationException ex = (ProjectOperationException)ee.getCause();
+            assertEquals(1, ex.getFiles().size());
+            assertSame(build, ex.getFiles().iterator().next());
+        }
+    }
+    
+    /**
+     * Check that a project load will fail, if the project files are modified in the memory.
+     * @throws Exception 
+     */
+    public void testFailWithModifiedFilesInRoot() throws Exception {
+        setupComplexProject();
+
+        FileObject build = prjDir.getFileObject("settings.gradle");
+        Document doc = build.getLookup().lookup(EditorCookie.class).openDocument();
+        doc.insertString(0, "/* comment */", null);
+        try {
+            ProjectState f = ProjectReload.withProjectState(libProject, StateRequest.refresh()).toCompletableFuture().get();
+            fail("Should fail with ProjectOperationException");
+        } catch (ExecutionException ee) {
+            assertTrue(ee.getCause() instanceof ProjectOperationException);
+            ProjectOperationException ex = (ProjectOperationException)ee.getCause();
+            assertEquals(1, ex.getFiles().size());
+            assertSame(build, ex.getFiles().iterator().next());
+        }
+    }
+
+    /**
+     * Check that the project can be loaded ignoring modified files.
+     * @throws Exception 
+     */
+    public void testIgnoreModifiedFiles() throws Exception {
+        setupSimpleProject();
+
+        FileObject build = prjDir.getFileObject("build.gradle");
+        Document doc = build.getLookup().lookup(EditorCookie.class).openDocument();
+        doc.insertString(0, "/* comment */", null);
+        CompletableFuture<ProjectState> f = ProjectReload.withProjectState(project, 
+                StateRequest.refresh().
+                // use fallback, to avoid downloads with empty cache
+                toQuality(ProjectReload.Quality.FALLBACK).consistent(false)).toCompletableFuture();
+        f.get();
+    }
+    
+    /**
+     * Checks that if the caller asks for a better quality than available, the project loads 
+     * even though the caller would accept inconsistent data.
+     * 
+     * @throws Exception 
+     */
+    public void testBetterQualityLoadsInconsistent() throws Exception {
+        setupSimpleProjectWithMissingArtifacts();
+
+        // need to establish some state, so the check has a baseline
+        ProjectState baseline = ProjectReload.getProjectState(project, true);
+
+        FileObject build = prjDir.getFileObject("build.gradle");
+        // let some time pass, so that the timestamp really changes.
+        Thread.sleep(1000);
+        FileUtil.toFile(build).setLastModified(System.currentTimeMillis());
+        build.refresh();
+
+        AtomicInteger phase = new AtomicInteger();
+        CompletableFuture<ProjectState> f;
+        synchronized (this) {
+            f = ProjectReload.withProjectState(project, 
+                    StateRequest.refresh().
+                    // use fallback, to avoid downloads with empty cache
+                    toQuality(ProjectReload.Quality.SIMPLE).consistent(false)).toCompletableFuture();
+            f = f.thenApply((x) -> {
+                // should block until the caller's sync blok ends
+                synchronized (this) {
+                    assertEquals(1, phase.getAndIncrement());
+                }
+                return x;
+            });
+            
+            assertEquals(0, phase.getAndIncrement());
+        }
+        f.get();
+        NbGradleProject gp = NbGradleProject.get(project);
+        assertTrue(gp.getQuality().atLeast(NbGradleProject.Quality.EVALUATED));
+    }
+}

--- a/java/gradle.java/nbproject/project.xml
+++ b/java/gradle.java/nbproject/project.xml
@@ -337,6 +337,7 @@
                         <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
                         <recursive/>
                         <compile-dependency/>
+                        <test/>
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.projectui</code-name-base>


### PR DESCRIPTION
Gradle implementation, based on improvements in #7646 implementing SPI introduced in #7651.

The implementation allows the caller to grant project trust when loading the project. Doing so requires **implementation** dependency on Gradle Projects module ... I hope that the ProjectReload will be soon (~ within 24 release cycle) move into project API and the impl dependency can be removed.

Note: as the preerquisite PRs will be merged, I'll clean up the commits here. Only 9cf5c1c4f should remain at the end.