### PR TITLE
NbClipboard adjustments: Ease retries, remove dead code

### DIFF
--- a/platform/o.n.bootstrap/src/org/netbeans/NbClipboard.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/NbClipboard.java
@@ -424,20 +424,25 @@ implements LookupListener, FlavorListener, AWTEventListener
                 // that is used because accessing the clipboard can block
                 // indefinitely. Running the access loop here is deemed similar
                 // in nature.
-                final int MAX_TRIES = 50;
+
+                /* The loop will actually stop before getting to 10 iterations, per the delay
+                formula and conditional throw. But keep the MAX_TRIES just as a fail-safe. */
+                final int MAX_TRIES = 10;
                 final long start = System.currentTimeMillis();
+                int delay = 20;
                 for (int i = 0; i < MAX_TRIES; i++) {
                     try {
                         transferable = systemClipboard.getContents(this);
                         break;
                     } catch (IllegalStateException ex) {
                         // Throw exception if retries failed
-                        if (i == (MAX_TRIES - 1) || (System.currentTimeMillis() - start) > 980L) {
+                        if (i == (MAX_TRIES - 1) || (System.currentTimeMillis() + delay - start) > 1000L) {
                             throw ex;
                         } else {
-                            log.log(Level.INFO, "systemClipboard#getContents threw IllegalStateException (try: {0})", i + 1); // NOI18N
+                            log.log(Level.INFO, "systemClipboard#getContents ISE, attempt {0}", i + 1); // NOI18N
                         }
-                        Thread.sleep(20); // Give system time to settle
+                        Thread.sleep(delay); // Give system time to settle
+                        delay *= 2;
                     }
                 }
                 superSetContents(transferable, null);

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/NbClipboardNativeTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/NbClipboardNativeTest.java
@@ -146,7 +146,7 @@ public class NbClipboardNativeTest extends NbTestCase implements ClipboardListen
         
         
         // just simulate initial switch to NetBeans main window
-        ec.activateWindowHack (true);
+        ec.activateWindowHack ();
         waitFinished (ec);
         
         if (listenerCalls == 0) {
@@ -179,7 +179,7 @@ public class NbClipboardNativeTest extends NbTestCase implements ClipboardListen
         if (slowClipboardHack ()) {
             assertEquals ("The getContents rechecked the clipboard just for the first time, not now, so the content is the same", "data2", s);
 
-            ec.activateWindowHack (true);
+            ec.activateWindowHack ();
             Thread.sleep (200);
 
             t = this.ec.getContents(this);


### PR DESCRIPTION
Some improvements to the NbClipboard class, in three separate commits:
1) Adjust the retry logic from https://github.com/apache/netbeans/pull/6443 by applying an exponential backoff on the delays. I saw a large number of retries in the log on various occasions, as well as a case where Microsoft Excel complained about not being able to access the clipboard because NetBeans was hogging it (error message screenshot below).

![image](https://github.com/user-attachments/assets/d2635970-1275-4eaf-a912-6288ffa03976)

(This commit I have been using in my working IDE and platform app since January 2024.)

2) Avoid blocking the Event Dispatch Thread during calls to systemClipboard.addFlavorListener()/removeFlavorListener(). This can happen because these methods are synchronized on the same object as the expensive systemClipboard.getContents() method. I once saw NetBeans Platform app hang for a long time in removeFlavorListener(), and tracked it down (with the VirtualVM profiler) to attempting to acquire the same lock as getContents(). The hang itself was caused by a different misbehaving application (Oracle VirtualBox), but I can imagine other cases where a more normal situation can also cause a multi-second hang.

Event dispatch thread (AWT-EventQueue):
<img width="623" alt="image" src="https://github.com/user-attachments/assets/dbbe92bf-624d-4cf3-893d-0f20fd163352">
Clipboard synchronizer thread concurrently holding the lock:
<img width="391" alt="image" src="https://github.com/user-attachments/assets/c2dd23eb-eeb5-45b8-af40-d414d222f820">

(This commit I have been using in my working IDE on Windows for only 5 days, but I haven't seen any problems with it so far. I'll be switching to a new MacBook laptop now, so my Windows setup won't see too much organic usage after this.)

3) Get rid of some dead code, after reviewing the historical commit from 2012 that left it unused. See the description of the third commit in this PR.

There are some long-standing [intermittent bugs](https://github.com/apache/netbeans/issues/3962) with Cut and Paste on Windows, which are either caused by, or have to be fixed with, changes in the NbClipboard class. The changes above were not specifically made to fix those bugs, but improving the code is probably a good thing in any case.

