### PR TITLE
cdnjs: Support handling of resources with embedded slashes afte e6b5e0d

### DIFF
--- a/webcommon/javascript.cdnjs/nbproject/project.properties
+++ b/webcommon/javascript.cdnjs/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=11
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/LibraryCustomizer.java
+++ b/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/LibraryCustomizer.java
@@ -86,7 +86,7 @@ public class LibraryCustomizer implements ProjectCustomizer.CompositeCategoryPro
         return customizer;
     }
 
-    static class StoreListener implements ActionListener, Runnable {
+    private static class StoreListener implements ActionListener, Runnable {
 
         static final Logger LOGGER = Logger.getLogger(StoreListener.class.getName());
 
@@ -418,7 +418,7 @@ public class LibraryCustomizer implements ProjectCustomizer.CompositeCategoryPro
             }
 
             Library.Version versionToStore = newVersion.filterVersion(Collections.emptySet());
-            versionToStore.setFileInfo(fileList.toArray(new String[0]), localFileList.toArray(new String[0]));
+            versionToStore.setFileInfo(fileList.toArray(String[]::new), localFileList.toArray(String[]::new));
             return versionToStore;
         }
 
@@ -437,13 +437,14 @@ public class LibraryCustomizer implements ProjectCustomizer.CompositeCategoryPro
         }
 
         private void removeFile(File file) {
-            while (!webRoot.equals(file)) {
-                File parent = file.getParentFile();
-                if (!file.delete()) {
+            File targetFile = file;
+            while (!webRoot.equals(targetFile)) {
+                File parent = targetFile.getParentFile();
+                if (!targetFile.delete()) {
                     // We have reached a parent directory that is not empty
                     break;
                 }
-                file = parent;
+                targetFile = parent;
             }
         }
 

--- a/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/LibraryCustomizer.java
+++ b/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/LibraryCustomizer.java
@@ -309,10 +309,6 @@ public class LibraryCustomizer implements ProjectCustomizer.CompositeCategoryPro
                                 fileFolder = FileUtil.createFolder(fileFolder, pathElements[j]);
                             }
                             String fileName = pathElements[pathElements.length-1];
-                            int index = fileName.lastIndexOf('.');
-                            if (index != -1) {
-                                fileName = fileName.substring(0,index);
-                            }
                             fob = FileUtil.moveFile(fob, fileFolder, fileName);
                             localFiles[i] = PropertyUtils.relativizeFile(projectDir, FileUtil.toFile(fob));
                             removeFile(file.getParentFile());
@@ -389,10 +385,6 @@ public class LibraryCustomizer implements ProjectCustomizer.CompositeCategoryPro
                         File file = libraryProvider.downloadLibraryFile(newVersion, fileIndex);
                         FileObject tmpFob = FileUtil.toFileObject(file);
                         String fileName = pathElements[pathElements.length-1];
-                        int index = fileName.lastIndexOf('.');
-                        if (index != -1) {
-                            fileName = fileName.substring(0,index);
-                        }
                         FileObject fob = FileUtil.copyFile(tmpFob, fileFolder, fileName);
                         if (!file.delete()) {
                             LOGGER.log(Level.INFO, "Cannot delete file {0}", file);
@@ -478,10 +470,6 @@ public class LibraryCustomizer implements ProjectCustomizer.CompositeCategoryPro
             for (int i=0; i<fileNames.length; i++) {
                 FileObject tmpFob = FileUtil.toFileObject(libraryFiles[i]);
                 String fileName = fileNames[i];
-                int index = fileName.lastIndexOf('.');
-                if (index != -1) {
-                    fileName = fileName.substring(0, index);
-                }
                 String[] path = fileName.split("/"); // NOI18N
                 FileObject fileFolder = libraryFob;
                 for (int j=0; j<path.length-1; j++) {

--- a/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/LibraryProvider.java
+++ b/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/LibraryProvider.java
@@ -243,13 +243,7 @@ public final class LibraryProvider {
         URL urlObject = URI.create(url).toURL();
         URLConnection urlConnection = urlObject.openConnection();
         try (InputStream input = urlConnection.getInputStream()) {
-            int index = fileName.lastIndexOf('.');
-            String prefix = (index == -1) ? fileName : fileName.substring(0,index);
-            if (prefix.length() < 3) {
-                prefix = "tmp" + prefix; // NOI18N
-            }
-            String suffix = (index == -1) ? "" : fileName.substring(index);
-            File file = Files.createTempFile(prefix, suffix).toFile();
+            File file = Files.createTempFile("cdjns-download-", "tmp").toFile();
             try (OutputStream output = new FileOutputStream(file)) {
                 FileUtil.copy(input, output);
                 return file;

--- a/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/LibraryProvider.java
+++ b/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/LibraryProvider.java
@@ -27,7 +27,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
-import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
@@ -240,7 +240,7 @@ public final class LibraryProvider {
         String[] fileNames = version.getFiles();
         String fileName = fileNames[fileIndex];
         String url = MessageFormat.format(LIBRARY_FILE_URL_PATTERN, libraryName, versionName, fileName);
-        URL urlObject = new URL(url);
+        URL urlObject = URI.create(url).toURL();
         URLConnection urlConnection = urlObject.openConnection();
         try (InputStream input = urlConnection.getInputStream()) {
             int index = fileName.lastIndexOf('.');
@@ -269,12 +269,10 @@ public final class LibraryProvider {
     /**
      * Comparator that helps to sort library versions.
      */
-    static final Comparator<Pair<Library.Version, Version>> VERSION_COMPARATOR = new Comparator<Pair<Library.Version, Version>>() {
-        @Override
-        public int compare(Pair<Library.Version, Version> pair1, Pair<Library.Version, Version> pair2) {
-            return Version.Comparator.getInstance(false).compare(pair1.second(), pair2.second());
-        }
-    };
+    static final Comparator<Pair<Library.Version, Version>> VERSION_COMPARATOR = 
+            (Pair<Library.Version, Version> pair1, Pair<Library.Version, Version> pair2) -> {
+                return Version.Comparator.getInstance(false).compare(pair1.second(), pair2.second());
+            };
 
     private static void extractVersionInformation(JSONObject data, Library library) {
         JSONArray versionsData = (JSONArray) data.get(PROPERTY_VERSIONS);
@@ -297,6 +295,7 @@ public final class LibraryProvider {
      * @param versions versions to sort.
      */
     private static void sort(Library.Version[] versions) {
+        @SuppressWarnings({"unchecked", "rawtypes"})
         Pair<Library.Version, Version>[] pairs = new Pair[versions.length];
         for (int i = 0; i < versions.length; i++) {
             Library.Version libraryVersion = versions[i];
@@ -327,14 +326,12 @@ public final class LibraryProvider {
         String[] files = new String[filesData.size()];
         for (int i = 0; i < files.length; i++) {
             Object fileInfo = filesData.get(i);
-            String fileName;
             if (fileInfo instanceof JSONObject) {
                 JSONObject fileData = (JSONObject) fileInfo;
-                fileName = (String) fileData.get(PROPERTY_FILE_NAME);
-            } else {
-                fileName = fileInfo.toString();
+                files[i] = (String) fileData.get(PROPERTY_FILE_NAME);
+            } else if (fileInfo != null) {
+                files[i] = fileInfo.toString();
             }
-            files[i] = fileName;
         }
         version.setFileInfo(files, null);
 
@@ -348,10 +345,11 @@ public final class LibraryProvider {
      *
      * @return content of the given URL.
      */
+    @SuppressWarnings("NestedAssignment")
     static String readUrl(String url) {
         String urlContent = null;
         try {
-            URL urlObject = new URL(url);
+            URL urlObject = URI.create(url).toURL();
             URLConnection urlConnection = urlObject.openConnection();
             StringBuilder content = new StringBuilder();
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(
@@ -362,10 +360,8 @@ public final class LibraryProvider {
                 }
             }
             urlContent = content.toString();
-        } catch (MalformedURLException muex) {
+        } catch (IOException muex) {
             Logger.getLogger(LibraryProvider.class.getName()).log(Level.INFO, null, muex);
-        } catch (IOException ioex) {
-            Logger.getLogger(LibraryProvider.class.getName()).log(Level.INFO, null, ioex);
         }
         return urlContent;
     }


### PR DESCRIPTION
With commit https://github.com/apache/netbeans/commit/e6b5e0d57f0e9deb2ab5f2e36caec3c892fd45ed java.io.File.createTempFile was replaced by
java.nio.file.Files.createTempFile. The latter has better security
properties, but fails to handle prefixes/suffixes, that contain
slashes and instead raises an exception.

The temporary files don't need files, that follow the names of their
base resources, so with this commit the tempfiles are created with
fixed prefixes and suffixes.

Closes: #7783