### PR TITLE
Warn if JDK appears invalid and offer configuration.

### DIFF
--- a/java/java.lsp.server/vscode/src/jdk/jdk.ts
+++ b/java/java.lsp.server/vscode/src/jdk/jdk.ts
@@ -106,18 +106,23 @@ export async function findAll(knownJavas?: Java[]): Promise<Java[]> {
     for (const javaRoot of javaRoots) {
         const dirents = fs.readdirSync(javaRoot, { withFileTypes: true });
         for (const dirent of dirents) {
-            if (dirent.isDirectory()) {
-                const javaHome = path.join(javaRoot, dirent.name);
-                const java = new Java(javaHome);
-                if (java.isJdk()) {
-                    jdks.push(java);
-                } else if (isMac()) {
-                    const macJavaHome = path.join(javaHome, 'Contents', 'Home');
-                    const macJava = new Java(macJavaHome);
-                    if (macJava.isJdk()) {
-                        jdks.push(macJava);
+            const javaHome = path.join(javaRoot, dirent.name);
+            // statSync returns true even for symlinked dirs
+            try {
+                if (fs.statSync(javaHome).isDirectory()) {
+                    const java = new Java(javaHome);
+                    if (java.isJdk()) {
+                        jdks.push(java);
+                    } else if (isMac()) {
+                        const macJavaHome = path.join(javaHome, 'Contents', 'Home');
+                        const macJava = new Java(macJavaHome);
+                        if (macJava.isJdk()) {
+                            jdks.push(macJava);
+                        }
                     }
                 }
+            } catch (statErr : any) {
+                // just ignore
             }
         }
     }

--- a/java/java.lsp.server/vscode/src/jdk/validation/extensionUtils.ts
+++ b/java/java.lsp.server/vscode/src/jdk/validation/extensionUtils.ts
@@ -18,7 +18,7 @@
  */
 
 import * as vscode from 'vscode';
-import { client as nblsClient } from '../../extension';
+import { client as nblsClient, clientRuntimeJDK} from '../../extension';
 
 const RH_EXTENSION_ID = 'redhat.java';
 
@@ -27,6 +27,12 @@ export function isRHExtensionActive(): boolean {
     return rh ? true : false;
 }
 
+export async function currentClientJDK() : Promise<string | null> {
+    await nblsClient;
+    return clientRuntimeJDK;
+}
+
 export async function waitForNblsCommandToBeAvailable() {
     await nblsClient;
+
 }

--- a/java/java.lsp.server/vscode/src/jdk/validation/validation.ts
+++ b/java/java.lsp.server/vscode/src/jdk/validation/validation.ts
@@ -20,19 +20,20 @@
 import * as vscode from 'vscode';
 import * as jdkUtils from 'jdk-utils';
 
-import { isRHExtensionActive, waitForNblsCommandToBeAvailable } from './extensionUtils';
+import { isRHExtensionActive, waitForNblsCommandToBeAvailable, currentClientJDK } from './extensionUtils';
 import { getJavaVersion } from './javaUtil';
 import { getProjectFrom } from './project';
 
 const CONFIGURE_JDK_COMMAND = 'nbls.jdk.configuration'
 const CONFIGURE_JDK = 'Configure JDK';
 
-export async function validateJDKCompatibility(javaPath: string | null, projectPath: string | null) {
+export async function validateJDKCompatibility(projectPath: string | null) {
     // In this case RH will try it's best to validate Java versions
     if (isRHExtensionActive()) return;
 
     const projectJavaVersion = await getProjectJavaVersion();
-    const ideJavaVersion = await parseJavaVersion(javaPath);
+    // at this point, the NBLS client should be running, so clientRuntimeJDK should be set.
+    const ideJavaVersion = await parseJavaVersion(await currentClientJDK());
     const ideProjectJavaVersion = await parseJavaVersion(projectPath);
 
     let conflictingVersion : number = 0;
@@ -55,7 +56,7 @@ export async function validateJDKCompatibility(javaPath: string | null, projectP
     }
 }
 
-async function parseJavaVersion(javaPath: string | null): Promise<number | undefined> {
+export async function parseJavaVersion(javaPath: string | null): Promise<number | undefined> {
     if (!javaPath) return undefined;
 
     const javaRuntime = await jdkUtils.getRuntime(javaPath, { checkJavac: true });


### PR DESCRIPTION
If the NBLS is about to start with no JDK or JDK that appears invalid (strawman check: `bin/java` and `bin/javac` must be present), the extension displays an error and suggests to run the configuration command (which, in turn, will restart NBLS):
![warning](https://github.com/user-attachments/assets/7a5fca35-65e3-4921-a6fb-0879e0cf5f03)

The list of configured settings now contains note(s) about required JDK version:
![selector](https://github.com/user-attachments/assets/a094a72f-44a9-49a6-bcab-8c29669be288)

+ the JDK selection indicates it has been filtered:
![filtered](https://github.com/user-attachments/assets/c09b62d0-053a-4386-a062-6ac6d0ce035a)

If by a chance, the user picks a Custom JDK which is not compatible, last warning appears:
![incompatible](https://github.com/user-attachments/assets/7b97f4bd-bf89-4ee7-93a4-ed3a18dd4317)
