### PR TITLE
Proper registration/usage of LSP client ApplyEdits implementation.

### DIFF
--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/impl/DefaultApplyEditsImplementation.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/impl/DefaultApplyEditsImplementation.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.netbeans.modules.project.dependency;
+package org.netbeans.modules.project.dependency.impl;
 
 import java.io.IOException;
 import java.net.URI;
@@ -34,7 +34,6 @@ import org.netbeans.api.lsp.ResourceModificationException;
 import org.netbeans.api.lsp.ResourceOperation;
 import org.netbeans.api.lsp.TextDocumentEdit;
 import org.netbeans.api.lsp.WorkspaceEdit;
-import org.netbeans.modules.project.dependency.impl.TextDocumentEditProcessor;
 import org.netbeans.spi.lsp.ApplyEditsImplementation;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;

--- a/ide/project.dependency/src/org/netbeans/modules/project/dependency/impl/WorkspaceEditAdapter.java
+++ b/ide/project.dependency/src/org/netbeans/modules/project/dependency/impl/WorkspaceEditAdapter.java
@@ -22,11 +22,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.netbeans.api.lsp.ResourceOperation;
 import org.netbeans.api.lsp.TextDocumentEdit;
 import org.netbeans.api.lsp.WorkspaceEdit;
 import org.netbeans.modules.refactoring.spi.ModificationResult;
@@ -34,7 +34,6 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
 import org.openide.util.NbBundle;
-import org.openide.util.Union2;
 
 /**
  * Wraps a LSP modification result (WorkspaceEdit) in ProjectModificationResultImpl into a refactoring API's ModificationResult.
@@ -94,36 +93,7 @@ public final class WorkspaceEditAdapter implements ModificationResult {
     })
     @Override
     public void commit() throws IOException {
-        // PENDING: the implementation could attach to undoable edits for each of the documents,
-        // trying to revert if something goes wrong in the middle.
-        
         WorkspaceEdit edit = impl.getWorkspaceEdit();
-        
-        for (Union2<TextDocumentEdit, ResourceOperation> ch : edit.getDocumentChanges()) {
-            if (ch.hasSecond()) {
-                ResourceOperation op = ch.second();
-                if (op instanceof ResourceOperation.CreateFile) {
-                    ResourceOperation.CreateFile cf = (ResourceOperation.CreateFile)op;
-                    FileObject f = ProjectModificationResultImpl.fromString(cf.getNewFile());
-                    if (f.isValid()) {
-                        throw new IOException(Bundle.ERR_CreatedFileAlreadyExists(f.getPath()));
-                    }
-                    FileObject parent = f.getParent();
-                    while (parent != null && parent.isVirtual()) {
-                        parent = parent.getParent();
-                    }
-                    String relative = FileUtil.getRelativePath(parent, f);
-                    // PENDING: how CreateFile denotes creation of a folder (alone) ??
-                    FileUtil.createData(f, relative);
-                    continue;
-                }
-                
-                throw new IllegalStateException("Unknown resource operation");
-            } else if (ch.hasFirst()) {
-                TextDocumentEdit e = ch.first();
-                TextDocumentEditProcessor proc = new TextDocumentEditProcessor(e).setSaveAfterEdit(true);
-                proc.execute();
-            }
-        }
+        WorkspaceEdit.applyEdits(Collections.singletonList(edit), true);
     }
 }

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspApplyEditsImplementation.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspApplyEditsImplementation.java
@@ -19,13 +19,14 @@
 package org.netbeans.modules.nbcode.integration;
 
 import org.netbeans.modules.java.lsp.server.ui.AbstractApplyEditsImplementation;
+import org.netbeans.spi.lsp.ApplyEditsImplementation;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
  *
  * @author sdedic
  */
-@ServiceProvider(service = AbstractApplyEditsImplementation.class, position = 10000)
+@ServiceProvider(service = ApplyEditsImplementation.class, position = 10000)
 public class LspApplyEditsImplementation extends AbstractApplyEditsImplementation{
     
 }


### PR DESCRIPTION
When testing implementation of [adding OCI assets](https://github.com/apache/netbeans/blob/master/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/assets/DependencyUtils.java#L53), @petrovic-d discovered that the maven dependency gets duplicated, instead of ignored 2nd time `vault` dependency was added. It can be only reproduced if the LSP client starst up with a pom.xml that does not contain the dependency at all, it is added . And subsequent calls to `modifyDependencies` add it despite the option `Options.skipConflicts`.

Surprisingly it was not because the pom.xml was not reparsed (so the IDE would "think" the dependency is still missing), or the duplicate detection in the dependency modification code failed, but the final save operation was done using `SaveCookie` and not remoted to the client, which means the old good "duplicating text" issue:
- NBLS saves a file
- LSP client detects a file change, makes a diff and interprets it as a change that needs to be reported to NBLS through `didChange`
- NBLS edits its document, appending a change that was already applied -> 2nd occurrence

In addition `LspApplyEditsImplementation` was incorrectly registered, so it was not found :(