### PR TITLE
Closed editors after successful save to avoid duplication

### DIFF
--- a/java/maven.model/src/org/netbeans/modules/maven/model/Utilities.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/Utilities.java
@@ -256,9 +256,13 @@ public class Utilities {
             }
         } else {
             SaveCookie save = dobj.getLookup().lookup(SaveCookie.class);
+            EditorCookie ec = dobj.getLookup().lookup(EditorCookie.class);
             if (save != null) {
                 logger.log(Level.FINE, "saving changes in {0}", dobj);
                 save.save();
+                if(!ec.close()){
+                    throw new IOException("saving changes action failed");
+                }
             } else {
                 logger.log(Level.FINE, "no changes in {0} where modified={1}", new Object[] {dobj, dobj.isModified()});
             }


### PR DESCRIPTION
These changes fix [Issue #279](https://github.com/oracle/javavscode/issues/279)
The changes made in [PR #7749](https://github.com/apache/netbeans/pull/7749) do not fix this issue, although the issues seem similar

### Brief
1. The QuickFix action to enable the preview uses `node.cookie` (`SaveCookie`) to save the changes to pom.xml.
2. The `EditorCookie` is not closed after a successful save.
3. In subsequent run operations, the `LifecycleManager` (line 167) in `MavenCommandLineExecutor.java` saves the previous changes again.
