### PR TITLE
Prototype: run long-spanning tasks cancellably on background in the (Java) LSP server.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/RunOnceFactory.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/RunOnceFactory.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.netbeans.api.java.source.CancellableTask;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.JavaSource.Phase;
+import org.netbeans.api.java.source.JavaSource.Priority;
+import org.netbeans.api.java.source.JavaSourceTaskFactory;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.Lookup;
+import org.openide.util.Pair;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author Jan Lahoda
+ */
+@ServiceProvider(service=JavaSourceTaskFactory.class)
+public class RunOnceFactory extends JavaSourceTaskFactory {
+
+    private static final Logger LOG = Logger.getLogger(RunOnceFactory.class.getName());
+    
+//    static {
+//        LOG.setLevel(Level.ALL);
+//    }
+    
+    private static RunOnceFactory INSTANCE;
+    
+    private List<Pair<FileObject, CancellableTask<CompilationInfo>>> work = new LinkedList<Pair<FileObject, CancellableTask<CompilationInfo>>>();
+    private FileObject currentFile;
+    private CancellableTask<CompilationInfo> task;
+    
+    public RunOnceFactory() {
+        super(Phase.RESOLVED, Priority.BELOW_NORMAL);
+        INSTANCE = this;
+    }
+
+    protected synchronized CancellableTask<CompilationInfo> createTask(FileObject file) {
+        final CancellableTask<CompilationInfo> task = this.task;
+        return new CancellableTask<CompilationInfo>() {
+            public void cancel() {
+                task.cancel();
+            }
+            public void run(CompilationInfo parameter) throws Exception {
+                task.run(parameter);
+                next();
+            }
+        };
+    }
+
+    protected synchronized Collection<FileObject> getFileObjects() {
+        if (currentFile == null)
+            return Collections.<FileObject>emptyList();
+        
+        return Collections.<FileObject>singletonList(currentFile);
+    }
+
+    private synchronized void addImpl(FileObject file, CancellableTask<CompilationInfo> task) {
+        if (LOG.isLoggable(Level.FINE)) {
+            LOG.log(Level.FINE, "addImpl({0}, {1})", new Object[] {FileUtil.getFileDisplayName(file), task.getClass().getName()});
+        }
+        
+        work.add(Pair.<FileObject, CancellableTask<CompilationInfo>>of(file, task));
+        
+        if (currentFile == null)
+            next();
+    }
+    
+    private synchronized void next() {
+        LOG.fine("next, phase 1");
+        
+        if (currentFile != null) {
+            currentFile = null;
+            task = null;
+            fileObjectsChanged();
+        }
+        
+        LOG.fine("next, phase 1 done");
+        
+        if (work.isEmpty())
+            return ;
+        
+        LOG.fine("next, phase 2");
+        
+        Pair<FileObject, CancellableTask<CompilationInfo>> p = work.remove(0);
+        
+        currentFile = p.first();
+        task = p.second();
+        
+        fileObjectsChanged();
+        
+        LOG.fine("next, phase 2 done");
+    }
+    
+
+    public static void add(FileObject file, CancellableTask<CompilationInfo> task) {
+        Lookup.getDefault().lookupAll(JavaSourceTaskFactory.class).forEach(x -> {});
+        if (INSTANCE == null)
+            return ;
+        
+        INSTANCE.addImpl(file, task);
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -66,6 +66,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
 import java.util.logging.Level;
@@ -239,6 +240,7 @@ import org.netbeans.modules.refactoring.spi.RefactoringElementImplementation;
 import org.netbeans.modules.refactoring.spi.Transaction;
 import org.netbeans.api.lsp.StructureElement;
 import org.netbeans.modules.editor.indent.api.Reformat;
+import org.netbeans.modules.java.lsp.server.RunOnceFactory;
 import org.netbeans.modules.java.lsp.server.URITranslator;
 import org.netbeans.modules.java.lsp.server.ui.AbstractJavaPlatformProviderOverride;
 import org.netbeans.modules.parsing.impl.SourceAccessor;
@@ -1908,11 +1910,11 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                 return BACKGROUND_TASKS.create(() -> {
                     Document originalDoc = server.getOpenedDocuments().getDocument(uri);
                     long originalVersion = documentVersion(originalDoc);
-                    List<Diagnostic> errorDiags = computeDiags(u, -1, ErrorProvider.Kind.ERRORS, originalVersion);
+                    List<Diagnostic> errorDiags = doRunComputeDiagsOnBackground(uri, ErrorProvider.Kind.ERRORS, originalVersion);
                     if (documentVersion(originalDoc) == originalVersion) {
                         publishDiagnostics(uri, errorDiags);
                         BACKGROUND_TASKS.create(() -> {
-                            List<Diagnostic> hintDiags = computeDiags(u, -1, ErrorProvider.Kind.HINTS, originalVersion);
+                            List<Diagnostic> hintDiags = doRunComputeDiagsOnBackground(uri, ErrorProvider.Kind.HINTS, originalVersion);
                             Document doc = server.getOpenedDocuments().getDocument(uri);
                             if (documentVersion(doc) == originalVersion) {
                                 publishDiagnostics(uri, hintDiags);
@@ -1923,7 +1925,31 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
             }).schedule(DELAY);
         }
     }
-    
+
+    private List<Diagnostic> doRunComputeDiagsOnBackground(String uri, ErrorProvider.Kind kind, long originalVersion) {
+        return computeCancallablyOnBackground(uri, new CancellableTask<List<Diagnostic>>() {
+            private final AtomicBoolean cancelled = new AtomicBoolean();
+            private final AtomicReference<Runnable> cancelCallback = new AtomicReference<>();
+            @Override
+            public void cancel() {
+                cancelled.set(true);
+                Runnable callback = cancelCallback.get();
+                if (callback != null) {
+                    callback.run();
+                }
+            }
+            @Override
+            public List<Diagnostic> compute() {
+                return computeDiags(uri, -1, kind, originalVersion, cancelCallback -> {
+                    this.cancelCallback.set(cancelCallback);
+                    if (cancelled.get()) {
+                        cancelCallback.run();
+                    }
+                });
+            }
+        }, null, 100).join();
+    }
+
     CompletableFuture<List<Diagnostic>> computeDiagnostics(String uri, EnumSet<ErrorProvider.Kind> types) {
         CompletableFuture<List<Diagnostic>> r = new CompletableFuture<>();
         BACKGROUND_TASKS.post(() -> {
@@ -1963,6 +1989,10 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
      * @return complete list of diagnostics for the file.
      */
     private List<Diagnostic> computeDiags(String uri, int offset, ErrorProvider.Kind errorKind, long orgV) {
+        return computeDiags(uri, offset, errorKind, orgV, c -> {});
+    }
+
+    private List<Diagnostic> computeDiags(String uri, int offset, ErrorProvider.Kind errorKind, long orgV, Consumer<Runnable> registerCancel) {
         List<Diagnostic> result = new ArrayList<>();
         FileObject file = fromURI(uri);
         if (file == null) {
@@ -2323,80 +2353,103 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
         put(ColoringAttributes.STATIC, Arrays.asList("static"));
     }};
 
+    private static final SemanticTokens EMPTY_TOKENS = new SemanticTokens(Collections.emptyList());
+
     @Override
     public CompletableFuture<SemanticTokens> semanticTokensFull(SemanticTokensParams params) {
-        JavaSource js = getJavaSource(params.getTextDocument().getUri());
-        List<Integer> result = new ArrayList<>();
-        if (js != null) {
-            try {
-                js.runUserActionTask(cc -> {
-                    cc.toPhase(JavaSource.Phase.RESOLVED);
-                    Document doc = cc.getSnapshot().getSource().getDocument(true);
-                    new SemanticHighlighterBase() {
-                        @Override
-                        protected boolean process(CompilationInfo info, Document doc) {
-                            process(info, doc, new ErrorDescriptionSetter() {
-                                @Override
-                                public void setHighlights(Document doc, Collection<Pair<int[], ColoringAttributes.Coloring>> highlights, Map<int[], String> preText) {
-                                    //...nothing
-                                }
+        String uri = params.getTextDocument().getUri();
+        return computeCancallablyOnBackground(uri, new CancellableTask<SemanticTokens>() {
+            private final AtomicBoolean cancel = new AtomicBoolean();
+            private final AtomicReference<SemanticHighlighterBase> computeTask = new AtomicReference<>();
+            @Override
+            public void cancel() {
+                cancel.set(true);
 
+                SemanticHighlighterBase task = computeTask.get();
+
+                if (task != null) {
+                    task.cancel();
+                }
+            }
+
+            @Override
+            public SemanticTokens compute() {
+                JavaSource js = getJavaSource(uri);
+                List<Integer> result = new ArrayList<>();
+                if (js != null) {
+                    try {
+                        js.runUserActionTask(cc -> {
+                            cc.toPhase(JavaSource.Phase.RESOLVED);
+                            Document doc = cc.getSnapshot().getSource().getDocument(true);
+                            class SemanticHighlighterBaseImpl extends SemanticHighlighterBase {
                                 @Override
-                                public void setColorings(Document doc, Map<Token, ColoringAttributes.Coloring> colorings) {
-                                    int line = 0;
-                                    long column = 0;
-                                    int lastLine = 0;
-                                    long currentLineStart = 0;
-                                    long nextLineStart = getStartPosition(line + 2);
-                                    Map<Token, ColoringAttributes.Coloring> ordered = new TreeMap<>((t1, t2) -> t1.offset(null) - t2.offset(null));
-                                    ordered.putAll(colorings);
-                                    for (Entry<Token, ColoringAttributes.Coloring> e : ordered.entrySet()) {
-                                        int currentOffset = e.getKey().offset(null);
-                                        while (nextLineStart < currentOffset) {
-                                            line++;
-                                            currentLineStart = nextLineStart;
-                                            nextLineStart = getStartPosition(line + 2);
-                                            column = 0;
+                                protected boolean process(CompilationInfo info, Document doc) {
+                                    process(info, doc, new ErrorDescriptionSetter() {
+                                        @Override
+                                        public void setHighlights(Document doc, Collection<Pair<int[], ColoringAttributes.Coloring>> highlights, Map<int[], String> preText) {
+                                            //...nothing
                                         }
-                                        Optional<Integer> tokenType = e.getValue().stream().map(c -> coloring2TokenType[c.ordinal()]).collect(Collectors.maxBy((v1, v2) -> v1.intValue() - v2.intValue()));
-                                        int modifiers = 0;
-                                        for (ColoringAttributes c : e.getValue()) {
-                                            int mod = coloring2TokenModifier[c.ordinal()];
-                                            if (mod != (-1)) {
-                                                modifiers |= mod;
+
+                                        @Override
+                                        public void setColorings(Document doc, Map<Token, ColoringAttributes.Coloring> colorings) {
+                                            int line = 0;
+                                            long column = 0;
+                                            int lastLine = 0;
+                                            long currentLineStart = 0;
+                                            long nextLineStart = getStartPosition(line + 2);
+                                            Map<Token, ColoringAttributes.Coloring> ordered = new TreeMap<>((t1, t2) -> t1.offset(null) - t2.offset(null));
+                                            ordered.putAll(colorings);
+                                            for (Entry<Token, ColoringAttributes.Coloring> e : ordered.entrySet()) {
+                                                int currentOffset = e.getKey().offset(null);
+                                                while (nextLineStart < currentOffset) {
+                                                    line++;
+                                                    currentLineStart = nextLineStart;
+                                                    nextLineStart = getStartPosition(line + 2);
+                                                    column = 0;
+                                                }
+                                                Optional<Integer> tokenType = e.getValue().stream().map(c -> coloring2TokenType[c.ordinal()]).collect(Collectors.maxBy((v1, v2) -> v1.intValue() - v2.intValue()));
+                                                int modifiers = 0;
+                                                for (ColoringAttributes c : e.getValue()) {
+                                                    int mod = coloring2TokenModifier[c.ordinal()];
+                                                    if (mod != (-1)) {
+                                                        modifiers |= mod;
+                                                    }
+                                                }
+                                                if (tokenType.isPresent() && tokenType.get() >= 0) {
+                                                    result.add(line - lastLine);
+                                                    result.add((int) (currentOffset - currentLineStart - column));
+                                                    result.add(e.getKey().length());
+                                                    result.add(tokenType.get());
+                                                    result.add(modifiers);
+                                                    lastLine = line;
+                                                    column = currentOffset - currentLineStart;
+                                                }
                                             }
                                         }
-                                        if (tokenType.isPresent() && tokenType.get() >= 0) {
-                                            result.add(line - lastLine);
-                                            result.add((int) (currentOffset - currentLineStart - column));
-                                            result.add(e.getKey().length());
-                                            result.add(tokenType.get());
-                                            result.add(modifiers);
-                                            lastLine = line;
-                                            column = currentOffset - currentLineStart;
-                                        }
-                                    }
-                                }
 
-                                private long getStartPosition(int line) {
-                                    try {
-                                        return line < 0 ? -1 : info.getCompilationUnit().getLineMap().getStartPosition(line);
-                                    } catch (Exception e) {
-                                        return info.getText().length();
-                                    }
+                                        private long getStartPosition(int line) {
+                                            try {
+                                                return line < 0 ? -1 : info.getCompilationUnit().getLineMap().getStartPosition(line);
+                                            } catch (Exception e) {
+                                                return info.getText().length();
+                                            }
+                                        }
+                                    });
+                                    return true;
                                 }
-                            });
-                            return true;
-                        }
-                    }.process(cc, doc);
-                }, true);
-            } catch (IOException ex) {
-                //TODO: include stack trace:
-                client.logMessage(new MessageParams(MessageType.Error, ex.getMessage()));
+                            };
+                            SemanticHighlighterBaseImpl task = new SemanticHighlighterBaseImpl();
+                            computeTask.set(task);
+                            task.process(cc, doc);
+                        }, true);
+                    } catch (IOException ex) {
+                        //TODO: include stack trace:
+                        client.logMessage(new MessageParams(MessageType.Error, ex.getMessage()));
+                    }
+                }
+                return new SemanticTokens(result);
             }
-        }
-        SemanticTokens tokens = new SemanticTokens(result);
-        return CompletableFuture.completedFuture(tokens);
+        }, EMPTY_TOKENS, 10_000);
     }
 
     @Override
@@ -2599,4 +2652,55 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
         return t.processRequest();
     }
 
+    private static final RequestProcessor DELAYED_RESCHEDULE = new RequestProcessor(TextDocumentServiceImpl.class.getName(), 1, false, false);
+    private <T> CompletableFuture<T> computeCancallablyOnBackground(String uri, CancellableTask<T> task, T defaultValue, int priority) {
+        CompletableFuture<T> result = new CompletableFuture<T>() {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                task.cancel();
+                return super.cancel(mayInterruptIfRunning);
+            }
+        };
+        FileObject file = fromURI(uri);
+        if (file == null) {
+            result.complete(defaultValue);
+        } else {
+            if ("text/x-java".equals(file.getMIMEType())) {
+                RunOnceFactory.add(file, new org.netbeans.api.java.source.CancellableTask<CompilationInfo>() {
+                    private final AtomicBoolean cancel = new AtomicBoolean();
+                    @Override
+                    public void cancel() {
+                        cancel.set(true);
+                        task.cancel();
+                        if (!result.isCancelled()) {
+                            DELAYED_RESCHEDULE.post(() -> {
+                                RunOnceFactory.add(file, this);
+                            }, DELAY);
+                        }
+                    }
+                    @Override
+                    public void run(CompilationInfo parameter) throws Exception {
+                        cancel.set(false);
+                        if (result.isCancelled()) {
+                            return ;
+                        }
+                        T resultValue = task.compute();
+                        if (!cancel.get() && !result.isCancelled()) {
+                            result.complete(resultValue);
+                        }
+                    }
+                });
+            } else {
+                BACKGROUND_TASKS.post(() -> {
+                    result.complete(task.compute());
+                });
+            }
+        }
+        return result;
+    }
+
+    private interface CancellableTask<T> {
+        public void cancel();
+        public T compute();
+    }
 }


### PR DESCRIPTION
@jtulach reported the code completion inside VS Code is sometimes slow for him. I was thinking of that, and experimenting, and I think at least part of the problem is that tasks that should be background tasks are not properly cancellable in the VS Code (Java) server.

I was doing experiments on:
https://github.com/openjdk/jdk/blob/master/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java

and it seemed there were three particular pain points:
- the `documentSymbol`, which I attempted to tackle in https://github.com/apache/netbeans/pull/7707
- diagnostics (especially hints) computation, which can take a fairly long time to compute
- semantic coloring computation, which can also take some time to compute

Neither of these can be cancelled when the request to compute code completion. This draft is attempting to improve that, and run diagnostics and semantic coloring in a cancellable way.

It only properly cancels for Java sources at this time, for other sources runs only the CompletableFuture cancel will work. Some work on Schedulers will be needed to fully enable this for non-Java sources.

This PR is primarily for experimentation/validation that it helps, but feedback is welcome nonetheless.

I also have a separate/independent commit that adds additional logging for code completion, namely:
- logs time the CC took,
- and if it takes more 1 second, it will print a thread dump, and start self sampler.

The self sampler ran out of heap for me when running without https://github.com/apache/netbeans/pull/7707, so I would suggest to either use this additional logging with `LspElementUtils` fixed, or disable the self sampler part.

The additional logging commit is:
https://github.com/lahodaj/netbeans/commit/e3d5b2fc0e09c2f6571798bde3acd06388cec01e
