### PR TITLE
Attempt to repair PartialReparseTest

### DIFF
--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PartialReparseTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PartialReparseTest.java
@@ -91,137 +91,161 @@ public class PartialReparseTest extends NbTestCase {
     }
 
     public void testPartialReparse() throws Exception {
-        doRunTest("package test;\n" +
-                  "public class Test {\n" +
-                  "    private void test() {\n" +
-                  "        System.err.println(1);^^\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      private void test() {
+                          System.err.println(1);^^
+                      }
+                  }
+                  """,
                   "\n        System.err.println(2);");
     }
 
     public void testIntroduceParseError1() throws Exception {
-        doRunTest("package test;\n" +
-                  "public class Test {\n" +
-                  "    private void test() {\n" +
-                  "        System.err.println(1);^^\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      private void test() {
+                          System.err.println(1);^^
+                      }
+                  }
+                  """,
                   "\n        if (");
     }
 
     public void testIntroduceParseError2() throws Exception {
-        doRunTest("package test;\n" +
-                  "public class Test {\n" +
-                  "    private void test() {\n" +
-                  "        System.err.println(1);^^\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      private void test() {
+                          System.err.println(1);^^
+                      }
+                  }
+                  """,
                   "\n        if (tr");
     }
 
     public void testRemoveParseError() throws Exception {
-        doRunTest("package test;\n" +
-                  "public class Test {\n" +
-                  "    private void test() {\n" +
-                  "        System.err.println(1);^\n" +
-                  "        if (^\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      private void test() {
+                          System.err.println(1);^
+                          if (^
+                      }
+                  }
+                  """,
                   "");
     }
 
     public void testResolutionError() throws Exception {
-        doRunTest("package test;\n" +
-                  "public class Test {\n" +
-                  "    private void test() {\n" +
-                  "        System.err.println(1);^^\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      private void test() {
+                          System.err.println(1);^^
+                      }
+                  }
+                  """,
                   "\n        a = 15;");
     }
 
     public void testRemoveResolution() throws Exception {
-        doRunTest("package test;\n" +
-                  "public class Test {\n" +
-                  "    private void test() {\n" +
-                  "        System.err.println(1);^\n" +
-                  "        a = 15;^\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      private void test() {
+                          System.err.println(1);^
+                          a = 15;^
+                      }
+                  }
+                  """,
                   "");
     }
 
     public void testIntroduceSomeNewErrors() throws Exception {
-        doRunTest("package test;\n" +
-                  "public class Test {\n" +
-                  "    private void test() {\n" +
-                  "        System.err.println(1);\n" +
-                  "        if (^^\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      private void test() {
+                          System.err.println(1);
+                          if (^^
+                      }
+                  }
+                  """,
                   "a");
     }
 
     public void testErrorsRemain() throws Exception {
-        doRunTest("package test;\n" +
-                  "public class Test {\n" +
-                  "    private void test() {\n" +
-                  "        System.err.println(1);\n" +
-                  "        ^if (^a\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      private void test() {
+                          System.err.println(1);
+                          ^if (^a
+                      }
+                  }
+                  """,
                   "if (");
     }
 
     public void testFlowErrors1() throws Exception {
-        doRunTest("package test;\n" +
-                  "public class Test {\n" +
-                  "    private void test() {\n" +
-                  "        final int i = 5;\n" +
-                  "        ^^\n" +
-                  "        System.err.println(i);\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      private void test() {
+                          final int i = 5;
+                          ^^
+                          System.err.println(i);
+                      }
+                  }
+                  """,
                   "return ;");
     }
 
     public void testFlowErrors2() throws Exception {
-        doRunTest("package test;\n" +
-                  "public class Test {\n" +
-                  "    private void test() {\n" +
-                  "        final int i = 5;\n" +
-                  "        ^return ;^\n" +
-                  "        System.err.println(i);\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      private void test() {
+                          final int i = 5;
+                          ^return ;^
+                          System.err.println(i);
+                      }
+                  }
+                  """,
                   "");
     }
 
     public void testAnonymous() throws Exception {
-        doRunTest("package test;\n" +
-                  "public class Test {\n" +
-                  "    private void test() {\n" +
-                  "        new Object() {\n" +
-                  "        };" +
-                  "        final int i = 5;\n" +
-                  "        ^^\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      private void test() {
+                          new Object() {
+                          };
+                          final int i = 5;
+                          ^^
+                      }
+                  }
+                  """,
                   "final int j = 5;");
     }
 
     public void testAnonymousName() throws Exception {
-        doRunTest("package test;\n" +
-                  "public class Test {\n" +
-                  "    private Object o = new Object() {};\n" +
-                  "    private void test() {\n" +
-                  "        new Object() {\n" +
-                  "        };" +
-                  "        final int i = 5;\n" +
-                  "        ^^\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      private Object o = new Object() {};
+                      private void test() {
+                          new Object() {
+                          };
+                          final int i = 5;
+                          ^^
+                      }
+                  }
+                  """,
                   "final int j = 5;",
                   info -> {
                       new TreePathScanner<Void, Void>() {
@@ -238,101 +262,119 @@ public class PartialReparseTest extends NbTestCase {
     }
 
     public void testAnonymousFullReparse1() throws Exception {
-        doVerifyFullReparse("package test;\n" +
-                            "public class Test {\n" +
-                            "    private void test() {\n" +
-                            "        ^new Object() {};^\n" +
-                            "        final int i = 5;\n" +
-                            "    }" +
-                            "}",
+        doVerifyFullReparse("""
+                            package test;
+                            public class Test {
+                                private void test() {
+                                    ^new Object() {};^
+                                    final int i = 5;
+                                }
+                            }
+                            """,
                             "");
     }
 
     public void testAnonymousFullReparse2() throws Exception {
-        doVerifyFullReparse("package test;\n" +
-                            "public class Test {\n" +
-                            "    private void test() {\n" +
-                            "        new Object() {};\n" +
-                            "        final int i = 5;\n" +
-                            "        ^^\n" +
-                            "    }" +
-                            "}",
+        doVerifyFullReparse("""
+                            package test;
+                            public class Test {
+                                private void test() {
+                                    new Object() {};
+                                    final int i = 5;
+                                    ^^
+                                }
+                            }
+                            """,
                             "new Object() {};");
     }
 
     public void testDocComments() throws Exception {
-        doRunTest("package test;\n" +
-                  "public class Test {\n" +
-                  "        /**javadoc1*/" +
-                  "    private void test() {\n" +
-                  "        new Object() {" +
-                  "            /**javadoc2*/" +
-                  "            final int i = 5;\n" +
-                  "            ^^\n" +
-                  "       };\n" +
-                  "    }" +
-                  "}",
-                  "        /**javadoc3*/\n" +
-                  "        final int j = 5;\n");
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      /**javadoc1*/
+                      private void test() {
+                          new Object() {
+                              /**javadoc2*/
+                              final int i = 5;
+                              ^^
+                         };
+                      }
+                  }
+                  """, 
+                  """
+                  /**javadoc3*/
+                              final int j = 5;
+                  """);
     }
 
     public void testConstructor1() throws Exception {
-        doRunTest("package test;\n" +
-                  "public class Test {\n" +
-                  "    public Test() {\n" +
-                  "        System.err.println(1);\n" +
-                  "        ^^\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      public Test() {
+                          System.err.println(1);
+                          ^^
+                      }
+                  }
+                  """,
                   "System.err.println(2);");
     }
 
     public void testConstructor2() throws Exception {
-        doRunTest("package test;\n" +
-                  "public class Test {\n" +
-                  "    public Test() {\n" +
-                  "        super();" +
-                  "        System.err.println(1);\n" +
-                  "        ^^\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      public Test() {
+                          super();
+                          System.err.println(1);
+                          ^^
+                      }
+                  }
+                  """,
                   "System.err.println(2);");
     }
 
     public void testConstructorEnum1() throws Exception {
-        doRunTest("package test;\n" +
-                  "public enum Test {\n" +
-                  "    A(1);\n" +
-                  "    public Test(int i) {\n" +
-                  "        System.err.println(i);\n" +
-                  "        ^^\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public enum Test {
+                      A(1);
+                      public Test(int i) {
+                          System.err.println(i);
+                          ^^
+                      }
+                  }
+                  """,
                   "System.err.println(2);");
     }
 
     public void testConstructorEnum2() throws Exception {
-        doRunTest("package test;\n" +
-                  "public enum Test {\n" +
-                  "    A(1);\n" +
-                  "    public Test(int i) {\n" +
-                  "        super();\n" +
-                  "        System.err.println(i);\n" +
-                  "        ^^\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public enum Test {
+                      A(1);
+                      public Test(int i) {
+                          super();
+                          System.err.println(i);
+                          ^^
+                      }
+                  }
+                  """,
                   "System.err.println(2);");
     }
 
     public void testConstructorEnum3() throws Exception {
-        doRunTest("package test;\n" +
-                  "public enum E {\n" +
-                  "    A;\n" +
-                  "    E() {\n" +
-                  "        super();\n" +
-                  "        System.err.println(\"^^\");\n" +
-                  "    }" +
-                  "}",
+        doRunTest("""
+                  package test;
+                  public enum E {
+                      A;
+                      E() {
+                          super();
+                          System.err.println("^^");
+                      }
+                  }
+                  """,
                   "a",
                   info -> {});
     }

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PartialReparseTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PartialReparseTest.java
@@ -71,6 +71,7 @@ public class PartialReparseTest extends NbTestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
+        clearWorkDir();
         SourceUtilsTestUtil.prepareTest(new String[0], new Object[0]);
         // ensure JavaKit is present, so that NbEditorDocument is eventually created.
         // it handles PositionRefs differently than PlainDocument/PlainEditorKit.
@@ -385,8 +386,8 @@ public class PartialReparseTest extends NbTestCase {
 
     private void doRunTest(String code, String inject, Consumer<CompilationInfo> callback) throws Exception {
 
-        FileObject srcDir = FileUtil.createMemoryFileSystem().getRoot();
-        FileObject src = srcDir.createData("Test.java");
+        FileObject srcDir = FileUtil.createFolder(getWorkDir());
+        FileObject src = srcDir.createFolder("test").createData("Test.java");
 
         // parse original source
         String codeInput = code.replace("^", "");
@@ -437,8 +438,8 @@ public class PartialReparseTest extends NbTestCase {
 
     private void doVerifyFullReparse(String code, String inject) throws Exception {
 
-        FileObject srcDir = FileUtil.createMemoryFileSystem().getRoot();
-        FileObject src = srcDir.createData("Test.java");
+        FileObject srcDir = FileUtil.createFolder(getWorkDir());
+        FileObject src = srcDir.createFolder("test").createData("Test.java");
 
         // parse original source
         String codeInput = code.replace("^", "");


### PR DESCRIPTION
`PartialReparseTest` has a fairly high failure rate (a [recent merge](https://github.com/apache/netbeans/actions/runs/11121267403) required 7 restarts).

Investigation showed that it had multiple issues. Fixing those does seem
to improve stability, however, likely does not fix the underlying race condition.
With the changes applied, 1 out of of 50 local runs failed.

But what is more important: the test is hopefully working correctly now

issues fixed:

`code.replaceFirst("^", "")` was used by accident. This method expects
regexps and won't have the desired effect. This essentially means
that the first parsing run had always errors since the test code
contained `^` characters.

The second parsing run, which did replace the injected snippet had
and off-by-one copy/paste mistake in one of the doRun methods.

But since the first run was already wrong, the result of reparse run
didn't really matter since both were compared - that is also why the
missing semicolon wasn't noticed in `testAnonymousFullReparse2()` or
the double escaped newline character in `testAnonymous()`.

More asserts added to exclude potential document update issues.

Enabled a previously disabled test case.

first commit has the fixes, second switches to multi-line-string blocks