### PR TITLE
Use OCI profile based on an item

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/CloudChildFactory.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/CloudChildFactory.java
@@ -43,7 +43,7 @@ public class CloudChildFactory extends ChildFactory<OCIItem> {
     }
 
     public CloudChildFactory(OCIItem parent) {
-        this(OCIManager.getDefault().getActiveSession(), parent);
+        this(OCIManager.getDefault().getActiveProfile(parent), parent);
     }
 
     @Override

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/NodeProvider.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/NodeProvider.java
@@ -35,10 +35,13 @@ public interface NodeProvider<T extends OCIItem> {
     }
     
     public interface SessionAware<T extends OCIItem> extends NodeProvider<T> {
+        
+        @Override
         public default Node apply(T t) {
-            return apply(t, OCIManager.getDefault().getActiveSession());
+            return apply(t, OCIManager.getDefault().getActiveProfile(t));
         }
 
+        @Override
         public Node apply(T t, OCISessionInitiator session);
     }
 }

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCIChildFactory.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCIChildFactory.java
@@ -39,7 +39,7 @@ public class OCIChildFactory extends ChildFactory<OCIItem> {
     
     public OCIChildFactory(OCIItem parent) {
         this.parent = parent;
-        this.session = OCIManager.getDefault().getActiveSession();
+        this.session = OCIManager.getDefault().getActiveProfile(parent);
     }
 
     public OCIChildFactory(OCIItem parent, OCISessionInitiator session) {

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCIManager.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCIManager.java
@@ -49,6 +49,7 @@ import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
 import org.netbeans.api.server.properties.InstanceProperties;
 import org.netbeans.api.server.properties.InstancePropertiesManager;
+import org.netbeans.modules.cloud.oracle.compartment.CompartmentItem;
 import org.netbeans.modules.cloud.oracle.items.TenancyItem;
 import org.openide.filesystems.FileChangeAdapter;
 import org.openide.filesystems.FileChangeListener;
@@ -622,8 +623,8 @@ public final class OCIManager {
      * @param password Password of ADMIN user
      * @return true if DB was created
      */
-    public Optional<String> createAutonomousDatabase(String compartmentId, String dbName, char[] password) {
-        return getActiveProfile().createAutonomousDatabase(compartmentId, dbName, password);
+    public Optional<String> createAutonomousDatabase(CompartmentItem compartment, String dbName, char[] password) {
+        return getActiveProfile(compartment).createAutonomousDatabase(compartment, dbName, password);
     }
 
     /**
@@ -638,7 +639,7 @@ public final class OCIManager {
      * @throws IOException
      */
     public Path downloadWallet(OCIItem dbInstance, String password, String parentPath) throws FileNotFoundException, IOException {
-        return getActiveProfile().downloadWallet(dbInstance, password, parentPath);
+        return getActiveProfile(dbInstance).downloadWallet(dbInstance, password, parentPath);
     }
     
     @FunctionalInterface

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCINode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCINode.java
@@ -46,7 +46,7 @@ public class OCINode extends AbstractNode {
     private final OCISessionInitiator session;
 
     public OCINode(OCIItem item) {
-        this(new CloudChildFactory(item), item, OCIManager.getDefault().getActiveSession(), Lookups.fixed(item));
+        this(new CloudChildFactory(item), item, OCIManager.getDefault().getActiveProfile(item), Lookups.fixed(item));
     }
     
     public OCINode(OCIItem item, OCISessionInitiator session) {
@@ -64,11 +64,11 @@ public class OCINode extends AbstractNode {
     }
     
     public OCINode(OCIItem item, Children children) {
-        super(children, Lookups.fixed(item, OCIManager.getDefault().getActiveSession()));
+        super(children, Lookups.fixed(item, OCIManager.getDefault().getActiveProfile(item)));
         setName(item.getName());
         this.item = item;
         this.factory = null;
-        this.session = OCIManager.getDefault().getActiveSession();
+        this.session = OCIManager.getDefault().getActiveProfile(item);
         refreshListener = new RefreshListener();
         item.addChangeListener(refreshListener);
     }

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCIProfile.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/OCIProfile.java
@@ -48,6 +48,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import org.netbeans.modules.cloud.oracle.compartment.CompartmentItem;
 import org.netbeans.modules.cloud.oracle.items.OCID;
 import org.netbeans.modules.cloud.oracle.items.OCIItem;
 import org.netbeans.modules.cloud.oracle.items.TenancyItem;
@@ -279,12 +280,15 @@ public final class OCIProfile implements OCISessionInitiator {
      * @param password Password of ADMIN user
      * @return true if DB was created
      */
-    public Optional<String> createAutonomousDatabase(String compartmentId, String dbName, char[] password) {
+    public Optional<String> createAutonomousDatabase(CompartmentItem compartment, String dbName, char[] password) {
         if (configProvider == null) {
             return Optional.empty();
         }
         try (final DatabaseClient client = new DatabaseClient(configProvider)) {
-            CreateAutonomousDatabaseBase createAutonomousDatabaseBase = CreateAutonomousDatabaseDetails.builder().compartmentId(compartmentId).dbName(dbName).adminPassword(new String(password)).cpuCoreCount(1).dataStorageSizeInTBs(1).build();
+            CreateAutonomousDatabaseBase createAutonomousDatabaseBase 
+                    = CreateAutonomousDatabaseDetails.builder().compartmentId(
+                            compartment.getKey().getValue()).dbName(dbName).adminPassword(
+                                    new String(password)).cpuCoreCount(1).dataStorageSizeInTBs(1).build();
             CreateAutonomousDatabaseRequest createAutonomousDatabaseRequest = CreateAutonomousDatabaseRequest.builder().createAutonomousDatabaseDetails(createAutonomousDatabaseBase).build();
             try {
                 CreateAutonomousDatabaseResponse response = client.createAutonomousDatabase(createAutonomousDatabaseRequest);
@@ -320,6 +324,5 @@ public final class OCIProfile implements OCISessionInitiator {
         }
         return Objects.equals(this.configPath, other.configPath);
     }
-    
     
 }

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/TenancyNode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/TenancyNode.java
@@ -59,7 +59,7 @@ public class TenancyNode extends OCINode implements PropertyChangeListener {
     })
     @Override
     public String getHtmlDisplayName() {
-        if (OCIManager.getDefault().getActiveProfile() == session) {
+        if (OCIManager.getDefault().getActiveProfile(getItem()) == session) {
             return Bundle.HTML_EmphasizeName(getDisplayName());
         } else {
             return null;

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/ConfigMapUploader.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/ConfigMapUploader.java
@@ -167,7 +167,7 @@ public class ConfigMapUploader {
 
     private static boolean updateConfigMap(ProgressHandle h, DevopsProjectItem devopsProject, PropertiesGenerator propGen) {
         // Add Vault to the ConfigMap artifact
-        DevopsClient devopsClient = DevopsClient.builder().build(OCIManager.getDefault().getActiveProfile().getConfigProvider());
+        DevopsClient devopsClient = DevopsClient.builder().build(OCIManager.getDefault().getActiveProfile(devopsProject).getConfigProvider());
         ListDeployArtifactsRequest request = ListDeployArtifactsRequest.builder()
                 .projectId(devopsProject.getKey().getValue()).build();
         ListDeployArtifactsResponse response = devopsClient.listDeployArtifacts(request);
@@ -202,7 +202,7 @@ public class ConfigMapUploader {
 
     private static void updateVault(ProgressHandle h, KeyItem key, VaultItem vault, PropertiesGenerator propGen, Project project) {
         h.progress(Bundle.UpdatingVault(vault.getName()));
-        VaultsClient client = VaultsClient.builder().build(getDefault().getActiveProfile().getConfigProvider());
+        VaultsClient client = VaultsClient.builder().build(getDefault().getActiveProfile(vault).getConfigProvider());
         ListSecretsRequest listSecretsRequest = ListSecretsRequest.builder()
                 .compartmentId(vault.getCompartmentId())
                 .vaultId(vault.getKey().getValue())

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/CreateAutonomousDBAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/CreateAutonomousDBAction.java
@@ -67,7 +67,7 @@ public class CreateAutonomousDBAction extends AbstractAction implements ContextA
 
     public CreateAutonomousDBAction(CompartmentItem context) {
         this.context = context;
-        this.session = OCIManager.getDefault().getActiveProfile();
+        this.session = OCIManager.getDefault().getActiveProfile(context);
     }
 
     CreateAutonomousDBAction(OCIProfile session, CompartmentItem context) {
@@ -86,7 +86,7 @@ public class CreateAutonomousDBAction extends AbstractAction implements ContextA
         Optional<Pair<String, char[]>> result = CreateAutonomousDBDialog.showDialog(context);
         result.ifPresent((p) -> {
             RequestProcessor.getDefault().execute(() -> {
-                Optional<String> message = session.createAutonomousDatabase(context.getKey().getValue(), p.first(), p.second());
+                Optional<String> message = session.createAutonomousDatabase(context, p.first(), p.second());
                 if (!message.isPresent()) {
                     context.refresh();
                     DialogDisplayer.getDefault().notifyLater(

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/CreateContainerRepository.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/CreateContainerRepository.java
@@ -51,9 +51,9 @@ public class CreateContainerRepository implements OCIItemCreator {
 
     @Override
     public CompletableFuture<? extends OCIItem> create(Steps.Values values, Map<String, Object> params) {
-        String compartmentId = ((CompartmentItem)values.getValueForStep(CompartmentStep.class)).getKey().getValue();
+        CompartmentItem compartment = ((CompartmentItem)values.getValueForStep(CompartmentStep.class));
         String displayName = (String) params.get(REPOSITORY_NAME_FIELD);
-        OCIItemCreationDetails creationDetails = new ContainerRepositoryRequest(compartmentId, displayName);
+        OCIItemCreationDetails creationDetails = new ContainerRepositoryRequest(compartment, displayName);
         return new org.netbeans.modules.cloud.oracle.actions.CreateContainerRepositoryCommand().create(creationDetails);
     }
    

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/CreateContainerRepositoryCommand.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/CreateContainerRepositoryCommand.java
@@ -22,6 +22,7 @@ import com.oracle.bmc.artifacts.ArtifactsClient;
 import com.oracle.bmc.artifacts.model.ContainerRepository;
 import com.oracle.bmc.artifacts.requests.CreateContainerRepositoryRequest;
 import com.oracle.bmc.artifacts.responses.CreateContainerRepositoryResponse;
+import org.netbeans.modules.cloud.oracle.OCIManager;
 import org.netbeans.modules.cloud.oracle.developer.ContainerRepositoryItem;
 import org.netbeans.modules.cloud.oracle.items.OCID;
 import org.netbeans.modules.cloud.oracle.requests.OCIItemCreationDetails;
@@ -34,23 +35,21 @@ public class CreateContainerRepositoryCommand extends CreateResourceCommand<Cont
     
     @Override
     ContainerRepositoryItem callCreate(OCIItemCreationDetails itemCreator) {
-        ArtifactsClient client = this.getProfile().newClient(ArtifactsClient.class);
+        ArtifactsClient client = OCIManager.getDefault().getActiveProfile(itemCreator.getCompartment()).newClient(ArtifactsClient.class);
         
         CreateContainerRepositoryRequest request = (CreateContainerRepositoryRequest) itemCreator.getRequest();
         CreateContainerRepositoryResponse response = client.createContainerRepository(request);
         ContainerRepository res = response.getContainerRepository();
 
-        String tenancyId = this.getProfile().getTenancy().isPresent() ? this.getProfile().getTenancy().get().getKey().getValue() : null;
-
         return new ContainerRepositoryItem(
                 OCID.of(res.getId(), "ContainerRepository"), //NOI18N
                 res.getCompartmentId(),
                 res.getDisplayName(),
-                this.getProfile().getRegion().getRegionCode(),
+                itemCreator.getCompartment().getRegionCode(),
                 res.getNamespace(),
                 res.getIsPublic(), 
                 res.getImageCount(),
-                tenancyId
+                itemCreator.getCompartment().getTenancyId()
         );
     }
     

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/CreateResourceCommand.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/CreateResourceCommand.java
@@ -19,8 +19,6 @@
 package org.netbeans.modules.cloud.oracle.actions;
 
 import java.util.concurrent.CompletableFuture;
-import org.netbeans.modules.cloud.oracle.OCIManager;
-import org.netbeans.modules.cloud.oracle.OCISessionInitiator;
 import org.netbeans.modules.cloud.oracle.items.OCIItem;
 import org.netbeans.modules.cloud.oracle.requests.OCIItemCreationDetails;
 
@@ -30,16 +28,9 @@ import org.netbeans.modules.cloud.oracle.requests.OCIItemCreationDetails;
  */
 public abstract class CreateResourceCommand<T extends OCIItem> {
     
-    private final OCISessionInitiator profile;
-    
     public CreateResourceCommand() {
-        this.profile = OCIManager.getDefault().getActiveProfile();
     }
 
-    public OCISessionInitiator getProfile() {
-        return profile;
-    }
-    
     abstract T callCreate(OCIItemCreationDetails itemCreator);
     
     public CompletableFuture<T> create(OCIItemCreationDetails creationDetails) {

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/actions/DownloadWalletAction.java
@@ -90,7 +90,7 @@ public class DownloadWalletAction extends AbstractAction implements ContextAware
 
     public DownloadWalletAction(DatabaseItem context) {
         this.context = context;
-        this.session = OCIManager.getDefault().getActiveProfile();
+        this.session = OCIManager.getDefault().getActiveProfile(context);
     }
 
     DownloadWalletAction(OCIProfile session, DatabaseItem context) {

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/AuditOptions.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/AuditOptions.java
@@ -80,10 +80,6 @@ public final class AuditOptions {
         return this;
     }
 
-    public OCISessionInitiator getSession() {
-        return session != null ? session : OCIManager.getDefault().getActiveSession();
-    }
-
     /**
      * @return true, if data structure should be returned instead of just error/OK
      */

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/CreateKnowledgeBaseAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/CreateKnowledgeBaseAction.java
@@ -85,7 +85,7 @@ public class CreateKnowledgeBaseAction implements ActionListener {
                 progressHandle.start();
                 
                 try (ApplicationDependencyManagementClient client
-                        = new ApplicationDependencyManagementClient(OCIManager.getDefault().getConfigProvider())) {
+                        = new ApplicationDependencyManagementClient(OCIManager.getDefault().getActiveProfile(context).getConfigProvider())) {
 
                     CreateKnowledgeBaseDetails params = CreateKnowledgeBaseDetails.builder()
                             .compartmentId(context.getKey().getValue())

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/ProjectVulnerability.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/ProjectVulnerability.java
@@ -224,7 +224,7 @@ public final class ProjectVulnerability {
         AuxiliaryProperties props = project.getLookup().lookup(AuxiliaryProperties.class);
         if (props != null) {
             OCID kbOcid = item.getKey();
-            OCIProfile profile = OCIManager.getDefault().getActiveProfile();
+            OCIProfile profile = OCIManager.getDefault().getActiveProfile(item);
             props.put(PROJECT_PROPERTY_KB_OCID, kbOcid.toPersistentForm(), false);
             props.put(PROJECT_PROPERTY_PROFILE_ID, profile.getId(), false);
             props.put(PROJECT_PROPERTY_PROFILE_PATH, profile.getConfigPath().toString(), false);
@@ -234,7 +234,7 @@ public final class ProjectVulnerability {
     
     private KnowledgeBaseItem setProjectKnowledgeBase0(KnowledgeBaseItem item) {
         synchronized (this) {
-            lastProfile = OCIManager.getDefault().getActiveProfile();
+            lastProfile = OCIManager.getDefault().getActiveProfile(item);
             return knowledgeBaseItem = item;
         }
     }

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/RunFileADMAction.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/RunFileADMAction.java
@@ -20,7 +20,6 @@ package org.netbeans.modules.cloud.oracle.adm;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.Optional;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectUtils;
@@ -81,8 +80,7 @@ public class RunFileADMAction implements ActionListener{
                 ErrorUtils.processError(exc, Bundle.MSG_CreatingAuditFailed(projectDisplayName));
             }
         } else {
-            if (OCIManager.getDefault().getActiveSession()== null
-                    || OCIManager.getDefault().getTenancy().equals(Optional.empty())) {
+            if (OCIManager.getDefault().getActiveProfile(kbItem) == null) {
                 DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(Bundle.MSG_ProjectAuditInfo()));
             } else {
                 DialogDisplayer.getDefault().notifyLater(new NotifyDescriptor.Message(Bundle.MSG_ProjectAuditNoKB(projectDisplayName)));

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
@@ -703,7 +703,7 @@ public class VulnerabilityWorker implements ErrorProvider{
             auditOptions.setAuditName(projectDisplayName);
         }
         try {
-            return doFindVulnerability(project, kbItem.getCompartmentId(), kbItem.getKey().getValue(), 
+            return doFindVulnerability(project, kbItem, 
                     projectDisplayName, auditOptions, progressHandle, remoteCall);
         } finally {
             if (remoteCall.get()) {
@@ -722,7 +722,7 @@ public class VulnerabilityWorker implements ErrorProvider{
         }
     }
 
-    private AuditResult doFindVulnerability(Project project, String compartmentId, String knowledgeBaseId, String projectDisplayName, AuditOptions auditOptions,
+    private AuditResult doFindVulnerability(Project project, KnowledgeBaseItem knowledgeBase, String projectDisplayName, AuditOptions auditOptions,
             ProgressHandle progressHandle, AtomicBoolean remoteCall) throws AuditException {
         List<ApplicationDependency> result = new ArrayList<>();
         
@@ -736,7 +736,7 @@ public class VulnerabilityWorker implements ErrorProvider{
         if (!auditOptions.isForceAuditExecution()) {
             if (!auditOptions.isDisableCache()) {
                 try {
-                    savedAudit = AuditCache.getInstance().loadAudit(project, knowledgeBaseId);
+                    savedAudit = AuditCache.getInstance().loadAudit(project, knowledgeBase.getKey().getValue());
                 } catch (IOException ex) {
                     LOG.log(Level.WARNING, "Could not load cached audit data", ex); 
                 }
@@ -747,11 +747,11 @@ public class VulnerabilityWorker implements ErrorProvider{
                 progressHandle.start();
                 progressHandle.progress(Bundle.MSG_SearchingAuditReport());
                 try (ApplicationDependencyManagementClient admClient
-                        = new ApplicationDependencyManagementClient(OCIManager.getDefault().getConfigProvider())) {
+                        = new ApplicationDependencyManagementClient(OCIManager.getDefault().getActiveProfile(knowledgeBase).getConfigProvider())) {
                     ListVulnerabilityAuditsRequest request = ListVulnerabilityAuditsRequest
                             .builder()
-                            .compartmentId(compartmentId)
-                            .knowledgeBaseId(knowledgeBaseId)
+                            .compartmentId(knowledgeBase.getCompartmentId())
+                            .knowledgeBaseId(knowledgeBase.getKey().getValue())
                             .lifecycleState(LifecycleState.Active)
                             .sortBy(ListVulnerabilityAuditsRequest.SortBy.TimeCreated)
                             .limit(200)
@@ -782,7 +782,7 @@ public class VulnerabilityWorker implements ErrorProvider{
                     }
                 } catch (BmcException ex) {
                     LOG.log(Level.FINE, "Unable to list newest audit for knowledgebase {0}, compartment {1}", new Object[] {
-                        knowledgeBaseId, compartmentId
+                        knowledgeBase.getKey().getValue(), knowledgeBase.getCompartmentId()
                     });
                 }
             }
@@ -798,7 +798,7 @@ public class VulnerabilityWorker implements ErrorProvider{
                 convert(dr.getRoot(), new HashMap<>(), result);
             }
             try (ApplicationDependencyManagementClient admClient
-                    = new ApplicationDependencyManagementClient(OCIManager.getDefault().getConfigProvider())) {
+                    = new ApplicationDependencyManagementClient(OCIManager.getDefault().getActiveProfile(knowledgeBase).getConfigProvider())) {
                 final VulnerabilityAuditConfiguration auditConfiguration = VulnerabilityAuditConfiguration
                         .builder()
                         .maxPermissibleCvssV2Score(1f)
@@ -807,8 +807,8 @@ public class VulnerabilityWorker implements ErrorProvider{
                         .build();
                 final CreateVulnerabilityAuditDetails auditDetails = CreateVulnerabilityAuditDetails
                         .builder()
-                        .compartmentId(compartmentId)
-                        .knowledgeBaseId(knowledgeBaseId)
+                        .compartmentId(knowledgeBase.getCompartmentId())
+                        .knowledgeBaseId(knowledgeBase.getKey().getValue())
                         .displayName(auditOptions.getAuditName().replaceAll("[^A-Za-z0-9-_]", "_")) // remove offending characters
                         .buildType(VulnerabilityAudit.BuildType.Maven)
                         .configuration(auditConfiguration)

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/assets/ImageBuilderCommand.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/assets/ImageBuilderCommand.java
@@ -227,7 +227,7 @@ public class ImageBuilderCommand implements CommandProvider {
 
     private boolean dockerLogin(ContainerRepositoryItem repo) {
         try {
-            String path = (String) BearerTokenCommand.generateBearerToken(OCIManager.getDefault().getActiveProfile(), repo.getRegistry());
+            String path = (String) BearerTokenCommand.generateBearerToken(OCIManager.getDefault().getActiveProfile(repo), repo.getRegistry());
             String[] command;
             if (BaseUtilities.isWindows()) {
                 command = new String[]{"cmd.exe", "/c",

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/compute/ComputeInstanceNode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/compute/ComputeInstanceNode.java
@@ -74,7 +74,7 @@ public class ComputeInstanceNode extends OCINode {
     
     static public void update(ComputeInstanceItem instance) {
         ComputeClient computeClient = ComputeClient.builder()
-                .build(OCIManager.getDefault().getActiveProfile().getAuthenticationProvider());
+                .build(OCIManager.getDefault().getActiveProfile(instance).getAuthenticationProvider());
         if (instance.getImageId() != null) {
             GetImageRequest request = GetImageRequest.builder()
                     .imageId(instance.getImageId()).build();
@@ -96,7 +96,7 @@ public class ComputeInstanceNode extends OCINode {
         }
          
         VirtualNetworkClient virtualNetworkClient = VirtualNetworkClient.builder()
-                .build(OCIManager.getDefault().getActiveProfile().getAuthenticationProvider());
+                .build(OCIManager.getDefault().getActiveProfile(instance).getAuthenticationProvider());
 
         ListVnicAttachmentsRequest listVnicAttachmentsRequest = ListVnicAttachmentsRequest.builder()
                 .compartmentId(instance.getCompartmentId())

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/developer/ContainerRepositoryNode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/developer/ContainerRepositoryNode.java
@@ -58,7 +58,7 @@ public class ContainerRepositoryNode extends OCINode {
     @Override
     public void update(OCIItem item) {
         ContainerRepositoryItem orig = (ContainerRepositoryItem) item;
-        ArtifactsClient client = OCIManager.getDefault().getActiveProfile().newClient(ArtifactsClient.class);
+        ArtifactsClient client = OCIManager.getDefault().getActiveProfile(item).newClient(ArtifactsClient.class);
         GetContainerRepositoryRequest listContainerRepositoriesRequest = GetContainerRepositoryRequest.builder()
                 .repositoryId(item.getKey().getValue())
                 .build();

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/developer/ContainerTagNode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/developer/ContainerTagNode.java
@@ -90,7 +90,7 @@ public class ContainerTagNode extends OCINode {
             if (!confirmAction(Bundle.MSG_ConfirmDeleteAction(this.getName()))) {
                 return;
             }
-            ArtifactsClient client = OCIManager.getDefault().getActiveSession().newClient(ArtifactsClient.class);
+            ArtifactsClient client = OCIManager.getDefault().getActiveProfile(getItem()).newClient(ArtifactsClient.class);
             DeleteContainerImageRequest request = DeleteContainerImageRequest.builder()
                     .imageId(this.getItem().getKey().getValue())
                     .build();

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/devops/BuildRunNode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/devops/BuildRunNode.java
@@ -76,7 +76,7 @@ public class BuildRunNode extends OCINode {
     
     public static ChildrenProvider.SessionAware<BuildRunFolderItem, BuildRunItem> expandBuildRuns() {
         return (project, session) -> {
-            try ( DevopsClient client = new DevopsClient(OCIManager.getDefault().getConfigProvider())) {
+            try ( DevopsClient client = session.newClient(DevopsClient.class)) {
                 ListBuildRunsRequest request = ListBuildRunsRequest.builder()
                         .projectId(project.getKey().getValue())
                         .sortBy(ListBuildRunsRequest.SortBy.TimeCreated)

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/devops/DeployArtifactNode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/devops/DeployArtifactNode.java
@@ -55,7 +55,7 @@ public class DeployArtifactNode extends OCINode {
 
     public static ChildrenProvider.SessionAware<DevopsProjectItem, DeployArtifactItem.DeployArtifactFolder> listDeployArtifacts() {
         return (project, session) -> {
-            try ( DevopsClient client = new DevopsClient(OCIManager.getDefault().getConfigProvider())) {
+            try ( DevopsClient client = session.newClient(DevopsClient.class)) {
                 ListDeployArtifactsRequest request = ListDeployArtifactsRequest.builder()
                         .projectId(project.getKey().getValue()).build();
                 ListDeployArtifactsResponse response = client.listDeployArtifacts(request);

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/devops/DevopsProjectNode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/devops/DevopsProjectNode.java
@@ -56,9 +56,7 @@ public class DevopsProjectNode extends OCINode {
    
     public static ChildrenProvider.SessionAware<CompartmentItem, DevopsProjectItem> listDevopsProjects() {
         return (compartmentId, session) -> {
-            try (
-                DevopsClient client = new DevopsClient(OCIManager.getDefault().getConfigProvider());
-            ) {
+            try ( DevopsClient client = session.newClient(DevopsClient.class)) {
                 ListProjectsRequest request = ListProjectsRequest.builder().compartmentId(compartmentId.getKey().getValue()).build();
                 ListProjectsResponse response = client.listProjects(request);
 

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/devops/RepositoryNode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/devops/RepositoryNode.java
@@ -56,7 +56,7 @@ public class RepositoryNode extends OCINode {
 
     public static ChildrenProvider.SessionAware<DevopsProjectItem, RepositoryFolder> listRepositories() {
         return (project, session) -> {
-            try ( DevopsClient client = new DevopsClient(OCIManager.getDefault().getConfigProvider())) {
+            try ( DevopsClient client = session.newClient(DevopsClient.class)) {
                 ListRepositoriesRequest listRepositoriesRequest = ListRepositoriesRequest.builder()
                         .projectId(project.getKey().getValue()).build();
                 ListRepositoriesResponse response = client.listRepositories(listRepositoriesRequest);

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/policy/PolicyGenerator.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/policy/PolicyGenerator.java
@@ -45,7 +45,6 @@ public class PolicyGenerator {
                     result.add("Allow any-user to manage autonomous-database-family" //NOI18N
                             + " in compartment id " + item.getCompartmentId() //NOI18N
                             + " where ALL {" //NOI18N
-                            + " request.principal.type = '" + principalType + "'," //NOI18N
                             + " request.principal.compartment.id = '" + execution.getCompartmentId() + "' }"); //NOI18N
                     break;
                 case "Bucket": //NOI18N

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/requests/ContainerRepositoryRequest.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/requests/ContainerRepositoryRequest.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.cloud.oracle.requests;
 
 import com.oracle.bmc.artifacts.model.CreateContainerRepositoryDetails;
 import com.oracle.bmc.artifacts.requests.CreateContainerRepositoryRequest;
+import org.netbeans.modules.cloud.oracle.compartment.CompartmentItem;
 
 /**
  *
@@ -29,14 +30,14 @@ public class ContainerRepositoryRequest extends OCIItemCreationDetails<CreateCon
 
     private static final Boolean IS_REPOSITORY_PUBLIC = Boolean.FALSE;
 
-    public ContainerRepositoryRequest(String compartmentId, String name) {
-        super(compartmentId, name);
+    public ContainerRepositoryRequest(CompartmentItem compartment, String name) {
+        super(compartment, name);
     }
 
     @Override
     public CreateContainerRepositoryRequest getRequest() {
         CreateContainerRepositoryDetails createContainerRepositoryDetails = CreateContainerRepositoryDetails.builder()
-                .compartmentId(this.getCompartmentId())
+                .compartmentId(this.getCompartment().getKey().getValue())
                 .displayName(this.getName())
                 .isPublic(IS_REPOSITORY_PUBLIC)
                 .build(); 

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/requests/OCIItemCreationDetails.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/requests/OCIItemCreationDetails.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.cloud.oracle.requests;
 
 import com.oracle.bmc.requests.BmcRequest;
+import org.netbeans.modules.cloud.oracle.compartment.CompartmentItem;
 
 
 /**
@@ -28,10 +29,10 @@ import com.oracle.bmc.requests.BmcRequest;
 public abstract class OCIItemCreationDetails<T extends BmcRequest<?>> {
     
     final String name;
-    final String compartmentId;
+    final CompartmentItem compartment;
 
-    public OCIItemCreationDetails(String compartmentId, String name) {
-        this.compartmentId = compartmentId;
+    public OCIItemCreationDetails(CompartmentItem compartment, String name) {
+        this.compartment = compartment;
         this.name = name;
     }
     
@@ -41,7 +42,7 @@ public abstract class OCIItemCreationDetails<T extends BmcRequest<?>> {
         return name;
     }
 
-    public String getCompartmentId() {
-        return compartmentId;
+    public CompartmentItem getCompartment() {
+        return compartment;
     }
 }

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/steps/CompartmentStep.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/steps/CompartmentStep.java
@@ -115,7 +115,7 @@ public final class CompartmentStep extends AbstractStep<CompartmentItem> {
      */
     static private Map<String, OCIItem> getFlatCompartment(TenancyItem tenancy) {
         Map<OCID, FlatCompartmentItem> compartments = new HashMap<>();
-        OCISessionInitiator session = OCIManager.getDefault().getActiveSession();
+        OCISessionInitiator session = OCIManager.getDefault().getActiveProfile(tenancy);
         Identity identityClient = session.newClient(IdentityClient.class);
         String nextPageToken = null;
         String tenancyId = session.getTenancy().isPresent() ? session.getTenancy().get().getKey().getValue() : null;

--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/vault/SecretNode.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/vault/SecretNode.java
@@ -100,7 +100,7 @@ public class SecretNode extends OCINode {
     @Override
     public void update(OCIItem item) {
         SecretItem orig = (SecretItem) item;
-        VaultsClient client = OCIManager.getDefault().getActiveProfile().newClient(VaultsClient.class);
+        VaultsClient client = OCIManager.getDefault().getActiveProfile(item).newClient(VaultsClient.class);
         GetSecretRequest request = GetSecretRequest.builder()
                 .secretId(orig.getKey().getValue())
                 .build();
@@ -135,7 +135,7 @@ public class SecretNode extends OCINode {
                 return;
             }
             
-            VaultsClient client = OCIManager.getDefault().getActiveSession().newClient(VaultsClient.class);
+            VaultsClient client = OCIManager.getDefault().getActiveProfile(getItem()).newClient(VaultsClient.class);
             Date deletionTime = getDeletionTime();
             ScheduleSecretDeletionRequest request = buildScheduleDeletionRequest(deletionTime);
             ScheduleSecretDeletionResponse response;


### PR DESCRIPTION
When an OCI operation is run, the active OCI profile is used to interact with OCI resources. If the active profile is switched, operations on resources or items that were previously loaded using the old profile may stop working or behave unexpectedly, since they rely on the context of the original active profile.
Changed the implementation so that the profile used for running operations is selected based on the item's tenancy ID and region code.