### PR TITLE
Support for string[] vmArgs

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
@@ -468,19 +468,18 @@ public abstract class NbLaunchDelegate {
     }
 
     @NonNull
-    private static List<String> argsToStringList(Object o) {
+    static List<String> argsToStringList(Object o) {
         if (o == null) {
             return Collections.emptyList();
         }
         if (o instanceof List) {
             for (Object item : (List)o) {
-                if (!(o instanceof String)) {
+                if (!(item instanceof String)) {
                     throw new IllegalArgumentException("Only string parameters expected");
                 }
             }
             return (List<String>)o;
         } else if (o instanceof String) {
-            List<String> res = new ArrayList<>();
             return Arrays.asList(BaseUtilities.parseParameters(o.toString()));
         } else {
             throw new IllegalArgumentException("Expected String or String list");

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
@@ -187,11 +187,14 @@ public final class NbLaunchRequestHandler {
         }
 
         if (!isNative) {
-            if (StringUtils.isBlank((String)launchArguments.get("vmArgs"))) {
+            List<String> vmArgList = NbLaunchDelegate.argsToStringList(launchArguments.get("vmArgs"));
+            if (vmArgList.isEmpty()) {
                 launchArguments.put("vmArgs", String.format("-Dfile.encoding=%s", context.getDebuggeeEncoding().name()));
             } else {
+                vmArgList = new ArrayList<>(vmArgList);
+                vmArgList.add(String.format("-Dfile.encoding=%s", context.getDebuggeeEncoding().name()));
                 // if vmArgs already has the file.encoding settings, duplicate options for jvm will not cause an error, the right most value wins
-                launchArguments.put("vmArgs", String.format("%s -Dfile.encoding=%s", launchArguments.get("vmArgs"), context.getDebuggeeEncoding().name()));
+                launchArguments.put("vmArgs", vmArgList);
             }
         }
         context.setDebugMode(!noDebug);

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -322,8 +322,13 @@
 							"vmArgs": {
 								"type": [
 									"string",
+									"array",
 									"null"
 								],
+								"items": {
+									"type": "string",
+									"description": "Single argument to the VM"
+								},
 								"description": "Arguments for the Java VM",
 								"default": null
 							},
@@ -618,7 +623,7 @@
 			{
 				"command": "nbls.project.buildPushImage",
 				"title": "Build and Push container image",
-                                "icon": "$(live-share)"
+				"icon": "$(live-share)"
 			},
 			{
 				"command": "cloud.assets.policy.create",
@@ -1082,7 +1087,7 @@
 					"when": "viewItem =~ /publicIp:.*/ && viewItem =~ /imageUrl:.*/",
 					"group": "inline@10"
 				},
-                                {
+				{
 					"command": "nbls.project.buildPushImage",
 					"when": "viewItem =~ /class:oracle.developer.ContainerRepositoryItem/",
 					"group": "inline@9"

--- a/java/java.lsp.server/vscode/src/runConfiguration.ts
+++ b/java/java.lsp.server/vscode/src/runConfiguration.ts
@@ -35,7 +35,7 @@ class RunConfigurationProvider implements vscode.DebugConfigurationProvider {
 			resolve(config);
 		});
 	}
-
+	
 	resolveDebugConfigurationWithSubstitutedVariables?(_folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, _token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
         return new Promise<vscode.DebugConfiguration>(resolve => {
 			const args = argumentsNode.getValue();
@@ -51,7 +51,11 @@ class RunConfigurationProvider implements vscode.DebugConfigurationProvider {
 			if (vmArgs) {
 				if (!config.vmArgs) {
 					config.vmArgs = vmArgs;
+				} else if (Array.isArray(config.vmArgs)) {
+					let cfg : string[] = config.vmArgs;
+					cfg.push(vmArgs);
 				} else {
+					// assume the config is a string
 					config.vmArgs = `${config.vmArgs} ${vmArgs}`;
 				}
 			}


### PR DESCRIPTION
The launch config vmParameters is quite often composed from several parameters. While it is convenient to write one string, as the number of parameters grows, or parameters are "fancy" (contain spaces, quotes, ...), it may be better to express them as an array. 

MS Java extension also allows to configure vmargs as an array, so this addition may make user migration to NBLS or extension switching easier.
