### PR TITLE
add quotes around javaExecPath in vscode extension

### DIFF
--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -479,7 +479,7 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
         if (jdkOK) {
             log.appendLine(`Verifying java: ${javaExecPath}`);
             // let the shell interpret PATH and .exe extension
-            let javaCheck = spawnSync(`${javaExecPath} -version`, { shell : true });
+            let javaCheck = spawnSync(`"${javaExecPath}" -version`, { shell : true });
             if (javaCheck.error || javaCheck.status) {
                 jdkOK = false;
             } else {


### PR DESCRIPTION
Put quotes around path so `C:\Program Files\Java\jdk-22\bin\java` can run.


---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
