### PR TITLE
Primitive wrapper property editors should use valueOf

### DIFF
--- a/platform/o.n.core/src/org/netbeans/beaninfo/editors/BooleanEditor.java
+++ b/platform/o.n.core/src/org/netbeans/beaninfo/editors/BooleanEditor.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.beaninfo.editors;
 
-import java.beans.*;
 
 /**
  * Editor for property of type java.lang.Boolean
@@ -29,9 +28,10 @@ import java.beans.*;
 public class BooleanEditor extends WrappersEditor {
 
     public BooleanEditor() {
-        super(java.lang.Boolean.TYPE);
+        super(Boolean.TYPE);
     }
 
+    @Override
     public String getJavaInitializationString() {
         Boolean val = (Boolean) getValue();
         return Boolean.TRUE.equals(val) ? "java.lang.Boolean.TRUE" :

--- a/platform/o.n.core/src/org/netbeans/beaninfo/editors/ByteEditor.java
+++ b/platform/o.n.core/src/org/netbeans/beaninfo/editors/ByteEditor.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.beaninfo.editors;
 
-import java.beans.*;
 
 /**
  * Editor for property of type java.lang.Byte
@@ -29,12 +28,8 @@ import java.beans.*;
 public class ByteEditor extends WrappersEditor {
 
     public ByteEditor() {
-        super(java.lang.Byte.TYPE);
+        super(Byte.TYPE);
     }
-
-
-    //----------------------------------------------------------------------
-
 
     /**
      * This method is intended for use when generating Java code to set
@@ -47,8 +42,9 @@ public class ByteEditor extends WrappersEditor {
      * @return A fragment of Java code representing an initializer for the
      *   	current value.
      */
+    @Override
     public String getJavaInitializationString() {
-	return "new java.lang.Byte((byte)" + getAsText() + ")"; // NOI18N
+	return "Byte.valueOf((byte)" + getAsText() + ")"; // NOI18N
     }
 
 }

--- a/platform/o.n.core/src/org/netbeans/beaninfo/editors/CharacterEditor.java
+++ b/platform/o.n.core/src/org/netbeans/beaninfo/editors/CharacterEditor.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.beaninfo.editors;
 
-import java.beans.*;
 
 /**
  * Editor for property of type java.lang.Character
@@ -29,12 +28,8 @@ import java.beans.*;
 public class CharacterEditor extends WrappersEditor {
 
     public CharacterEditor() {
-        super(java.lang.Character.TYPE);
+        super(Character.TYPE);
     }
-
-
-    //----------------------------------------------------------------------
-
 
     /**
      * This method is intended for use when generating Java code to set
@@ -47,11 +42,12 @@ public class CharacterEditor extends WrappersEditor {
      * @return A fragment of Java code representing an initializer for the
      *   	current value.
      */
+    @Override
     public String getJavaInitializationString() {
-        if ( ((Character)getValue()).charValue() == '\'' )
-            return "new java.lang.Character('\\'')";                 // NOI18N
+        if ((Character)getValue() == '\'')
+            return "Character.valueOf('\\'')";                 // NOI18N
         else
-            return "new java.lang.Character('" + getAsText() + "')"; // NOI18N
+            return "Character.valueOf('" + getAsText() + "')"; // NOI18N
     }
 
 }

--- a/platform/o.n.core/src/org/netbeans/beaninfo/editors/DoubleEditor.java
+++ b/platform/o.n.core/src/org/netbeans/beaninfo/editors/DoubleEditor.java
@@ -19,8 +19,6 @@
 
 package org.netbeans.beaninfo.editors;
 
-import java.beans.*;
-
 /**
  * Editor for property of type java.lang.Double
  *
@@ -29,12 +27,8 @@ import java.beans.*;
 public class DoubleEditor extends WrappersEditor {
 
     public DoubleEditor() {
-        super(java.lang.Double.TYPE);
+        super(Double.TYPE);
     }
-
-
-    //----------------------------------------------------------------------
-
 
     /**
      * This method is intended for use when generating Java code to set
@@ -47,8 +41,9 @@ public class DoubleEditor extends WrappersEditor {
      * @return A fragment of Java code representing an initializer for the
      *   	current value.
      */
+    @Override
     public String getJavaInitializationString() {
-	return "new java.lang.Double(" + getAsText() + ")"; // NOI18N
+	return "Double.valueOf(" + getAsText() + "D)"; // NOI18N
     }
 
 }

--- a/platform/o.n.core/src/org/netbeans/beaninfo/editors/FloatEditor.java
+++ b/platform/o.n.core/src/org/netbeans/beaninfo/editors/FloatEditor.java
@@ -19,8 +19,6 @@
 
 package org.netbeans.beaninfo.editors;
 
-import java.beans.*;
-
 /**
  * Editor for property of type java.lang.Float
  *
@@ -29,12 +27,8 @@ import java.beans.*;
 public class FloatEditor extends WrappersEditor {
 
     public FloatEditor() {
-        super(java.lang.Float.TYPE);
+        super(Float.TYPE);
     }
-
-
-    //----------------------------------------------------------------------
-
 
     /**
      * This method is intended for use when generating Java code to set
@@ -47,8 +41,9 @@ public class FloatEditor extends WrappersEditor {
      * @return A fragment of Java code representing an initializer for the
      *   	current value.
      */
+    @Override
     public String getJavaInitializationString() {
-	return "new java.lang.Float(" + getAsText() + "F)"; // NOI18N
+	return "Float.valueOf(" + getAsText() + "F)"; // NOI18N
     }
 
 }

--- a/platform/o.n.core/src/org/netbeans/beaninfo/editors/IntegerEditor.java
+++ b/platform/o.n.core/src/org/netbeans/beaninfo/editors/IntegerEditor.java
@@ -19,9 +19,6 @@
 
 package org.netbeans.beaninfo.editors;
 
-import java.beans.*;
-import org.openide.explorer.propertysheet.PropertyEnv;
-import org.openide.explorer.propertysheet.ExPropertyEditor;
 
 /**
  * Editor for property of type java.lang.Integer
@@ -31,13 +28,15 @@ import org.openide.explorer.propertysheet.ExPropertyEditor;
 public class IntegerEditor extends WrappersEditor {
 
     public IntegerEditor() {
-        super(java.lang.Integer.TYPE);
+        super(Integer.TYPE);
     }
 
+    @Override
     public String getJavaInitializationString() {
-    	return "new java.lang.Integer(" + pe.getJavaInitializationString() + ")"; // NOI18N
+    	return "Integer.valueOf(" + pe.getJavaInitializationString() + ")"; // NOI18N
     }
 
+    @Override
     public void setAsText(String text) throws IllegalArgumentException {
         super.setAsText (text.trim());
     }    

--- a/platform/o.n.core/src/org/netbeans/beaninfo/editors/LongEditor.java
+++ b/platform/o.n.core/src/org/netbeans/beaninfo/editors/LongEditor.java
@@ -19,8 +19,6 @@
 
 package org.netbeans.beaninfo.editors;
 
-import java.beans.*;
-
 /**
  * Editor for property of type java.lang.Long
  *
@@ -29,11 +27,12 @@ import java.beans.*;
 public class LongEditor extends WrappersEditor {
 
     public LongEditor() {
-        super(java.lang.Long.TYPE);
+        super(Long.TYPE);
     }
 
+    @Override
     public String getJavaInitializationString() {
-	return "new java.lang.Long(" + getAsText() + "L)"; // NOI18N
+	return "Long.valueOf(" + getAsText() + "L)"; // NOI18N
     }
 
 }

--- a/platform/o.n.core/src/org/netbeans/beaninfo/editors/ShortEditor.java
+++ b/platform/o.n.core/src/org/netbeans/beaninfo/editors/ShortEditor.java
@@ -19,8 +19,6 @@
 
 package org.netbeans.beaninfo.editors;
 
-import java.beans.*;
-
 /**
  * Editor for property of type java.lang.Short
  *
@@ -29,12 +27,8 @@ import java.beans.*;
 public class ShortEditor extends WrappersEditor {
 
     public ShortEditor() {
-        super(java.lang.Short.TYPE);
+        super(Short.TYPE);
     }
-
-
-    //----------------------------------------------------------------------
-
 
     /**
      * This method is intended for use when generating Java code to set
@@ -47,8 +41,9 @@ public class ShortEditor extends WrappersEditor {
      * @return A fragment of Java code representing an initializer for the
      *   	current value.
      */
+    @Override
     public String getJavaInitializationString() {
-	return "new java.lang.Short((short)" + getAsText() + ")"; // NOI18N
+	return "Short.valueOf((short)" + getAsText() + ")"; // NOI18N
     }
 
 }

--- a/platform/o.n.core/src/org/netbeans/beaninfo/editors/WrappersEditor.java
+++ b/platform/o.n.core/src/org/netbeans/beaninfo/editors/WrappersEditor.java
@@ -19,7 +19,9 @@
 
 package org.netbeans.beaninfo.editors;
 
-import java.beans.*;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyEditor;
+import java.beans.PropertyEditorManager;
 import java.text.MessageFormat;
 import org.netbeans.core.UIExceptions;
 import org.openide.explorer.propertysheet.ExPropertyEditor;
@@ -41,31 +43,39 @@ public abstract class WrappersEditor implements ExPropertyEditor {
         pe = PropertyEditorManager.findEditor(type);
     }
     
+    @Override
     public void setValue(Object newValue) throws IllegalArgumentException {
         pe.setValue(newValue);
     }
     
+    @Override
     public Object getValue() {
 	return pe.getValue();
     }        
     
+    @Override
     public boolean isPaintable() {
 	return pe.isPaintable();
     }
 
+    @Override
     public void paintValue(java.awt.Graphics gfx, java.awt.Rectangle box) {
         pe.paintValue(gfx, box);
     }        
     
+    @Override
     public String getAsText () {
         if ( pe.getValue() == null )
             return "null";              // NOI18N
         return pe.getAsText();
     }
 
+    @Override
     public void setAsText(String text) throws IllegalArgumentException {
-        if ( "null".equals( text ) )    // NOI18N
+        if ( "null".equals( text ) ) {    // NOI18N
+            pe.setValue(null);
             return;
+        }
         try {
             pe.setAsText(text);
         } catch (Exception e) {
@@ -83,26 +93,32 @@ public abstract class WrappersEditor implements ExPropertyEditor {
         }
     }
     
+    @Override
     public String[] getTags() {
 	return pe.getTags();
     }
     
+    @Override
     public java.awt.Component getCustomEditor() {
 	return pe.getCustomEditor();
     }
 
+    @Override
     public boolean supportsCustomEditor() {
 	return pe.supportsCustomEditor();
     }
   
+    @Override
     public synchronized void addPropertyChangeListener(PropertyChangeListener listener) {
         pe.addPropertyChangeListener(listener);
     }
 
+    @Override
     public synchronized void removePropertyChangeListener(PropertyChangeListener listener) {
         pe.removePropertyChangeListener(listener);
     }    
     
+    @Override
     public void attachEnv(PropertyEnv env) {
         //Delegate if the primitive editor is an ExPropertyEditor -
         //boolean and int editors will be


### PR DESCRIPTION
 - the wrapper class constructors are all deprecated for removal -> lets use `valueOf`
 - this will also allow setting wrapper properties to null. The only exception is Character, since CharEditor (for primitives) maps null to a char before it is passed to the CharacterEditor which never sees null.
 - affects code generation in GUI forms

fixes https://github.com/apache/netbeans/issues/7049

test:
1) 
```java
public class TextField extends JTextField {
    
    private Long valLong = 123L;
    private Double valDouble = 123.0;
    private Float valFloat = 123.0f;
    private Integer valInteger = 123;
    private Character valCharacter = 'a';
    private Short valShort = 123;
    private Byte valByte = 123;
    private Boolean valBoolean = true;
    
    private long primLong = 123;
    private int primInt = 123;
    
    // generate getter/setters
}
```
2) create JPanel form and drag TextField into form via design view.
3) click on the component in design view, edit the properties via Properties window, check generated code which should now look like:
```java
        textField1.setText("textField1");
        textField1.setValBoolean(java.lang.Boolean.FALSE);
        textField1.setValByte(Byte.valueOf((byte)111));
        textField1.setValCharacter(Character.valueOf('b'));
        textField1.setValDouble(Double.valueOf(111.0D));
        textField1.setValFloat(Float.valueOf(111.0F));
        textField1.setValInteger(Integer.valueOf(111));
        textField1.setValLong(Long.valueOf(111L));
        textField1.setValShort(Short.valueOf((short)111));
```