### PR TITLE
Default Parser.Result is created when no Parser is available.

### DIFF
--- a/ide/parsing.api/src/org/netbeans/modules/parsing/impl/SourceCache.java
+++ b/ide/parsing.api/src/org/netbeans/modules/parsing/impl/SourceCache.java
@@ -212,7 +212,14 @@ public final class SourceCache {
     ) throws ParseException {
         assert TaskProcessor.holdsParserLock();
         Parser _parser = getParser ();
-        if (_parser == null) return null;
+        if (_parser == null) {
+            final Snapshot _snapshot = getSnapshot();
+            return snapshot != null ? new Result(_snapshot) {
+                @Override
+                protected void invalidate() {
+                }
+            } : null;
+        }
         boolean _parsed;
         synchronized (TaskProcessor.INTERNAL_LOCK) {
             _parsed = this.parsed;


### PR DESCRIPTION
Call to `SourceCache.getResult(Task)` should return a default `Parser.Result` providing access to the corresponding `Snapshot` in case when no `Parser` is available for the given source mime-type.