### PR TITLE
Fix Janitor directory comparison.

### DIFF
--- a/platform/janitor/src/org/netbeans/modules/janitor/Janitor.java
+++ b/platform/janitor/src/org/netbeans/modules/janitor/Janitor.java
@@ -247,7 +247,7 @@ public class Janitor {
         if (cacheDir != null) {
             File cacheParent = cacheDir.getParentFile();
             for (File f : cacheParent.listFiles()) {
-                if (f.isDirectory() && !f.equals(userDir)) {
+                if (f.isDirectory() && !f.equals(cacheDir)) {
                     names.add(f.getName());
                 }
             }


### PR DESCRIPTION
Replace userDir with cacheDir from the copy paste operation.

Doing this on delivery as suggested by @mbien on the dev list
https://lists.apache.org/thread/wplbt15md09hmgkqozn54wmk6b2zjnf0
