### PR TITLE
Prevent nblogger from dying on errors during format.

### DIFF
--- a/platform/core.startup/src/org/netbeans/core/startup/logging/NbFormatter.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/logging/NbFormatter.java
@@ -54,7 +54,21 @@ public final class NbFormatter extends java.util.logging.Formatter {
     }
 
     private void print(StringBuilder sb, LogRecord record, Set<Throwable> beenThere) {
-        String message = formatMessage(record);
+        String message;
+        try {
+            message = formatMessage(record);
+        } catch (ThreadDeath td) {
+            throw td;
+        } catch (Throwable t) {
+            message = record.getMessage();
+            sb.append("*** Error occured during formatting of message: ");
+            sb.append(lineSeparator);
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            t.printStackTrace(pw);
+            sb.append(sw.toString());
+            sb.append(lineSeparator);
+        }
         if (message != null && message.indexOf('\n') != -1 && record.getThrown() == null) {
             // multi line messages print witout any wrappings
             sb.append(message);


### PR DESCRIPTION
During bug hunting in NBLS, I run into a very funny situation where the logging of NBLS suddenly stopped. It eventually resumed after a looooong time, but only sometimes.

I debugged into it and found out that some Google commons class was missing which was not used at runtime at all - except to print out JSON-RPC message from NBLS. If that happened, the message formatting failed with an `Error`  (rather than `Exception` that is handled in `java.util.logging.Formatter.formatMessage. This led to death of the log publishing thread. The thread eventually resumed when the buffer was full - but dies again on another 'unformattable' message.

This PR adds additional wrapper that catches everything except `ThreadDeath` and prevents the logging thread from dying.