### PR TITLE
MacOS: Support HiDPI scaling in long filename tooltips

### DIFF
--- a/platform/openide.explorer/src/org/openide/explorer/view/ViewTooltips.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/ViewTooltips.java
@@ -496,8 +496,7 @@ final class ViewTooltips extends MouseAdapter implements MouseMotionListener {
             // get some reasonable limit for the width
             int width = Math.min(dd.width, 2 * currentScreenBounds.width);
             int height = Math.min(dd.height + 2, 2 * currentScreenBounds.height);
-            Image nue = !Utilities.isMac() ? owner.createVolatileImage(width, height) :
-                        new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+            Image nue = owner.createVolatileImage(width, height);
             Graphics g = nue.getGraphics();
             g.setColor (bg);
             g.fillRect (0, 0, width, dd.height + 2);


### PR DESCRIPTION
On MacOS, show long filename tooltips in e.g. the Projects pane in proper Retina resolution (2x scaling).

Before:
![image](https://github.com/user-attachments/assets/2650c74a-5090-49c6-b55f-856cfa23c792)

After:
![image](https://github.com/user-attachments/assets/9e6404a3-afd4-4cc5-b10a-16bbfbe57211)

The relevant improvement had already been made for Windows back in 2016, but seems to have been left unactivated for MacOS, probably because the author didn't have a Mac to test on. The trick is to create the BufferedImage via JComponent.createVolatileImage instead of 'new BufferedImage' (matching my own earlier experience with how HiDPI support in implemented in Swing). I simply removed the !isMac() condition.

The historical commit that introduced the related code is here: https://github.com/eirikbakke/netbeans-releases/commit/707013e449d6147402c92e2ba7d348a933c3e8d6#diff-4bc2ee6c72afdca0c960c205bedd2a606eb0657dad93ff82c7a93fbd1d5b0dc5R524

This issue was previously tracked at https://issues.apache.org/jira/browse/NETBEANS-5729