### PR TITLE
Added code preview for “search results”

### DIFF
--- a/platform/api.search/src/org/netbeans/modules/search/ui/BasicSearchResultsPanel.java
+++ b/platform/api.search/src/org/netbeans/modules/search/ui/BasicSearchResultsPanel.java
@@ -18,15 +18,24 @@
  */
 package org.netbeans.modules.search.ui;
 
+import java.beans.PropertyChangeEvent;
+import javax.swing.BoxLayout;
+import javax.swing.JPanel;
+import javax.swing.JSplitPane;
 import org.netbeans.modules.search.BasicComposition;
+import org.netbeans.modules.search.ContextView;
+import org.netbeans.modules.search.FindDialogMemory;
 import org.netbeans.modules.search.ResultModel;
 import org.openide.nodes.Node;
+import org.openide.util.RequestProcessor;
 
 /**
  *
  * @author jhavlin
  */
 public class BasicSearchResultsPanel extends BasicAbstractResultsPanel {
+    private final RequestProcessor.Task SAVE_TASK = RequestProcessor.getDefault().create(new BasicSearchResultsPanel.SaveTask());
+    private JSplitPane splitPane;
 
     public BasicSearchResultsPanel(ResultModel resultModel,
             BasicComposition composition, boolean details, Node infoNode) {
@@ -37,6 +46,39 @@ public class BasicSearchResultsPanel extends BasicAbstractResultsPanel {
     }
 
     private void init() {
-        getContentPanel().add(resultsOutlineSupport.getOutlineView());
+        JPanel leftPanel = new JPanel();
+        leftPanel.setLayout(new BoxLayout(leftPanel, BoxLayout.PAGE_AXIS));
+        leftPanel.add(resultsOutlineSupport.getOutlineView());
+
+        this.splitPane = new JSplitPane();
+        splitPane.setLeftComponent(leftPanel);
+        splitPane.setRightComponent(new ContextView(resultModel,
+                getExplorerManager()));
+        initSplitDividerLocationHandling();
+        getContentPanel().add(splitPane);
+    }
+
+    private void initSplitDividerLocationHandling() {
+        int location = FindDialogMemory.getDefault().getReplaceResultsDivider();
+        if (location > 0) {
+            splitPane.setDividerLocation(location);
+        }
+        splitPane.addPropertyChangeListener((PropertyChangeEvent evt) -> {
+            String pn = evt.getPropertyName();
+            if (pn.equals(JSplitPane.DIVIDER_LOCATION_PROPERTY)) {
+                SAVE_TASK.schedule(1000);
+            }
+        });
+    }
+
+    private class SaveTask implements Runnable {
+
+        @Override
+        public void run() {
+            if (splitPane != null) {
+                FindDialogMemory.getDefault().setReplaceResultsDivider(
+                        splitPane.getDividerLocation());
+            }
+        }
     }
 }


### PR DESCRIPTION
I often have to use the `find in projects` feature, and I really miss being able to quickly see the contents of files in the `search results`. I have to open tabs in the main editor, which sometimes leads to a lot of unnecessary tabs.

Example of code preview: 

https://github.com/user-attachments/assets/7870cd89-57e1-4a42-9eec-0d881e2cbad6

I borrowed the preview implementation from `replace in projects`:
https://github.com/apache/netbeans/blob/master/platform/api.search/src/org/netbeans/modules/search/ui/BasicReplaceResultsPanel.java



