### PR TITLE
Added code preview for “find usages” and related refactorings

### DIFF
--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/CheckNodeListener.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/CheckNodeListener.java
@@ -109,9 +109,9 @@ class CheckNodeListener implements MouseListener, KeyListener {
                         o = ((TreeElement) o).getUserObject();
                         if (o instanceof RefactoringElement) {
                                 openDiff(node);
-                            }
                         }
                     }
+                }
             } else {
                 Rectangle chRect = CheckRenderer.getCheckBoxRectangle();
                 Rectangle rowRect = tree.getPathBounds(path);
@@ -356,10 +356,7 @@ class CheckNodeListener implements MouseListener, KeyListener {
         } while (!node.isLeaf());
         tree.setSelectionRow(newRow);
         tree.scrollRowToVisible(newRow);
-        if (isQuery) {
-            CheckNodeListener.findInSource(node);
-        } else {
-            CheckNodeListener.openDiff(node);
-        }
+        CheckNodeListener.openDiff(node);
     }
+
 } // end CheckNodeListener

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/PreviewManager.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/PreviewManager.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.refactoring.spi.impl;
 
+import java.awt.Component;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Reader;
@@ -27,12 +28,18 @@ import java.util.HashMap;
 import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.swing.JEditorPane;
+import javax.swing.JScrollPane;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
+import javax.swing.text.EditorKit;
 import javax.swing.text.StyledDocument;
 import org.netbeans.api.diff.DiffController;
 import org.netbeans.api.diff.Difference;
 import org.netbeans.api.diff.StreamSource;
+import org.netbeans.api.editor.mimelookup.MimeLookup;
+import org.netbeans.editor.EditorUI;
+import org.netbeans.editor.Utilities;
 import org.netbeans.modules.refactoring.api.impl.SPIAccessor;
 import org.netbeans.modules.refactoring.spi.SimpleRefactoringElementImplementation;
 import org.netbeans.modules.refactoring.spi.ui.UI;
@@ -106,6 +113,47 @@ public class PreviewManager {
     }
     
     public void refresh(SimpleRefactoringElementImplementation element) {
+        RefactoringPanel current = RefactoringPanel.getCurrentRefactoringPanel();
+        if (current != null && current.isQuery()) {
+            showQueryPreview(element);
+        } else {
+            showDiffView(element);
+        }
+    }
+
+    private void showQueryPreview(SimpleRefactoringElementImplementation element) {
+        try {
+            FileObject fileObject = element.getParentFile();
+            DataObject dataObject = DataObject.find(fileObject);
+            EditorCookie editorCookie = dataObject != null ? dataObject.getLookup().lookup(org.openide.cookies.EditorCookie.class) : null;
+            if (editorCookie != null) {
+                StyledDocument document = editorCookie.openDocument();
+                if (document != null) {
+                    String mimeType = (String) document.getProperty("mimeType"); //NOI18N
+                    if (mimeType != null) {
+                        JEditorPane pane = new JEditorPane();
+                        EditorKit editorKit = MimeLookup.getLookup(mimeType).lookup(EditorKit.class);
+                        pane.setEditorKit(editorKit);
+                        pane.setDocument(document);
+                        pane.setEditable(false);
+                        Component editorComponent;
+                        EditorUI editorUI = Utilities.getEditorUI(pane);
+                        if (editorUI != null) {
+                            editorComponent = editorUI.getExtComponent();
+                        } else {
+                            editorComponent = new JScrollPane(pane);
+                        }
+                        pane.setCaretPosition(element.getPosition().getBegin().getOffset());
+                        UI.setComponentForRefactoringPreview(editorComponent);
+                    }
+                }
+            }
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        }
+    }
+
+    private void showDiffView(SimpleRefactoringElementImplementation element) {
         try {
             String newText = SPIAccessor.DEFAULT.getNewFileContent(element);
             if (newText==null) {

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/UI.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/ui/UI.java
@@ -80,18 +80,7 @@ public final class UI {
      * @return component was successfuly set
      */ 
     public static boolean setComponentForRefactoringPreview(Component component) {
-        TopComponent activated = TopComponent.getRegistry().getActivated();
-        RefactoringPanel refactoringPanel = null;
-        if (activated instanceof RefactoringPanelContainer) {
-            RefactoringPanelContainer panel = (RefactoringPanelContainer) activated;
-            refactoringPanel = panel.getCurrentPanel();
-        }
-        if (refactoringPanel == null) {
-            refactoringPanel = RefactoringPanelContainer.getRefactoringComponent().getCurrentPanel();
-        }
-        if (refactoringPanel == null) {
-            refactoringPanel = RefactoringPanelContainer.getUsagesComponent().getCurrentPanel();
-        }
+        RefactoringPanel refactoringPanel = RefactoringPanel.getCurrentRefactoringPanel();
         if (refactoringPanel == null) 
             return false;
         if (component == null) {


### PR DESCRIPTION
I have to use `find usages` a lot and I really miss the ability to quickly view the contents of files.
I have to open tabs in the main editor, which sometimes leads to a lot of unnecessary tabs.

Example of code preview for `find usages`:


https://github.com/user-attachments/assets/0c82aa69-739a-42f2-8124-16e68771e644


An example of code preview for refactoring `safely delete`, which uses `find usages` functionality:


https://github.com/user-attachments/assets/21a2588e-6602-4af5-9a2e-ec24bca4f55f




I borrowed the preview implementation from here:
 https://github.com/apache/netbeans/blob/6c6beed97e32e20e3f5daa4301470fbc87458ba5/ide/editor.bookmarks/src/org/netbeans/modules/editor/bookmarks/ui/BookmarksView.java#L536-L563

