### PR TITLE
Editor: Enable display of characters unsupported by chosen editor font

### DIFF
--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/FontInfo.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/FontInfo.java
@@ -26,6 +26,7 @@ import java.awt.font.TextLayout;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.text.JTextComponent;
+import javax.swing.text.StyleContext;
 
 /**
  * Info about font measurements.
@@ -83,8 +84,8 @@ final class FontInfo {
 
     FontInfo(Font origFont, JTextComponent textComponent, FontRenderContext frc, float rowHeightCorrection, int textZoom) {
         renderFont = (textZoom != 0)
-                ? new Font(origFont.getName(), origFont.getStyle(), Math.max(origFont.getSize() + textZoom, 1))
-                : origFont;
+                ? StyleContext.getDefaultStyleContext().getFont(origFont.getName(), origFont.getStyle(), Math.max(origFont.getSize() + textZoom, 1))
+                : StyleContext.getDefaultStyleContext().getFont(origFont.getName(), origFont.getStyle(), origFont.getSize());
         char defaultChar = 'A';
         String defaultCharText = String.valueOf(defaultChar);
         TextLayout defaultCharTextLayout = new TextLayout(defaultCharText, renderFont, frc); // NOI18N

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewUtils.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewUtils.java
@@ -131,6 +131,7 @@ public final class ViewUtils {
     }
 
     public static Font getFont(AttributeSet attrs, Font defaultFont) {
+        Font font = defaultFont;
         if (attrs != null) {
             String fontName = (String) attrs.getAttribute(StyleConstants.FontFamily);
             Boolean bold = (Boolean) attrs.getAttribute(StyleConstants.Bold);
@@ -154,10 +155,10 @@ public final class ViewUtils {
                     }
                 }
                 int fontSize = (fontSizeInteger != null) ? fontSizeInteger : defaultFont.getSize();
-                defaultFont = new Font(fontName, fontStyle, fontSize);
+                font = StyleContext.getDefaultStyleContext().getFont(fontName, fontStyle, fontSize);
             }
         }
-        return defaultFont;
+        return font;
     }
 
     /**
@@ -181,7 +182,7 @@ public final class ViewUtils {
                 if (italic != null && italic) {
                     fontStyle |= Font.ITALIC;
                 }
-                font = new Font(fontName, fontStyle, fontSizeInteger);
+                font = StyleContext.getDefaultStyleContext().getFont(fontName, fontStyle, fontSizeInteger);
             }
         }
         return font;


### PR DESCRIPTION
It was noticed, that in some contexts Swing was able to display characters unsupported by the currently chosen font. The problem was observed with emojis. Investigation showed, that the problem appears if a font is explicitly constructed via the constructor, but vanishes if the font is accessed via StyleContext#getFont.

The difference is that StyleContext#getFont returns a CompositeFont, that fallsback to other fonts for undefined glyphs.

As CompositeFont is located in the sun.font package, it can't be accessed directly. Instead the font acccess via the DefaultStyleContext is used.

Before:
![Bildschirmfoto vom 2024-09-15 17-27-56](https://github.com/user-attachments/assets/5330d926-424f-40e3-9541-07fba44e3d63)

After:
![Bildschirmfoto vom 2024-09-15 17-35-26](https://github.com/user-attachments/assets/04e379db-dde4-4177-9e5d-e620fe52f6cb)
