### PR TITLE
Attempt to verify that Java exists, and is new enough

### DIFF
--- a/java/java.lsp.server/vscode/src/jdk/settings.ts
+++ b/java/java.lsp.server/vscode/src/jdk/settings.ts
@@ -21,6 +21,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as process from 'process';
 import * as jdk from './jdk';
+import { MINIMAL_JDK_VERSION } from '../extension';
 
 
 export abstract class Setting {
@@ -341,7 +342,7 @@ const NBLS_EXTENSION_ID = 'asf.apache-netbeans-java';
 const NBLS_SETTINGS_NAME = 'Language Server by Apache NetBeans';
 const NBLS_SETTINGS_PROPERTY = 'netbeans.jdkhome';
 function nblsSetting(): Setting {
-    return new JavaSetting(NBLS_SETTINGS_NAME, NBLS_SETTINGS_PROPERTY, 17, true);
+    return new JavaSetting(NBLS_SETTINGS_NAME, NBLS_SETTINGS_PROPERTY, MINIMAL_JDK_VERSION, true);
 }
 
 const NBLS_SETTINGS_PROJECT_NAME = 'Language Server by Apache NetBeans - Java Runtime for Projects';


### PR DESCRIPTION
A hotfix to improve PR #7813 : sadly I forgot that if no JDK is configured or inferred, the NBLS launcher is executed without `--jdkhome` switch and uses the default java, whatever it is.
I included a check that runs `java -version` in that case, and if it reads the version string, checks if it is >= 17.

I've created a constant `MINIMAL_JAVA_VERSION`  that should be used throughout the extension