### PR TITLE
Multi-project audit caching improved

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
@@ -70,6 +70,7 @@ import org.netbeans.spi.lsp.ErrorProvider;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
@@ -126,6 +127,8 @@ public class VulnerabilityWorker implements ErrorProvider{
     
     // PENDING: should be customizable from project configuration somehow.
     private static final String GOV_DETAIL_URL = "https://nvd.nist.gov/vuln/detail/";
+    
+    private static final String TAG_SUBPROJECT_PATH = "netbeans_cloud_oracle_SubProjectPath"; // NOI18N
     
     // @GuardedBy(self)
     private static final HashMap<Project, CacheItem> cache = new HashMap<>();
@@ -558,6 +561,12 @@ public class VulnerabilityWorker implements ErrorProvider{
             
             List<Diagnostic> result = new ArrayList<>();
             SourceLocation containerLocation = null;
+            if (!sourceMapping.files.contains(file)) {
+                return null;
+            }
+            if (dependencyResult.getProject().getProjectDirectory() != file.getParent()) {
+                return null;
+            }
             
             for (VulnerabilityItem item : this.itemIndex.values()) {
                 boolean unreported = true;
@@ -703,6 +712,15 @@ public class VulnerabilityWorker implements ErrorProvider{
             kbItem.refresh();
         }
     }
+    
+    private static String findSubprojectPath(Project project) {
+        Project p2 = ProjectUtils.rootOf(project);
+        if (p2 == project) {
+            return "";
+        } else {
+            return FileUtil.getRelativePath(p2.getProjectDirectory(), project.getProjectDirectory()).replace('/', '.');
+        }
+    }
 
     private AuditResult doFindVulnerability(Project project, String compartmentId, String knowledgeBaseId, String projectDisplayName, AuditOptions auditOptions,
             ProgressHandle progressHandle, AtomicBoolean remoteCall) throws AuditException {
@@ -714,16 +732,15 @@ public class VulnerabilityWorker implements ErrorProvider{
         boolean auditDone = false;
 
         DependencyResult dr = null;
-        
+        String subprojectPath = findSubprojectPath(project);        
         if (!auditOptions.isForceAuditExecution()) {
             if (!auditOptions.isDisableCache()) {
                 try {
-                    savedAudit = AuditCache.getInstance().loadAudit(knowledgeBaseId);
+                    savedAudit = AuditCache.getInstance().loadAudit(project, knowledgeBaseId);
                 } catch (IOException ex) {
                     LOG.log(Level.WARNING, "Could not load cached audit data", ex); 
                 }
             }
-
             if (savedAudit == null) {
                 // attempt to find an active most recent audit:
                 remoteCall.set(true);
@@ -737,14 +754,30 @@ public class VulnerabilityWorker implements ErrorProvider{
                             .knowledgeBaseId(knowledgeBaseId)
                             .lifecycleState(LifecycleState.Active)
                             .sortBy(ListVulnerabilityAuditsRequest.SortBy.TimeCreated)
+                            .limit(200)
                             .sortOrder(SortOrder.Desc).build();
                     ListVulnerabilityAuditsResponse response = admClient.listVulnerabilityAudits(request);
                     if (!response.getVulnerabilityAuditCollection().getItems().isEmpty()) {
-                        VulnerabilityAuditSummary summary = response.getVulnerabilityAuditCollection().getItems().get(0);
+                        VulnerabilityAuditSummary found = null;
+                        D: while (true) {
+                            for (VulnerabilityAuditSummary summary : response.getVulnerabilityAuditCollection().getItems()) {
+                                String p = summary.getFreeformTags().get(TAG_SUBPROJECT_PATH);
+                                if (subprojectPath.equals(p)) {
+                                    found = summary;
+                                    break D;
+                                }
+                            }
+                            if (response.getOpcNextPage() == null) {
+                                break;
+                            }
+                            request = ListVulnerabilityAuditsRequest
+                                .builder().copy(request).page(response.getOpcNextPage()).build();
+                            response = admClient.listVulnerabilityAudits(request);
+                        }
                         progressHandle.progress(Bundle.MSG_AuditCollectDependencies());
                         dr = ProjectDependencies.findDependencies(project, ProjectDependencies.newQuery(Scopes.RUNTIME));
                         convert(dr.getRoot(), new HashMap<>(), result);
-                        cacheItem = fetchVulnerabilityItems(project, admClient, dr, summary, projectDisplayName);
+                        cacheItem = fetchVulnerabilityItems(project, admClient, dr, found, projectDisplayName);
                         savedAudit = new VulnerabilityReport(cacheItem.getAudit(), cacheItem.getVulnerabilities());
                     }
                 } catch (BmcException ex) {
@@ -780,6 +813,7 @@ public class VulnerabilityWorker implements ErrorProvider{
                         .buildType(VulnerabilityAudit.BuildType.Maven)
                         .configuration(auditConfiguration)
                         .applicationDependencies(result)
+                        .freeformTags(Map.of(TAG_SUBPROJECT_PATH, subprojectPath))
                         .build();
                 progressHandle.progress(Bundle.MSG_ExecuteAudit());
                 CreateVulnerabilityAuditResponse response = admClient.createVulnerabilityAudit(CreateVulnerabilityAuditRequest
@@ -977,7 +1011,7 @@ public class VulnerabilityWorker implements ErrorProvider{
         report.setMappedVulnerabilities(mapped);
         
         try {
-            AuditCache.getInstance().cacheAuditResults(report);
+            AuditCache.getInstance().cacheAuditResults(project, report);
         } catch (IOException ex) {
             LOG.log(Level.WARNING, "Could not cache audit results for knowledgebase {0}, compartment {1}, project {2}", new Object[] {
                 auditSummary.getKnowledgeBaseId(), auditSummary.getCompartmentId(),

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/DependencyText.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/DependencyText.java
@@ -110,6 +110,14 @@ public class DependencyText {
         return sb.toString();
     }
     
+    static String stripStrict(String s) {
+        if (!s.endsWith("!!")) {
+            return s;
+        } else {
+            return s.substring(0, s.length() - 2);
+        }
+    }
+    
     public String getContentsOrGav() {
         if (contents != null) {
             return contents;
@@ -117,7 +125,7 @@ public class DependencyText {
             StringBuilder sb = new StringBuilder();
             sb.append(group).append(':').append(name);
             if (version != null && !version.isEmpty()) {
-                sb.append(':').append(version);
+                sb.append(":").append(stripStrict(version));
             }
             return sb.toString();
         }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/TextDependencyScanner.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/TextDependencyScanner.java
@@ -685,13 +685,13 @@ public class TextDependencyScanner {
             if (DependencyText.KEYWORD_PROJECT.equals(t.keyword) &&
                 t.contents.equals(projectName)) {
                 return t;
-            } else if (t.keyword == null && t.getContentsOrGav().equals(gav) && scopeMatches(d, t)) {
+            } else if (t.keyword == null && DependencyText.stripStrict(t.getContentsOrGav()).equals(gav) && scopeMatches(d, t)) {
                 return t;
             }
         }
         
         for (DependencyText t : dependencies) {
-            if (t.keyword == null && t.contents != null && t.contents.equals(groupAndName) && scopeMatches(d, t)) {
+            if (t.keyword == null && t.contents != null && DependencyText.stripStrict(t.contents).equals(groupAndName) && scopeMatches(d, t)) {
                 return t;
             }
         }


### PR DESCRIPTION
This PR adds limited support for constraints in Gradle dependency versions, accepts !! as a `strict` modifier. 
The main part is a change that separates cache for individual projects in a knowledgebase; for multi-module projects, the audit cache was be overwritten with each subsequent audit even though the audit executed for a different submodule.