### PR TITLE
Make FlatLaf module standard not autoload

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/nbproject/project.properties
+++ b/platform/o.n.swing.laf.flatlaf/nbproject/project.properties
@@ -15,6 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-is.autoload=true
 javac.compilerargs=-Xlint:unchecked
 javac.source=1.8


### PR DESCRIPTION
A simple change.  The FlatLaf module should not be autoload.  This causes a bunch of confusion when people are using parts of the platform cluster without `core.kit`.  The FlatLaf module does not enable when included unless a non-API dependency is declared on it (which in the Maven build also requires change of scope or disabling validation).

See eg. https://lists.apache.org/thread/dkpmgwo4m15ndpw0hbz9rf8rgbglbk1k although it's come up before https://lists.apache.org/thread/n97kj9fmzl0whjr74y3kpcvhocmljwjq