### PR TITLE
Improving "internal reload" during project reload

### DIFF
--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectReload.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectReload.java
@@ -965,7 +965,9 @@ public final class ProjectReload {
         // special case if the state matches & is consistent: if the attempted quality is LESS 
         // than this request's target, the ReloadImplementation might give up 
         if (!doReload && lastKnown.target.isAtLeast(stateRequest.getTargetQuality())) {
-            LOG.log(Level.FINE, "FINISHED: Reload {0}, request: {1}, state {2} - NOOP, finished", new Object[] { p, stateRequest, lastKnown.toString() });
+            if (LOG.isLoggable(Level.FINE)) {
+                LOG.log(Level.FINE, "FINISHED: Reload {0}, request: {1}, state {2} - NOOP, finished", new Object[] { p, stateRequest, lastKnown.toString() });
+            }
             return CompletableFuture.completedFuture(lastKnown);
         }
         String reason = stateRequest.getReason();

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectReload.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/ProjectReload.java
@@ -438,7 +438,7 @@ public final class ProjectReload {
             sb.append(project).
             append("@").append(Integer.toHexString(System.identityHashCode(this))).
             append("[");
-            sb.append(", quality=").append(getQuality());
+            sb.append("quality=").append(getQuality());
             sb.append(", consistent=").append(isConsistent());
             sb.append(", valid=").append(isValid());
             sb.append(", loaded=").append(getLoadedFiles());
@@ -727,7 +727,8 @@ public final class ProjectReload {
         @Override
         public String toString() {
             return String.format(
-                "Reload[quality=%s, force=%b, consistent=%b, offline=%b, save=%b, reason:%s]",
+                "Request@%s[quality=%s, force=%b, consistent=%b, offline=%b, save=%b, reason:%s]",
+                    Integer.toHexString(System.identityHashCode(this)),
                     minQuality.name(), forceReload, consistent, offlineOperation, saveModifications, reason
             );
         }
@@ -954,7 +955,7 @@ public final class ProjectReload {
     public static CompletableFuture<ProjectState> withProjectState(Project p, final StateRequest stateRequest) {
         Throwable origin = new Throwable();
         
-        LOG.log(Level.FINE, "Reload {0}, request: {1}", new Object[] { p, stateRequest });
+        LOG.log(Level.FINE, "REQUESTED: Reload {0}, request: {1}", new Object[] { p, stateRequest });
         Pair<ProjectReloadInternal.StateRef, ProjectState> projectData = ProjectReloadInternal.getInstance().getProjectState0(p, 
                 stateRequest.getContext() == null ? Lookup.EMPTY : stateRequest.getContext(), false);
         ProjectState lastKnown = projectData.second();
@@ -964,7 +965,7 @@ public final class ProjectReload {
         // special case if the state matches & is consistent: if the attempted quality is LESS 
         // than this request's target, the ReloadImplementation might give up 
         if (!doReload && lastKnown.target.isAtLeast(stateRequest.getTargetQuality())) {
-            LOG.log(Level.FINE, "Reload {0}, request: {1}, state {2} - NOOP, finished", new Object[] { p, stateRequest, lastKnown });
+            LOG.log(Level.FINE, "FINISHED: Reload {0}, request: {1}, state {2} - NOOP, finished", new Object[] { p, stateRequest, lastKnown.toString() });
             return CompletableFuture.completedFuture(lastKnown);
         }
         String reason = stateRequest.getReason();
@@ -973,14 +974,20 @@ public final class ProjectReload {
             // configure a default reason, so it is always defined.
             stateRequest.reloadReason(reason);
         }
+        if (LOG.isLoggable(Level.FINE)) {
+            LOG.log(Level.FINE, "Reload {0}, last known state: {1}", new Object[] { p, lastKnown == null ? "null" : lastKnown.toString() });
+        }
         
         if (lastKnown.getQuality() == Quality.NONE && stateRequest.isConsistent()) {
             // we do not have ANY state, but there may be files modified known to the project. Let's read to the lowest possible quality:
-            LOG.log(Level.FINE, "{0}: Have NONE but need to have files for consistency check", lastKnown);
+            LOG.log(Level.FINE, "Reload {0}: Have NONE but need to have files for consistency check", lastKnown);
             CompletableFuture<ProjectState> initialF = withProjectState1(p, StateRequest.load().toQuality(Quality.NONE).consistent(false).offline(), lastKnown, projectData, origin);
             AtomicReference<CompletableFuture> nested = new AtomicReference<>();
             
             CompletableFuture<ProjectState> toReturn = initialF.thenCompose(initS -> {
+                if (LOG.isLoggable(Level.FINE)) {
+                    LOG.log(Level.FINE, "Reload {0}: got initial state {1}", new Object[] { p, initS.toString() });
+                }
                 CompletableFuture<ProjectState> n;
                 // if the project was loaded to better quality than NONE, retry the whole process, as that one will be returned from getProjectState0 now, and everything will be checked again.
                 if (Quality.NONE.isWorseThan(initS.getQuality())) {
@@ -1115,14 +1122,19 @@ public final class ProjectReload {
             final int id = eventId.incrementAndGet();
             @Override
             public void run() {
-                LOG.log(Level.FINE, "Firing state change {1} for {0}", new Object[] { s, this });
                 // Postpone the actual fire until after project is unlocked
+                boolean[] processed = new boolean[1];
                 ProjectReloadInternal.getInstance().runProjectAction(s.getProject(), () -> {
+                    processed[0] = true;
                     synchronized (notifiers) {
                         notifiers.remove(s, cur.get());
                     }
+                    LOG.log(Level.FINE, "Firing state change {1} for {0}", new Object[] { s, this });
                     ProjectReloadInternal.RELOAD_RP.post(s::fireChange);
                 });
+                if (!processed[0]) {
+                    LOG.log(Level.FINE, "Postponed state change {1} for {0}", new Object[] { s, this });
+                }
             }
             
             @Override
@@ -1198,6 +1210,9 @@ public final class ProjectReload {
              */
             @Override
             public void fireInvalid(ProjectState ps) {
+                if (LOG.isLoggable(Level.FINER)) {
+                    LOG.log(Level.FINER, "State " + ps + " invalidated", new Throwable());
+                }
                 ps.valid = false;
                 queueStateChange(ps);
             }
@@ -1228,6 +1243,9 @@ public final class ProjectReload {
                     }
                 }
                 if (fire) {
+                    if (LOG.isLoggable(Level.FINER)) {
+                        LOG.log(Level.FINER, "State {0} changed - consistent={1}, valid={2}", new Object[] { ps.toString(), ps.isConsistent(), ps.isValid() });
+                    }
                     queueStateChange(ps);
                 }
             }

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/reload/StateDataListener.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/reload/StateDataListener.java
@@ -33,6 +33,7 @@ import java.util.logging.Logger;
 import javax.swing.event.ChangeEvent;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.project.dependency.ProjectReload;
+import org.netbeans.modules.project.dependency.ProjectReload.ProjectState;
 import org.netbeans.modules.project.dependency.spi.ProjectReloadImplementation;
 import org.netbeans.modules.project.dependency.spi.ProjectReloadImplementation.ProjectStateData;
 import org.openide.cookies.SaveCookie;
@@ -188,6 +189,10 @@ class StateDataListener extends FileChangeAdapter implements ProjectStateListene
 
     private void reportFile(FileObject f, long t) {
         ProjectReload.ProjectState state = this.tracker.get();
+        if (LOG.isLoggable(Level.FINE)) {
+            LOG.log(Level.FINE, "{0} received file report: {1}, time {2}, file time {4}, state time: {3}", new Object[] { state == null ? "null" : state.toString(), f, t, 
+                state == null ? -3 : state.getTimestamp(), f.lastModified().getTime() });
+        }
         if (state == null) {
             detachListeners();
             return;
@@ -199,17 +204,20 @@ class StateDataListener extends FileChangeAdapter implements ProjectStateListene
         ReloadApiAccessor.get().updateProjectState(state, true, false, Collections.singleton(f), null, null);
         watchedFiles.getOrDefault(f, Collections.emptyList()).forEach(d -> d.fireChanged(false, true));
     }
-
+    
     @Override
     public void stateChanged(ChangeEvent e) {
         ProjectReload.ProjectState state = this.tracker.get();
-        if (state == null) {
-            detachListeners();
-            return;
-        }
         ProjectReloadImplementation.ProjectStateData d = (ProjectReloadImplementation.ProjectStateData) e.getSource();
         boolean c = d.isConsistent();
         boolean v = d.isValid();
+        if (state == null) {
+            if (LOG.isLoggable(Level.FINE)) {
+                LOG.log(Level.FINE, "DETACHING on stateData from {1}", new Object[] { d.toString() });
+            }
+            detachListeners();
+            return;
+        }
         Collection<FileObject> obs = new HashSet<>(d.getFiles());
         boolean fire = false;
         boolean invalid = false;
@@ -240,7 +248,9 @@ class StateDataListener extends FileChangeAdapter implements ProjectStateListene
             // invalid states
             detachListeners();
         }
-        LOG.log(Level.FINE, "Got state change on {0}, firing change: {1}", new Object[]{d, fire});
+        if (LOG.isLoggable(Level.FINE)) {
+            LOG.log(Level.FINE, "{0} received stateData from {1}, updating: {2}", new Object[] { state.toString(), d.toString(), fire });
+        }
         if (fire) {
             ReloadApiAccessor.get().updateProjectState(state, inconsistent, invalid, setModified, null, null);
         }
@@ -270,6 +280,9 @@ class StateDataListener extends FileChangeAdapter implements ProjectStateListene
         Lookup.Result lr = (Lookup.Result) ev.getSource();
         if (!lr.allItems().isEmpty()) {
             Set<FileObject> ed = new HashSet<>(state.getEditedFiles());
+            if (LOG.isLoggable(Level.FINE)) {
+                LOG.log(Level.FINE, "{0} received SaveCookie on file {1}; present {2}", new Object[] { state.toString(), f, ed.contains(f) });
+            }
             if (ed.add(f)) {
                 Set<FileObject> ch = new HashSet<>(state.getChangedFiles());
                 if (!ch.add(f)) {

--- a/ide/project.dependency/test/unit/src/org/netbeans/modules/project/dependency/reload/MockProjectReloadImplementation.java
+++ b/ide/project.dependency/test/unit/src/org/netbeans/modules/project/dependency/reload/MockProjectReloadImplementation.java
@@ -58,6 +58,7 @@ public class MockProjectReloadImplementation implements ProjectReloadImplementat
     
     public static class ProjectData {
         public String contents;
+        public volatile int counter;
 
         public ProjectData(String s) {
             this.contents = s;
@@ -118,10 +119,13 @@ public class MockProjectReloadImplementation implements ProjectReloadImplementat
     
     Reference<ProjectStateData> sdRef = new WeakReference<>(null);
     
+    volatile ProjectData loadProjectData;
+    
     protected ProjectStateData doCreateStateData(Project project, ProjectReload.StateRequest request, LoadContext<ProjectData> context) {
         ProjectStateBuilder<ProjectData> b = ProjectStateData.builder(
                 request.getMinQuality().isAtLeast(ProjectReload.Quality.LOADED) ? request.getMinQuality() : ProjectReload.Quality.LOADED);
         b.timestamp(Instant.now().toEpochMilli());
+        loadProjectData = context.getLoadContext(ProjectData.class);
         ProjectStateData<ProjectData> psd = createStateData(b, request).
                 privateData(
                     (d) -> {

--- a/java/gradle.dependencies/src/org/netbeans/modules/gradle/reload/GradleReloadImplementation.java
+++ b/java/gradle.dependencies/src/org/netbeans/modules/gradle/reload/GradleReloadImplementation.java
@@ -74,6 +74,11 @@ public class GradleReloadImplementation implements ProjectReloadImplementation {
         gp.addPropertyChangeListener(WeakListeners.propertyChange(reloadL, gp));
     }
     
+    // tests only
+    public ProjectStateData getLastCachedData() {
+        return last.get();
+    }
+    
     private static void includeFile(File f, Collection<FileObject> into) {
         if (f == null) {
             return;
@@ -151,15 +156,9 @@ public class GradleReloadImplementation implements ProjectReloadImplementation {
         ProjectStateData sd = ProjectStateData.builder(q).
                 files(files).
                 attachLookup(NbGradleProject.get(project).curretLookup()).
+                timestamp(time).
                 build();
-        /*
-        ProjectStateControl track = new ProjectStateControl(
-                "gradle", null, files, pq == NbGradleProject.Quality.FALLBACK || pq.betterThan(NbGradleProject.Quality.EVALUATED), 
-                q, time, NbGradleProject.get(project).projectDataLookup()
-        );
-        */
         synchronized (this) {
-//            states.add(new WeakReference<>(track));
             last = new WeakReference<>(sd);
         }
         return sd;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -1792,7 +1792,9 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
             org.openide.util.Task t = (org.openide.util.Task)reload.invoke(cake);
             // wait for a limited time, this could be enough for the reload to complete, blocking LSP queue. We do not want to block LSP queue indefinitely:
             // in case of an error, the server could become unresponsive.
-            t.waitFinished(300);
+            if (!t.waitFinished(300)) {
+                LOG.log(Level.WARNING, "{0}: document reload did not finish in 300ms", file);
+            }
         } catch (ReflectiveOperationException | InterruptedException | SecurityException ex) {
             // nop 
         }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -1763,14 +1763,20 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
 
     @Override
     public void didSave(DidSaveTextDocumentParams savedParams) {
-        LOG.log(Level.FINER, "didSave: {0}", savedParams);
+        LOG.log(Level.FINE, "didSave: {0}", savedParams.getTextDocument().getUri());
         FileObject file = fromURI(savedParams.getTextDocument().getUri());
         if (file == null) {
             return;
         }
         // refresh the file systems, potentially fire events
+        if (LOG.isLoggable(Level.FINE)) {
+            LOG.log(Level.FINE, "Refreshing file {0}, timestamp {1}", new Object[] { file, file.lastModified().getTime() });
+        }
         file.refresh();
         EditorCookie cake = file.getLookup().lookup(EditorCookie.class);
+        if (LOG.isLoggable(Level.FINE)) {
+            LOG.log(Level.FINE, "Refresh done on {0}, timestamp {1}, existing editor: {2}", new Object[] { file, file.lastModified().getTime(), cake });
+        }
         if (cake == null) {
             return;
         }

--- a/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
@@ -141,7 +141,7 @@ public final class NbMavenProjectImpl implements Project {
                     x = project == null ? null : project.get();
                 }
                 LOG.log(Level.FINE, "Project {0} starting reload. Currentproject is: {1}", 
-                        new Object[] { System.identityHashCode(x == null ? this : x ), x });
+                        new Object[] { Integer.toHexString(System.identityHashCode(x)), x });
             }
             problemReporter.clearReports(); //#167741 -this will trigger node refresh?
             MavenProject prj = loadOriginalMavenProject(true);
@@ -149,7 +149,7 @@ public final class NbMavenProjectImpl implements Project {
             synchronized (NbMavenProjectImpl.this) {
                 old = project == null ? null : project.get();
                 LOG.log(Level.FINE, "Project {0} reloaded. Old project is: {1}, new project {2}", 
-                        new Object[] { prj, System.identityHashCode(old == null ? this : old), System.identityHashCode(prj) });
+                        new Object[] { prj, Integer.toHexString(System.identityHashCode(old)), Integer.toHexString(System.identityHashCode(prj)) });
                 if (old != null && MavenProjectCache.isFallbackproject(prj)) {
                     prj.setPackaging(old.getPackaging()); //#229366 preserve packaging for broken projects to avoid changing lookup.
                 }
@@ -486,6 +486,7 @@ public final class NbMavenProjectImpl implements Project {
             LOG.log(Level.FINE, "Asked for project {0} being updated, waiting for the refresh to complete.", projectFile);
             CompletableFuture<MavenProject> f = new CompletableFuture<>();
             reloadTask.addTaskListener((e) -> {
+                 // TODO: must remove the listener, it is one shot !
                 LOG.log(Level.FINE, "Project {0} update done.", projectFile);
                 f.complete(getOriginalMavenProject());
             });

--- a/java/maven/src/org/netbeans/modules/maven/queries/MavenPrimingReloadImplementation.java
+++ b/java/maven/src/org/netbeans/modules/maven/queries/MavenPrimingReloadImplementation.java
@@ -159,7 +159,6 @@ public class MavenPrimingReloadImplementation implements ProjectReloadImplementa
             synchronized (this) {
                 placeholderArtifactNames.clear();
             }
-            context.saveLoadContext(this);
             return CompletableFuture.completedFuture(null);
         } 
         

--- a/java/maven/src/org/netbeans/modules/maven/queries/MavenReloadImplementation.java
+++ b/java/maven/src/org/netbeans/modules/maven/queries/MavenReloadImplementation.java
@@ -78,6 +78,18 @@ public class MavenReloadImplementation implements ProjectReloadImplementation, P
     }
 
     @Override
+    public void projectDataReleased(ProjectStateData data) {
+        if (lastData.get() == data) {
+            lastData.clear();
+        }
+    }
+    
+    // test only
+    ProjectStateData getLastCachedData() {
+        return lastData.get();
+    }
+
+    @Override
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName() == null) {
             return;
@@ -260,7 +272,7 @@ public class MavenReloadImplementation implements ProjectReloadImplementation, P
         }
         loadMavenProject3(future);
     }
-    
+        
     private void loadMavenProject3(CF future) {
         NbMavenProjectImpl nbImpl = project.getLookup().lookup(NbMavenProjectImpl.class);
         MavenProject current = nbImpl.getOriginalMavenProjectOrNull();


### PR DESCRIPTION
Seems awkward... but sometimes events are delivered *in the middle* of a project loading process. The API checks the project's state at the end for quality and/or consistency - and that can cause spurious errors about project reloads while reading it. This PR improves stability by allowing a recovery - but at the same time if a reload would be repeated again because of file changes, the `ProjectReload.withProjectState()` fails indicating that project is being modified, as it was before. Similar approach was already implemented for the case the `ProjectReloadImplementation` requested a retry: one is OK, but the same (super)set repeated again will result in an error.

During investigation, I needed quite detailed logging, so I've added that as a separate commit; the "logging" commit should bring no functional changes, just diagnostics.

