### PR TITLE
Added a keymap for VS Code

### DIFF
--- a/ide/defaults/src/org/netbeans/modules/defaults/Code-keybindings-mac.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/Code-keybindings-mac.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE bindings PUBLIC "-//NetBeans//DTD Editor KeyBindings settings 1.1//EN" "http://www.netbeans.org/dtds/EditorKeyBindings-1_1.dtd">
+
+<bindings>
+  <!-- Basic Editing -->
+  <bind actionName="cut-to-clipboard" key="⌘X"/>
+  <bind actionName="copy-to-clipboard" key="⌘C"/>
+  <bind actionName="move-line-down" key="⌥↓"/>
+  <bind actionName="move-line-up" key="⌥↑"/>
+  <bind actionName="copy-line-down" key="⇧⌥↓"/>
+  <bind actionName="copy-line-up" key="⇧⌥↑"/>
+  <bind actionName="delete-line" key="⇧⌘K"/>
+  <bind actionName="insert-line-below" key="⌘Enter"/>
+  <bind actionName="insert-line-above" key="⇧⌘Enter"/>
+  <bind actionName="jump-to-matching-bracket" key="⇧⌘\"/>
+  <bind actionName="indent-line" key="⌘]"/>
+  <bind actionName="outdent-line" key="⌘["/>
+  <bind actionName="go-to-beginning-of-line" key="Home"/>
+  <bind actionName="go-to-end-of-line" key="End"/>
+  <bind actionName="go-to-beginning-of-file" key="⌘↑"/>
+  <bind actionName="go-to-end-of-file" key="⌘↓"/>
+  <bind actionName="scroll-line-up" key="⌃PgUp"/>
+  <bind actionName="scroll-line-down" key="⌃PgDn"/>
+  <bind actionName="scroll-page-up" key="⌘PgUp"/>
+  <bind actionName="scroll-page-down" key="⌘PgDn"/>
+  <bind actionName="fold-region" key="⌥⌘["/>
+  <bind actionName="unfold-region" key="⌥⌘]"/>
+  <bind actionName="fold-all-subregions" key="⌘K ⌘["/>
+  <bind actionName="unfold-all-subregions" key="⌘K ⌘]"/>
+  <bind actionName="fold-all-regions" key="⌘K ⌘0"/>
+  <bind actionName="unfold-all-regions" key="⌘K ⌘J"/>
+  <bind actionName="add-line-comment" key="⌘K ⌘C"/>
+  <bind actionName="remove-line-comment" key="⌘K ⌘U"/>
+  <bind actionName="toggle-line-comment" key="⌘/"/>
+  <bind actionName="toggle-block-comment" key="⇧⌥A"/>
+  <bind actionName="toggle-word-wrap" key="⌥Z"/>
+
+  <!-- Multi-cursor and Selection -->
+  <bind actionName="add-caret" key="⌥ + click"/>
+  <bind actionName="add-caret-above" key="⌥⌘↑"/>
+  <bind actionName="add-caret-below" key="⌥⌘↓"/>
+  <bind actionName="undo-last-caret-operation" key="⌘U"/>
+  <bind actionName="add-caret-to-end-of-lines" key="⇧⌥I"/>
+  <bind actionName="select-current-line" key="⌘L"/>
+  <bind actionName="select-all-occurrences-of-selection" key="⇧⌘L"/>
+  <bind actionName="select-all-occurrences-of-word" key="⌘F2"/>
+  <bind actionName="expand-selection" key="⌃⇧⌘→"/>
+  <bind actionName="shrink-selection" key="⌃⇧⌘←"/>
+  <bind actionName="column-selection" key="⇧⌥ + drag mouse"/>
+  <bind actionName="column-selection-up" key="⇧⌥⌘↑"/>
+  <bind actionName="column-selection-down" key="⇧⌥⌘↓"/>
+  <bind actionName="column-selection-left" key="⇧⌥⌘←"/>
+  <bind actionName="column-selection-right" key="⇧⌥⌘→"/>
+  <bind actionName="column-selection-page-up" key="⇧⌥⌘PgUp"/>
+  <bind actionName="column-selection-page-down" key="⇧⌥⌘PgDn"/>
+
+  <!-- Search and Replace -->
+  <bind actionName="find" key="⌘F"/>
+  <bind actionName="replace" key="⌥⌘F"/>
+  <bind actionName="find-next" key="⌘G"/>
+  <bind actionName="find-previous" key="⇧⌘G"/>
+  <bind actionName="select-all-occurrences-of-find-match" key="⌥Enter"/>
+  <bind actionName="add-selection-to-next-find-match" key="⌘D"/>
+  <bind actionName="move-last-selection-to-next-find-match" key="⌘K ⌘D"/>
+
+  <!-- Rich Languages Editing -->
+  <bind actionName="trigger-suggestion" key="⌃Space"/>
+  <bind actionName="trigger-parameter-hints" key="⌘I"/>
+  <bind actionName="format-document" key="⇧⌥F"/>
+  <bind actionName="format-selection" key="⌘K ⌘F"/>
+  <bind actionName="go-to-definition" key="F12"/>
+  <bind actionName="peek-definition" key="⌥F12"/>
+  <bind actionName="open-definition-to-the-side" key="⌘K F12"/>
+  <bind actionName="quick-fix" key="⌘."/>
+  <bind actionName="show-references" key="⇧F12"/>
+  <bind actionName="rename-symbol" key="F2"/>
+  <bind actionName="trim-trailing-whitespace" key="⌘K ⌘X"/>
+  <bind actionName="change-file-language" key="⌘K M"/>
+
+  <!-- Navigation -->
+  <bind actionName="show-all-symbols" key="⌘T"/>
+  <bind actionName="go-to-line" key="⌃G"/>
+  <bind actionName="go-to-file" key="⌘P"/>
+  <bind actionName="go-to-symbol" key="⇧⌘O"/>
+  <bind actionName="show-problems-panel" key="⇧⌘M"/>
+  <bind actionName="go-to-next-error-or-warning" key="F8"/>
+  <bind actionName="go-to-previous-error-or-warning" key="⇧F8"/>
+  <bind actionName="navigate-editor-group-history" key="⌃⇧Tab"/>
+  <bind actionName="go-back" key="⌃-"/>
+  <bind actionName="go-forward" key="⌃⇧-"/>
+  <bind actionName="toggle-tab-focus" key="⌃⇧M"/>
+
+  <!-- Editor Management -->
+  <bind actionName="close-editor" key="⌘W"/>
+  <bind actionName="close-folder" key="⌘K F"/>
+  <bind actionName="split-editor" key="⌘"/>
+  <bind actionName="focus-editor-group-1" key="⌘1"/>
+  <bind actionName="focus-editor-group-2" key="⌘2"/>
+  <bind actionName="focus-editor-group-3" key="⌘3"/>
+  <bind actionName="focus-previous-editor-group" key="⌘K ⌘←"/>
+  <bind actionName="focus-next-editor-group" key="⌘K ⌘→"/>
+  <bind actionName="move-editor-left" key="⌘K ⇧⌘←"/>
+  <bind actionName="move-editor-right" key="⌘K ⇧⌘→"/>
+  <bind actionName="move-active-editor-group-left" key="⌘K ←"/>
+  <bind actionName="move-active-editor-group-right" key="⌘K →"/>
+
+  <!-- File Management -->
+  <bind actionName="new-file" key="⌘N"/>
+  <bind actionName="open-file" key="⌘O"/>
+  <bind actionName="save" key="⌘S"/>
+  <bind actionName="save-as" key="⇧⌘S"/>
+  <bind actionName="save-all" key="⌥⌘S"/>
+  <bind actionName="close-file" key="⌘W"/>
+  <bind actionName="close-all-files" key="⌘K ⌘W"/>
+  <bind actionName="reopen-closed-editor" key="⇧⌘T"/>
+  <bind actionName="keep-preview-mode-editor-open" key="⌘K Enter"/>
+  <bind actionName="open-next" key="⌃Tab"/>
+  <bind actionName="open-previous" key="⌃⇧Tab"/>
+  <bind actionName="copy-path-of-active-file" key="⌘K P"/>
+  <bind actionName="reveal-active-file-in-finder" key="⌘K R"/>
+  <bind actionName="show-active-file-in-new-window" key="⌘K O"/>
+
+  <!-- Display -->
+  <bind actionName="toggle-full-screen" key="⌃⌘F"/>
+  <bind actionName="toggle-editor-layout" key="⌥⌘0"/>
+  <bind actionName="zoom-in" key="⌘="/>
+  <bind actionName="zoom-out" key="⇧⌘-"/>
+  <bind actionName="toggle-sidebar-visibility" key="⌘B"/>
+  <bind actionName="show-explorer" key="⇧⌘E"/>
+  <bind actionName="show-search" key="⇧⌘F"/>
+  <bind actionName="show-source-control" key="⌃⇧G"/>
+  <bind actionName="show-debug" key="⇧⌘D"/>
+  <bind actionName="show-extensions" key="⇧⌘X"/>
+  <bind actionName="replace-in-files" key="⇧⌘H"/>
+  <bind actionName="toggle-search-details" key="⇧⌘J"/>
+  <bind actionName="show-output-panel" key="⇧⌘U"/>
+  <bind actionName="open-markdown-preview" key="⇧⌘V"/>
+  <bind actionName="open-markdown-preview-to-the-side" key="⌘K V"/>
+  <bind actionName="zen-mode" key="⌘K Z"/>
+
+  <!-- Debug -->
+  <bind actionName="toggle-breakpoint" key="F9"/>
+  <bind actionName="start-continue" key="F5"/>
+  <bind actionName="stop" key="⇧F5"/>
+  <bind actionName="step-into" key="F11"/>
+  <bind actionName="step-out" key="⇧F11"/>
+  <bind actionName="step-over" key="F10"/>
+  <bind actionName="show-hover" key="⌘K ⌘I"/>
+
+  <!-- Integrated Terminal -->
+  <bind actionName="show-integrated-terminal" key="⌃`"/>
+  <bind actionName="create-new-terminal" key="⌃⇧`"/>
+  <bind actionName="copy-selection" key="⌘C"/>
+  <bind actionName="scroll-up" key="⌘↑"/>
+  <bind actionName="scroll-down" key="⌘↓"/>
+  <bind actionName="scroll-page-up" key="PgUp"/>
+  <bind actionName="scroll-page-down" key="PgDn"/>
+  <bind actionName="scroll-to-top" key="⌘Home"/>
+  <bind actionName="scroll-to-bottom" key="⌘End"/>
+</bindings>

--- a/ide/defaults/src/org/netbeans/modules/defaults/Code-keybindings.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/Code-keybindings.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<!DOCTYPE bindings PUBLIC "-//NetBeans//DTD Editor KeyBindings settings 1.1//EN" "http://www.netbeans.org/dtds/EditorKeyBindings-1_1.dtd">
+<bindings>
+  <!-- General -->
+  <bind actionName="show-command-palette" key="C-SHIFT-P"/>
+  <bind actionName="quick-open" key="C-P"/>
+  <bind actionName="new-window" key="C-SHIFT-N"/>
+  <bind actionName="close-window" key="C-SHIFT-W"/>
+  <bind actionName="user-settings" key="C-,"/>
+  <bind actionName="keyboard-shortcuts" key="C-K C-S"/>
+
+  <!-- Basic Editing -->
+  <bind actionName="cut-line" key="C-X"/>
+  <bind actionName="copy-line" key="C-C"/>
+  <bind actionName="move-line-up" key="A-UP"/>
+  <bind actionName="move-line-down" key="A-DOWN"/>
+  <bind actionName="copy-line-up" key="S-A-DOWN"/>
+  <bind actionName="copy-line-down" key="S-A-UP"/>
+  <bind actionName="delete-line" key="C-SHIFT-K"/>
+  <bind actionName="insert-line-below" key="C-ENTER"/>
+  <bind actionName="insert-line-above" key="C-SHIFT-ENTER"/>
+  <bind actionName="jump-to-matching-bracket" key="C-SHIFT-\\"/>
+  <bind actionName="indent-line" key="C-]"/>
+  <bind actionName="outdent-line" key="C-["/>
+  <bind actionName="go-to-beginning-of-line" key="HOME"/>
+  <bind actionName="go-to-end-of-line" key="END"/>
+  <bind actionName="go-to-beginning-of-file" key="C-HOME"/>
+  <bind actionName="go-to-end-of-file" key="C-END"/>
+  <bind actionName="scroll-line-up" key="C-UP"/>
+  <bind actionName="scroll-line-down" key="C-DOWN"/>
+  <bind actionName="scroll-page-up" key="A-PgUp"/>
+  <bind actionName="scroll-page-down" key="A-PgDn"/>
+  <bind actionName="fold-region" key="C-SHIFT-["/>
+  <bind actionName="unfold-region" key="C-SHIFT-]"/>
+  <bind actionName="fold-all-subregions" key="C-K C-["/>
+  <bind actionName="unfold-all-subregions" key="C-K C]"/>
+  <bind actionName="fold-all-regions" key="C-K C-0"/>
+  <bind actionName="unfold-all-regions" key="C-K C-J"/>
+  <bind actionName="add-line-comment" key="C-K C-C"/>
+  <bind actionName="remove-line-comment" key="C-K C-U"/>
+  <bind actionName="toggle-line-comment" key="C-/"/>
+  <bind actionName="toggle-block-comment" key="S-A"/>
+  <bind actionName="toggle-word-wrap" key="A-Z"/>
+
+  <!-- Navigation -->
+  <bind actionName="show-all-symbols" key="C-T"/>
+  <bind actionName="go-to-line" key="C-G"/>
+  <bind actionName="go-to-symbol" key="C-SHIFT-O"/>
+  <bind actionName="show-problems-panel" key="C-SHIFT-M"/>
+  <bind actionName="go-to-next-error" key="F8"/>
+  <bind actionName="go-to-previous-error" key="S-F8"/>
+  <bind actionName="navigate-editor-group-history" key="C-SHIFT-TAB"/>
+  <bind actionName="go-back" key="A-LEFT"/>
+  <bind actionName="go-forward" key="A-RIGHT"/>
+  <bind actionName="toggle-tab-focus" key="C-M"/>
+
+  <!-- Search and Replace -->
+  <bind actionName="find" key="C-F"/>
+  <bind actionName="replace" key="C-H"/>
+  <bind actionName="find-next" key="F3"/>
+  <bind actionName="find-previous" key="S-F3"/>
+  <bind actionName="select-all-occurrences" key="A-ENTER"/>
+  <bind actionName="add-selection-to-next-match" key="C-D"/>
+  <bind actionName="move-last-selection-to-next-match" key="C-K C-D"/>
+  <bind actionName="toggle-case-sensitive" key="A-C"/>
+  <bind actionName="toggle-regex" key="A-R"/>
+  <bind actionName="toggle-whole-word" key="A-W"/>
+
+  <!-- Multi-cursor and Selection -->
+  <bind actionName="insert-cursor" key="A-CLICK"/>
+  <bind actionName="insert-cursor-above" key="C-A-UP"/>
+  <bind actionName="insert-cursor-below" key="C-A-DOWN"/>
+  <bind actionName="undo-last-cursor-operation" key="C-U"/>
+  <bind actionName="insert-cursor-end-of-lines" key="S-A-I"/>
+  <bind actionName="select-current-line" key="C-L"/>
+  <bind actionName="select-all-occurrences" key="C-SHIFT-L"/>
+  <bind actionName="select-all-occurrences-word" key="C-F2"/>
+  <bind actionName="expand-selection" key="S-A-RIGHT"/>
+  <bind actionName="shrink-selection" key="S-A-LEFT"/>
+  <bind actionName="column-selection" key="C-SHIFT-A"/>
+  <bind actionName="column-selection-page-up" key="C-SHIFT-A PgUp"/>
+  <bind actionName="column-selection-page-down" key="C-SHIFT-A PgDn"/>
+
+  <!-- Rich Language Editing -->
+  <bind actionName="trigger-suggestion" key="C-Space"/>
+  <bind actionName="trigger-parameter-hints" key="C-SHIFT-Space"/>
+  <bind actionName="format-document" key="S-A-F"/>
+  <bind actionName="format-selection" key="C-K C-F"/>
+  <bind actionName="go-to-definition" key="F12"/>
+  <bind actionName="peek-definition" key="A-F12"/>
+  <bind actionName="open-definition-side" key="C-K F12"/>
+  <bind actionName="quick-fix" key="C-."/>
+  <bind actionName="show-references" key="S-F12"/>
+  <bind actionName="rename-symbol" key="F2"/>
+  <bind actionName="trim-trailing-whitespace" key="C-K C-X"/>
+  <bind actionName="change-file-language" key="C-K M"/>
+
+  <!-- Editor Management -->
+  <bind actionName="close-editor" key="C-F4"/>
+  <bind actionName="close-folder" key="C-K F"/>
+  <bind actionName="split-editor" key="C-\\"/>
+  <bind actionName="focus-editor-group-1" key="C-1"/>
+  <bind actionName="focus-editor-group-2" key="C-2"/>
+  <bind actionName="focus-editor-group-3" key="C-3"/>
+  <bind actionName="focus-prev-editor-group" key="C-K LEFT"/>
+  <bind actionName="focus-next-editor-group" key="C-K RIGHT"/>
+  <bind actionName="move-editor-left" key="C-SHIFT-PgUp"/>
+  <bind actionName="move-editor-right" key="C-SHIFT-PgDn"/>
+  <bind actionName="move-active-editor-group-left" key="C-K LEFT"/>
+  <bind actionName="move-active-editor-group-right" key="C-K RIGHT"/>
+
+  <!-- File Management -->
+  <bind actionName="new-file" key="C-N"/>
+  <bind actionName="open-file" key="C-O"/>
+  <bind actionName="save-file" key="C-S"/>
+  <bind actionName="save-as" key="C-SHIFT-S"/>
+  <bind actionName="save-all" key="C-K S"/>
+  <bind actionName="close-file" key="C-F4"/>
+  <bind actionName="close-all-files" key="C-K C-W"/>
+  <bind actionName="reopen-closed-editor" key="C-SHIFT-T"/>
+  <bind actionName="keep-preview-mode-open" key="C-K ENTER"/>
+  <bind actionName="open-next" key="C-TAB"/>
+  <bind actionName="open-previous" key="C-SHIFT-TAB"/>
+  <bind actionName="copy-file-path" key="C-K P"/>
+  <bind actionName="reveal-file-in-explorer" key="C-K R"/>
+  <bind actionName="show-file-in-new-window" key="C-K O"/>
+
+  <!-- Display -->
+  <bind actionName="toggle-fullscreen" key="F11"/>
+  <bind actionName="toggle-editor-layout" key="S-A-0"/>
+  <bind actionName="zoom-in" key="C-EQUAL"/>
+  <bind actionName="zoom-out" key="C-MINUS"/>
+  <bind actionName="toggle-sidebar-visibility" key="C-B"/>
+  <bind actionName="show-explorer" key="C-SHIFT-E"/>
+  <bind actionName="show-search" key="C-SHIFT-F"/>
+  <bind actionName="show-source-control" key="C-SHIFT-G"/>
+  <bind actionName="show-debug" key="C-SHIFT-D"/>
+  <bind actionName="show-extensions" key="C-SHIFT-X"/>
+  <bind actionName="replace-in-files" key="C-SHIFT-H"/>
+  <bind actionName="toggle-search-details" key="C-SHIFT-J"/>
+  <bind actionName="show-output" key="C-SHIFT-U"/>
+  <bind actionName="open-markdown-preview" key="C-SHIFT-V"/>
+  <bind actionName="open-markdown-preview-side" key="C-K V"/>
+  <bind actionName="zen-mode" key="C-K Z"/>
+
+  <!-- Debug -->
+  <bind actionName="toggle-breakpoint" key="F9"/>
+  <bind actionName="start-continue-debugging" key="F5"/>
+  <bind actionName="stop-debugging" key="S-F5"/>
+  <bind actionName="step-into-debug" key="F11"/>
+  <bind actionName="step-out-debug" key="S-F11"/>
+  <bind actionName="step-over-debug" key="F10"/>
+  <bind actionName="show-hover" key="C-K I"/>
+
+  <!-- Integrated Terminal -->
+  <bind actionName="show-integrated-terminal" key="C-`"/>
+  <bind actionName="create-new-terminal" key="C-SHIFT-`"/>
+  <bind actionName="copy-selection-terminal" key="C-C"/>
+  <bind actionName="paste-into-terminal" key="C-V"/>
+  <bind actionName="scroll-terminal-up" key="C-UP"/>
+  <bind actionName="scroll-terminal-down" key="C-DOWN"/>
+  <bind actionName="scroll-page-up-terminal" key="S-PgUp"/>
+  <bind actionName="scroll-page-down-terminal" key="S-PgDn"/>
+  <bind actionName="scroll-to-top-terminal" key="C-HOME"/>
+  <bind actionName="scroll-to-bottom-terminal" key="C-END"/>
+</bindings>

--- a/ide/defaults/src/org/netbeans/modules/defaults/mf-layer-eclipse-keybinding.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/mf-layer-eclipse-keybinding.xml
@@ -119,7 +119,7 @@
     <file name="S-F2.shadow">
         <attr name="originalFile" stringvalue="Actions/Edit/bookmark-history-popup-previous.instance"/>
     </file>
-<!--    <file name="D-F2.shadow">
+    <!--    <file name="D-F2.shadow">
         <attr name="originalFile" stringvalue="Actions/Edit/bookmark-toggle.instance"/>
     </file>-->
     <file name="D-F11.shadow">
@@ -131,10 +131,10 @@
     <file name="CS-8.shadow">
         <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-modules-palette-ShowPaletteAction.instance"/>
     </file>
-<!--    <file name="D-7.shadow">
+    <!--    <file name="D-7.shadow">
         <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-modules-navigator-ShowNavigatorAction.instance"/>
     </file>-->
-<!--    <file name="D-3.shadow">
+    <!--    <file name="D-3.shadow">
         <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-modules-favorites-View.instance"/>
     </file>-->
     <file name="D-5.shadow">
@@ -143,7 +143,7 @@
     <file name="CS-F.shadow">
         <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-ReplaceAction.instance"/>
     </file>
-<!--    <file name="C-L.shadow">
+    <!--    <file name="C-L.shadow">
         <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-GotoAction.instance"/>
     </file>-->
     <file name="DELETE.shadow">
@@ -188,7 +188,7 @@
     <file name="CS-W.shadow">
         <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseAllDocumentsAction.instance"/>
     </file>
-<!--    <file name="C-F6.shadow">
+    <!--    <file name="C-F6.shadow">
         <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-RecentViewListAction.instance"/>
     </file>-->
     <file name="COPY.shadow">
@@ -263,10 +263,10 @@
     <file name="D-H.shadow">
         <attr name="originalFile" stringvalue="Actions/Edit/org-netbeans-modules-search-FindInFilesAction.instance"/>
     </file>
-<!--    <file name="DO-H.shadow">
+    <!--    <file name="DO-H.shadow">
         <attr name="originalFile" stringvalue="Actions/Refactoring/org-netbeans-modules-refactoring-api-ui-WhereUsedAction.instance"/>
     </file>-->
-<!--    <file name="OS-D.shadow">
+    <!--    <file name="OS-D.shadow">
         <attr name="originalFile" stringvalue="Actions/Debug/org-netbeans-modules-debugger-ui-actions-DebugMainProjectAction.instance"/>
     </file>-->
     <file name="OS-R.shadow">
@@ -275,18 +275,18 @@
     <file name="D-1.shadow">
         <attr name="originalFile" stringvalue="Actions/Source/org-netbeans-modules-editor-hints-FixAction.instance"/>
     </file>
-    
+
     <file name="DS-O.removed"/>
     <file name="C-Q.removed"/>
-    
+
     <file name="D-2.removed"/>
     <file name="OS-D.removed"/>
     <file name="OS-X.removed"/>
     <file name="AS-X.removed"/>
-    
+
     <file name="SO-L.removed"/>
     <file name="OS-L.removed"/>
-    
+
     <file name="D-F6.shadow">
         <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-NextTabAction.instance"/>
     </file>

--- a/ide/defaults/src/org/netbeans/modules/defaults/mf-layer.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/mf-layer.xml
@@ -160,8 +160,8 @@
                 <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-RunSingle.instance"/>
             </file>
             <file name="D-F4.shadow">
-        	    <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
-        	</file>
+                <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
+            </file>
             <file name="F8.shadow">
                 <attr name="originalFile" stringvalue="Actions/Debug/org-netbeans-modules-debugger-ui-actions-StepOverAction.instance"/>
             </file>
@@ -199,8 +199,8 @@
                 <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-PopupAction.instance"/>
             </file>
             <file name="S-F10.shadow">
-        	    <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-PopupAction.instance"/>
-        	</file>
+                <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-PopupAction.instance"/>
+            </file>
             <file name="SO-8.shadow">
                 <attr name="originalFile" stringvalue="Actions/Window/Debug/org-netbeans-modules-debugger-ui-actions-SourcesViewAction.instance"/>
             </file>
@@ -487,8 +487,8 @@
                 <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
             </file>
             <file name="D-F4.shadow">
-        	    <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
-        	</file>
+                <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
+            </file>
             <file name="F8.shadow">
                 <attr name="originalFile" stringvalue="Actions/Debug/org-netbeans-modules-debugger-ui-actions-StepOverAction.instance"/>
             </file>
@@ -583,9 +583,7 @@
                 <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-BuildMainProject.instance"/>
             </file>
         </folder>
-        
-        
-        
+
         <folder name="NetBeans">
             <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
             <file name="COPY.shadow">
@@ -739,11 +737,11 @@
                 <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-RunSingle.instance"/>
             </file>
             <file name="D-F4.shadow">
-        	    <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
-        	</file>
+                <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
+            </file>
             <file name="D-W.shadow">
-        	    <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
-        	</file>
+                <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
+            </file>
             <file name="F8.shadow">
                 <attr name="originalFile" stringvalue="Actions/Debug/org-netbeans-modules-debugger-ui-actions-StepOverAction.instance"/>
             </file>
@@ -837,12 +835,44 @@
             <file name="O-Enter.shadow">
                 <attr name="originalFile" stringvalue="Actions/Source/org-netbeans-modules-editor-hints-FixAction.instance"/>
             </file>
-            <file name="DOS-O.shadow"> <!--Temporary until nicer shortcut s found-->
+            <file name="DOS-O.shadow">                <!--Temporary until nicer shortcut s found-->
                 <attr name="originalFile" stringvalue="Actions/Edit/org-netbeans-modules-jumpto-symbol-GoToSymbol.instance"/>
             </file>
         </folder>
         
         &eclipse-keys;
+
+        <folder name="Code">
+            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+            <file name="CTRL-C.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-CopyAction.instance"/>
+            </file>
+            <file name="CTRL-X.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-CutAction.instance"/>
+            </file>
+            <file name="CTRL-V.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-PasteAction.instance"/>
+            </file>
+            <file name="CTRL-Z.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-UndoAction.instance"/>
+            </file>
+            <file name="CTRL-Y.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-RedoAction.instance"/>
+            </file>
+            <file name="CTRL-F.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-FindAction.instance"/>
+            </file>
+            <file name="A-ENTER.shadow">
+                <attr name="originalFile" stringvalue="Actions/Source/org-netbeans-modules-editor-hints-FixAction.instance"/>
+            </file>
+            <file name="CTRL-SHIFT-B.shadow">
+                <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-BuildMainProject.instance"/>
+            </file>
+            <file name="F5.shadow">
+                <attr name="originalFile" stringvalue="Actions/Refactoring/org-netbeans-modules-refactoring-api-ui-CopyAction.instance"/>
+            </file>
+        </folder>
+
 
         <folder name="Idea">
             <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
@@ -1096,93 +1126,101 @@
                 <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-UndoAction.instance"/>
             </file>
         </folder>
-        </folder>
-        <folder name="Editors">
+    </folder>
+    <folder name="Editors">
 
-            <folder name="FontsColors">
-                <folder name="NetBeans55">
-                    <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                    <folder name="Defaults">
-                        <file name="org-netbeans-modules-defaults-token-colorings.xml" url="NetBeans55-fontsColorsDefaults.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                        </file>
-                        <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="NetBeans55-editor.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                            <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
-                        </file>
-                    </folder>
+        <folder name="FontsColors">
+            <folder name="NetBeans55">
+                <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-token-colorings.xml" url="NetBeans55-fontsColorsDefaults.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                    </file>
+                    <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="NetBeans55-editor.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                        <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
+                    </file>
                 </folder>
-            
-                <folder name="NetBeansEarth">
-                    <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                    <folder name="Defaults">
-                        <file name="org-netbeans-modules-defaults-token-colorings.xml" url="NetBeansEarth-fontsColorsDefaults.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                        </file>
-                        <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="NetBeansEarth-editor.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                            <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
-                        </file>
-                    </folder>
-                </folder>
-            
-            
-                <folder name="CityLights">
-                    <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                    <folder name="Defaults">
-                        <file name="org-netbeans-modules-defaults-token-colorings.xml" url="CityLights-fontsColorsDefaults.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                        </file>
-                        <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="CityLights-editor.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                            <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
-                        </file>
-                    </folder>
-                </folder>
-            
-                <folder name="BlueTheme">
-                    <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                    <folder name="Defaults">
-                        <file name="org-netbeans-modules-defaults-token-colorings.xml" url="BlueTheme-fontsColorsDefaults.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                        </file>
-                        <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="BlueTheme-editor.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                            <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
-                        </file>
-                        <file name="org-netbeans-modules-editor-annotations-colorings.xml" url="BlueTheme-annotations.xml">
-                            <attr name="nbeditor-settings-ColoringType" stringvalue="annotation"/>
-                        </file>
-                    </folder>
-                </folder>
-            
             </folder>
-        
-            <folder name="Keybindings">
-                <folder name="Eclipse">
-                    <folder name="Defaults">
-                        <file name="org-netbeans-modules-defaults-keybindings.xml" url="Eclipse-keybindings.xml"/>
-                        <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="Eclipse-keybindings-mac.xml">
-                            <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
-                        </file>
-                    </folder>
+
+            <folder name="NetBeansEarth">
+                <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-token-colorings.xml" url="NetBeansEarth-fontsColorsDefaults.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                    </file>
+                    <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="NetBeansEarth-editor.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                        <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
+                    </file>
                 </folder>
-                <folder name="Emacs">
-                    <folder name="Defaults">
-                        <file name="org-netbeans-modules-defaults-keybindings.xml" url="Emacs-keybindings.xml"/>
-                        <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="Emacs-keybindings-mac.xml">
-                            <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
-                        </file>
-                    </folder>
+            </folder>
+
+
+            <folder name="CityLights">
+                <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-token-colorings.xml" url="CityLights-fontsColorsDefaults.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                    </file>
+                    <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="CityLights-editor.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                        <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
+                    </file>
                 </folder>
-                <folder name="Idea">
-                    <folder name="Defaults">
-                        <file name="org-netbeans-modules-defaults-keybindings.xml" url="Idea-keybindings.xml"/>
-                        <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="Idea-keybindings-mac.xml">
-                            <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
-                        </file>
-                    </folder>
+            </folder>
+
+            <folder name="BlueTheme">
+                <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-token-colorings.xml" url="BlueTheme-fontsColorsDefaults.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                    </file>
+                    <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="BlueTheme-editor.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                        <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
+                    </file>
+                    <file name="org-netbeans-modules-editor-annotations-colorings.xml" url="BlueTheme-annotations.xml">
+                        <attr name="nbeditor-settings-ColoringType" stringvalue="annotation"/>
+                    </file>
                 </folder>
+            </folder>
+
+        </folder>
+
+        <folder name="Keybindings">
+            <folder name="Eclipse">
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-keybindings.xml" url="Eclipse-keybindings.xml"/>
+                    <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="Eclipse-keybindings-mac.xml">
+                        <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
+                    </file>
+                </folder>
+            </folder>
+            <folder name="Emacs">
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-keybindings.xml" url="Emacs-keybindings.xml"/>
+                    <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="Emacs-keybindings-mac.xml">
+                        <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
+                    </file>
+                </folder>
+            </folder>
+            <folder name="Idea">
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-keybindings.xml" url="Idea-keybindings.xml"/>
+                    <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="Idea-keybindings-mac.xml">
+                        <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
+                    </file>
+                </folder>
+            </folder>
+            <folder name="Code">
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-keybindings.xml" url="Code-keybindings.xml"/>
+                    <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="Code-keybindings-mac.xml">
+                        <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
+                    </file>
+                </folder>
+            </folder>
             <folder name="NetBeans55">
                 <folder name="Defaults">
                     <file name="org-netbeans-modules-defaults-keybindings.xml" url="NetBeans55-keybindings.xml"/>
@@ -1264,7 +1302,7 @@
                     </folder>
                 </folder>
             </folder>
-            
+
             <folder name="plain">
                 <folder name="FontsColors">
                     <folder name="CityLights">
@@ -1281,9 +1319,9 @@
                             </file>
                         </folder>
                     </folder>
-                </folder>                
+                </folder>
             </folder>
-            
+
             <folder name="x-java">
                 <folder name="FontsColors">
                     <folder name="CityLights">
@@ -1299,7 +1337,7 @@
                                 <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
                             </file>
                         </folder>
-                    </folder>                    
+                    </folder>
                     <folder name="NetBeansEarth">
                         <folder name="Defaults">
                             <file name="org-netbeans-modules-editor-java-token-colorings.xml" url="NetBeansEarth-Java-fontsColors.xml">
@@ -1316,7 +1354,7 @@
                     </folder>
                 </folder>
             </folder>
-            
+
             <folder name="css">
                 <folder name="FontsColors">
                     <folder name="CityLights">
@@ -1332,7 +1370,7 @@
                                 <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
                             </file>
                         </folder>
-                    </folder>                    
+                    </folder>
                     <folder name="BlueTheme">
                         <folder name="Defaults">
                             <file name="org-netbeans-modules-editor-java-token-colorings.xml" url="BlueTheme-CSS-fontsColors.xml">
@@ -1368,7 +1406,7 @@
                     </folder>
                 </folder>
             </folder>
-            
+
             <folder name="x-jsp">
                 <folder name="FontsColors">
                     <folder name="CityLights">
@@ -1394,7 +1432,7 @@
                     </folder>
                 </folder>
             </folder>
-            
+
             <folder name="x-el">
                 <folder name="FontsColors">
                     <folder name="CityLights">
@@ -1406,7 +1444,7 @@
                     </folder>
                 </folder>
             </folder>
-            
+
             <folder name="xml">
                 <folder name="FontsColors">
                     <folder name="CityLights">
@@ -1439,7 +1477,7 @@
                     </folder>
                 </folder>
             </folder>
-            
+
             <folder name="x-sql">
                 <folder name="FontsColors">
                     <folder name="NetBeans55">
@@ -1451,9 +1489,9 @@
                     </folder>
                 </folder>
             </folder>
-            
+
         </folder>
-        
+
         <folder name="application">
             <folder name="xml-dtd">
                 <folder name="FontsColors">
@@ -1480,8 +1518,7 @@
     <folder name="Services">
         <folder name="MIMEResolver">
             <file name="org-netbeans-modules-defaults-mime-wav.xml">
-                <attr
-                    methodvalue="org.openide.filesystems.MIMEResolver.create" name="instanceCreate"/>
+                <attr methodvalue="org.openide.filesystems.MIMEResolver.create" name="instanceCreate"/>
                 <attr name="instanceClass" stringvalue="org.openide.filesystems.MIMEResolver"/>
                 <attr name="mimeType" stringvalue="audio/wav"/>
                 <attr name="ext.0" stringvalue="wav"/>


### PR DESCRIPTION
### Description:

This is a draft pull request designed to facilitate the migration of keybindings from VSCode to NetBeans, aiming to ensure a smooth transition for users without altering their familiar keybinding setup.

### Fixes the Issue
Add a keymap for VS Code #6458

### Changes:
- **Mapped VSCode Keybindings:** Replaced the keybinding file names and actions from VSCode with their corresponding NetBeans equivalents.
- **Preserved Functionality:** Maintained the original functionality of keybindings to provide a seamless transition.

### Current Status:
- **Partial Functionality:** While several keybindings have been successfully mapped, only a few are currently working as intended. For example, the `A-F1.shadow` file is mapped to the VSCode equivalent action, but issues remain in accurately mapping actions such as `Actions/Window/org-netbeans-core-windows-actions-SwitchToRecentDocumentAction.instance`.

### Next Steps:
- **Action Mapping:** I am still working on identifying and mapping the correct actions from the `stringvalue` attribute in NetBeans to ensure complete functionality.
- **Request for Assistance:** I would appreciate any guidance or suggestions on navigating through this process. Additionally, I am exploring alternative approaches to achieve the desired results.

### Objective:
Enable users migrating from VSCode to NetBeans to retain their existing keybindings and workflows effectively.

### Attachments:
- Screenshot of the updated NetBeans keymap reflecting the VSCode keybindings.
![Screenshot (543)](https://github.com/user-attachments/assets/3c99b537-8d5e-4980-b148-2c6ab47c53ac)


---

**By opening this pull request you confirm that, unless explicitly stated otherwise:**

- The changes are all your own work, and you have the right to contribute them.  
  **Yes**
- The contributions are made solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).  
  **Yes**