### PR TITLE
Use tripleslash file:/// URIs uniformly. Avoid null text in TextEdits.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/URITranslator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/URITranslator.java
@@ -89,6 +89,12 @@ public final class URITranslator {
                     Exceptions.printStackTrace(ex);
                 }
             }
+            if ("file".equals(uriUri.getScheme()) && !uri.startsWith("file:///")) { // NOI18N
+                // in "file:/C:" the : drive separator is at char 7. The leading slash before "C" is at 5.
+                if ((uri.length() <= 7) || uri.charAt(7) != ':') { // NOI18N
+                    uri = "file://" + uri.substring(5); // NOI18N
+                }
+            }
             return uri;
         });
     }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
@@ -547,6 +547,10 @@ public class Utils {
         }
     }
     
+    private static String nonNull(String t) {
+        return t == null ? "" : t;
+    }
+    
     public static WorkspaceEdit workspaceEditFromApi(org.netbeans.api.lsp.WorkspaceEdit edit, String uri, NbCodeLanguageClient client) {
         Set<String> createdResources = new HashSet<>();
         List<Either<TextDocumentEdit, ResourceOperation>> documentChanges = new ArrayList<>();
@@ -560,14 +564,14 @@ public class Utils {
                     }
                     FileObject fo = file;
                     if (fo != null) {
-                        List<TextEdit> edits = parts.first().getEdits().stream().map(te -> new TextEdit(new Range(Utils.createPosition(fo, te.getStartOffset()), Utils.createPosition(fo, te.getEndOffset())), te.getNewText())).collect(Collectors.toList());
+                        List<TextEdit> edits = parts.first().getEdits().stream().map(te -> new TextEdit(new Range(Utils.createPosition(fo, te.getStartOffset()), Utils.createPosition(fo, te.getEndOffset())), nonNull(te.getNewText()))).collect(Collectors.toList());
                         TextDocumentEdit tde = new TextDocumentEdit(new VersionedTextDocumentIdentifier(docUri, -1), edits);
                         documentChanges.add(Either.forLeft(tde));
                     } else if (createdResources.contains(docUri)) {
                         // PENDING: now accept just initial content. In theory, no edits can overlap, so for a new resource,
                         // only inserts with 0 offset are permitted.
                         List<TextEdit> edits = parts.first().getEdits().stream().filter(te -> te.getStartOffset() == 0 && te.getEndOffset() == 0).
-                                map(te -> new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), te.getNewText())).
+                                map(te -> new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), nonNull(te.getNewText()))).
                                 collect(Collectors.toList());
                         TextDocumentEdit tde = new TextDocumentEdit(new VersionedTextDocumentIdentifier(docUri, -1), edits);
                         documentChanges.add(Either.forLeft(tde));


### PR DESCRIPTION
The PR provides two small fixes:
- Utils.toUri returns `file:///path/somewhere` URIs even though native translation returns "file:/path/somewhere". Incoming URIs seem to use file:/// consistently, so we should do as well, so they can compare as strings
- When converting from lsp API TextEdit to lsp4j protocol structure, make sure that the `text` property is always non-null
