### PR TITLE
Java completion enhanced to support no insertion of method parameters

### DIFF
--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorPreferencesKeys.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorPreferencesKeys.java
@@ -537,7 +537,13 @@ public final class EditorPreferencesKeys {
     public static final String JAVADOC_PREFERRED_SIZE = SimpleValueNames.JAVADOC_PREFERRED_SIZE;
     public static final String POPUP_MENU_ENABLED = SimpleValueNames.POPUP_MENU_ENABLED;
     public static final String SHOW_DEPRECATED_MEMBERS = SimpleValueNames.SHOW_DEPRECATED_MEMBERS;
-    
+
+    /**
+     * Whether the code completion should insert text for the parameters of executable items.
+     * Values: java.lang.Boolean
+     */
+    public static final String COMPLETION_INSERT_TEXT_PARAMETERS = "completion-insert-text-parameters"; // NOI18N
+
     /** List of the action names that should be shown in the popup menu.
     * Null name means separator.
     * Values: java.util.List containing java.lang.String instances

--- a/ide/editor/src/org/netbeans/modules/editor/resources/NetBeans-preferences.xml
+++ b/ide/editor/src/org/netbeans/modules/editor/resources/NetBeans-preferences.xml
@@ -52,6 +52,9 @@
     <entry category="private" javaType="java.lang.Boolean" name="completion-case-sensitive" xml:space="preserve">
         <value><![CDATA[false]]></value>
     </entry>
+    <entry category="private" javaType="java.lang.Boolean" name="completion-insert-text-parameters" xml:space="preserve">
+        <value><![CDATA[true]]></value>
+    </entry>
     <entry category="private" javaType="java.lang.Boolean" name="completion-instant-substitution" xml:space="preserve">
         <value><![CDATA[true]]></value>
     </entry>

--- a/java/java.completion/nbproject/org-netbeans-modules-java-completion.sig
+++ b/java/java.completion/nbproject/org-netbeans-modules-java-completion.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.18.0
+#Version 2.19.0
 
 CLSS public abstract interface java.io.Serializable
 
@@ -106,7 +106,7 @@ meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$It
 meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createAttributeValueItem(org.netbeans.api.java.source.CompilationInfo,java.lang.String,java.lang.String,javax.lang.model.element.TypeElement,int,org.netbeans.api.java.source.support.ReferencesCount)
 meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createChainedMembersItem(org.netbeans.api.java.source.CompilationInfo,java.util.List<? extends javax.lang.model.element.Element>,java.util.List<? extends javax.lang.model.type.TypeMirror>,int,boolean,boolean)
 meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createDefaultConstructorItem(javax.lang.model.element.TypeElement,int,boolean)
-meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createExecutableItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.element.ExecutableElement,javax.lang.model.type.ExecutableType,int,org.netbeans.api.java.source.support.ReferencesCount,boolean,boolean,boolean,boolean,boolean,int,boolean)
+meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createExecutableItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.element.ExecutableElement,javax.lang.model.type.ExecutableType,int,org.netbeans.api.java.source.support.ReferencesCount,boolean,boolean,boolean,boolean,boolean,int,boolean,boolean)
 meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createGetterSetterMethodItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.element.VariableElement,javax.lang.model.type.TypeMirror,int,java.lang.String,boolean)
 meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createInitializeAllConstructorItem(org.netbeans.api.java.source.CompilationInfo,boolean,java.lang.Iterable<? extends javax.lang.model.element.VariableElement>,javax.lang.model.element.ExecutableElement,javax.lang.model.element.TypeElement,int)
 meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createKeywordItem(java.lang.String,java.lang.String,int,boolean)
@@ -115,13 +115,13 @@ meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$It
 meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createParametersItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.element.ExecutableElement,javax.lang.model.type.ExecutableType,int,boolean,int,java.lang.String)
 meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createStaticMemberItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.type.DeclaredType,javax.lang.model.element.Element,javax.lang.model.type.TypeMirror,boolean,int,boolean,boolean,boolean)
 meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createStaticMemberItem(org.netbeans.api.java.source.ElementHandle<javax.lang.model.element.TypeElement>,java.lang.String,int,boolean,org.netbeans.api.java.source.support.ReferencesCount,org.netbeans.modules.parsing.api.Source,boolean)
-meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createThisOrSuperConstructorItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.element.ExecutableElement,javax.lang.model.type.ExecutableType,int,boolean,java.lang.String)
+meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createThisOrSuperConstructorItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.element.ExecutableElement,javax.lang.model.type.ExecutableType,int,boolean,java.lang.String,boolean)
 meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createTypeItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.element.TypeElement,javax.lang.model.type.DeclaredType,int,org.netbeans.api.java.source.support.ReferencesCount,boolean,boolean,boolean,boolean,boolean,boolean)
 meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createTypeItem(org.netbeans.api.java.source.ElementHandle<javax.lang.model.element.TypeElement>,java.util.EnumSet<javax.lang.model.element.ElementKind>,int,org.netbeans.api.java.source.support.ReferencesCount,org.netbeans.modules.parsing.api.Source,boolean,boolean,boolean)
 meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createTypeParameterItem(javax.lang.model.element.TypeParameterElement,int)
 meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createVariableItem(org.netbeans.api.java.source.CompilationInfo,java.lang.String,int,boolean,boolean)
 meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createVariableItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.element.VariableElement,javax.lang.model.type.TypeMirror,int,org.netbeans.api.java.source.support.ReferencesCount,boolean,boolean,boolean,int)
-meth public {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createExecutableItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.element.ExecutableElement,javax.lang.model.type.ExecutableType,int,org.netbeans.api.java.source.support.ReferencesCount,boolean,boolean,boolean,boolean,boolean,boolean,int,boolean)
+meth public {org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory%0} createExecutableItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.element.ExecutableElement,javax.lang.model.type.ExecutableType,int,org.netbeans.api.java.source.support.ReferencesCount,boolean,boolean,boolean,boolean,boolean,boolean,int,boolean,boolean)
 
 CLSS public abstract interface static org.netbeans.modules.java.completion.JavaCompletionTask$LambdaItemFactory<%0 extends java.lang.Object>
  outer org.netbeans.modules.java.completion.JavaCompletionTask
@@ -150,7 +150,7 @@ meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$Re
 CLSS public abstract interface static org.netbeans.modules.java.completion.JavaCompletionTask$TypeCastableItemFactory<%0 extends java.lang.Object>
  outer org.netbeans.modules.java.completion.JavaCompletionTask
 intf org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory<{org.netbeans.modules.java.completion.JavaCompletionTask$TypeCastableItemFactory%0}>
-meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$TypeCastableItemFactory%0} createTypeCastableExecutableItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.element.ExecutableElement,javax.lang.model.type.ExecutableType,javax.lang.model.type.TypeMirror,int,org.netbeans.api.java.source.support.ReferencesCount,boolean,boolean,boolean,boolean,boolean,int,boolean)
+meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$TypeCastableItemFactory%0} createTypeCastableExecutableItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.element.ExecutableElement,javax.lang.model.type.ExecutableType,javax.lang.model.type.TypeMirror,int,org.netbeans.api.java.source.support.ReferencesCount,boolean,boolean,boolean,boolean,boolean,int,boolean,boolean)
 meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$TypeCastableItemFactory%0} createTypeCastableVariableItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.element.VariableElement,javax.lang.model.type.TypeMirror,javax.lang.model.type.TypeMirror,int,org.netbeans.api.java.source.support.ReferencesCount,boolean,boolean,boolean,int)
 
 CLSS public final org.netbeans.modules.java.completion.JavaDocumentationTask<%0 extends java.lang.Object>
@@ -189,6 +189,7 @@ hfds INIT,SUPER_KEYWORD,THIS_KEYWORD,activeSignatureIndex,anchorOffset,toolTipDa
 
 CLSS public final org.netbeans.modules.java.completion.Utilities
 meth public static boolean isCaseSensitive()
+meth public static boolean isCompletionInsertTextParameters()
 meth public static boolean isExcludeMethods()
 meth public static boolean isExcluded(java.lang.CharSequence)
 meth public static boolean isShowDeprecatedMembers()
@@ -198,7 +199,7 @@ meth public static boolean startsWithCamelCase(java.lang.String,java.lang.String
 meth public static java.util.List<java.lang.String> varNamesSuggestions(javax.lang.model.type.TypeMirror,javax.lang.model.element.ElementKind,java.util.Set<javax.lang.model.element.Modifier>,java.lang.String,java.lang.String,javax.lang.model.util.Types,javax.lang.model.util.Elements,java.lang.Iterable<? extends javax.lang.model.element.Element>,org.netbeans.api.java.source.CodeStyle)
 meth public static void exclude(java.lang.CharSequence)
 supr java.lang.Object
-hfds COMPLETION_CASE_SENSITIVE,COMPLETION_CASE_SENSITIVE_DEFAULT,EMPTY,ERROR,JAVA_COMPLETION_BLACKLIST,JAVA_COMPLETION_BLACKLIST_DEFAULT,JAVA_COMPLETION_EXCLUDER_METHODS,JAVA_COMPLETION_EXCLUDER_METHODS_DEFAULT,JAVA_COMPLETION_SUBWORDS,JAVA_COMPLETION_SUBWORDS_DEFAULT,JAVA_COMPLETION_WHITELIST,SHOW_DEPRECATED_MEMBERS,SHOW_DEPRECATED_MEMBERS_DEFAULT,cachedCamelCasePattern,cachedPrefix,cachedSubwordsPattern,caseSensitive,excludeRef,includeRef,inited,javaCompletionExcluderMethods,javaCompletionSubwords,preferences,preferencesTracker,showDeprecatedMembers
+hfds COMPLETION_CASE_SENSITIVE,COMPLETION_CASE_SENSITIVE_DEFAULT,COMPLETION_INSERT_TEXT_PARAMETERS,COMPLETION_INSERT_TEXT_PARAMETERS_DEFAULT,EMPTY,ERROR,JAVA_COMPLETION_BLACKLIST,JAVA_COMPLETION_BLACKLIST_DEFAULT,JAVA_COMPLETION_EXCLUDER_METHODS,JAVA_COMPLETION_EXCLUDER_METHODS_DEFAULT,JAVA_COMPLETION_SUBWORDS,JAVA_COMPLETION_SUBWORDS_DEFAULT,JAVA_COMPLETION_WHITELIST,SHOW_DEPRECATED_MEMBERS,SHOW_DEPRECATED_MEMBERS_DEFAULT,cachedCamelCasePattern,cachedPrefix,cachedSubwordsPattern,caseSensitive,completionInsertTextParameters,excludeRef,includeRef,inited,javaCompletionExcluderMethods,javaCompletionSubwords,preferences,preferencesTracker,showDeprecatedMembers
 
 CLSS public abstract interface org.netbeans.modules.parsing.api.ResultProcessor
  anno 0 java.lang.FunctionalInterface()

--- a/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
+++ b/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
@@ -88,13 +88,13 @@ public final class JavaCompletionTask<T> extends BaseTask {
 
         T createVariableItem(CompilationInfo info, String varName, int substitutionOffset, boolean newVarName, boolean smartType);
 
-        T createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean smartType, int assignToVarOffset, boolean memberRef);
+        T createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean smartType, int assignToVarOffset, boolean memberRef, boolean insertTextParams);
 
-        default T createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean afterConstructorTypeParams, boolean smartType, int assignToVarOffset, boolean memberRef) {
-            return createExecutableItem(info, elem, type, substitutionOffset, referencesCount, isInherited, isDeprecated, inImport, addSemicolon, smartType, assignToVarOffset, memberRef);
+        default T createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean afterConstructorTypeParams, boolean smartType, int assignToVarOffset, boolean memberRef, boolean insertTextParams) {
+            return createExecutableItem(info, elem, type, substitutionOffset, referencesCount, isInherited, isDeprecated, inImport, addSemicolon, smartType, assignToVarOffset, memberRef, insertTextParams);
         }
 
-        T createThisOrSuperConstructorItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, boolean isDeprecated, String name);
+        T createThisOrSuperConstructorItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, boolean isDeprecated, String name, boolean insertTextParams);
 
         T createOverrideMethodItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, boolean implement);
 
@@ -123,7 +123,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
 
         T createTypeCastableVariableItem(CompilationInfo info, VariableElement elem, TypeMirror type, TypeMirror castType, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean smartType, int assignToVarOffset);
 
-        T createTypeCastableExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, TypeMirror castType, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean smartType, int assignToVarOffset, boolean memberRef);        
+        T createTypeCastableExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, TypeMirror castType, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean smartType, int assignToVarOffset, boolean memberRef, boolean insertTextParams);
     }
     
     public static interface LambdaItemFactory<T> extends ItemFactory<T> {
@@ -3724,7 +3724,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
                     if (e.getEnclosingElement() != enclClass && conflictsWithLocalMethods(e.getSimpleName(), enclClass, methodsIn)) {
                         results.add(itemFactory.createStaticMemberItem(env.getController(), (DeclaredType)e.getEnclosingElement().asType(), e, et, false, anchorOffset, elements.isDeprecated(e), env.addSemicolon(), true));
                     } else {
-                        results.add(itemFactory.createExecutableItem(env.getController(), (ExecutableElement) e, et, anchorOffset, null, env.getScope().getEnclosingClass() != e.getEnclosingElement(), elements.isDeprecated(e), false, env.addSemicolon(), isOfSmartType(env, getCorrectedReturnType(env, et, (ExecutableElement) e, enclClass != null ? enclClass.asType() : null), smartTypes), env.assignToVarPos(), false));
+                        results.add(itemFactory.createExecutableItem(env.getController(), (ExecutableElement) e, et, anchorOffset, null, env.getScope().getEnclosingClass() != e.getEnclosingElement(), elements.isDeprecated(e), false, env.addSemicolon(), isOfSmartType(env, getCorrectedReturnType(env, et, (ExecutableElement) e, enclClass != null ? enclClass.asType() : null), smartTypes), env.assignToVarPos(), false, Utilities.isCompletionInsertTextParameters()));
                     }
                     break;
             }
@@ -4088,7 +4088,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
             switch (e.getKind()) {
                 case METHOD:
                     ExecutableType et = (ExecutableType) asMemberOf(e, type, types);
-                    results.add(itemFactory.createExecutableItem(env.getController(), (ExecutableElement) e, et, anchorOffset, null, typeElem != e.getEnclosingElement(), elements.isDeprecated(e), false, false, isOfSmartType(env, et, smartTypes), env.assignToVarPos(), true));
+                    results.add(itemFactory.createExecutableItem(env.getController(), (ExecutableElement) e, et, anchorOffset, null, typeElem != e.getEnclosingElement(), elements.isDeprecated(e), false, false, isOfSmartType(env, et, smartTypes), env.assignToVarPos(), true, false));  // insertTextParams is hard-coded to false because memberRef is true for method-references, thus, irrelevant.
                     break;
             }
         }
@@ -4245,16 +4245,16 @@ public final class JavaCompletionTask<T> extends BaseTask {
                     break;
                 case CONSTRUCTOR:
                     ExecutableType et = (ExecutableType) asMemberOf(e, actualType, types);
-                    results.add(itemFactory.createExecutableItem(env.getController(), (ExecutableElement) e, et, anchorOffset, autoImport ? env.getReferencesCount() : null, typeElem != e.getEnclosingElement(), elements.isDeprecated(e), inImport, false, afterConstructorTypeParams, isOfSmartType(env, actualType, smartTypes), env.assignToVarPos(), false));
+                    results.add(itemFactory.createExecutableItem(env.getController(), (ExecutableElement) e, et, anchorOffset, autoImport ? env.getReferencesCount() : null, typeElem != e.getEnclosingElement(), elements.isDeprecated(e), inImport, false, afterConstructorTypeParams, isOfSmartType(env, actualType, smartTypes), env.assignToVarPos(), false, Utilities.isCompletionInsertTextParameters()));
                     break;
                 case METHOD:
                     et = (ExecutableType) asMemberOf(e, actualType, types);
                     if (addCast && itemFactory instanceof TypeCastableItemFactory
                             && !types.isSubtype(type, e.getEnclosingElement().asType())
                             && type.getKind() == TypeKind.DECLARED && !hasBaseMethod(elements, (DeclaredType) type, (ExecutableElement) e)) {
-                        results.add(((TypeCastableItemFactory<T>)itemFactory).createTypeCastableExecutableItem(env.getController(), (ExecutableElement) e, et, actualType, anchorOffset, autoImport ? env.getReferencesCount() : null, typeElem != e.getEnclosingElement(), elements.isDeprecated(e), inImport, env.addSemicolon(), isOfSmartType(env, getCorrectedReturnType(env, et, (ExecutableElement) e, actualType), smartTypes), env.assignToVarPos(), false));
+                        results.add(((TypeCastableItemFactory<T>)itemFactory).createTypeCastableExecutableItem(env.getController(), (ExecutableElement) e, et, actualType, anchorOffset, autoImport ? env.getReferencesCount() : null, typeElem != e.getEnclosingElement(), elements.isDeprecated(e), inImport, env.addSemicolon(), isOfSmartType(env, getCorrectedReturnType(env, et, (ExecutableElement) e, actualType), smartTypes), env.assignToVarPos(), false, Utilities.isCompletionInsertTextParameters()));
                     } else {
-                        results.add(itemFactory.createExecutableItem(env.getController(), (ExecutableElement) e, et, anchorOffset, autoImport ? env.getReferencesCount() : null, typeElem != e.getEnclosingElement(), elements.isDeprecated(e), inImport, env.addSemicolon(), isOfSmartType(env, getCorrectedReturnType(env, et, (ExecutableElement) e, actualType), smartTypes), env.assignToVarPos(), false));
+                        results.add(itemFactory.createExecutableItem(env.getController(), (ExecutableElement) e, et, anchorOffset, autoImport ? env.getReferencesCount() : null, typeElem != e.getEnclosingElement(), elements.isDeprecated(e), inImport, env.addSemicolon(), isOfSmartType(env, getCorrectedReturnType(env, et, (ExecutableElement) e, actualType), smartTypes), env.assignToVarPos(), false, Utilities.isCompletionInsertTextParameters()));
                     }
                     break;
                 case CLASS:
@@ -4313,7 +4313,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
         for (Element e : controller.getElementUtilities().getMembers(type, acceptor)) {
             if (e.getKind() == CONSTRUCTOR) {
                 ExecutableType et = (ExecutableType) asMemberOf(e, type, types);
-                results.add(itemFactory.createThisOrSuperConstructorItem(env.getController(), (ExecutableElement) e, et, anchorOffset, elements.isDeprecated(e), name));
+                results.add(itemFactory.createThisOrSuperConstructorItem(env.getController(), (ExecutableElement) e, et, anchorOffset, elements.isDeprecated(e), name, Utilities.isCompletionInsertTextParameters()));
             }
         }
     }

--- a/java/java.completion/src/org/netbeans/modules/java/completion/Utilities.java
+++ b/java/java.completion/src/org/netbeans/modules/java/completion/Utilities.java
@@ -51,6 +51,8 @@ public final class Utilities {
     private static final String ERROR = "<error>"; //NOI18N
     private static final String COMPLETION_CASE_SENSITIVE = "completion-case-sensitive"; // NOI18N
     private static final boolean COMPLETION_CASE_SENSITIVE_DEFAULT = true;
+    private static final String COMPLETION_INSERT_TEXT_PARAMETERS = "completion-insert-text-parameters"; // NOI18N
+    private static final boolean COMPLETION_INSERT_TEXT_PARAMETERS_DEFAULT = true;
     private static final String SHOW_DEPRECATED_MEMBERS = "show-deprecated-members"; // NOI18N
     private static final boolean SHOW_DEPRECATED_MEMBERS_DEFAULT = true;
     private static final String JAVA_COMPLETION_WHITELIST = "javaCompletionWhitelist"; //NOI18N
@@ -62,6 +64,7 @@ public final class Utilities {
     private static final boolean JAVA_COMPLETION_SUBWORDS_DEFAULT = false;
 
     private static boolean caseSensitive = COMPLETION_CASE_SENSITIVE_DEFAULT;
+    private static boolean completionInsertTextParameters = COMPLETION_INSERT_TEXT_PARAMETERS_DEFAULT;
     private static boolean showDeprecatedMembers = SHOW_DEPRECATED_MEMBERS_DEFAULT;
     private static boolean javaCompletionExcluderMethods = JAVA_COMPLETION_EXCLUDER_METHODS_DEFAULT;
     private static boolean javaCompletionSubwords = JAVA_COMPLETION_SUBWORDS_DEFAULT;
@@ -91,6 +94,9 @@ public final class Utilities {
             }
             if (settingName == null || JAVA_COMPLETION_SUBWORDS.equals(settingName)) {
                 javaCompletionSubwords = preferences.getBoolean(JAVA_COMPLETION_SUBWORDS, JAVA_COMPLETION_SUBWORDS_DEFAULT);
+            }
+            if (settingName == null || COMPLETION_INSERT_TEXT_PARAMETERS.equals(settingName)) {
+                completionInsertTextParameters = preferences.getBoolean(COMPLETION_INSERT_TEXT_PARAMETERS, COMPLETION_INSERT_TEXT_PARAMETERS_DEFAULT);
             }
         }
     };
@@ -206,6 +212,11 @@ public final class Utilities {
     public static boolean isShowDeprecatedMembers() {
         lazyInit();
         return showDeprecatedMembers;
+    }
+
+    public static boolean isCompletionInsertTextParameters() {
+        lazyInit();
+        return completionInsertTextParameters;
     }
 
     private static final AtomicReference<Collection<String>> excludeRef = new AtomicReference<>();

--- a/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/CompletionTestBase.java
+++ b/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/CompletionTestBase.java
@@ -246,7 +246,7 @@ public class CompletionTestBase extends CompletionTestBaseBase {
         }
 
         @Override
-        public CI createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean smartType, int assignToVarOffset, boolean memberRef) {
+        public CI createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean smartType, int assignToVarOffset, boolean memberRef, boolean insertTextParams) {
             String simpleName = elem.getKind() == ElementKind.CONSTRUCTOR ? elem.getEnclosingElement().getSimpleName().toString() : elem.getSimpleName().toString();
             StringBuilder sb = new StringBuilder();
             StringBuilder sortParams = new StringBuilder();
@@ -297,7 +297,7 @@ public class CompletionTestBase extends CompletionTestBaseBase {
         }
 
         @Override
-        public CI createThisOrSuperConstructorItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, boolean isDeprecated, String name) {
+        public CI createThisOrSuperConstructorItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, boolean isDeprecated, String name, boolean insertTextParams) {
             if (elem.getKind() == ElementKind.CONSTRUCTOR) {
                 StringBuilder sb = new StringBuilder();
                 StringBuilder sortParams = new StringBuilder();

--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionCollector.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionCollector.java
@@ -528,28 +528,28 @@ public class JavaCompletionCollector implements CompletionCollector {
         }
 
         @Override
-        public Completion createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean smartType, int assignToVarOffset, boolean memberRef) {
-            return createExecutableItem(info, elem, type, substitutionOffset, referencesCount, isInherited, isDeprecated, inImport, addSemicolon, false, smartType, assignToVarOffset, memberRef);
+        public Completion createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean smartType, int assignToVarOffset, boolean memberRef, boolean insertTextParams) {
+            return createExecutableItem(info, elem, type, substitutionOffset, referencesCount, isInherited, isDeprecated, inImport, addSemicolon, false, smartType, assignToVarOffset, memberRef, insertTextParams);
         }
 
         @Override
-        public Completion createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean afterConstructorTypeParams, boolean smartType, int assignToVarOffset, boolean memberRef) {
-            return createExecutableItem(info, elem, type, null, null, substitutionOffset, referencesCount, isInherited, isDeprecated, inImport, addSemicolon, afterConstructorTypeParams, smartType, assignToVarOffset, memberRef);
+        public Completion createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean afterConstructorTypeParams, boolean smartType, int assignToVarOffset, boolean memberRef, boolean insertTextParams) {
+            return createExecutableItem(info, elem, type, null, null, substitutionOffset, referencesCount, isInherited, isDeprecated, inImport, addSemicolon, afterConstructorTypeParams, smartType, assignToVarOffset, memberRef, insertTextParams);
         }
 
         @Override
-        public Completion createTypeCastableExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, TypeMirror castType, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean smartType, int assignToVarOffset, boolean memberRef) {
-            return createExecutableItem(info, elem, type, null, castType, substitutionOffset, referencesCount, isInherited, isDeprecated, inImport, addSemicolon, false, smartType, assignToVarOffset, memberRef);
+        public Completion createTypeCastableExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, TypeMirror castType, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean smartType, int assignToVarOffset, boolean memberRef, boolean insertTextParams) {
+            return createExecutableItem(info, elem, type, null, castType, substitutionOffset, referencesCount, isInherited, isDeprecated, inImport, addSemicolon, false, smartType, assignToVarOffset, memberRef, insertTextParams);
         }
 
         @Override
-        public Completion createThisOrSuperConstructorItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, boolean isDeprecated, String name) {
-            return createExecutableItem(info, elem, type, name, null, substitutionOffset, null, false, isDeprecated, false, false, false, false, -1, false);
+        public Completion createThisOrSuperConstructorItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, boolean isDeprecated, String name, boolean insertTextParams) {
+            return createExecutableItem(info, elem, type, name, null, substitutionOffset, null, false, isDeprecated, false, false, false, false, -1, false, insertTextParams);
         }
 
         @Override
         public Completion createOverrideMethodItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, boolean implement) {
-            Completion item = createExecutableItem(info, elem, type, substitutionOffset, null, false, false, false, false, false, -1, false);
+            Completion item = createExecutableItem(info, elem, type, substitutionOffset, null, false, false, false, false, false, -1, false, true);
             CompletionCollector.Builder builder = CompletionCollector.newBuilder(item.getLabel())
                     .kind(elementKind2CompletionItemKind(elem.getKind()))
                     .labelDetail(String.format("%s - %s", item.getLabelDetail(), implement ? "implement" : "override"))
@@ -640,7 +640,7 @@ public class JavaCompletionCollector implements CompletionCollector {
                     } else {
                         insertText.append("\n{\n$0}");
                     }
-                    builder.command(new Command("Complete Abstract Methods", "java.complete.abstract.methods"));
+                    builder.command(new Command("Complete Abstract Methods", "nbls.java.complete.abstract.methods"));
                 } catch (IOException ioe) {
                 }
                 builder.insertTextFormat(Completion.TextFormat.Snippet);
@@ -1111,7 +1111,7 @@ public class JavaCompletionCollector implements CompletionCollector {
             return builder.build();
         }
 
-        private Completion createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, String name, TypeMirror castType, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean afterConstructorTypeParams, boolean smartType, int assignToVarOffset, boolean memberRef) {
+        private Completion createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, String name, TypeMirror castType, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean afterConstructorTypeParams, boolean smartType, int assignToVarOffset, boolean memberRef, boolean insertTextParams) {
             String simpleName = name != null ? name : (elem.getKind() == ElementKind.METHOD ? elem : elem.getEnclosingElement()).getSimpleName().toString();
             Iterator<? extends VariableElement> it = elem.getParameters().iterator();
             Iterator<? extends TypeMirror> tIt = type.getParameterTypes().iterator();
@@ -1135,7 +1135,7 @@ public class JavaCompletionCollector implements CompletionCollector {
                 if (tm == null) {
                     break;
                 }
-                if (!inImport && !memberRef && cnt == 0 && cs.spaceWithinMethodCallParens()) {
+                if (!inImport && !memberRef && insertTextParams && cnt == 0 && cs.spaceWithinMethodCallParens()) {
                     insertText.append(' ');
                 }
                 cnt++;
@@ -1144,14 +1144,19 @@ public class JavaCompletionCollector implements CompletionCollector {
                 labelDetail.append(paramTypeName).append(' ').append(paramName);
                 sortParams.append(paramTypeName);
                 if (!inImport && !memberRef) {
-                    VariableElement inst = instanceOf(tm, paramName);
-                    insertText.append("${").append(cnt).append(":").append(inst != null ? inst.getSimpleName() : paramName).append("}");
                     asTemplate = true;
+                    if (insertTextParams) {
+                        VariableElement inst = instanceOf(tm, paramName);
+                        insertText.append("${").append(cnt).append(":").append(inst != null ? inst.getSimpleName() : paramName).append("}");
+                    } else if (cnt == 1) {
+                        // Ensure that the cursor is placed in-between the inserted parentheses i.e. "(|)"
+                        insertText.append("$1");
+                    }
                 }
                 if (tIt.hasNext()) {
                     labelDetail.append(", ");
                     sortParams.append(',');
-                    if (!inImport && !memberRef) {
+                    if (!inImport && !memberRef && insertTextParams) {
                         if (cs.spaceBeforeComma()) {
                             insertText.append(' ');
                         }
@@ -1160,7 +1165,7 @@ public class JavaCompletionCollector implements CompletionCollector {
                             insertText.append(' ');
                         }
                     }
-                } else if (!inImport && !memberRef && cs.spaceWithinMethodCallParens()) {
+                } else if (!inImport && !memberRef && insertTextParams && cs.spaceWithinMethodCallParens()) {
                     insertText.append(' ');
                 }
             }
@@ -1183,7 +1188,7 @@ public class JavaCompletionCollector implements CompletionCollector {
                     } else {
                         insertText.append("\n{\n$0}");
                     }
-                    command = new Command("Complete Abstract Methods", "java.complete.abstract.methods");
+                    command = new Command("Complete Abstract Methods", "nbls.java.complete.abstract.methods");
                     asTemplate = true;
                 } else if (asTemplate) {
                     insertText.append("$0");
@@ -1231,6 +1236,12 @@ public class JavaCompletionCollector implements CompletionCollector {
             }
             if (isDeprecated) {
                 builder.addTag(Completion.Tag.Deprecated);
+            }
+            if (command == null && !insertTextParams && cnt > 0) {
+                command = new Command("Show Signature Help", "editor.action.triggerParameterHints");
+            }
+            if (command != null) {
+                builder.command(command);
             }
             return builder.build();
         }

--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItemFactory.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItemFactory.java
@@ -108,23 +108,23 @@ public final class JavaCompletionItemFactory implements JavaCompletionTask.TypeC
     }
 
     @Override
-    public JavaCompletionItem createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean smartType, int assignToVarOffset, boolean memberRef) {
-        return createExecutableItem(info, elem, type, substitutionOffset, referencesCount, isInherited, isDeprecated, inImport, addSemicolon, false, smartType, assignToVarOffset, memberRef);
+    public JavaCompletionItem createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean smartType, int assignToVarOffset, boolean memberRef, boolean insertTextParams) {
+        return createExecutableItem(info, elem, type, substitutionOffset, referencesCount, isInherited, isDeprecated, inImport, addSemicolon, false, smartType, assignToVarOffset, memberRef, insertTextParams);
     }
 
     @Override
-    public JavaCompletionItem createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean afterConstructorTypeParams, boolean smartType, int assignToVarOffset, boolean memberRef) {
-        return JavaCompletionItem.createExecutableItem(info, elem, type, null, substitutionOffset, referencesCount, isInherited, isDeprecated, inImport, addSemicolon, afterConstructorTypeParams, smartType, assignToVarOffset, memberRef, whiteList);
+    public JavaCompletionItem createExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean afterConstructorTypeParams, boolean smartType, int assignToVarOffset, boolean memberRef, boolean insertTextParams) {
+        return JavaCompletionItem.createExecutableItem(info, elem, type, null, substitutionOffset, referencesCount, isInherited, isDeprecated, inImport, addSemicolon, afterConstructorTypeParams, smartType, assignToVarOffset, memberRef, insertTextParams, whiteList);
     }
 
     @Override
-    public JavaCompletionItem createTypeCastableExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, TypeMirror castType, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean smartType, int assignToVarOffset, boolean memberRef) {
-        return JavaCompletionItem.createExecutableItem(info, elem, type, castType, substitutionOffset, referencesCount, isInherited, isDeprecated, inImport, addSemicolon, false, smartType, assignToVarOffset, memberRef, whiteList);
+    public JavaCompletionItem createTypeCastableExecutableItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, TypeMirror castType, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean inImport, boolean addSemicolon, boolean smartType, int assignToVarOffset, boolean memberRef, boolean insertTextParams) {
+        return JavaCompletionItem.createExecutableItem(info, elem, type, castType, substitutionOffset, referencesCount, isInherited, isDeprecated, inImport, addSemicolon, false, smartType, assignToVarOffset, memberRef, insertTextParams, whiteList);
     }
 
     @Override
-    public JavaCompletionItem createThisOrSuperConstructorItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, boolean isDeprecated, String name) {
-        return JavaCompletionItem.createThisOrSuperConstructorItem(info, elem, type, substitutionOffset, isDeprecated, name, whiteList);
+    public JavaCompletionItem createThisOrSuperConstructorItem(CompilationInfo info, ExecutableElement elem, ExecutableType type, int substitutionOffset, boolean isDeprecated, String name, boolean insertTextParams) {
+        return JavaCompletionItem.createThisOrSuperConstructorItem(info, elem, type, substitutionOffset, isDeprecated, name, insertTextParams, whiteList);
     }
 
     @Override

--- a/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionItem.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionItem.java
@@ -212,7 +212,7 @@ final class JavadocCompletionItem implements CompletionItem {
         @Override
         public CompletionItem createJavadocExecutableItem(CompilationInfo info, ExecutableElement e, ExecutableType et, int startOffset, boolean isInherited, boolean isDeprecated) {
             CompletionItem delegate = JavaCompletionItem.createExecutableItem(
-                    info, e, et, null, startOffset, null, isInherited, isDeprecated, false, false, false, false, -1, false, null);
+                    info, e, et, null, startOffset, null, isInherited, isDeprecated, false, false, false, false, -1, false, true, null);
             return new JavadocExecutableItem(delegate, e, startOffset);
         }
 

--- a/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaCompletionCollectorTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaCompletionCollectorTest.java
@@ -24,10 +24,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
 import javax.swing.text.Document;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
+import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.editor.mimelookup.MimePath;
 import org.netbeans.api.java.lexer.JavaTokenId;
 import org.netbeans.api.java.source.JavaSource;
@@ -35,6 +38,7 @@ import org.netbeans.api.java.source.SourceUtilsTestUtil;
 import org.netbeans.api.java.source.TestUtilities;
 import org.netbeans.api.lsp.Completion;
 import org.netbeans.api.lsp.Completion.Context;
+import org.netbeans.api.lsp.Completion.Kind;
 import org.netbeans.api.lsp.Completion.TextFormat;
 import org.netbeans.api.lsp.Completion.TriggerKind;
 import org.netbeans.api.lsp.TextEdit;
@@ -343,15 +347,107 @@ public class JavaCompletionCollectorTest extends NbTestCase {
         assertTrue(found.get());
     }
 
-    private void runJavaCollector(List<FileDescription> files, Validator<List<Completion>> validator) throws Exception {
-        SourceUtilsTestUtil.prepareTest(new String[]{"org/netbeans/modules/java/editor/resources/layer.xml"}, new Object[]{new MIMEResolverImpl(), new MIMEDataProvider()});
+    public void testMethodWithoutParameterInsertion() throws Exception {
+        Set<String> found = new HashSet<>();
+        FileDescription fileDescription = new FileDescription("test/Test.java",
+                """
+                package test;
+                public class Test {
+                    public static void test(String s) {
+                        Test.|
+                    }
+                }
+                """);
 
+        runJavaCollector(List.of(fileDescription),
+                preferences -> preferences.putBoolean("completion-insert-text-parameters", false),
+                completions -> {
+                    for (Completion completion : completions) {
+                        if ("test".equals(completion.getLabel())) {
+                            assertNull(completion.getTextEdit());
+                            assertNull(completion.getAdditionalTextEdits());
+                            assertEquals(TextFormat.Snippet, completion.getInsertTextFormat());
+                            assertEquals("test($1);$0", completion.getInsertText());
+                            found.add(completion.getLabelDetail());
+                        }
+                    }
+                });
+        assertEquals(Set.of("(String s)"), found);
+    }
+
+    public void testConstructorWithoutParameterInsertion() throws Exception {
+        Set<String> found = new HashSet<>();
+        FileDescription fileDescription = new FileDescription("test/Test.java",
+                """
+                package test;
+                public class Test {
+                    private String s;
+                    public Test(String s) {
+                        this.s = s;
+                    }
+                    public static void test() {
+                        Test m = new Test|
+                    }
+                }
+                """);
+
+        runJavaCollector(List.of(fileDescription),
+                preferences -> preferences.putBoolean("completion-insert-text-parameters", false),
+                completions -> {
+                    for (Completion completion : completions) {
+                        if ("Test".equals(completion.getLabel()) && completion.getKind() == Kind.Constructor) {
+                            assertNull(completion.getTextEdit());
+                            assertNull(completion.getAdditionalTextEdits());
+                            assertEquals("Test($1)$0", completion.getInsertText());
+                            found.add(completion.getLabelDetail());
+                        }
+                    }
+                });
+        assertEquals(Set.of("(String s)"), found);
+    }
+
+    public void testThisConstructorWithoutParameterInsertion() throws Exception {
+        Set<String> found = new HashSet<>();
+        FileDescription fileDescription = new FileDescription("test/Test.java",
+                """
+                package test;
+                public class Test {
+                    private String s;
+                    public Test(String s) {
+                        this.s = s;
+                    }
+                    public Test() {
+                        this|
+                    }
+                }
+                """);
+
+        runJavaCollector(List.of(fileDescription),
+                preferences -> preferences.putBoolean("completion-insert-text-parameters", false),
+                completions -> {
+                    for (Completion completion : completions) {
+                        if ("this".equals(completion.getLabel()) && completion.getKind() == Kind.Constructor) {
+                            assertNull(completion.getTextEdit());
+                            assertNull(completion.getAdditionalTextEdits());
+                            assertEquals("this($1);$0", completion.getInsertText());
+                            found.add(completion.getLabelDetail());
+                        }
+                    }
+                });
+        assertEquals(Set.of("(String s)"), found);
+    }
+
+    private void runJavaCollector(List<FileDescription> files, Validator<List<Completion>> validator) throws Exception {
+        runJavaCollector(files, preferences -> {}, validator);
+    }
+
+    private void runJavaCollector(List<FileDescription> files, Consumer<Preferences> alterSettings, Validator<List<Completion>> validator) throws Exception {
+        SourceUtilsTestUtil.prepareTest(new String[]{"org/netbeans/modules/java/editor/resources/layer.xml"}, new Object[]{new MIMEResolverImpl(), new MIMEDataProvider()});
         FileObject scratch = SourceUtilsTestUtil.makeScratchDir(this);
         FileObject cache = scratch.createFolder("cache");
         FileObject src = scratch.createFolder("src");
         primaryTestFO = null;
         int caretPosition = -1;
-
         for (FileDescription testFile : files) {
             FileObject testFO = FileUtil.createData(src, testFile.fileName);
             String code = testFile.code;
@@ -367,27 +463,29 @@ public class JavaCompletionCollectorTest extends NbTestCase {
 
             TestUtilities.copyStringToFile(testFO, code);
         }
-
         assertNotNull(primaryTestFO);
-
         if (sourceLevel != null) {
             SourceUtilsTestUtil.setSourceLevel(primaryTestFO, sourceLevel);
         }
-
         SourceUtilsTestUtil.prepareTest(src, FileUtil.createFolder(scratch, "test-build"), cache);
-        SourceUtilsTestUtil.compileRecursively(src);
-
-        EditorCookie ec = primaryTestFO.getLookup().lookup(EditorCookie.class);
-        Document doc = ec.openDocument();
-        JavaCompletionCollector collector = new JavaCompletionCollector();
-        Context ctx = new Context(TriggerKind.Invoked, null);
-        List<Completion> completions = new ArrayList<>();
-
-        JavaSource.forDocument(doc).runUserActionTask(cc -> {
-            cc.toPhase(JavaSource.Phase.RESOLVED);
-        }, true);
-        collector.collectCompletions(doc, caretPosition, ctx, completions::add);
-        validator.validate(completions);
+        
+        Preferences preferences = MimeLookup.getLookup(JavaTokenId.language().mimeType()).lookup(Preferences.class);
+        try {
+            alterSettings.accept(preferences);
+            SourceUtilsTestUtil.compileRecursively(src);
+            EditorCookie ec = primaryTestFO.getLookup().lookup(EditorCookie.class);
+            Document doc = ec.openDocument();
+            JavaCompletionCollector collector = new JavaCompletionCollector();
+            Context ctx = new Context(TriggerKind.Invoked, null);
+            List<Completion> completions = new ArrayList<>();
+            JavaSource.forDocument(doc).runUserActionTask(cc -> {
+                cc.toPhase(JavaSource.Phase.RESOLVED);
+            }, true);
+            collector.collectCompletions(doc, caretPosition, ctx, completions::add);
+            validator.validate(completions);
+        } finally {
+            preferences.clear();
+        }
     }
 
     private static String textEdit2String(TextEdit te) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -307,6 +307,8 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
     private static final String NETBEANS_COMPLETION_WARNING_TIME = "completion.warning.time";// NOI18N
     private static final String NETBEANS_JAVA_ON_SAVE_ORGANIZE_IMPORTS = "java.onSave.organizeImports";// NOI18N
     private static final String NETBEANS_CODE_COMPLETION_COMMIT_CHARS = "java.completion.commit.chars";// NOI18N
+    private static final String CLIENT_JAVA_COMPLETION_DISABLE_INSERT_METHOD_PARAMS = "java.completion.disable.insertMethodParameters";// NOI18N
+    private static final String NETBEANS_JAVA_COMPLETION_INSERT_TEXT_PARAMS = "completion-insert-text-parameters";// NOI18N
     private static final String URL = "url";// NOI18N
     private static final String INDEX = "index";// NOI18N
     
@@ -422,7 +424,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                 return CompletableFuture.completedFuture(Either.forRight(completionList));
             }
             StyledDocument doc = (StyledDocument)rawDoc;
-            List<String> configValues = List.of(NETBEANS_JAVADOC_LOAD_TIMEOUT, NETBEANS_COMPLETION_WARNING_TIME, NETBEANS_CODE_COMPLETION_COMMIT_CHARS);
+            List<String> configValues = List.of(NETBEANS_JAVADOC_LOAD_TIMEOUT, NETBEANS_COMPLETION_WARNING_TIME, NETBEANS_CODE_COMPLETION_COMMIT_CHARS, CLIENT_JAVA_COMPLETION_DISABLE_INSERT_METHOD_PARAMS);
             return client.getClientConfigurationManager().getConfigurations(configValues, uri).thenApply(c -> {
                 if (c != null && !c.isEmpty()) {
                     if (c.get(0).isJsonPrimitive()) {
@@ -439,6 +441,14 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                         JsonArray commitCharsJsonArray = (JsonArray) c.get(2);
                         codeCompletionCommitChars.set(commitCharsJsonArray.asList().stream().map(ch -> ch.toString()).collect(Collectors.toList()));
                     }
+                    if (c.size() >= 4 && c.get(3) instanceof JsonPrimitive) {
+                        boolean extDisabledSetting = ((JsonPrimitive) c.get(3)).getAsBoolean();
+                        Preferences langPreferences = MimeLookup.getLookup(JavaTokenId.language().mimeType()).lookup(Preferences.class);
+                        boolean insertTextParams = langPreferences == null || langPreferences.getBoolean(NETBEANS_JAVA_COMPLETION_INSERT_TEXT_PARAMS, true);
+                        if (langPreferences != null && extDisabledSetting == insertTextParams) {
+                            langPreferences.putBoolean(NETBEANS_JAVA_COMPLETION_INSERT_TEXT_PARAMS, !extDisabledSetting);
+                        }
+                    }
                 }
                 final int caret = Utils.getOffset(doc, params.getPosition());
                 List<CompletionItem> items = new ArrayList<>();
@@ -446,7 +456,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                         ? new Completion.Context(Completion.TriggerKind.valueOf(params.getContext().getTriggerKind().name()),
                                 params.getContext().getTriggerCharacter() == null || params.getContext().getTriggerCharacter().isEmpty() ? null : params.getContext().getTriggerCharacter().charAt(0))
                         : null;
-                Preferences prefs = CodeStylePreferences.get(doc, "text/x-java").getPreferences();
+                Preferences prefs = CodeStylePreferences.get(doc, JavaTokenId.language().mimeType()).getPreferences();
                 String point = prefs.get("classMemberInsertionPoint", null);
                 try {
                     prefs.put("classMemberInsertionPoint", CodeStyle.InsertionPoint.CARET_LOCATION.name());


### PR DESCRIPTION
This configurable enhancement is based on end-user feedback received in oracle/javavscode#197
- This seems to be a matter of personal preference
- It is not a reflection on the correctness of the default functionality.

1. Added a user preference for insertion of method parameters in code completions.
    - `"completion-insert-text-parameters"`
    - default value = `true`
    - Also available via:
        - ide/editor.lib2: `EditorPreferencesKeys.COMPLETION_INSERT_TEXT_PARAMETERS`
        - java/java.completion: `Utilities.isCompletionInsertTextParameters()`

2. Added disabling of the above preference from the LSP client via the client config key `PREFIX + "java.completion.disable.insertMethodParameters"`
    - Updation occurs in `TextDocumentServiceImpl.completion()`

3. Added an extra arg `insertTextParams` in the following interface methods with the default value `true`:
    - `JavaCompletionTask.ItemFactory`:
        - `createExecutableItem`
        - `createThisOrSuperConstructorItem`
    - `JavaCompletionTask.TypeCastableItemFactory`:
        - `createTypeCastableExecutableItem`

4. Invoked the above methods in `JavaCompletionTask` with this parameter value set by `Utilities.isCompletionInsertTextParameters()`.

5. Enhanced the implementations of the above methods in `JavaCompletionCollector` and `JavaCompletionItem` to insert text for method arguments when `insertTextParams` (or `!memberRef`).
    - The cursor would be placed inside the parentheses if it is _not_ a no-args method completion.

6. Added a follow-up LSP command to the completion item **"editor.action.triggerParameterHints"** for showing the signature help when not inserting text parameters. 
    - This is a necessary guide for the user. 
    - It would not be triggered without this addition, since the trigger character '(' is not typed by the user.

7. Unrelated minor fixes in `JavaCompletionCollector.ItemFactoryImpl`: 
    - Added the default prefix (**"nbls"**) to the usages of the follow-up command **"java.complete.abstract.methods"**. 
    - Without this, the command would not get launched by the client. 
    - Added to the builder in `createExecutableItem()`, the instantiated follow-up command "nbls.java.complete.abstract.methods".
