### PR TITLE
Maven settings lang level combo should not have fixed width

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/customizer/CompilePanel.form
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/CompilePanel.form
@@ -216,7 +216,7 @@
                   </Group>
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="comSourceLevel" min="-2" pref="72" max="-2" attributes="0"/>
+                      <Component id="comSourceLevel" min="-2" max="-2" attributes="0"/>
                       <Group type="102" alignment="0" attributes="0">
                           <Component id="comJavaPlatform" max="32767" attributes="2"/>
                           <EmptySpace max="-2" attributes="0"/>

--- a/java/maven/src/org/netbeans/modules/maven/customizer/CompilePanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/CompilePanel.java
@@ -484,7 +484,7 @@ public class CompilePanel extends javax.swing.JPanel implements HelpCtx.Provider
                     .addComponent(lblJavaPlatform1))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(jdkPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(comSourceLevel, javax.swing.GroupLayout.PREFERRED_SIZE, 72, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(comSourceLevel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addGroup(jdkPanelLayout.createSequentialGroup()
                         .addComponent(comJavaPlatform, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)


### PR DESCRIPTION
set width to default so that the combo can automatically size itself when custom font sizes are used.

see https://github.com/apache/netbeans/pull/7512#issuecomment-2392277745