### PR TITLE
pom dependency update hint could also check annotation processors

### DIFF
--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/UpdateDependencyHint.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/UpdateDependencyHint.java
@@ -41,13 +41,13 @@ import org.netbeans.modules.maven.model.pom.DependencyManagement;
 import org.netbeans.modules.maven.model.pom.POMComponent;
 import org.netbeans.modules.maven.model.pom.POMExtensibilityElement;
 import org.netbeans.modules.maven.model.pom.POMModel;
+import org.netbeans.modules.maven.model.pom.POMQName;
 import org.netbeans.modules.maven.model.pom.Plugin;
 import org.netbeans.modules.maven.model.pom.PluginManagement;
 import org.netbeans.modules.maven.model.pom.Profile;
 import org.netbeans.modules.maven.model.pom.Properties;
 import org.netbeans.modules.maven.model.pom.ReportPlugin;
 import org.netbeans.modules.maven.model.pom.Reporting;
-import org.netbeans.modules.maven.model.pom.VersionablePOMComponent;
 import org.netbeans.spi.editor.hints.ChangeInfo;
 import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.editor.hints.ErrorDescriptionFactory;
@@ -132,61 +132,56 @@ public class UpdateDependencyHint implements POMErrorFixProvider {
         }
     }
 
-    private void addHintsTo(List<? extends VersionablePOMComponent> components, Map<POMComponent, ErrorDescription> hints) {
+    // components typically implement VersionablePOMComponent, exceptions would be annotation processor lists
+    private void addHintsTo(List<? extends POMComponent> components, Map<POMComponent, ErrorDescription> hints) {
 
-        for (VersionablePOMComponent comp : components) {
+        for (POMComponent comp : components) {
 
-            String groupId = comp.getGroupId() != null && !comp.getGroupId().isBlank() ? comp.getGroupId() : null;
-            String artifactId = comp.getArtifactId() != null && !comp.getArtifactId().isBlank() ? comp.getArtifactId() : null;
+            String groupId = getTextOrNull(comp, comp.getModel().getPOMQNames().GROUPID);
+            String artifactId = getTextOrNull(comp, comp.getModel().getPOMQNames().ARTIFACTID);
+            String version = getTextOrNull(comp, comp.getModel().getPOMQNames().VERSION);
 
             // no group ID could indicate it is a default maven plugin
             if (groupId == null && (comp instanceof Plugin || comp instanceof ReportPlugin)) {
                 groupId = Constants.GROUP_APACHE_PLUGINS;
             }
 
-            if (artifactId != null && groupId != null && comp.getVersion() != null) {
+            // plugin/configuration/annotationProcessorPaths/*/gav
+            if (Constants.GROUP_APACHE_PLUGINS.equals(groupId) && Constants.PLUGIN_COMPILER.equals(artifactId)
+                    && comp instanceof Plugin plugin && plugin.getConfiguration() != null
+                    && PomModelUtils.getFirstChild(plugin.getConfiguration(), "annotationProcessorPaths") instanceof POMExtensibilityElement procs) {
+                addHintsTo(procs.getExtensibilityElements(), hints);
+            }
 
-                class HintCandidate { // can be record
-                    final String version;
-                    final POMExtensibilityElement component;
-                    HintCandidate(String version, POMExtensibilityElement component) {
-                       this.version = version;
-                       this.component = component;
-                    }
-                }
+            if (artifactId != null && groupId != null && version != null) {
+
+                record HintCandidate(String version, POMExtensibilityElement component) {}
 
                 List<HintCandidate> candidates = List.of();
 
-                if (PomModelUtils.isPropertyExpression(comp.getVersion())) {
+                if (PomModelUtils.isPropertyExpression(version)) {
                     // properties can be set in profiles and the properties section
                     // this collects all candidates which might need an annotation, versions are checked later
                     candidates = new ArrayList<>();
-                    String propName = PomModelUtils.getPropertyName(comp.getVersion());
+                    String propName = PomModelUtils.getPropertyName(version);
                     Properties props = comp.getModel().getProject().getProperties();
-                    if (props != null) {
-                        POMComponent c = PomModelUtils.getFirstChild(props, propName);
-                        if (c instanceof POMExtensibilityElement) {
-                            candidates.add(new HintCandidate(props.getProperty(propName), (POMExtensibilityElement) c));
-                        }
+                    if (props != null && PomModelUtils.getFirstChild(props, propName) instanceof POMExtensibilityElement e) {
+                        candidates.add(new HintCandidate(props.getProperty(propName), e));
                     }
                     // check profile properties for candidates
                     List<Profile> profiles = comp.getModel().getProject().getProfiles();
                     if (profiles != null) {
                         for (Profile profile : profiles) {
                             Properties profProps = profile.getProperties();
-                            if (profProps != null) {
-                                POMComponent c = PomModelUtils.getFirstChild(profProps, propName);
-                                if (c instanceof POMExtensibilityElement) {
-                                    candidates.add(new HintCandidate(profProps.getProperty(propName), (POMExtensibilityElement) c));
-                                }
+                            if (profProps != null && PomModelUtils.getFirstChild(profProps, propName) instanceof POMExtensibilityElement e) {
+                                candidates.add(new HintCandidate(profProps.getProperty(propName), e));
                             }
                         }
                     }
                 } else {
-                    // simple case, were the version is directly set where the artifact is declared
-                    POMComponent c = PomModelUtils.getFirstChild(comp, "version");
-                    if (c instanceof POMExtensibilityElement) {
-                        candidates = List.of(new HintCandidate(comp.getVersion(), (POMExtensibilityElement) c));
+                    // simple case - version is directly set where the artifact is declared
+                    if (PomModelUtils.getFirstChild(comp, "version") instanceof POMExtensibilityElement e) {
+                        candidates = List.of(new HintCandidate(version, e));
                     }
                 }
 
@@ -222,6 +217,11 @@ public class UpdateDependencyHint implements POMErrorFixProvider {
         }
     }
 
+    private static String getTextOrNull(POMComponent comp, POMQName name) {
+        String text = comp.getChildElementText(name.getQName());
+        return text != null && !text.isBlank() ? text : null;
+    }
+
     private static boolean isNumerical(String v) {
         for (char c : v.toCharArray()) {
             if (!(Character.isDigit(c) || c == '.')) {
@@ -231,7 +231,7 @@ public class UpdateDependencyHint implements POMErrorFixProvider {
         return true;
     }
 
-    private boolean noTimestamp(String v) {
+    private static boolean noTimestamp(String v) {
         char[] chars = v.toCharArray();
         for (int i = 0; i < chars.length; i++) {
             if (!(Character.isDigit(chars[i]))) {
@@ -242,7 +242,7 @@ public class UpdateDependencyHint implements POMErrorFixProvider {
     }
 
     // example: in '3.14' -> out '3.'
-    private String getMajorComponentPrefix(String v) {
+    private static String getMajorComponentPrefix(String v) {
         int dot = v.indexOf('.');
         if (dot > 0) {
             String major = v.substring(0, dot+1);

--- a/java/maven.model/nbproject/project.xml
+++ b/java/maven.model/nbproject/project.xml
@@ -225,7 +225,6 @@
                 <friend>org.netbeans.modules.maven.persistence</friend>
                 <friend>org.netbeans.modules.maven.refactoring</friend>
                 <friend>org.netbeans.modules.maven.repository</friend>
-                <friend>org.netbeans.modules.maven.refactoring</friend>
                 <friend>org.netbeans.modules.selenium.maven</friend>
                 <friend>org.netbeans.modules.selenium2.maven</friend>
                 <friend>org.netbeans.modules.testng.maven</friend>


### PR DESCRIPTION
java/maven.hints

 - this will show dep update hints for annotation processors declared in `plugin/configuration/annotationProcessorPaths/*`
 - had to update the implementation slightly since the list items didn't implement `VersionablePOMComponent`
 - auto completion is not implemented for this path

java/maven.model

 - removed duplicated friend declaration

example:
```xml
    <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-compiler-plugin</artifactId>
        <version>3.13.0</version>
        <configuration>
            <compilerArgs>
                <arg>-Xlint</arg>
            </compilerArgs>
            <annotationProcessorPaths>
                <path>
                    <groupId>org.hibernate.orm</groupId>
                    <artifactId>hibernate-jpamodelgen</artifactId>
                    <version>6.6.0.Final</version>  <!--  hint should appear if a newer version is known -->
                </path>
            </annotationProcessorPaths>
        </configuration>
    </plugin>
```