### PR TITLE
Fix parsing of JDK 17+ Javadoc of methods without HTML a tags.

### DIFF
--- a/java/java.sourceui/src/org/netbeans/api/java/source/ui/HTMLJavadocParser.java
+++ b/java/java.sourceui/src/org/netbeans/api/java/source/ui/HTMLJavadocParser.java
@@ -401,7 +401,7 @@ class HTMLJavadocParser {
                             String attrId = (String) a.getAttribute(HTML.Attribute.ID);
                             if (names.contains(attrId)) {
                                 // we have found desired javadoc member info anchor
-                                state[0] = A_OPEN;
+                                state[0] = A_CLOSE;
                             }
                         } else {
                             section_counter++;

--- a/java/java.sourceui/test/unit/src/org/netbeans/api/java/source/ui/HTMLJavadocParserTest.java
+++ b/java/java.sourceui/test/unit/src/org/netbeans/api/java/source/ui/HTMLJavadocParserTest.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.api.java.source.ui;
 
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -83,7 +82,12 @@ public class HTMLJavadocParserTest extends TestCase {
     assertTrue(result.contains("This is an example class."));
     assertFalse(result.contains("</section>"));
 
-    URL url = appendFragment(root, "<init>(java.lang.String)");
+    URL url = appendFragment(root, "<init>()");
+    result = HTMLJavadocParser.getJavadocText(url, false);
+    assertTrue(result.contains("This is the default constructor."));
+    assertFalse(result.contains("</section>"));
+
+    url = appendFragment(root, "<init>(java.lang.String)");
     result = HTMLJavadocParser.getJavadocText(url, false);
     assertTrue(result.contains("This is a constructor taking a single String parameter."));
     assertFalse(result.contains("</section>"));


### PR DESCRIPTION
NetBeans didn't show Javadoc descriptions for a lot of OpenJDK (21) methods. This simple patch works for me, but feel free to drop this PR, and fix the bug whatever way you like.
