### PR TITLE
Self sampler for LSP server code completion

### DIFF
--- a/java/java.lsp.server/nbproject/project.xml
+++ b/java/java.lsp.server/nbproject/project.xml
@@ -567,6 +567,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.sampler</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.40</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.sendopts</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -187,6 +187,11 @@
 					"default": 100,
 					"description": "Timeout (in milliseconds) for loading Javadoc in code completion (-1 for unlimited)"
 				},
+				"netbeans.completion.warning.time": {
+					"type": "integer",
+					"default": 10000,
+					"description": "When code completion takes longer than this specified time (in milliseconds), there will be a warning produced (-1 to disable)"
+				},
 				"netbeans.format.codeFormatter": {
 					"type": "string",
 					"enum": [


### PR DESCRIPTION
This attempts to add user-configurable self sample for code completion in the VS Code extension, the sample CC invocations that are too long. If the given time (by default 10s) is elapsed, the snapshot is saved, and a warning is shown to the user.
