### PR TITLE
PHP: Fixed incorrect display of skipped tests in the Test Results window for Codeception.

### DIFF
--- a/php/php.codeception/src/org/netbeans/modules/php/codeception/run/CodeceptionLogParser.java
+++ b/php/php.codeception/src/org/netbeans/modules/php/codeception/run/CodeceptionLogParser.java
@@ -40,7 +40,8 @@ public final class CodeceptionLogParser extends DefaultHandler {
     private enum Content {
         NONE,
         ERROR,
-        FAILURE
+        FAILURE,
+        SKIPPED
     };
 
     final XMLReader xmlReader;
@@ -101,6 +102,9 @@ public final class CodeceptionLogParser extends DefaultHandler {
             case "error": // NOI18N
                 startTestError(attributes);
                 break;
+            case "skipped": // NOI18N
+                startTestSkipped(attributes);
+                break;
             default:
                 // noop
         }
@@ -132,6 +136,7 @@ public final class CodeceptionLogParser extends DefaultHandler {
         switch (content) {
             case FAILURE:
             case ERROR:
+            case SKIPPED:
                 buffer.append(new String(ch, start, length));
                 break;
             case NONE:
@@ -187,6 +192,11 @@ public final class CodeceptionLogParser extends DefaultHandler {
 
     private void startTestFailure(Attributes attributes) {
         content = Content.FAILURE;
+    }
+
+    private void startTestSkipped(Attributes attributes) {
+        content = Content.SKIPPED;
+        testCase.setSkippedStatus();
     }
 
     private void endTestContent() {

--- a/php/php.codeception/src/org/netbeans/modules/php/codeception/run/TestCaseVo.java
+++ b/php/php.codeception/src/org/netbeans/modules/php/codeception/run/TestCaseVo.java
@@ -159,6 +159,11 @@ public final class TestCaseVo {
         status = TestCase.Status.FAILED;
     }
 
+    public void setSkippedStatus() {
+        assert status == TestCase.Status.PASSED : "Expected PASSED status but was: " + status; // NOI18N;
+        status = TestCase.Status.SKIPPED;
+    }
+
     public TestCase.Status getStatus() {
         return status;
     }
@@ -169,6 +174,10 @@ public final class TestCaseVo {
 
     public boolean isFailure() {
         return status.equals(TestCase.Status.FAILED);
+    }
+
+    public boolean isSkipped() {
+        return status.equals(TestCase.Status.SKIPPED);
     }
 
     @Override

--- a/php/php.codeception/test/unit/data/codeception-log-skipped-functional-tests.xml
+++ b/php/php.codeception/test/unit/data/codeception-log-skipped-functional-tests.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="functional" tests="6" assertions="7" errors="0" failures="0" skipped="1" useless="0" time="0.190654">
+    <testcase name="openLoginPage" class="LoginFormCest" file="/var/www/new_yyi2/basic/tests/functional/LoginFormCest.php" feature="open login page" time="0.000000" assertions="0">
+      <skipped/>
+    </testcase>
+    <testcase name="internalLoginById" class="LoginFormCest" file="/var/www/new_yyi2/basic/tests/functional/LoginFormCest.php" feature="internal login by id" time="0.084995" assertions="1"/>
+    <testcase name="internalLoginByInstance" class="LoginFormCest" file="/var/www/new_yyi2/basic/tests/functional/LoginFormCest.php" feature="internal login by instance" time="0.020276" assertions="1"/>
+    <testcase name="loginWithEmptyCredentials" class="LoginFormCest" file="/var/www/new_yyi2/basic/tests/functional/LoginFormCest.php" feature="login with empty credentials" time="0.035114" assertions="2"/>
+    <testcase name="loginWithWrongCredentials" class="LoginFormCest" file="/var/www/new_yyi2/basic/tests/functional/LoginFormCest.php" feature="login with wrong credentials" time="0.026634" assertions="1"/>
+    <testcase name="loginSuccessfully" class="LoginFormCest" file="/var/www/new_yyi2/basic/tests/functional/LoginFormCest.php" feature="login successfully" time="0.023634" assertions="2"/>
+  </testsuite>
+</testsuites>

--- a/php/php.codeception/test/unit/data/codeception-log-skipped-unit-tests.xml
+++ b/php/php.codeception/test/unit/data/codeception-log-skipped-unit-tests.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="unit" tests="13" assertions="74" errors="0" failures="0" skipped="1" useless="0" time="0.043183">
+    <testcase name="testSingleErrorMessage" class="tests\unit\widgets\AlertTest" file="/var/www/new_yyi2/basic/tests/unit/widgets/AlertTest.php" time="0.022930" assertions="5"/>
+    <testcase name="testMultipleErrorMessages" class="tests\unit\widgets\AlertTest" file="/var/www/new_yyi2/basic/tests/unit/widgets/AlertTest.php" time="0.001102" assertions="0">
+      <skipped/>
+    </testcase>
+    <testcase name="testSingleDangerMessage" class="tests\unit\widgets\AlertTest" file="/var/www/new_yyi2/basic/tests/unit/widgets/AlertTest.php" time="0.001268" assertions="5"/>
+    <testcase name="testMultipleDangerMessages" class="tests\unit\widgets\AlertTest" file="/var/www/new_yyi2/basic/tests/unit/widgets/AlertTest.php" time="0.001294" assertions="6"/>
+    <testcase name="testSingleSuccessMessage" class="tests\unit\widgets\AlertTest" file="/var/www/new_yyi2/basic/tests/unit/widgets/AlertTest.php" time="0.001147" assertions="5"/>
+    <testcase name="testMultipleSuccessMessages" class="tests\unit\widgets\AlertTest" file="/var/www/new_yyi2/basic/tests/unit/widgets/AlertTest.php" time="0.001416" assertions="6"/>
+    <testcase name="testSingleInfoMessage" class="tests\unit\widgets\AlertTest" file="/var/www/new_yyi2/basic/tests/unit/widgets/AlertTest.php" time="0.002299" assertions="5"/>
+    <testcase name="testMultipleInfoMessages" class="tests\unit\widgets\AlertTest" file="/var/www/new_yyi2/basic/tests/unit/widgets/AlertTest.php" time="0.002400" assertions="6"/>
+    <testcase name="testSingleWarningMessage" class="tests\unit\widgets\AlertTest" file="/var/www/new_yyi2/basic/tests/unit/widgets/AlertTest.php" time="0.001816" assertions="5"/>
+    <testcase name="testMultipleWarningMessages" class="tests\unit\widgets\AlertTest" file="/var/www/new_yyi2/basic/tests/unit/widgets/AlertTest.php" time="0.001602" assertions="6"/>
+    <testcase name="testSingleMixedMessages" class="tests\unit\widgets\AlertTest" file="/var/www/new_yyi2/basic/tests/unit/widgets/AlertTest.php" time="0.001809" assertions="9"/>
+    <testcase name="testMultipleMixedMessages" class="tests\unit\widgets\AlertTest" file="/var/www/new_yyi2/basic/tests/unit/widgets/AlertTest.php" time="0.002266" assertions="14"/>
+    <testcase name="testFlashIntegrity" class="tests\unit\widgets\AlertTest" file="/var/www/new_yyi2/basic/tests/unit/widgets/AlertTest.php" time="0.001833" assertions="2"/>
+  </testsuite>
+</testsuites>

--- a/php/php.codeception/test/unit/src/org/netbeans/modules/php/codeception/run/CodeceptionLogParserTest.java
+++ b/php/php.codeception/test/unit/src/org/netbeans/modules/php/codeception/run/CodeceptionLogParserTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.Reader;
+import java.util.Arrays;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.php.spi.testing.run.TestCase;
 
@@ -214,6 +215,48 @@ public class CodeceptionLogParserTest extends NbTestCase {
         assertEquals(TestCase.Status.FAILED, testCase.getStatus());
         assertEquals(1, testCase.getStackTrace().length);
         assertEquals("Trying to configure method \"getBarAAA\" which cannot be configured because it does not exist, has not been specified, is final, or is static", testCase.getStackTrace()[0]);
+    }
+
+    public void testParseLogSkippedUnitTests() throws Exception {
+        Reader reader = createReader("codeception-log-skipped-unit-tests.xml");
+        TestSessionVo testSession = new TestSessionVo();
+
+        CodeceptionLogParser.parse(reader, testSession);
+        assertEquals(43, testSession.getTime());
+        assertEquals(13, testSession.getTests());
+
+        assertEquals(1, testSession.getTestSuites().size());
+
+        TestSuiteVo testSuite = testSession.getTestSuites().get(0);
+        assertEquals("unit", testSuite.getName());
+        assertEquals(null, testSuite.getLocation());
+        assertEquals(43, testSuite.getTime());
+        assertEquals(13, testSuite.getTestCases().size());
+
+        TestCaseVo testCase = testSuite.getTestCases().get(1);
+        assertTrue(testCase.isSkipped());
+        assertTrue(Arrays.asList(testCase.getStackTrace()).isEmpty());
+    }
+
+    public void testParseLogSkippedFunctionalTests() throws Exception {
+        Reader reader = createReader("codeception-log-skipped-functional-tests.xml");
+        TestSessionVo testSession = new TestSessionVo();
+
+        CodeceptionLogParser.parse(reader, testSession);
+        assertEquals(191, testSession.getTime());
+        assertEquals(6, testSession.getTests());
+
+        assertEquals(1, testSession.getTestSuites().size());
+
+        TestSuiteVo testSuite = testSession.getTestSuites().get(0);
+        assertEquals("functional", testSuite.getName());
+        assertEquals(null, testSuite.getLocation());
+        assertEquals(191, testSuite.getTime());
+        assertEquals(6, testSuite.getTestCases().size());
+
+        TestCaseVo testCase = testSuite.getTestCases().get(0);
+        assertTrue(testCase.isSkipped());
+        assertTrue(Arrays.asList(testCase.getStackTrace()).isEmpty());
     }
 
     private Reader createReader(String filename) throws FileNotFoundException {


### PR DESCRIPTION
The testing was done using [yii2 basic](https://www.yiiframework.com/doc/guide/2.0/en/start-installation) as an example.
The tests need to be changed so that there is at least one skippable test.
<details>
  <summary>unit tests: basic/tests/unit/widgets/AlertTest.php</summary>

```php
<?php

namespace tests\unit\widgets;

use app\widgets\Alert;
use Codeception\Test\Unit;
use Yii;

class AlertTest extends Unit
{
    public function testSingleErrorMessage()
    {
        $message = 'This is an error message';

        Yii::$app->session->setFlash('error', $message);

        $renderingResult = Alert::widget();

        verify($renderingResult)->stringContainsString($message);
        verify($renderingResult)->stringContainsString('alert-danger');

        verify($renderingResult)->stringNotContainsString('alert-success');
        verify($renderingResult)->stringNotContainsString('alert-info');
        verify($renderingResult)->stringNotContainsString('alert-warning');
    }


    public function testMultipleErrorMessages()
    {
        self::markTestSkipped('Manually skipped');
        $firstMessage = 'This is the first error message';
        $secondMessage = 'This is the second error message';

        Yii::$app->session->setFlash('error', [$firstMessage, $secondMessage]);

        $renderingResult = Alert::widget();

        verify($renderingResult)->stringContainsString($firstMessage);
        verify($renderingResult)->stringContainsString($secondMessage);
        verify($renderingResult)->stringContainsString('alert-danger');

        verify($renderingResult)->stringNotContainsString('alert-success');
        verify($renderingResult)->stringNotContainsString('alert-info');
        verify($renderingResult)->stringNotContainsString('alert-warning');
    }

    public function testSingleDangerMessage()
    {
        $message = 'This is a danger message';

        Yii::$app->session->setFlash('danger', $message);

        $renderingResult = Alert::widget();

        verify($renderingResult)->stringContainsString($message);
        verify($renderingResult)->stringContainsString('alert-danger');

        verify($renderingResult)->stringNotContainsString('alert-success');
        verify($renderingResult)->stringNotContainsString('alert-info');
        verify($renderingResult)->stringNotContainsString('alert-warning');
    }

    public function testMultipleDangerMessages()
    {
        $firstMessage = 'This is the first danger message';
        $secondMessage = 'This is the second danger message';

        Yii::$app->session->setFlash('danger', [$firstMessage, $secondMessage]);

        $renderingResult = Alert::widget();

        verify($renderingResult)->stringContainsString($firstMessage);
        verify($renderingResult)->stringContainsString($secondMessage);
        verify($renderingResult)->stringContainsString('alert-danger');

        verify($renderingResult)->stringNotContainsString('alert-success');
        verify($renderingResult)->stringNotContainsString('alert-info');
        verify($renderingResult)->stringNotContainsString('alert-warning');
    }

    public function testSingleSuccessMessage()
    {
        $message = 'This is a success message';

        Yii::$app->session->setFlash('success', $message);

        $renderingResult = Alert::widget();

        verify($renderingResult)->stringContainsString($message);
        verify($renderingResult)->stringContainsString('alert-success');

        verify($renderingResult)->stringNotContainsString('alert-danger');
        verify($renderingResult)->stringNotContainsString('alert-info');
        verify($renderingResult)->stringNotContainsString('alert-warning');
    }

    public function testMultipleSuccessMessages()
    {
        $firstMessage = 'This is the first danger message';
        $secondMessage = 'This is the second danger message';

        Yii::$app->session->setFlash('success', [$firstMessage, $secondMessage]);

        $renderingResult = Alert::widget();

        verify($renderingResult)->stringContainsString($firstMessage);
        verify($renderingResult)->stringContainsString($secondMessage);
        verify($renderingResult)->stringContainsString('alert-success');

        verify($renderingResult)->stringNotContainsString('alert-danger');
        verify($renderingResult)->stringNotContainsString('alert-info');
        verify($renderingResult)->stringNotContainsString('alert-warning');
    }

    public function testSingleInfoMessage()
    {
        $message = 'This is an info message';

        Yii::$app->session->setFlash('info', $message);

        $renderingResult = Alert::widget();

        verify($renderingResult)->stringContainsString($message);
        verify($renderingResult)->stringContainsString('alert-info');

        verify($renderingResult)->stringNotContainsString('alert-danger');
        verify($renderingResult)->stringNotContainsString('alert-success');
        verify($renderingResult)->stringNotContainsString('alert-warning');
    }

    public function testMultipleInfoMessages()
    {
        $firstMessage = 'This is the first info message';
        $secondMessage = 'This is the second info message';

        Yii::$app->session->setFlash('info', [$firstMessage, $secondMessage]);

        $renderingResult = Alert::widget();

        verify($renderingResult)->stringContainsString($firstMessage);
        verify($renderingResult)->stringContainsString($secondMessage);
        verify($renderingResult)->stringContainsString('alert-info');

        verify($renderingResult)->stringNotContainsString('alert-danger');
        verify($renderingResult)->stringNotContainsString('alert-success');
        verify($renderingResult)->stringNotContainsString('alert-warning');
    }

    public function testSingleWarningMessage()
    {
        $message = 'This is a warning message';

        Yii::$app->session->setFlash('warning', $message);

        $renderingResult = Alert::widget();

        verify($renderingResult)->stringContainsString($message);
        verify($renderingResult)->stringContainsString('alert-warning');

        verify($renderingResult)->stringNotContainsString('alert-danger');
        verify($renderingResult)->stringNotContainsString('alert-success');
        verify($renderingResult)->stringNotContainsString('alert-info');
    }

    public function testMultipleWarningMessages()
    {
        $firstMessage = 'This is the first warning message';
        $secondMessage = 'This is the second warning message';

        Yii::$app->session->setFlash('warning', [$firstMessage, $secondMessage]);

        $renderingResult = Alert::widget();

        verify($renderingResult)->stringContainsString($firstMessage);
        verify($renderingResult)->stringContainsString($secondMessage);
        verify($renderingResult)->stringContainsString('alert-warning');

        verify($renderingResult)->stringNotContainsString('alert-danger');
        verify($renderingResult)->stringNotContainsString('alert-success');
        verify($renderingResult)->stringNotContainsString('alert-info');
    }

    public function testSingleMixedMessages() {
        $errorMessage = 'This is an error message';
        $dangerMessage = 'This is a danger message';
        $successMessage = 'This is a success message';
        $infoMessage = 'This is a info message';
        $warningMessage = 'This is a warning message';

        Yii::$app->session->setFlash('error', $errorMessage);
        Yii::$app->session->setFlash('danger', $dangerMessage);
        Yii::$app->session->setFlash('success', $successMessage);
        Yii::$app->session->setFlash('info', $infoMessage);
        Yii::$app->session->setFlash('warning', $warningMessage);

        $renderingResult = Alert::widget();

        verify($renderingResult)->stringContainsString($errorMessage);
        verify($renderingResult)->stringContainsString($dangerMessage);
        verify($renderingResult)->stringContainsString($successMessage);
        verify($renderingResult)->stringContainsString($infoMessage);
        verify($renderingResult)->stringContainsString($warningMessage);

        verify($renderingResult)->stringContainsString('alert-danger');
        verify($renderingResult)->stringContainsString('alert-success');
        verify($renderingResult)->stringContainsString('alert-info');
        verify($renderingResult)->stringContainsString('alert-warning');
    }

    public function testMultipleMixedMessages() {
        $firstErrorMessage = 'This is the first error message';
        $secondErrorMessage = 'This is the second error message';
        $firstDangerMessage = 'This is the first danger message';
        $secondDangerMessage = 'This is the second';
        $firstSuccessMessage = 'This is the first success message';
        $secondSuccessMessage = 'This is the second success message';
        $firstInfoMessage = 'This is the first info message';
        $secondInfoMessage = 'This is the second info message';
        $firstWarningMessage = 'This is the first warning message';
        $secondWarningMessage = 'This is the second warning message';

        Yii::$app->session->setFlash('error', [$firstErrorMessage, $secondErrorMessage]);
        Yii::$app->session->setFlash('danger', [$firstDangerMessage, $secondDangerMessage]);
        Yii::$app->session->setFlash('success', [$firstSuccessMessage, $secondSuccessMessage]);
        Yii::$app->session->setFlash('info', [$firstInfoMessage, $secondInfoMessage]);
        Yii::$app->session->setFlash('warning', [$firstWarningMessage, $secondWarningMessage]);

        $renderingResult = Alert::widget();

        verify($renderingResult)->stringContainsString($firstErrorMessage);
        verify($renderingResult)->stringContainsString($secondErrorMessage);
        verify($renderingResult)->stringContainsString($firstDangerMessage);
        verify($renderingResult)->stringContainsString($secondDangerMessage);
        verify($renderingResult)->stringContainsString($firstSuccessMessage);
        verify($renderingResult)->stringContainsString($secondSuccessMessage);
        verify($renderingResult)->stringContainsString($firstInfoMessage);
        verify($renderingResult)->stringContainsString($secondInfoMessage);
        verify($renderingResult)->stringContainsString($firstWarningMessage);
        verify($renderingResult)->stringContainsString($secondWarningMessage);

        verify($renderingResult)->stringContainsString('alert-danger');
        verify($renderingResult)->stringContainsString('alert-success');
        verify($renderingResult)->stringContainsString('alert-info');
        verify($renderingResult)->stringContainsString('alert-warning');
    }

    public function testFlashIntegrity()
    {
        $errorMessage = 'This is an error message';
        $unrelatedMessage = 'This is a message that is not related to the alert widget';

        Yii::$app->session->setFlash('error', $errorMessage);
        Yii::$app->session->setFlash('unrelated', $unrelatedMessage);

        Alert::widget();

        // Simulate redirect
        Yii::$app->session->close();
        Yii::$app->session->open();

        verify(Yii::$app->session->getFlash('error'))->empty();
        verify(Yii::$app->session->getFlash('unrelated'))->equals($unrelatedMessage);
    }
}
```
</details>

before:
![skipped_unit_test_before](https://github.com/user-attachments/assets/3a5af241-caa5-4b02-a219-6bd7901ed90e)

after:
![skipped_unit_test_after](https://github.com/user-attachments/assets/3c2dbb81-2858-489c-ba0a-195421be8065)

<details>
  <summary>functional tests: basic/tests/functional/LoginFormCest.php</summary>

```php
<?php

use app\models\User;
use Codeception\Attribute\Skip;

class LoginFormCest
{
    public function _before(FunctionalTester $I)
    {
        $I->amOnRoute('site/login');
    }


    #[Skip]
    public function openLoginPage(FunctionalTester $I, $scenario)
    {
        $scenario->skip('your message');
        $I->see('Login', 'h1');

    }

    // demonstrates `amLoggedInAs` method
    public function internalLoginById(FunctionalTester $I)
    {
        $I->amLoggedInAs(100);
        $I->amOnPage('/');
        $I->see('Logout (admin)');
    }

    // demonstrates `amLoggedInAs` method
    public function internalLoginByInstance(FunctionalTester $I)
    {
        $I->amLoggedInAs(User::findByUsername('admin'));
        $I->amOnPage('/');
        $I->see('Logout (admin)');
    }

    public function loginWithEmptyCredentials(FunctionalTester $I)
    {
        $I->submitForm('#login-form', []);
        $I->expectTo('see validations errors');
        $I->see('Username cannot be blank.');
        $I->see('Password cannot be blank.');
    }

    public function loginWithWrongCredentials(FunctionalTester $I)
    {
        $I->submitForm('#login-form', [
            'LoginForm[username]' => 'admin',
            'LoginForm[password]' => 'wrong',
        ]);
        $I->expectTo('see validations errors');
        $I->see('Incorrect username or password.');
    }

    public function loginSuccessfully(FunctionalTester $I)
    {
        $I->submitForm('#login-form', [
            'LoginForm[username]' => 'admin',
            'LoginForm[password]' => 'admin',
        ]);
        $I->see('Logout (admin)');
        $I->dontSeeElement('form#login-form');              
    }
}
```

</details>

before:
![skipped_functional_test_before](https://github.com/user-attachments/assets/97703327-a480-459a-bf5f-f245a546ce3a)

after:
![skipped_functional_test_after](https://github.com/user-attachments/assets/af7fca91-8c70-4cc9-8275-8aa49134af6e)

