### PR TITLE
LSP Client: Reduce concurrency in LSP communication and register document sychronously on startup

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
@@ -220,6 +220,7 @@ public class LSPBindings {
                 for(String mt: description.mimeTypes) {
                     mimeType2Server.put(mt, description);
                 }
+                TextDocumentSyncServerCapabilityHandler.refreshOpenedFilesInServers();
                 WORKER.post(() -> cs.fireChange());
             }
         }
@@ -357,7 +358,6 @@ public class LSPBindings {
                     new LSPReference(b, Utilities.activeReferenceQueue());
                     lci.setBindings(b);
                     LanguageServerProviderAccessor.getINSTANCE().setBindings(desc, b);
-                    TextDocumentSyncServerCapabilityHandler.refreshOpenedFilesInServers();
                     return b;
                 } catch (InterruptedException | ExecutionException ex) {
                     LOG.log(Level.WARNING, null, ex);

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/LspStructureNavigatorPanel.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/LspStructureNavigatorPanel.java
@@ -18,32 +18,23 @@
  */
 package org.netbeans.modules.lsp.client.bindings;
 
-import java.awt.BorderLayout;
-import java.awt.EventQueue;
 import java.util.Collection;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.swing.Action;
-import javax.swing.JComponent;
-import javax.swing.JPanel;
 import javax.swing.text.StyledDocument;
 import org.netbeans.api.actions.Openable;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.lsp.StructureElement;
 import org.netbeans.spi.lsp.StructureProvider;
-import org.netbeans.spi.navigator.NavigatorPanel;
 import org.openide.awt.Actions;
 import org.openide.cookies.EditorCookie;
 import org.openide.cookies.LineCookie;
-import org.openide.explorer.ExplorerManager;
-import org.openide.explorer.view.BeanTreeView;
 import org.openide.filesystems.FileObject;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
 import org.openide.text.Line;
 import org.openide.text.NbDocument;
-import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.lookup.AbstractLookup;

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/MarkOccurrences.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/MarkOccurrences.java
@@ -51,7 +51,6 @@ import org.netbeans.spi.editor.highlighting.support.OffsetsBag;
 import org.openide.filesystems.FileObject;
 import org.openide.loaders.DataObject;
 import org.openide.util.Exceptions;
-import org.openide.util.RequestProcessor;
 
 /**
  *
@@ -59,7 +58,6 @@ import org.openide.util.RequestProcessor;
  */
 public class MarkOccurrences implements BackgroundTask, CaretListener, PropertyChangeListener {
 
-    private static final RequestProcessor WORKER = new RequestProcessor(MarkOccurrences.class.getName(), 1, false, false);
     private final JTextComponent component;
     private Document doc;
     private int caretPos;
@@ -139,13 +137,11 @@ public class MarkOccurrences implements BackgroundTask, CaretListener, PropertyC
         } else {
             caretPos = -1;
         }
-        WORKER.post(() -> {
-            FileObject file = NbEditorUtilities.getFileObject(doc);
+        FileObject file = NbEditorUtilities.getFileObject(doc);
 
-            if (file != null) {
-                LSPBindings.rescheduleBackgroundTask(file, this);
-            }
-        });
+        if (file != null) {
+            LSPBindings.rescheduleBackgroundTask(file, this);
+        }
     }
 
     @Override


### PR DESCRIPTION
- Run open document registration in LSP servers synchronously with initialization
- Instead of spinning custom RequestProcessors use the existing queue on the LSP Bindings via runOnBackground
- Where possible drop RequestProcessor usage and run code directly

Closes: #3812