### PR TITLE
CPPLite: Improve configuration of clangd/CCLS

### DIFF
--- a/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/UnconfiguredHint.java
+++ b/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/UnconfiguredHint.java
@@ -89,8 +89,8 @@ public class UnconfiguredHint implements Runnable {
         List<ErrorDescription> errors = new ArrayList<>();
         String ccls = Utils.getCCLSPath();
         String clangd = Utils.getCLANGDPath();
-        if ((ccls == null || !new File(ccls).canExecute() || !new File(ccls).isFile()) &&
-            (clangd == null || !new File(clangd).canExecute() || !new File(clangd).isFile())) {
+        if ((ccls == null || !new File(ccls).canExecute()) &&
+            (clangd == null || !new File(clangd).canExecute())) {
             errors.add(ErrorDescriptionFactory.createErrorDescription(Severity.WARNING, "Neither ccls nor clangd configured!", Collections.singletonList(new ConfigureCCLS()), doc, 0));
         } else {
             Project prj = FileOwnerQuery.getOwner(file);

--- a/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/Utils.java
+++ b/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/Utils.java
@@ -39,6 +39,8 @@ import org.openide.util.Parameters;
 public class Utils {
     public static final String KEY_CCLS_PATH = "ccls";
     public static final String KEY_CLANGD_PATH = "clangd";
+    public static final String KEY_PREFFERED_LS = "preferredLS";
+    public static final String[] AVAILABLE_LS = new String[]{Utils.KEY_CCLS_PATH, Utils.KEY_CLANGD_PATH};
 
     private static final String[] CCLS_NAMES = new String[] {"ccls"};
     private static final String[] CLANGD_NAMES = new String[] {"clangd-10", "clangd", "clangd-9"};
@@ -81,6 +83,15 @@ public class Utils {
             return null;
         }
         return path;
+    }
+
+    public static String getPreferredLs() {
+        String preferredLs = Utils.settings().get(KEY_PREFFERED_LS, KEY_CCLS_PATH);
+        if(Arrays.stream(AVAILABLE_LS).anyMatch(s -> s.equals(preferredLs))) {
+            return preferredLs;
+        } else {
+            return KEY_CCLS_PATH;
+        }
     }
 
     //TODO: copied from webcommon/javascript.nodejs/src/org/netbeans/modules/javascript/nodejs/util/FileUtils.java:

--- a/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/LanguageServerImpl.java
+++ b/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/LanguageServerImpl.java
@@ -88,7 +88,8 @@ public class LanguageServerImpl implements LanguageServerProvider {
         });
         String ccls = Utils.getCCLSPath();
         String clangd = Utils.getCLANGDPath();
-        if (ccls != null || clangd != null) {
+        if ((ccls != null && new File(ccls).canExecute())
+                || (clangd != null && new File(clangd).canExecute())) {
             Pair<Process, LanguageServerDescription> serverEntry = prj2Server.compute(prj, (p, pair) -> {
                 if (pair != null && pair.first().isAlive()) {
                     return pair;
@@ -108,7 +109,7 @@ public class LanguageServerImpl implements LanguageServerProvider {
                     File compileCommandDirs = getCompileCommandsDir(config);
 
                     if (compileCommandDirs != null) {
-                        if (ccls != null) {
+                        if (ccls != null && new File(ccls).canExecute()) {
                             command.add(ccls);
                             StringBuilder initOpt = new StringBuilder();
                             initOpt.append("--init={\"compilationDatabaseDirectory\":\"");

--- a/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/LanguageServerImpl.java
+++ b/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/LanguageServerImpl.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.ProcessBuilder.Redirect;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,7 +78,10 @@ public class LanguageServerImpl implements LanguageServerProvider {
         Utils.settings().addPreferenceChangeListener(new PreferenceChangeListener() {
             @Override
             public void preferenceChange(PreferenceChangeEvent evt) {
-                if (evt.getKey() == null || Utils.KEY_CCLS_PATH.equals(evt.getKey()) || Utils.KEY_CLANGD_PATH.equals(evt.getKey())) {
+                if (evt.getKey() == null
+                        || Utils.KEY_CCLS_PATH.equals(evt.getKey())
+                        || Utils.KEY_CLANGD_PATH.equals(evt.getKey())
+                        || Utils.KEY_PREFFERED_LS.equals(evt.getKey())) {
                     prj2Server.remove(prj);
                     restarter.restart();
                     Utils.settings().removePreferenceChangeListener(this);
@@ -95,7 +97,6 @@ public class LanguageServerImpl implements LanguageServerProvider {
                     return pair;
                 }
                 try {
-                    List<String> command = new ArrayList<>();
 
                     CProjectConfigurationProvider config = getProjectSettings(prj);
                     config.addChangeListener(new ChangeListener() {
@@ -106,21 +107,31 @@ public class LanguageServerImpl implements LanguageServerProvider {
                             config.removeChangeListener(this);
                         }
                     });
-                    File compileCommandDirs = getCompileCommandsDir(config);
 
+
+                    File compileCommandDirs = getCompileCommandsDir(config);
                     if (compileCommandDirs != null) {
-                        if (ccls != null && new File(ccls).canExecute()) {
-                            command.add(ccls);
-                            StringBuilder initOpt = new StringBuilder();
-                            initOpt.append("--init={\"compilationDatabaseDirectory\":\"");
-                            initOpt.append(compileCommandDirs.getAbsolutePath());
-                            initOpt.append("\"}");
-                            command.add(initOpt.toString());
+                        Map<String,List<String>> commands = new HashMap<>();
+                        commands.put(Utils.KEY_CCLS_PATH, List.of(
+                                ccls,
+                                "--init={\"compilationDatabaseDirectory\":\"" + compileCommandDirs.getAbsolutePath() + "\"}"
+                        ));
+                        commands.put(Utils.KEY_CLANGD_PATH, List.of(
+                                clangd,
+                                "--compile-commands-dir=" + compileCommandDirs.getAbsolutePath(),
+                                "--clang-tidy",
+                                "--completion-style=detailed"
+                        ));
+
+                        List<String> command;
+                        if (Utils.getPreferredLs().equals(Utils.KEY_CCLS_PATH) && ccls != null && new File(ccls).canExecute()) {
+                            command = commands.get(Utils.KEY_CCLS_PATH);
+                        } else if (Utils.getPreferredLs().equals(Utils.KEY_CLANGD_PATH) && clangd != null && new File(clangd).canExecute()) {
+                            command = commands.get(Utils.KEY_CLANGD_PATH);
+                        } else if (ccls != null && new File(ccls).canExecute()) {
+                            command = commands.get(Utils.KEY_CCLS_PATH);
                         } else {
-                            command.add(clangd);
-                            command.add("--compile-commands-dir=" + compileCommandDirs.getAbsolutePath());
-                            command.add("--clang-tidy");
-                            command.add("--completion-style=detailed");
+                            command = commands.get(Utils.KEY_CLANGD_PATH);
                         }
                         ProcessBuilder builder = new ProcessBuilder(command);
                         if (LOG.isLoggable(Level.FINEST)) {

--- a/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/options/Bundle.properties
+++ b/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/options/Bundle.properties
@@ -15,10 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-CPPLitePanel.jLabel1.text=CCLS Location:
 CPPLitePanel.cclsPath.text=
-CPPLitePanel.jLabel2.text=clangd Location:
 CPPLitePanel.jLabel3.text=<html><body>Please provide a path to either the <a href="https://github.com/MaskRay/ccls">ccls</a> or the <a href="https://clangd.llvm.org/">clangd</a> language protocol servers.\n<br>\nThese will be used by the editor to provide features like code completion.
 CPPLitePanel.clangdPath.text=
 CPPLitePanel.cclsBrowse.text=...
 CPPLitePanel.clangdBrowse.text=...
+CPPLitePanel.cclsLabel.text=CCLS Location:
+CPPLitePanel.clangdLabel.text=clangd Location:
+CPPLitePanel.preferredLsLabel.text=Preferred server:
+languageServer.ccls=CCLS
+languageServer.clangd=clangd

--- a/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/options/CPPLitePanel.form
+++ b/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/options/CPPLitePanel.form
@@ -32,66 +32,22 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,0,-83,0,0,1,-29"/>
   </AuxValues>
 
-  <Layout>
-    <DimensionLayout dim="0">
-      <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" attributes="0">
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" attributes="0">
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="jLabel1" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="jLabel2" alignment="0" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="cclsPath" max="32767" attributes="0"/>
-                          <Component id="clangdPath" max="32767" attributes="0"/>
-                      </Group>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="clangdBrowse" min="-2" max="-2" attributes="0"/>
-                          <Component id="cclsBrowse" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                  </Group>
-                  <Group type="102" attributes="0">
-                      <Component id="jLabel3" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-                  </Group>
-              </Group>
-              <EmptySpace max="-2" attributes="0"/>
-          </Group>
-      </Group>
-    </DimensionLayout>
-    <DimensionLayout dim="1">
-      <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="1" attributes="0">
-              <Component id="jLabel3" min="-2" max="-2" attributes="0"/>
-              <EmptySpace type="separate" max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="3" attributes="0">
-                  <Component id="jLabel1" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Component id="cclsPath" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Component id="cclsBrowse" alignment="3" min="-2" max="-2" attributes="0"/>
-              </Group>
-              <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
-                  <Component id="clangdPath" min="-2" max="-2" attributes="0"/>
-                  <Component id="clangdBrowse" min="-2" max="-2" attributes="0"/>
-              </Group>
-              <EmptySpace max="32767" attributes="0"/>
-          </Group>
-      </Group>
-    </DimensionLayout>
-  </Layout>
+  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
   <SubComponents>
-    <Component class="javax.swing.JLabel" name="jLabel1">
+    <Component class="javax.swing.JLabel" name="cclsLabel">
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/cpplite/editor/lsp/options/Bundle.properties" key="CPPLitePanel.jLabel1.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+          <ResourceString bundle="org/netbeans/modules/cpplite/editor/lsp/options/Bundle.properties" key="CPPLitePanel.cclsLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="1" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="6" insetsRight="6" anchor="17" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
     </Component>
     <Component class="javax.swing.JTextField" name="cclsPath">
       <Properties>
@@ -99,6 +55,11 @@
           <ResourceString bundle="org/netbeans/modules/cpplite/editor/lsp/options/Bundle.properties" key="CPPLitePanel.cclsPath.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="1" gridY="1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="6" insetsRight="6" anchor="17" weightX="1.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
     </Component>
     <Component class="javax.swing.JButton" name="cclsBrowse">
       <Properties>
@@ -109,13 +70,23 @@
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="cclsBrowseActionPerformed"/>
       </Events>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="2" gridY="1" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="6" insetsRight="6" anchor="17" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
     </Component>
-    <Component class="javax.swing.JLabel" name="jLabel2">
+    <Component class="javax.swing.JLabel" name="clangdLabel">
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/cpplite/editor/lsp/options/Bundle.properties" key="CPPLitePanel.jLabel2.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+          <ResourceString bundle="org/netbeans/modules/cpplite/editor/lsp/options/Bundle.properties" key="CPPLitePanel.clangdLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="2" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="6" insetsRight="6" anchor="17" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
     </Component>
     <Component class="javax.swing.JTextField" name="clangdPath">
       <Properties>
@@ -123,6 +94,11 @@
           <ResourceString bundle="org/netbeans/modules/cpplite/editor/lsp/options/Bundle.properties" key="CPPLitePanel.clangdPath.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="1" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="6" insetsRight="6" anchor="17" weightX="1.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
     </Component>
     <Component class="javax.swing.JButton" name="clangdBrowse">
       <Properties>
@@ -133,6 +109,11 @@
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="clangdBrowseActionPerformed"/>
       </Events>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="2" gridY="2" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="6" insetsRight="6" anchor="17" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
     </Component>
     <Component class="javax.swing.JLabel" name="jLabel3">
       <Properties>
@@ -140,6 +121,53 @@
           <ResourceString bundle="org/netbeans/modules/cpplite/editor/lsp/options/Bundle.properties" key="CPPLitePanel.jLabel3.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="0" gridWidth="3" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="6" insetsRight="6" anchor="18" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+    <Component class="javax.swing.Box$Filler" name="filler1">
+      <Properties>
+        <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+          <Dimension value="[32767, 32767]"/>
+        </Property>
+      </Properties>
+      <AuxValues>
+        <AuxValue name="classDetails" type="java.lang.String" value="Box.Filler.Glue"/>
+      </AuxValues>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="4" gridWidth="3" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="1.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+    <Component class="javax.swing.JLabel" name="preferredLsLabel">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/cpplite/editor/lsp/options/Bundle.properties" key="CPPLitePanel.preferredLsLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="0" gridY="3" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="6" insetsRight="6" anchor="21" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+    <Component class="javax.swing.JComboBox" name="preferredLsChooser">
+      <Properties>
+        <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+          <StringArray count="0"/>
+        </Property>
+      </Properties>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+      </AuxValues>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="1" gridY="3" gridWidth="2" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="6" insetsRight="6" anchor="21" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
     </Component>
   </SubComponents>
 </Form>

--- a/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/options/CPPLitePanel.java
+++ b/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/options/CPPLitePanel.java
@@ -18,20 +18,39 @@
  */
 package org.netbeans.modules.cpplite.editor.lsp.options;
 
+import java.awt.Component;
 import java.io.File;
+import java.util.ResourceBundle;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.DefaultListCellRenderer;
 import javax.swing.JFileChooser;
+import javax.swing.JList;
 import javax.swing.JTextField;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import org.netbeans.modules.cpplite.editor.Utils;
+import org.openide.util.NbBundle;
 
 final class CPPLitePanel extends javax.swing.JPanel {
 
+    private final ResourceBundle bundle = NbBundle.getBundle(CPPLitePanel.class);
     private final CPPLiteOptionsPanelController controller;
 
     CPPLitePanel(CPPLiteOptionsPanelController controller) {
         this.controller = controller;
         initComponents();
+        preferredLsChooser.setModel(new DefaultComboBoxModel<>(Utils.AVAILABLE_LS));
+        preferredLsChooser.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+                String translatedValue = String.valueOf(value);
+                String translationKey = "languageServer." + value;
+                if(bundle.containsKey(translationKey)) {
+                    translatedValue = bundle.getString(translationKey);
+                }
+                return super.getListCellRendererComponent(list, translatedValue, index, isSelected, cellHasFocus);
+            }
+        });
         DocumentListener pathsModified = new DocumentListener() {
             @Override
             public void insertUpdate(DocumentEvent e) {
@@ -57,18 +76,38 @@ final class CPPLitePanel extends javax.swing.JPanel {
      */
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
+        java.awt.GridBagConstraints gridBagConstraints;
 
-        jLabel1 = new javax.swing.JLabel();
+        cclsLabel = new javax.swing.JLabel();
         cclsPath = new javax.swing.JTextField();
         cclsBrowse = new javax.swing.JButton();
-        jLabel2 = new javax.swing.JLabel();
+        clangdLabel = new javax.swing.JLabel();
         clangdPath = new javax.swing.JTextField();
         clangdBrowse = new javax.swing.JButton();
         jLabel3 = new javax.swing.JLabel();
+        filler1 = new javax.swing.Box.Filler(new java.awt.Dimension(0, 0), new java.awt.Dimension(0, 0), new java.awt.Dimension(32767, 32767));
+        preferredLsLabel = new javax.swing.JLabel();
+        preferredLsChooser = new javax.swing.JComboBox<>();
 
-        org.openide.awt.Mnemonics.setLocalizedText(jLabel1, org.openide.util.NbBundle.getMessage(CPPLitePanel.class, "CPPLitePanel.jLabel1.text")); // NOI18N
+        setLayout(new java.awt.GridBagLayout());
+
+        org.openide.awt.Mnemonics.setLocalizedText(cclsLabel, org.openide.util.NbBundle.getMessage(CPPLitePanel.class, "CPPLitePanel.cclsLabel.text")); // NOI18N
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 1;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(6, 6, 6, 6);
+        add(cclsLabel, gridBagConstraints);
 
         cclsPath.setText(org.openide.util.NbBundle.getMessage(CPPLitePanel.class, "CPPLitePanel.cclsPath.text")); // NOI18N
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 1;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.insets = new java.awt.Insets(6, 6, 6, 6);
+        add(cclsPath, gridBagConstraints);
 
         org.openide.awt.Mnemonics.setLocalizedText(cclsBrowse, org.openide.util.NbBundle.getMessage(CPPLitePanel.class, "CPPLitePanel.cclsBrowse.text")); // NOI18N
         cclsBrowse.addActionListener(new java.awt.event.ActionListener() {
@@ -76,10 +115,30 @@ final class CPPLitePanel extends javax.swing.JPanel {
                 cclsBrowseActionPerformed(evt);
             }
         });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 2;
+        gridBagConstraints.gridy = 1;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(6, 6, 6, 6);
+        add(cclsBrowse, gridBagConstraints);
 
-        org.openide.awt.Mnemonics.setLocalizedText(jLabel2, org.openide.util.NbBundle.getMessage(CPPLitePanel.class, "CPPLitePanel.jLabel2.text")); // NOI18N
+        org.openide.awt.Mnemonics.setLocalizedText(clangdLabel, org.openide.util.NbBundle.getMessage(CPPLitePanel.class, "CPPLitePanel.clangdLabel.text")); // NOI18N
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(6, 6, 6, 6);
+        add(clangdLabel, gridBagConstraints);
 
         clangdPath.setText(org.openide.util.NbBundle.getMessage(CPPLitePanel.class, "CPPLitePanel.clangdPath.text")); // NOI18N
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.insets = new java.awt.Insets(6, 6, 6, 6);
+        add(clangdPath, gridBagConstraints);
 
         org.openide.awt.Mnemonics.setLocalizedText(clangdBrowse, org.openide.util.NbBundle.getMessage(CPPLitePanel.class, "CPPLitePanel.clangdBrowse.text")); // NOI18N
         clangdBrowse.addActionListener(new java.awt.event.ActionListener() {
@@ -87,48 +146,43 @@ final class CPPLitePanel extends javax.swing.JPanel {
                 clangdBrowseActionPerformed(evt);
             }
         });
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 2;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(6, 6, 6, 6);
+        add(clangdBrowse, gridBagConstraints);
 
         org.openide.awt.Mnemonics.setLocalizedText(jLabel3, org.openide.util.NbBundle.getMessage(CPPLitePanel.class, "CPPLitePanel.jLabel3.text")); // NOI18N
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.gridwidth = 3;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.insets = new java.awt.Insets(6, 6, 6, 6);
+        add(jLabel3, gridBagConstraints);
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 4;
+        gridBagConstraints.gridwidth = 3;
+        gridBagConstraints.weighty = 1.0;
+        add(filler1, gridBagConstraints);
 
-        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
-        this.setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(layout.createSequentialGroup()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(layout.createSequentialGroup()
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(jLabel1)
-                            .addComponent(jLabel2))
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(cclsPath)
-                            .addComponent(clangdPath))
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(clangdBrowse)
-                            .addComponent(cclsBrowse)))
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(jLabel3, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addGap(0, 0, Short.MAX_VALUE)))
-                .addContainerGap())
-        );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
-                .addComponent(jLabel3, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addGap(18, 18, 18)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(jLabel1)
-                    .addComponent(cclsPath, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(cclsBrowse))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(jLabel2)
-                    .addComponent(clangdPath, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(clangdBrowse))
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-        );
+        org.openide.awt.Mnemonics.setLocalizedText(preferredLsLabel, org.openide.util.NbBundle.getMessage(CPPLitePanel.class, "CPPLitePanel.preferredLsLabel.text")); // NOI18N
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 3;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.LINE_START;
+        gridBagConstraints.insets = new java.awt.Insets(6, 6, 6, 6);
+        add(preferredLsLabel, gridBagConstraints);
+
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 3;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.LINE_START;
+        gridBagConstraints.insets = new java.awt.Insets(6, 6, 6, 6);
+        add(preferredLsChooser, gridBagConstraints);
     }// </editor-fold>//GEN-END:initComponents
 
     private void cclsBrowseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cclsBrowseActionPerformed
@@ -150,11 +204,13 @@ final class CPPLitePanel extends javax.swing.JPanel {
     void load() {
         cclsPath.setText(Utils.getCCLSPath());
         clangdPath.setText(Utils.getCLANGDPath());
+        preferredLsChooser.setSelectedItem(Utils.getPreferredLs());
     }
 
     void store() {
         Utils.settings().put(Utils.KEY_CCLS_PATH, cclsPath.getText());
         Utils.settings().put(Utils.KEY_CLANGD_PATH, clangdPath.getText());
+        Utils.settings().put(Utils.KEY_PREFFERED_LS, (String) preferredLsChooser.getSelectedItem());
     }
 
     boolean valid() {
@@ -164,11 +220,14 @@ final class CPPLitePanel extends javax.swing.JPanel {
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton cclsBrowse;
+    private javax.swing.JLabel cclsLabel;
     private javax.swing.JTextField cclsPath;
     private javax.swing.JButton clangdBrowse;
+    private javax.swing.JLabel clangdLabel;
     private javax.swing.JTextField clangdPath;
-    private javax.swing.JLabel jLabel1;
-    private javax.swing.JLabel jLabel2;
+    private javax.swing.Box.Filler filler1;
     private javax.swing.JLabel jLabel3;
+    private javax.swing.JComboBox<String> preferredLsChooser;
+    private javax.swing.JLabel preferredLsLabel;
     // End of variables declaration//GEN-END:variables
 }


### PR DESCRIPTION
**Check if language server is executable, not only if path is configured before execution**

If both ccls and clangd had a path configured, but only the clangd one pointed to a usable binary, the clangd one was not used. To improve  this, now not only the existence of the ccls path is checked, but also whether it points to an executable file.

**Make it possible to select language server**

If both CCLS and clangd are installed, switching from CCLS to clangd requires users to input an invalid path to use clangd, else CCLS is always preferred.

This change allows the user to override the preferred order.

In the GUI:

![image](https://github.com/user-attachments/assets/cc21ce47-11e9-4746-a075-c1f89088a153)