### PR TITLE
Fix build issues for NetBeans Language Server VSCode extension on Windows platform

### DIFF
--- a/java/java.lsp.server/build.xml
+++ b/java/java.lsp.server/build.xml
@@ -21,6 +21,9 @@
 -->
 <project basedir="." default="netbeans" name="java/java.lsp.server">
     <description>Builds, tests, and runs the project org.netbeans.modules.java.lsp.server</description>
+    <condition property="cmd.suffix" value=".cmd" else="">
+        <os family="windows"/>
+    </condition>
     <import file="../../nbbuild/templates/projectized.xml"/>
     <target name="proxy-setup" depends="test-init">
         <taskdef name="autoupdate" classname="org.netbeans.nbbuild.AutoUpdate" classpath="${nbantext.jar}"/>
@@ -77,17 +80,17 @@
         </condition>
         <property name="vsix.version" value="0.1.0"/>
 
-        <exec executable="npm" failonerror="true" dir="vscode">
+        <exec executable="npm${cmd.suffix}" failonerror="true" dir="vscode">
             <arg value="--allow-same-version"/>
             <arg value="version" />
             <arg value="${vsix.version}" />
         </exec>
 
-        <exec executable="npm" failonerror="true" dir="vscode">
+        <exec executable="npm${cmd.suffix}" failonerror="true" dir="vscode">
             <arg value="install" />
         </exec>
 
-        <exec executable="npm" failonerror="true" dir="vscode">
+        <exec executable="npm${cmd.suffix}" failonerror="true" dir="vscode">
             <arg value="run" />
             <arg value="compile" />
         </exec>
@@ -97,7 +100,7 @@
         <copy file="vscode/package.json" todir="${build.dir}/bundles/package" />
         <copy file="vscode/package-lock.json" todir="${build.dir}/bundles/package" />
 
-        <exec executable="mvn" failonerror="true" dir="${nb_all}/nbbuild/misc/prepare-bundles">
+        <exec executable="mvn${cmd.suffix}" failonerror="true" dir="${nb_all}/nbbuild/misc/prepare-bundles">
             <arg value="package" />
             <arg value="exec:java" />
             <arg value="-Dexec.mainClass=org.netbeans.prepare.bundles.PrepareBundles" />
@@ -105,7 +108,7 @@
         </exec>
  
         <mkdir dir="${build.dir}/vsce" />
-        <exec executable="npm" failonerror="true" dir="${build.dir}/vsce">
+        <exec executable="npm${cmd.suffix}" failonerror="true" dir="${build.dir}/vsce">
             <arg value="install" />
             <arg value="--save" />
             <arg value="@vscode/vsce@2.19.0" />
@@ -152,12 +155,12 @@
     </target>
 
     <target name="test-vscode-ext" depends="test-lsp-server" description="Tests the Visual Studio Code extension built by 'build-vscode-ext' target.">
-        <exec executable="npm" failonerror="true" dir="vscode">
+        <exec executable="npm${cmd.suffix}" failonerror="true" dir="vscode">
             <arg value="--allow-same-version"/>
             <arg value="run" />
             <arg value="test" />
         </exec>
-        <exec executable="npm" failonerror="true" dir="vscode">
+        <exec executable="npm${cmd.suffix}" failonerror="true" dir="vscode">
             <arg value="--allow-same-version"/>
             <arg value="run" />
             <arg value="apisupport" />

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -1355,7 +1355,7 @@
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
-		"compile": "tsc -p ./; node ./esbuild.js",
+		"compile": "tsc -p ./ && node ./esbuild.js",
 		"watch": "tsc -watch -p ./ | node ./esbuild.js --watch",
 		"test": "node ./out/test/runTest.js",
 		"nbcode": "node ./out/nbcode.js",

--- a/nbbuild/misc/prepare-bundles/src/main/java/org/netbeans/prepare/bundles/PrepareBundles.java
+++ b/nbbuild/misc/prepare-bundles/src/main/java/org/netbeans/prepare/bundles/PrepareBundles.java
@@ -69,7 +69,12 @@ public class PrepareBundles {
 
         Path targetDir = Paths.get(args[0]);
         Path packagesDir = targetDir.resolve("package");
-        new ProcessBuilder("npm", "install").directory(packagesDir.toFile()).inheritIO().start().waitFor();
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("windows")) {
+            new ProcessBuilder("npm.cmd", "install").directory(packagesDir.toFile()).inheritIO().start().waitFor();
+        } else{
+            new ProcessBuilder("npm", "install").directory(packagesDir.toFile()).inheritIO().start().waitFor();   
+        }
         Path bundlesDir = targetDir.resolve("bundles");
         Files.createDirectories(bundlesDir);
         try (DirectoryStream<Path> ds = Files.newDirectoryStream(bundlesDir)) {


### PR DESCRIPTION
### Description
This PR addresses build issues for the NetBeans Language Server VSCode extension on the Windows platform.

1. **Ant Targets:** Certain Ant targets, such as `ant build-vscode-ext`, were failing on Windows due to missing suffixes required by the Windows environment. This has been corrected to ensure compatibility.

2. **NPM Compile Script:** The `npm run compile` command was not functioning correctly on Windows due to delimiter issues. This PR fixes the delimiter handling, allowing the command to run successfully on Windows.

### Changes Made

- Updated Ant target configurations to include necessary suffixes for Windows compatibility.
- Modified the `npm run compile` script to handle delimiter issue.