### PR TITLE
The id of the graalvmNative extension contains a typo.

### DIFF
--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/gradle/MicronautGradleArtifactsImpl.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/gradle/MicronautGradleArtifactsImpl.java
@@ -62,7 +62,7 @@ import org.openide.util.Lookup;
         }
 )
 public class MicronautGradleArtifactsImpl implements ProjectArtifactsImplementation<MicronautGradleArtifactsImpl.R>{
-    private static final String EXTENSION_GRAAL_VM_NATIVE = "graalVmNative";
+    private static final String EXTENSION_GRAAL_VM_NATIVE = "graalvmNative";
     private static final String TASK_NATIVE_COMPILE = "nativeCompile";
 
     private final Project project;


### PR DESCRIPTION
The micronaut support uses  an **incorrect** `graalvmNative` extension id: the "V" should be lowercase here.
See [graalvm native plugin sources](https://github.com/graalvm/native-build-tools/blob/master/native-gradle-plugin/src/main/java/org/graalvm/buildtools/gradle/NativeImagePlugin.java#L582)

This typo causes failure to read extension settings for native image's produced executable and other options.