### PR TITLE
Use nbfs url for custom flatlaf properties as fallback

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Installer.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Installer.java
@@ -23,6 +23,8 @@ import com.formdev.flatlaf.FlatDarkLaf;
 import com.formdev.flatlaf.FlatLightLaf;
 import com.formdev.flatlaf.themes.FlatMacDarkLaf;
 import com.formdev.flatlaf.themes.FlatMacLightLaf;
+import java.net.URI;
+import java.net.URL;
 import javax.swing.UIManager;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -51,6 +53,13 @@ public class Installer extends ModuleInstall {
         FileObject customFolder = FileUtil.getConfigFile("LookAndFeel");
         if (customFolder != null && customFolder.isFolder()) {
             FlatLaf.registerCustomDefaultsSource(customFolder.toURL());
+        } else {
+            try {
+                URL lafConfig = URI.create("nbfs://nbhost/SystemFileSystem/LookAndFeel/").toURL();
+                FlatLaf.registerCustomDefaultsSource(lafConfig);
+            } catch (Exception ex) {
+                // fall through
+            }
         }
 
         FlatLaf.setSystemColorGetter( name -> {


### PR DESCRIPTION
If the `LookAndFeel` folder doesn't exist when validating the FlatLaf module, then register the `nbfs` URL for the folder instead.

When I first added this in #4719 I'd considered a possibility was also for modules to be able to register these files in the layer system, particularly in a platform application.  But I didn't test for this use at the time.  It turns out this doesn't work, because the layer files aren't mounted during module validation.

We might just use the URL full stop, but I've left the previous logic as is for now.  I'm not 100% sure if the local / system config files can result in different URLs?

I think this is a quick, safe fix for delivery, but feel free to ask to retarget.