### PR TITLE
Forces refresh of a FileObject after the LSP client reports the file has been saved.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -71,6 +71,7 @@ import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.RenameOptions;
+import org.eclipse.lsp4j.SaveOptions;
 import org.eclipse.lsp4j.SemanticTokensCapabilities;
 import org.eclipse.lsp4j.SemanticTokensParams;
 import org.eclipse.lsp4j.ServerCapabilities;
@@ -847,6 +848,9 @@ public final class Server {
                 textDocumentSyncOptions.setChange(TextDocumentSyncKind.Incremental);
                 textDocumentSyncOptions.setOpenClose(true);
                 textDocumentSyncOptions.setWillSaveWaitUntil(true);
+                // TODO: we now do not request to send saved contents, but in case of client side applied text edits, it could be cool to 
+                // receive the current document contents at a savepoint.
+                textDocumentSyncOptions.setSave(new SaveOptions(false));
                 capabilities.setTextDocumentSync(textDocumentSyncOptions);
                 CompletionOptions completionOptions = new CompletionOptions();
                 completionOptions.setResolveProvider(true);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -40,6 +40,7 @@ import java.time.Instant;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
@@ -79,6 +80,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.swing.JEditorPane;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.text.BadLocationException;
@@ -256,6 +258,7 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
 import org.openide.loaders.DataObject;
+import org.openide.text.CloneableEditorSupport;
 import org.openide.text.NbDocument;
 import org.openide.text.PositionBounds;
 import org.openide.util.BaseUtilities;
@@ -1773,9 +1776,34 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
     }
 
     @Override
-    public void didSave(DidSaveTextDocumentParams arg0) {
-        //TODO: nothing for now?
-        LOG.log(Level.FINER, "didSave: {0}", arg0);
+    public void didSave(DidSaveTextDocumentParams savedParams) {
+        LOG.log(Level.FINER, "didSave: {0}", savedParams);
+        FileObject file = fromURI(savedParams.getTextDocument().getUri());
+        if (file == null) {
+            return;
+        }
+        // refresh the file systems, potentially fire events
+        file.refresh();
+        EditorCookie cake = file.getLookup().lookup(EditorCookie.class);
+        if (cake == null) {
+            return;
+        }
+        StyledDocument alreadyLoaded = cake.getDocument();
+        if (alreadyLoaded == null) {
+            return;
+        }
+        try {
+            // if the FileObject.refresh() only now discovered a change, it have fired an event and initiated a reload, which might
+            // be still pending. Grab the reload task and wait for it:
+            Method reload = CloneableEditorSupport.class.getDeclaredMethod("reloadDocument");
+            reload.setAccessible(true);
+            org.openide.util.Task t = (org.openide.util.Task)reload.invoke(cake);
+            // wait for a limited time, this could be enough for the reload to complete, blocking LSP queue. We do not want to block LSP queue indefinitely:
+            // in case of an error, the server could become unresponsive.
+            t.waitFinished(300);
+        } catch (ReflectiveOperationException | InterruptedException | SecurityException ex) {
+            // nop 
+        }
     }
 
     CompletableFuture<List<? extends Location>> superImplementations(String uri, Position position) {


### PR DESCRIPTION
If the LSP client makes file changes, and then immediately performs some NBLS operation, the NBLS currently does not get a timely file change event. This PR enables `didSave` notification that forces a FileObject refresh, firing appropriate events. 
Somewhat controversial is the wait for reloading task, so the affected editor is reloaded before a next instruction (i.e. text modification) is received from the LSP commnand stream.