### PR TITLE
Remove textArea border in MultiLineComboBoxEditor

### DIFF
--- a/platform/api.search/src/org/netbeans/modules/search/BasicSearchForm.java
+++ b/platform/api.search/src/org/netbeans/modules/search/BasicSearchForm.java
@@ -1096,10 +1096,10 @@ final class BasicSearchForm extends JPanel implements ChangeListener,
             area.setLineWrap(false);
 
             Border border = ((JComponent)reference.getEditor().getEditorComponent()).getBorder();
-            if (border == null) {
-                border = reference.getBorder();
+            
+            if (border != null) {
+                area.setBorder(border);
             }
-            area.setBorder(border);
 
             // retain standard focus traversal behavior
             area.setFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERS‌​AL_KEYS, null);


### PR DESCRIPTION
This PR update the UI. by removed textArea border in `MultiLineComboBoxEditor` class
This `MultiLineComboBoxEditor` use in:
- Find in Projects by pressed `Ctrl+F`
- Replace in Projects by pressed `Ctrl+H`

![2024-09-26_152246](https://github.com/user-attachments/assets/10e93599-8b4d-4a71-943e-2fa5c01ee5fc)

### After changed

Preview with flatlaf light laf

![2024-09-26_152149](https://github.com/user-attachments/assets/641374d3-fe18-4091-b77b-9b0ad1b4c43e)

Preview with flatlaf light cupertino (multi line search)

![2024-09-26_152528](https://github.com/user-attachments/assets/2d2db731-9205-4345-90bc-777069e573e2)

Please review, Thank you