### PR TITLE
Fixing LspElementUtils with anonymous classes extending an enclosing class, and speeding up the StructureElement computation.

### DIFF
--- a/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
+++ b/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
@@ -557,32 +557,38 @@ public final class ElementOpen {
                     }
 
                     if (elTree != null) {
-                        result[1] = (int)info.getTrees().getSourcePositions().getStartPosition(cu, elTree);
-                        result[2] = (int)info.getTrees().getSourcePositions().getEndPosition(cu, elTree);
-                        int[] span = null;
-                        switch(elTree.getKind()) {
-                            case CLASS:
-                            case INTERFACE:
-                            case ENUM:
-                            case ANNOTATION_TYPE:
-                                span = info.getTreeUtilities().findNameSpan((ClassTree)elTree);
-                                break;
-                            case METHOD:
-                                span = info.getTreeUtilities().findNameSpan((MethodTree)elTree);
-                                break;
-                            case VARIABLE:
-                                span = info.getTreeUtilities().findNameSpan((VariableTree)elTree);
-                                break;
-                        }
-                        if (span != null) {
-                            result[3] = span[0];
-                            result[4] = span[1];
-                        }
+                        fillInTreePositions(info, elTree, result);
                     }
                 }
             };
 
             js.runUserActionTask(t, true);
+        }
+    }
+
+    static void fillInTreePositions(CompilationInfo info, Tree forTree, Object[] target) {
+        CompilationUnitTree cu = info.getCompilationUnit();
+        target[1] = (int)info.getTrees().getSourcePositions().getStartPosition(cu, forTree);
+        target[2] = (int)info.getTrees().getSourcePositions().getEndPosition(cu, forTree);
+        int[] span = null;
+        switch(forTree.getKind()) {
+            case CLASS:
+            case INTERFACE:
+            case ENUM:
+            case ANNOTATION_TYPE:
+            case RECORD:
+                span = info.getTreeUtilities().findNameSpan((ClassTree)forTree);
+                break;
+            case METHOD:
+                span = info.getTreeUtilities().findNameSpan((MethodTree)forTree);
+                break;
+            case VARIABLE:
+                span = info.getTreeUtilities().findNameSpan((VariableTree)forTree);
+                break;
+        }
+        if (span != null) {
+            target[3] = span[0];
+            target[4] = span[1];
         }
     }
 
@@ -642,6 +648,11 @@ public final class ElementOpen {
             @Override
             public Object[] getOpenInfo(ClasspathInfo cpInfo, ElementHandle<? extends Element> el, AtomicBoolean cancel) {
                 return ElementOpen.getOpenInfo(cpInfo, el, null, cancel);
+            }
+
+            @Override
+            public void fillInTreePositions(CompilationInfo info, Tree forTree, Object[] target) {
+                ElementOpen.fillInTreePositions(info, forTree, target);
             }
 
             @Override

--- a/java/java.sourceui/src/org/netbeans/modules/java/source/ui/ElementOpenAccessor.java
+++ b/java/java.sourceui/src/org/netbeans/modules/java/source/ui/ElementOpenAccessor.java
@@ -18,10 +18,12 @@
  */
 package org.netbeans.modules.java.source.ui;
 
+import com.sun.source.tree.Tree;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.lang.model.element.Element;
 import org.netbeans.api.java.source.ClasspathInfo;
+import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.java.source.ElementHandle;
 import org.netbeans.api.java.source.ui.ElementOpen;
 
@@ -42,6 +44,7 @@ public abstract class ElementOpenAccessor {
     }
     
     public abstract Object[] getOpenInfo(final ClasspathInfo cpInfo, final ElementHandle<? extends Element> el, AtomicBoolean cancel);
+    public abstract void fillInTreePositions(CompilationInfo info, Tree forTree, Object[] target);
     
     public abstract CompletableFuture<Object[]> getOpenInfoFuture(final ClasspathInfo cpInfo, final ElementHandle<? extends Element> el, String nameOpt, AtomicBoolean cancel, boolean acquire);
 

--- a/java/java.sourceui/test/unit/src/org/netbeans/api/java/source/ui/ElementHeadersTest.java
+++ b/java/java.sourceui/test/unit/src/org/netbeans/api/java/source/ui/ElementHeadersTest.java
@@ -39,6 +39,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 
 import javax.swing.text.Document;
@@ -66,6 +67,7 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
 import org.openide.loaders.DataObject;
+import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 
 /**
@@ -379,6 +381,71 @@ public class ElementHeadersTest extends NbTestCase {
         assertNotNull(se);
     }
     
+    public void testAnonymousClass() throws Exception {
+        doStructureTest("""
+                        package test;
+                        public class Test {
+                            private Test test() {
+                                return new Test() {
+                                    private int anonymousClassField;
+                                };
+                            }
+                        }
+                        """,
+                        "(Class:Test:null:Test.java:14-151[27-31]:null (Method:test():: Test:Test.java:38-149[51-55]:null (Class:LBL_AnonymousClass: test.Test:null:Test.java:86-142[86-142]:null (Field:anonymousClassField:: int:Test.java:100-132[112-131]:null))))");
+    }
+
+    public void testAnonymousClassInFieldInit() throws Exception {
+        doStructureTest("""
+                        package test;
+                        public class Test {
+                            Test t = new Test() {
+                                private int anonymousClassField;
+                            };
+                    }
+                        """,
+                        "(Class:Test:null:Test.java:22-129[35-39]:null (Field:t:: Test:Test.java:50-127[55-56]:null (Class:LBL_AnonymousClass: test.Test:null:Test.java:70-126[70-126]:null (Field:anonymousClassField:: int:Test.java:84-116[96-115]:null))))");
+    }
+
+    private void doStructureTest(String code, String expected) throws Exception {
+        prepareTest("test/Test.java", code);
+        TypeElement topLevel = info.getTopLevelElements().get(0);
+        StructureElement structure = ElementHeaders.toStructureElement(info, topLevel, (el, type) -> true);
+        assertEquals(expected,
+                     structure2String(structure));
+    }
+
+    private String structure2String(StructureElement structure) {
+        StringBuilder result = new StringBuilder();
+        result.append("(")
+              .append(structure.getKind())
+              .append(":")
+              .append(structure.getName())
+              .append(":")
+              .append(structure.getDetail())
+              .append(":")
+              .append(structure.getFile() != null ? structure.getFile().getNameExt() : "null")
+              .append(":")
+              .append(structure.getExpandedStartOffset())
+              .append("-")
+              .append(structure.getExpandedEndOffset())
+              .append("[")
+              .append(structure.getSelectionStartOffset())
+              .append("-")
+              .append(structure.getSelectionEndOffset())
+              .append("]:")
+              .append(structure.getTags());
+
+        for (StructureElement child : structure.getChildren()) {
+            result.append(" ")
+                  .append(structure2String(child));
+        }
+
+        result.append(")");
+
+        return result.toString();
+    }
+
     FileObject openideBin;
     
     /**
@@ -456,5 +523,9 @@ public class ElementHeadersTest extends NbTestCase {
             return false;
         }
         
+    }
+
+    static {
+        NbBundle.setBranding("test");
     }
 }

--- a/java/java.sourceui/test/unit/src/org/netbeans/modules/java/source/ui/Bundle_test.properties
+++ b/java/java.sourceui/test/unit/src/org/netbeans/modules/java/source/ui/Bundle_test.properties
@@ -14,19 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javadoc.apichanges=${basedir}/apichanges.xml
-javac.compilerargs=-Xlint -Xlint:-serial
-javac.release=17
-javadoc.arch=${basedir}/arch.xml
-spec.version.base=1.74.0
 
-# failing or missing test files
-test.config.default.excludes=\
-    **/FastIndexTest.class,\
-    **/MarkupTagProcessorTest.class
-
-test.config.stableBTD.includes=**/*Test.class
-test.config.stableBTD.excludes=\
-    **/ElementHeadersTest.class
-
-requires.nb.javac=true
+LBL_AnonymousClass=LBL_AnonymousClass: {0}


### PR DESCRIPTION
@jtulach reported the code completion inside VS Code is sometimes slow for him. I was thinking of that, and experimenting, and I think at least part of the problem is that tasks that should be background tasks are not properly cancellable in the VS Code (Java) server.

But, while experimenting with sources like:
https://github.com/openjdk/jdk/blob/master/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
and:
https://github.com/openjdk/jdk/blob/master/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java

I've realized there are significant problems with the `documentSymbol` computation. Namely:

a) for code like:
```
public class NavigatorTest {
    public void test() {
        new NavigatorTest() {
        };
    }
}
```

the `LspElementUtils` will crash with `StackOverflowError`, the relevant part of the stacktrace is this:
```
	at org.netbeans.modules.java.source.ui.LspElementUtils.getAnonymousInnerClasses(LspElementUtils.java:398)
	at org.netbeans.modules.java.source.ui.LspElementUtils.element2StructureElement(LspElementUtils.java:119)
	at org.netbeans.modules.java.source.ui.LspElementUtils.element2StructureElement(LspElementUtils.java:111)
	at org.netbeans.modules.java.source.ui.LspElementUtils.element2StructureElement(LspElementUtils.java:129)
	at org.netbeans.modules.java.source.ui.LspElementUtils$1.visitNewClass(LspElementUtils.java:375)
	at org.netbeans.modules.java.source.ui.LspElementUtils$1.visitNewClass(LspElementUtils.java:365)
	at com.sun.tools.javac.tree.JCTree$JCNewClass.accept(JCTree.java:1934)
	at com.sun.source.util.TreePathScanner.scan(TreePathScanner.java:92)
	at com.sun.source.util.TreeScanner.visitExpressionStatement(TreeScanner.java:504)
	at com.sun.tools.javac.tree.JCTree$JCExpressionStatement.accept(JCTree.java:1652)
	at com.sun.source.util.TreePathScanner.scan(TreePathScanner.java:92)
	at com.sun.source.util.TreeScanner.scan(TreeScanner.java:110)
	at com.sun.source.util.TreeScanner.visitBlock(TreeScanner.java:271)
	at com.sun.tools.javac.tree.JCTree$JCBlock.accept(JCTree.java:1145)
	at com.sun.source.util.TreePathScanner.scan(TreePathScanner.java:92)
	at com.sun.source.util.TreeScanner.scanAndReduce(TreeScanner.java:95)
	at com.sun.source.util.TreeScanner.visitMethod(TreeScanner.java:223)
	at com.sun.tools.javac.tree.JCTree$JCMethodDecl.accept(JCTree.java:989)
	at com.sun.source.util.TreePathScanner.scan(TreePathScanner.java:66)
	at org.netbeans.modules.java.source.ui.LspElementUtils.getAnonymousInnerClasses(LspElementUtils.java:398)
```

The issues is that while computing `getAnonymousInnerClasses`, the code will not look at the anonymous class, but at its super class, looking for the super class' members. If this superclass is the enclosing class, it will get back to the same anonymous class. It is not clear to me why the code does what it does - the proposal in this patch is to simply look at the real members of the anonymous class, and show those in the structure. I may be missing something, but I don't see an end-user reason to look at the super-class members.

b) the code calls `Trees.getPath(Element)` a lot. While this method is not terribly slow, it is not fast either - it will scan the appropriate AST looking for the declaration of the given Element. And `LspElementUtils` is calling this method a lot, which slows down the process. It may be possible to speed up the method, but this patch proposes to 1) avoid calling the method if we already have the answer somewhere else; 2) for the typical case of getting enclosed element for a type, use an optimized implementation that will simply find the correct member's AST node directly.

c) `LspElementUtils` need to compute position info for `Element`s, and does so using `ElementOpenAccessor.getInstance().getOpenInfo(ci.getClasspathInfo(), h, new AtomicBoolean());` - and this method, again, is not particularly fast. And for `Element`s that originate in the current compilation unit, this method is unnecessarily heavyweight. The proposal is to use a shortcut for `Element`s originating in the current compilation unit, bypassing search for the source file and the `Element` in that source file (as we know it is the current file anyway).

Before this patch, the `documentSymbol` crashed for `Attr.java`, and took consistently over 1.5s on my (fairly fast) laptop for `JCTree` (which is full of declarations, for `getOpenInfo` was called a lot. With this patch, `documentSymbol` usually (although not always) takes under 100ms, sometimes even considerably faster.
