### PR TITLE
Gradle options lang level text field should not have fixed width

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/customizer/SourceSetPanel.form
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/customizer/SourceSetPanel.form
@@ -60,7 +60,7 @@
                       <EmptySpace max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Group type="102" attributes="0">
-                              <Component id="tfSourceLevel" min="-2" pref="39" max="-2" attributes="0"/>
+                              <Component id="tfSourceLevel" min="-2" max="-2" attributes="0"/>
                               <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                           </Group>
                           <Component id="jtPlatform" max="32767" attributes="0"/>

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/customizer/SourceSetPanel.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/customizer/SourceSetPanel.java
@@ -269,7 +269,7 @@ public class SourceSetPanel extends javax.swing.JPanel {
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addGroup(layout.createSequentialGroup()
-                                .addComponent(tfSourceLevel, javax.swing.GroupLayout.PREFERRED_SIZE, 39, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addComponent(tfSourceLevel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                                 .addGap(0, 0, Short.MAX_VALUE))
                             .addComponent(jtPlatform))))
                 .addContainerGap())


### PR DESCRIPTION
set width to default so that the combo can automatically size itself as needed. (analog to https://github.com/apache/netbeans/pull/7830)

fixes #7409