### PR TITLE
Making minor code modifications for better readability and validation

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/ProjectTrust.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ProjectTrust.java
@@ -25,10 +25,10 @@ import java.nio.file.Path;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -69,7 +69,7 @@ public class ProjectTrust {
         byte[] buf = prefs.getByteArray(KEY_SALT, null);
         if (buf == null) {
             buf = new byte[16];
-            new Random().nextBytes(buf);
+            new SecureRandom().nextBytes(buf);
             prefs.putByteArray(KEY_SALT, buf);
         }
         salt = buf;
@@ -134,7 +134,7 @@ public class ProjectTrust {
         if (permanently && !isTrustedPermanently(project)) {
             Path trustFile = getProjectTrustFile(project);
             byte[] rnd = new byte[16];
-            new Random().nextBytes(rnd);
+            new SecureRandom().nextBytes(rnd);
             String projectId = toHex(rnd);
             projectTrust.put(pathId, projectId);
             try {

--- a/ide/projectapi/arch.xml
+++ b/ide/projectapi/arch.xml
@@ -509,8 +509,9 @@ Nothing.
   <p>
       <api name="project.limitScanRoot" category="friend" group="systemproperty" type="export">
           <p>
-              If defined, limits search for a parent project to a certain subtree. The property defines <b>absolute path</b> of a folder
-              where upwards search for a project in parent folders is terminated. Queries outside of the root will not find any project.
+              If defined, limits search for a parent project to a certain subtree. The property defines the <b>absolute path</b> of a folder
+              where upwards search for a project in parent folders is terminated. Queries outside the root will not find any project.
+              Multiple folders may be specified when delimited with OS-specific path separators (':' on *nix, ';' on Windows).
               Currently used for tests so the tested runtime does not escape the workdir.
           </p>
       </api>

--- a/platform/o.n.bootstrap/src/org/netbeans/CLIHandler.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/CLIHandler.java
@@ -45,7 +45,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.openide.util.RequestProcessor;
@@ -580,7 +579,7 @@ public abstract class CLIHandler extends Object {
                 enterState(10, block);
                 
                 final byte[] arr = new byte[KEY_LENGTH];
-                new Random().nextBytes(arr);
+                new SecureRandom().nextBytes(arr);
 
                 
                 final RandomAccessFile os = raf;


### PR DESCRIPTION
Added minor improvements in `org.netbeans.modules.projectapi.SimpleFileOwnerQueryImplementation` to the config property values read for "project.limitScanRoot" and "project.forbiddenFolders" for:
    - path validations;
    - comparisons in `getOwner()`;
    - support multiple paths input for limitScanRoot.

Added minor readability improvements and removed unused imports.
