### PR TITLE
Command for uploading OCI policies

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/NotificationUtils.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/NotificationUtils.java
@@ -41,4 +41,9 @@ public class NotificationUtils {
     public static void showMessage(String message) {
         DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(message));
     }
+    
+    public static void showWarningMessage(String message) {
+        DialogDisplayer.getDefault()
+                .notifyLater(new NotifyDescriptor.Message(message, NotifyDescriptor.WARNING_MESSAGE));
+    }
 }

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/assets/CloudAssetsRefreshCommand.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/assets/CloudAssetsRefreshCommand.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.cloud.oracle.assets;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.netbeans.spi.lsp.CommandProvider;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author Dusan Petrovic
+ */
+@ServiceProvider(service = CommandProvider.class)
+public class CloudAssetsRefreshCommand implements CommandProvider {
+    
+    private static final String COMMAND_CLOUD_ASSETS_REFRESH = "nbls.cloud.assets.refresh"; //NOI18N
+
+    private static final Set COMMANDS = Collections.singleton(COMMAND_CLOUD_ASSETS_REFRESH);
+    
+    @Override
+    public Set<String> getCommands() {
+        return Collections.unmodifiableSet(COMMANDS);
+    }
+
+    @Override
+    public CompletableFuture<Object> runCommand(String command, List<Object> arguments) {
+        CloudAssets.getDefault().update();        
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/assets/CreateConfigCommand.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/assets/CreateConfigCommand.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.cloud.oracle.assets;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.netbeans.modules.cloud.oracle.actions.ConfigMapUploader;
+import org.netbeans.spi.lsp.CommandProvider;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author Dusan Petrovic
+ */
+@ServiceProvider(service = CommandProvider.class)
+public class CreateConfigCommand implements CommandProvider {
+
+    private static final String COMMAND_CREATE_CONFIG = "nbls.cloud.assets.config.create.local"; //NOI18N
+    private static final String COMMAND_UPLOAD_TO_CONFIGMAP = "nbls.cloud.assets.configmap.upload"; //NOI18N
+
+    private static final Set COMMANDS = new HashSet<>(Arrays.asList(
+            COMMAND_CREATE_CONFIG,
+            COMMAND_UPLOAD_TO_CONFIGMAP
+    ));
+    
+    @Override
+    public Set<String> getCommands() {
+        return Collections.unmodifiableSet(COMMANDS);
+    }
+
+    @Override
+    public CompletableFuture<Object> runCommand(String command, List<Object> arguments) {
+        CompletableFuture future = new CompletableFuture();
+        if (COMMAND_CREATE_CONFIG.equals(command)) {
+            PropertiesGenerator propGen = new PropertiesGenerator(false);
+            ApplicationPropertiesGenerator appPropGen = new ApplicationPropertiesGenerator(propGen);
+            String toWrite = appPropGen.getApplicationPropertiesString();
+            future.complete(toWrite);
+        } else if (COMMAND_UPLOAD_TO_CONFIGMAP.equals(command)) {
+            ConfigMapUploader.uploadConfigMap(future);
+        }
+        return future;
+    }
+    
+}

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/items/IncompatibleTenancyItem.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/items/IncompatibleTenancyItem.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.cloud.oracle.items;
+
+/**
+ *
+ * @author Dusan Petrovic
+ */
+public class IncompatibleTenancyItem extends TenancyItem {
+    
+}

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/policy/PolicyParser.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/policy/PolicyParser.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.cloud.oracle.policy;
+
+import com.oracle.bmc.identity.model.Policy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ *
+ * @author Dusan Petrovic
+ */
+public class PolicyParser {
+    
+    private static final List<String> OVER_PERMISSIVE_KEYWORDS = List.of(
+            "all-resources", "in tenancy", "manage policies", "manage groups",
+            "manage identity", "manage virtual-network-family",
+            "manage database-family"
+    );
+    
+    public static List<String> getAllStatementsFrom(List<Policy> policies) {
+        return policies
+                    .stream()
+                    .flatMap(i -> i.getStatements().stream())
+                    .collect(Collectors.toList());
+    }
+
+    public static List<String> filterOverpermissiveStatements(List<String> statements) {
+        List<String> overpermissive = new ArrayList();
+        for (String statement: statements) {
+            for (String keyword: OVER_PERMISSIVE_KEYWORDS) {
+                if (prepareForComparing(statement).contains(prepareForComparing(keyword))) {
+                    overpermissive.add(statement);
+                }
+            }
+        }
+        
+        return overpermissive;
+    }
+    
+    public static List<String> removeWhitespacesFromStatements(List<String> statements) {
+        return statements
+                    .stream()
+                    .map(PolicyParser::prepareForComparing)
+                    .collect(Collectors.toList());
+    }
+    
+    public static String prepareForComparing(String statementPart) {
+        return statementPart.replaceAll("\\s+", "").toLowerCase();
+    }
+}

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/policy/PolicyUploader.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/policy/PolicyUploader.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.cloud.oracle.policy;
+
+import com.oracle.bmc.identity.IdentityClient;
+import com.oracle.bmc.identity.model.CreatePolicyDetails;
+import com.oracle.bmc.identity.model.Policy;
+import com.oracle.bmc.identity.model.UpdatePolicyDetails;
+import com.oracle.bmc.identity.requests.CreatePolicyRequest;
+import com.oracle.bmc.identity.requests.ListPoliciesRequest;
+import com.oracle.bmc.identity.requests.UpdatePolicyRequest;
+import com.oracle.bmc.identity.responses.CreatePolicyResponse;
+import com.oracle.bmc.identity.responses.ListPoliciesResponse;
+import com.oracle.bmc.identity.responses.UpdatePolicyResponse;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import static org.netbeans.modules.cloud.oracle.NotificationUtils.showErrorMessage;
+import static org.netbeans.modules.cloud.oracle.NotificationUtils.showMessage;
+import static org.netbeans.modules.cloud.oracle.NotificationUtils.showWarningMessage;
+import org.netbeans.modules.cloud.oracle.OCIManager;
+import org.netbeans.modules.cloud.oracle.assets.Steps;
+import org.netbeans.modules.cloud.oracle.compartment.CompartmentItem;
+import org.netbeans.modules.cloud.oracle.steps.CompartmentStep;
+import org.netbeans.modules.cloud.oracle.steps.TenancyStep;
+import org.openide.util.Lookup;
+import org.openide.util.NbBundle;
+import org.openide.util.lookup.Lookups;
+
+/**
+ * Uploads OCI policies or modifies existing.
+ *
+ * @author Dusan Petrovic
+ */
+@NbBundle.Messages({
+    "MSG_PolicyUploaded=Policy: {0} successfully uploaded",
+    "MSG_StatementsExist=Generated policy statements already exist inisde the compartment",
+    "MSG_PolicyUploadError=Error while uploading policy: {0}",
+    "MSG_PolicyUpdated=Policy: {0} successfully updated",
+    "MSG_PolicyUpdateError=Error while updating policy: {0}",
+    "MSG_PotentialOverpermissivePolicies=Potential overly permissive policy found in compartment: {0}"
+})
+public class PolicyUploader {
+    
+    private static final String DEFAULT_POLICY_NAME = "cloud-assets-auto-generated-policy";
+    private static final String DEFAULT_POLICY_DESCRIPTION = "OCI Policy that allows access to added Cloud Assets";
+
+    private final IdentityClient client;
+    
+    public PolicyUploader() {
+        this.client = OCIManager.getDefault().getActiveSession().newClient(IdentityClient.class);
+    }
+    
+    public void uploadPolicies(List<String> statements) {   
+        Steps.NextStepProvider nsProvider = Steps.NextStepProvider.builder()
+            .stepForClass(TenancyStep.class, (s) -> new CompartmentStep())
+            .build();
+        
+        Lookup lookup = Lookups.fixed(nsProvider);
+        Steps.getDefault().executeMultistep(new TenancyStep(true), lookup)
+                .thenAccept(values -> {
+                    CompartmentItem compartment = values.getValueForStep(CompartmentStep.class);
+                    String compartmentId = compartment.getKey().getValue();
+                    try {
+                        List<String> statementsToAdd = filterExistingStatements(statements, compartmentId);
+                        if (statementsToAdd.isEmpty()) {
+                            showMessage(Bundle.MSG_StatementsExist());
+                            return;
+                        }
+                        
+                        Optional<Policy> policy = findPolicyByNameIfExist(DEFAULT_POLICY_NAME, compartmentId);
+                        
+                        if (policy.isPresent()) {
+                            updateExistingPolicy(policy.get(), statementsToAdd);
+                        } else {
+                            createNewPolicy(statementsToAdd, compartmentId);
+                        }
+                    } catch (Exception ex) {
+                        showErrorMessage(Bundle.MSG_PolicyUploadError(ex.getMessage()));
+                    }
+                    
+                });        
+    }
+    
+    private List<String> filterExistingStatements(List<String> statements, String compartmentId) {
+        ListPoliciesRequest request = ListPoliciesRequest.builder()
+                    .compartmentId(compartmentId)
+                    .build();
+        
+        ListPoliciesResponse response = this.client.listPolicies(request);
+        List<String> extractedStatements = PolicyParser.getAllStatementsFrom(response.getItems());        
+        List<String> noWhitespaceStatements = PolicyParser.removeWhitespacesFromStatements(extractedStatements);
+        
+        detectOverpermissivePolicies(extractedStatements, compartmentId);
+      
+        return statements
+                    .stream()
+                    .filter(i -> !noWhitespaceStatements.contains(PolicyParser.prepareForComparing(i)))
+                    .collect(Collectors.toList());
+    }
+
+    private void detectOverpermissivePolicies(List<String> extractedStatements, String compartmentId) {
+        List<String> overpermissive = PolicyParser.filterOverpermissiveStatements(extractedStatements);
+        if (!overpermissive.isEmpty()) {
+            showWarningMessage(Bundle.MSG_PotentialOverpermissivePolicies(compartmentId));
+        }
+    }
+
+    private Optional<Policy> findPolicyByNameIfExist(String policyName, String compartmentId) {
+        ListPoliciesRequest request = ListPoliciesRequest.builder()
+                .name(policyName)
+                .compartmentId(compartmentId)
+                .limit(1)
+                .build();
+        
+        ListPoliciesResponse response = this.client.listPolicies(request);
+        return !response.getItems().isEmpty() ? 
+                Optional.of(response.getItems().get(0)) : Optional.empty();
+    }
+
+    private void createNewPolicy(List<String> statementsToAdd, String compartmentId) {
+        CreatePolicyDetails createPolicyDetails = CreatePolicyDetails.builder()
+                .name(DEFAULT_POLICY_NAME)
+                .description(DEFAULT_POLICY_DESCRIPTION)
+                .compartmentId(compartmentId)
+                .statements(statementsToAdd)
+                .build();
+        CreatePolicyRequest request = CreatePolicyRequest.builder()
+                .createPolicyDetails(createPolicyDetails)
+                .build();
+
+        CreatePolicyResponse response = this.client.createPolicy(request);
+        if (response.get__httpStatusCode__() != 200) {
+            showErrorMessage(Bundle.MSG_PolicyUploadError(DEFAULT_POLICY_NAME));
+        }
+        showMessage(Bundle.MSG_PolicyUploaded(DEFAULT_POLICY_NAME));
+    }
+
+    private void updateExistingPolicy(Policy policy, List<String> statementsToAdd) {
+        List<String> resultStatements = Stream.concat(policy.getStatements().stream(), statementsToAdd.stream())
+                                          .collect(Collectors.toList());
+        UpdatePolicyDetails updatePolicyDetails = UpdatePolicyDetails.builder()
+                .statements(resultStatements)
+                .build();
+        UpdatePolicyRequest request = UpdatePolicyRequest.builder()
+                .policyId(policy.getId())
+                .updatePolicyDetails(updatePolicyDetails)
+                .build();
+
+        UpdatePolicyResponse response = this.client.updatePolicy(request);
+        if (response.get__httpStatusCode__() != 200) {
+            showErrorMessage(Bundle.MSG_PolicyUpdateError(DEFAULT_POLICY_NAME));
+        }
+        showMessage(Bundle.MSG_PolicyUpdated(DEFAULT_POLICY_NAME));
+    }
+}

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/steps/CompartmentStep.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/steps/CompartmentStep.java
@@ -23,6 +23,7 @@ import com.oracle.bmc.identity.IdentityClient;
 import com.oracle.bmc.identity.model.Compartment;
 import com.oracle.bmc.identity.requests.ListCompartmentsRequest;
 import com.oracle.bmc.identity.responses.ListCompartmentsResponse;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -33,6 +34,7 @@ import org.netbeans.modules.cloud.oracle.assets.AbstractStep;
 import org.netbeans.modules.cloud.oracle.assets.Steps.Values;
 import static org.netbeans.modules.cloud.oracle.assets.Steps.createQuickPick;
 import org.netbeans.modules.cloud.oracle.compartment.CompartmentItem;
+import org.netbeans.modules.cloud.oracle.items.IncompatibleTenancyItem;
 import org.netbeans.modules.cloud.oracle.items.OCID;
 import org.netbeans.modules.cloud.oracle.items.OCIItem;
 import org.netbeans.modules.cloud.oracle.items.TenancyItem;
@@ -44,6 +46,8 @@ import org.openide.util.NbBundle;
  * @author Jan Horvath
  */
 @NbBundle.Messages({
+    "NoTenancy=Tenancy is not selected",
+    "IncompatibleTenancy=Tenancy not compatible with other selected Cloud Assets. Please return and select other one.",
     "NoCompartment=There are no compartments in the Tenancy",
     "CollectingItems_Text=Listing compartments and databases",
     "SelectCompartment=Select Compartment",
@@ -53,17 +57,29 @@ import org.openide.util.NbBundle;
 public final class CompartmentStep extends AbstractStep<CompartmentItem> {
 
     private Map<String, OCIItem> compartments = null;
+    private TenancyItem tenancy;
     private CompartmentItem selected;
 
     @Override
     public void prepare(ProgressHandle h, Values values) {
         h.progress(Bundle.CollectingItems_Text());
-        TenancyItem tenancy = values.getValueForStep(TenancyStep.class);
-        compartments = getFlatCompartment(tenancy);
+        tenancy = values.getValueForStep(TenancyStep.class);
+        if (tenancy != null && !(tenancy instanceof IncompatibleTenancyItem)) {
+            compartments = getFlatCompartment(tenancy);
+
+        } else {
+            compartments = Collections.emptyMap();
+        }
     }
 
     @Override
     public NotifyDescriptor createInput() {
+        if (tenancy == null) {
+            return new NotifyDescriptor.QuickPick("", Bundle.NoTenancy(), Collections.emptyList(), false);
+        } 
+        if (tenancy instanceof IncompatibleTenancyItem) {
+            return new NotifyDescriptor.QuickPick("", Bundle.IncompatibleTenancy(), Collections.emptyList(), false);
+        }
         if (onlyOneChoice()) {
             throw new IllegalStateException("Input shouldn't be displayed for one choice"); // NOI18N
         }

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -379,6 +379,14 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
     const providerRegistration = vscode.workspace.registerTextDocumentContentProvider(scheme, provider);
 
     context.subscriptions.push(vscode.commands.registerCommand('cloud.assets.policy.create', async function (viewItem) {
+            const POLICIES_PREVIEW = 'Open a preview of the OCI policies';
+            const POLICIES_UPLOAD = 'Upload the OCI Policies to OCI';
+            const selected: any = await window.showQuickPick([POLICIES_PREVIEW, POLICIES_UPLOAD], { placeHolder: 'Select a target for the OCI policies' });
+            if (selected == POLICIES_UPLOAD) {
+                await vscode.commands.executeCommand('nbls.cloud.assets.policy.upload');
+                return;
+            } 
+
             const content = await vscode.commands.executeCommand('nbls.cloud.assets.policy.create.local') as string;
             const document = vscode.Uri.parse(`${scheme}:policies.txt?${encodeURIComponent(content)}`);
             vscode.workspace.openTextDocument(document).then(doc => {


### PR DESCRIPTION
Previously we were only getting the preview text representing a OCI policy that could be copied and manually pasted to OCI Console. Now we have a option to upload it directly.
Tenancy check was added to check if all Cloud Assets are from the same tenancy