### PR TITLE
Support for Payara Server instance running on WSL

### DIFF
--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/DeployOnSaveManager.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/DeployOnSaveManager.java
@@ -20,11 +20,15 @@
 package org.netbeans.modules.j2ee.deployment.impl;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -464,6 +468,12 @@ public final class DeployOnSaveManager {
                 LOGGER.log(Level.FINEST, builder.toString());
             }
 
+            try {
+                distributeOnSave(FileUtil.toFile(provider.getJ2eeModule().getContentDirectory()), artifacts);
+            } catch (IOException ex) {
+                LOGGER.log(Level.INFO, null, ex); // NOI18N
+            }
+
             String instanceID = provider.getServerInstanceID ();
             ServerInstance inst = ServerRegistry.getInstance ().getServerInstance (instanceID);
             if (inst == null && "DEV-NULL".equals(instanceID)) { // NOI18N
@@ -592,7 +602,162 @@ public final class DeployOnSaveManager {
                 Exceptions.printStackTrace(ex);
             }
         }
-        
+
+        private void distributeOnSave(File destDir, Iterable<Artifact> artifacts) throws IOException {
+
+            try {
+                FileObject destRoot = FileUtil.createFolder(destDir);
+
+                // create target FOs map keyed by relative paths
+                Enumeration<? extends FileObject> destFiles = destRoot.getChildren(true);
+                Map<String, FileObject> destMap = new HashMap<>();
+                int rootPathLen = destRoot.getPath().length();
+                for (; destFiles.hasMoreElements();) {
+                    FileObject destFO = (FileObject) destFiles.nextElement();
+                    destMap.put(destFO.getPath().substring(rootPathLen + 1), destFO);
+                }
+
+                FileObject contentDirectory = destRoot;
+                assert contentDirectory != null;
+
+                for (Artifact artifact : artifacts) {
+                    File fsFile = artifact.getFile();
+                    File altDistFile = artifact.getDistributionPath();
+                    if (altDistFile == null) {
+                        String classes = "target" + File.separator + "classes";
+                        String filePath = artifact.getFile().getPath();
+                        String altDistRelativePath = filePath.substring(filePath.indexOf(classes) + classes.length());
+                        altDistFile = new File(destRoot.getPath() + File.separator + "WEB-INF" + File.separator + "classes" + altDistRelativePath);
+                    }
+
+                    FileObject file = FileUtil.toFileObject(FileUtil.normalizeFile(fsFile));
+
+                    FileObject checkFile = FileUtil.toFileObject(FileUtil.normalizeFile(altDistFile));
+                    if (checkFile == null && file != null) { //#165045
+                        checkFile = FileUtil.createData(altDistFile);
+                    }
+
+                    if (checkFile != null && file != null) {
+                        String relative = FileUtil.getRelativePath(contentDirectory, checkFile);
+                        if (relative != null) {
+                            FileObject targetFO = destMap.get(relative);
+                            if (file.isFolder()) {
+                                destMap.remove(relative);
+                                //continue;
+                            }
+
+                            createOrReplace(file, targetFO, destRoot, relative, destMap, false);
+                        }
+                    } else if (checkFile != null && file == null) {
+                        checkFile.delete();
+                    }
+                }
+
+            } catch (Exception e) {
+                String msg = NbBundle.getMessage(DeployOnSaveManager.class, "MSG_IncrementalDeployFailed", e);
+                throw new RuntimeException(msg, e);
+            }
+        }
+
+        private void createOrReplace(
+                FileObject sourceFO,
+                FileObject targetFO,
+                FileObject destRoot,
+                String relativePath,
+                Map<String, FileObject> destMap, boolean checkTimeStamps) throws IOException {
+
+            FileObject destFolder;
+            OutputStream destStream = null;
+            InputStream sourceStream = null;
+
+            try {
+                // double check that the target does not exist... 107526
+                //   the destMap seems to be incomplete....
+                if (targetFO == null) {
+                    targetFO = destRoot.getFileObject(relativePath);
+                }
+                if (targetFO == null) {
+                    destFolder = findOrCreateParentFolder(destRoot, relativePath);
+                } else {
+                    // remove from map to form of to-remove-target-list
+                    destMap.remove(relativePath);
+
+                    //check timestamp
+                    if (checkTimeStamps) {
+                        if (!sourceFO.lastModified().after(targetFO.lastModified())) {
+                            return;
+                        }
+                    }
+                    if (targetFO.equals(sourceFO)) {
+                        // do not write a file onto itself...
+                        return;
+                    }
+                    destFolder = targetFO.getParent();
+
+                    // we need to rewrite the content of the file here... thanks,
+                    //   to windows file locking.
+                    destStream = targetFO.getOutputStream();
+
+                }
+
+                if (sourceFO.isFolder()) {
+                    FileUtil.createFolder(destFolder, sourceFO.getNameExt());
+                    return;
+                }
+                try {
+                    if (null == destStream) {
+                        FileUtil.copyFile(sourceFO, destFolder, sourceFO.getName());
+                    } else {
+                        // this is where we need to push the content into the file....
+                        sourceStream = sourceFO.getInputStream();
+                        FileUtil.copy(sourceStream, destStream);
+                    }
+                } catch (FileNotFoundException ex) {
+                    // this may happen when the source file disappears
+                    // perhaps when source is changing rapidly ?
+                    LOGGER.log(Level.INFO, null, ex);
+                }
+            } finally {
+                if (null != sourceStream) {
+                    try {
+                        sourceStream.close();
+                    } catch (IOException ioe) {
+                        LOGGER.log(Level.WARNING, null, ioe);
+                    }
+                }
+                if (null != destStream) {
+                    try {
+                        destStream.close();
+                    } catch (IOException ioe) {
+                        LOGGER.log(Level.WARNING, null, ioe);
+                    }
+                }
+            }
+        }
+
+        /**
+         * Find or create parent folder of a file given its root and its
+         * relative path. The target file does not need to exist.
+         *
+         * @param dest FileObject for the root of the target file
+         * @param relativePath relative path of the target file
+         * @return the FileObject for the parent folder target file.
+         * @throws java.io.IOException
+         */
+        private FileObject findOrCreateParentFolder(FileObject dest, String relativePath) throws IOException {
+            File parentRelativePath = (new File(relativePath)).getParentFile();
+            if (parentRelativePath == null) {
+                return dest;
+            }
+
+            FileObject folder = FileUtil.createFolder(dest, parentRelativePath.getPath());
+            if (folder.isData()) {
+                LOGGER.log(Level.FINER, "found file {0} when a folder was expecetd", folder.getPath());
+                folder = null;
+            }
+            return folder;
+        }
+
     }
     
 }

--- a/enterprise/payara.common/nbproject/org-netbeans-modules-payara-common.sig
+++ b/enterprise/payara.common/nbproject/org-netbeans-modules-payara-common.sig
@@ -1280,6 +1280,7 @@ intf org.openide.util.Lookup$Provider
 intf org.openide.util.LookupListener
 meth public boolean equals(java.lang.Object)
 meth public boolean isDocker()
+meth public boolean isWSL()
 meth public boolean isHotDeployEnabled()
 meth public boolean isHotDeployFeatureAvailable()
 meth public boolean isProcessRunning()
@@ -1338,7 +1339,7 @@ meth public org.openide.nodes.Node getFullNode()
 meth public org.openide.util.Lookup getLookup()
 meth public static java.lang.String getPasswordFromKeyring(java.lang.String,java.lang.String)
 meth public static java.lang.String passwordKey(java.lang.String,java.lang.String)
-meth public static org.netbeans.modules.payara.common.PayaraInstance create(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,int,int,java.lang.String,java.lang.String,boolean,java.lang.String,java.lang.String,java.lang.String,java.lang.String,org.netbeans.modules.payara.common.PayaraInstanceProvider)
+meth public static org.netbeans.modules.payara.common.PayaraInstance create(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,int,int,java.lang.String,java.lang.String,boolean,boolean,java.lang.String,java.lang.String,java.lang.String,java.lang.String,org.netbeans.modules.payara.common.PayaraInstanceProvider)
 meth public static org.netbeans.modules.payara.common.PayaraInstance create(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,int,int,java.lang.String,java.lang.String,java.lang.String,java.lang.String,org.netbeans.modules.payara.common.PayaraInstanceProvider)
  anno 0 java.lang.Deprecated()
 meth public static org.netbeans.modules.payara.common.PayaraInstance create(java.util.Map<java.lang.String,java.lang.String>,org.netbeans.modules.payara.common.PayaraInstanceProvider)
@@ -2148,6 +2149,7 @@ fld public final static java.lang.String USERNAME_ATTR = "username"
 fld public final static java.lang.String USE_IDE_PROXY_FLAG = "useIDEProxyOn"
 fld public final static java.lang.String USE_SHARED_MEM_ATTR = "use.shared.mem"
 fld public final static java.lang.String WEB_CONTAINER = "web"
+fld public final static java.lang.String WSL_ATTR = "wsl"
 innr public final static !enum ServerState
 meth public abstract boolean isRemote()
 meth public abstract boolean isRestfulLogAccessSupported()
@@ -2325,6 +2327,7 @@ meth public abstract short getUpdate()
 
 CLSS public abstract interface org.netbeans.modules.payara.tooling.data.PayaraServer
 meth public abstract boolean isDocker()
+meth public abstract boolean isWSL()
 meth public abstract boolean isRemote()
 meth public abstract int getAdminPort()
 meth public abstract int getPort()

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/LogViewMgr.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/LogViewMgr.java
@@ -1031,7 +1031,7 @@ public class LogViewMgr {
 
     public static void displayOutput(PayaraInstance instance, Lookup lookup) {
         String uri = instance.getProperty(PayaraModule.URL_ATTR);
-        if (null != uri && (uri.contains("pfv3ee6wc") || uri.contains("localhost"))) {
+        if (null != uri) {
                 FetchLog log = getServerLogStream(instance);
                 LogViewMgr mgr = LogViewMgr.getInstance(uri);
                 List<Recognizer> recognizers = new ArrayList<Recognizer>();

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/actions/ViewServerLogAction.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/actions/ViewServerLogAction.java
@@ -67,7 +67,7 @@ public class ViewServerLogAction extends NodeAction {
         PayaraInstance server = (PayaraInstance) commonSupport.getInstance();
         String uri = server.getUrl();
         return uri != null && uri.length() > 0
-                && ((!server.isRemote()
+                && (((!server.isRemote() || server.isWSL())
                 && ServerUtils.getServerLogFile(server).canRead())
                 || (commonSupport.isRestfulLogAccessSupported()
                 && server.isRemote() && isRunning(commonSupport)));

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/wizards/AddDomainLocationPanel.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/wizards/AddDomainLocationPanel.java
@@ -198,6 +198,7 @@ public class AddDomainLocationPanel implements WizardDescriptor.Panel, ChangeLis
         wizardIterator.setPassword(panel.getPasswordValue());
         wizardIterator.setAdminPort(Integer.parseInt(panel.getAdminPortValue()));
         wizardIterator.setHttpPort(Integer.parseInt(panel.getHttpPortValue()));
+        wizardIterator.setWSL(panel.getWSL());
         wizardIterator.setDocker(panel.getDockerValue());
         wizardIterator.setHostPath(panel.getHostPathValue());
         wizardIterator.setContainerPath(panel.getContainerPathValue());

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/wizards/AddDomainLocationVisualPanel.form
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/wizards/AddDomainLocationVisualPanel.form
@@ -93,7 +93,12 @@
                           </Group>
                       </Group>
                   </Group>
-                  <Component id="dockerVolumeCheckBox" min="-2" max="-2" attributes="0"/>
+                  <Group type="102" attributes="0">
+                      <Component id="dockerVolumeCheckBox" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                      <Component id="wslCheckBox" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                  </Group>
                   <Group type="102" attributes="0">
                       <Component id="hostPathLabel" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
@@ -155,7 +160,10 @@
                   <Component id="passwordField" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="dockerVolumeCheckBox" min="-2" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="dockerVolumeCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="wslCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="hostPathLabel" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -165,7 +173,7 @@
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="remoteLink" max="-2" attributes="0"/>
-              <EmptySpace max="32767" attributes="0"/>
+              <EmptySpace pref="53" max="32767" attributes="0"/>
               <Component id="remotePanel" min="-2" max="-2" attributes="0"/>
           </Group>
       </Group>
@@ -476,6 +484,16 @@
           <ResourceString bundle="org/netbeans/modules/payara/common/wizards/Bundle.properties" key="AddDomainLocationVisualPanel.containerPathField.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="wslCheckBox">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/payara/common/wizards/Bundle.properties" key="AddDomainLocationVisualPanel.wslCheckBox.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="wslCheckBoxActionPerformed"/>
+      </Events>
     </Component>
   </SubComponents>
 </Form>

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/wizards/AddDomainLocationVisualPanel.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/wizards/AddDomainLocationVisualPanel.java
@@ -92,6 +92,7 @@ public class AddDomainLocationVisualPanel extends javax.swing.JPanel {
             hostRemoteField.setVisible(false);
             remoteLink.setVisible(false);
             dockerVolumeCheckBox.setVisible(false);
+            wslCheckBox.setVisible(false);
         } else {
             domainLocalLabel.setVisible(false);
             domainLocalField.setVisible(false);
@@ -104,6 +105,7 @@ public class AddDomainLocationVisualPanel extends javax.swing.JPanel {
             hostRemoteField.setVisible(true);
             remoteLink.setVisible(true);
             dockerVolumeCheckBox.setVisible(true);
+            wslCheckBox.setVisible(true);
         }
         hostPathLabel.setVisible(dockerVolumeCheckBox.isSelected());
         hostPathField.setVisible(dockerVolumeCheckBox.isSelected());
@@ -224,6 +226,10 @@ public class AddDomainLocationVisualPanel extends javax.swing.JPanel {
      */
     String getUserNameValue() {
         return userNameField.getText().trim();
+    }
+
+    boolean getWSL() {
+        return wslCheckBox.isSelected();
     }
 
     boolean getDockerValue() {
@@ -469,6 +475,7 @@ public class AddDomainLocationVisualPanel extends javax.swing.JPanel {
         dockerVolumeCheckBox = new javax.swing.JCheckBox();
         hostPathField = new javax.swing.JTextField();
         containerPathField = new javax.swing.JTextField();
+        wslCheckBox = new javax.swing.JCheckBox();
 
         setPreferredSize(new java.awt.Dimension(438, 353));
 
@@ -568,6 +575,13 @@ public class AddDomainLocationVisualPanel extends javax.swing.JPanel {
         containerPathField.setColumns(5);
         containerPathField.setText(org.openide.util.NbBundle.getMessage(AddDomainLocationVisualPanel.class, "AddDomainLocationVisualPanel.containerPathField.text")); // NOI18N
 
+        wslCheckBox.setText(org.openide.util.NbBundle.getMessage(AddDomainLocationVisualPanel.class, "AddDomainLocationVisualPanel.wslCheckBox.text")); // NOI18N
+        wslCheckBox.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                wslCheckBoxActionPerformed(evt);
+            }
+        });
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
@@ -601,19 +615,23 @@ public class AddDomainLocationVisualPanel extends javax.swing.JPanel {
                                     .addComponent(userNameField, javax.swing.GroupLayout.Alignment.LEADING)
                                     .addComponent(targetValueField, javax.swing.GroupLayout.Alignment.LEADING)
                                     .addGroup(layout.createSequentialGroup()
-                                        .addComponent(dasPortField, javax.swing.GroupLayout.DEFAULT_SIZE, 7, Short.MAX_VALUE)
+                                        .addComponent(dasPortField, javax.swing.GroupLayout.PREFERRED_SIZE, 7, Short.MAX_VALUE)
                                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                         .addComponent(httpPortFieldLabel)))
                                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                                     .addGroup(layout.createSequentialGroup()
                                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                        .addComponent(httpPortField, javax.swing.GroupLayout.DEFAULT_SIZE, 7, Short.MAX_VALUE)
+                                        .addComponent(httpPortField, javax.swing.GroupLayout.PREFERRED_SIZE, 7, Short.MAX_VALUE)
                                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                         .addComponent(useDefaultPortsCB))
                                     .addGroup(layout.createSequentialGroup()
                                         .addGap(112, 112, 112)
                                         .addComponent(remotePanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))))))
-                    .addComponent(dockerVolumeCheckBox)
+                    .addGroup(layout.createSequentialGroup()
+                        .addComponent(dockerVolumeCheckBox)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                        .addComponent(wslCheckBox)
+                        .addGap(0, 0, Short.MAX_VALUE))
                     .addGroup(layout.createSequentialGroup()
                         .addComponent(hostPathLabel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -666,7 +684,9 @@ public class AddDomainLocationVisualPanel extends javax.swing.JPanel {
                     .addComponent(passwordLabel)
                     .addComponent(passwordField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(dockerVolumeCheckBox)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(dockerVolumeCheckBox)
+                    .addComponent(wslCheckBox))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(hostPathLabel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -675,7 +695,7 @@ public class AddDomainLocationVisualPanel extends javax.swing.JPanel {
                     .addComponent(containerPathField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(remoteLink)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 53, Short.MAX_VALUE)
                 .addComponent(remotePanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
         );
 
@@ -700,6 +720,10 @@ public class AddDomainLocationVisualPanel extends javax.swing.JPanel {
         containerPathLabel.setVisible(dockerVolumeCheckBox.isSelected());
         containerPathField.setVisible(dockerVolumeCheckBox.isSelected());
     }//GEN-LAST:event_dockerVolumeCheckBoxActionPerformed
+
+    private void wslCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_wslCheckBoxActionPerformed
+       fireChangeEvent();
+    }//GEN-LAST:event_wslCheckBoxActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JTextField containerPathField;
@@ -729,6 +753,7 @@ public class AddDomainLocationVisualPanel extends javax.swing.JPanel {
     private javax.swing.JCheckBox useDefaultPortsCB;
     private javax.swing.JTextField userNameField;
     private javax.swing.JLabel userNameLabel;
+    private javax.swing.JCheckBox wslCheckBox;
     // End of variables declaration//GEN-END:variables
 
     class MyKeyListener implements KeyListener {

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/wizards/Bundle.properties
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/wizards/Bundle.properties
@@ -177,3 +177,4 @@ AddDomainLocationVisualPanel.hostPathLabel.text=Host Path
 AddDomainLocationVisualPanel.hostPathField.text=
 AddDomainLocationVisualPanel.containerPathField.text=
 AddDomainLocationVisualPanel.dockerVolumeCheckBox.text=Docker Volume
+AddDomainLocationVisualPanel.wslCheckBox.text=WSL

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/wizards/ServerWizardIterator.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/wizards/ServerWizardIterator.java
@@ -234,6 +234,7 @@ public class ServerWizardIterator extends PortCollection implements WizardDescri
     /** Payara server administrator's password. */
     private String password;
     private boolean docker;
+    private boolean wsl;
     private String hostPath;
     private String containerPath;
     private String installRoot;
@@ -344,6 +345,14 @@ public class ServerWizardIterator extends PortCollection implements WizardDescri
 
     public void setDocker(boolean docker) {
         this.docker = docker;
+    }
+
+    public boolean isWSL() {
+        return wsl;
+    }
+
+    public void setWSL(boolean wsl) {
+        this.wsl = wsl;
     }
 
     public String getHostPath() {
@@ -518,7 +527,7 @@ public class ServerWizardIterator extends PortCollection implements WizardDescri
             PayaraInstance instance = PayaraInstance.create((String) wizard.getProperty("ServInstWizard_displayName"),  // NOI18N
                     installRoot, payaraRoot, domainsDir, domainName, 
                     newHttpPort, newAdminPort, userName, password,
-                    docker, hostPath, containerPath, targetValue,
+                    wsl, docker, hostPath, containerPath, targetValue,
                     formatUri(hostName, newAdminPort, getTargetValue(),domainsDir,domainName), 
                     instanceProvider);
             result.add(instance.getCommonInstance());
@@ -526,7 +535,7 @@ public class ServerWizardIterator extends PortCollection implements WizardDescri
             PayaraInstance instance = PayaraInstance.create((String) wizard.getProperty("ServInstWizard_displayName"),  // NOI18N
                     installRoot, payaraRoot, domainsDir, domainName,
                     getHttpPort(), getAdminPort(), userName, password, 
-                    docker, hostPath, containerPath, targetValue,
+                    wsl, docker, hostPath, containerPath, targetValue,
                     formatUri(hostName, getAdminPort(), getTargetValue(), domainsDir, domainName),
                     instanceProvider);
             result.add(instance.getCommonInstance());
@@ -541,7 +550,7 @@ public class ServerWizardIterator extends PortCollection implements WizardDescri
         PayaraInstance instance = PayaraInstance.create((String) wizard.getProperty("ServInstWizard_displayName"),   // NOI18N
                 installRoot, payaraRoot, null, domainName,
                 getHttpPort(), getAdminPort(), userName, password, 
-                docker, hostPath, containerPath, targetValue,
+                wsl, docker, hostPath, containerPath, targetValue,
                 formatUri(hn, getAdminPort(), getTargetValue(),null, domainName), 
                 instanceProvider);
         result.add(instance.getCommonInstance());

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/spi/PayaraModule.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/spi/PayaraModule.java
@@ -47,6 +47,7 @@ public interface PayaraModule {
     public static final String DISPLAY_NAME_ATTR = "displayName"; // NOI18N
     public static final String USERNAME_ATTR = "username"; // NOI18N
     public static final String PASSWORD_ATTR = "password"; // NOI18N
+    public static final String WSL_ATTR = "wsl"; // NOI18N
     public static final String DOCKER_ATTR = "docker"; // NOI18N
     public static final String HOST_PATH_ATTR = "hostPath"; // NOI18N
     public static final String CONTAINER_PATH_ATTR = "containerPath"; // NOI18N

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/Hk2DeploymentManager.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/Hk2DeploymentManager.java
@@ -621,6 +621,11 @@ public class Hk2DeploymentManager implements DeploymentManager2 {
         }
         return result;
     }
+    
+    public boolean isWSL() {
+        PayaraModule commonSupport = getCommonServerSupport();
+        return commonSupport != null && commonSupport.getInstance().isWSL();
+    }
 
     public static String getTargetFromUri(String uri) {
         String target = null;

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/Hk2OptionalFactory.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/Hk2OptionalFactory.java
@@ -86,7 +86,7 @@ public class Hk2OptionalFactory extends OptionalDeploymentManagerFactory {
         IncrementalDeployment result = null;
         if(dm instanceof Hk2DeploymentManager) {
             Hk2DeploymentManager hk2dm = (Hk2DeploymentManager) dm;
-            if(hk2dm.isLocal() || hk2dm.isDocker()) {
+            if(hk2dm.isLocal() || hk2dm.isDocker() || hk2dm.isWSL()) {
                 result = new FastDeploy(hk2dm);
             }
         }

--- a/enterprise/payara.tooling/nbproject/org-netbeans-modules-payara-tooling.sig
+++ b/enterprise/payara.tooling/nbproject/org-netbeans-modules-payara-tooling.sig
@@ -1383,6 +1383,7 @@ meth public abstract short getUpdate()
 
 CLSS public abstract interface org.netbeans.modules.payara.tooling.data.PayaraServer
 meth public abstract boolean isDocker()
+meth public abstract boolean isWSL()
 meth public abstract boolean isRemote()
 meth public abstract int getAdminPort()
 meth public abstract int getPort()
@@ -1407,6 +1408,7 @@ cons public init()
 cons public init(java.lang.String,java.lang.String,java.lang.String,java.lang.String)
 intf org.netbeans.modules.payara.tooling.data.PayaraServer
 meth public boolean isDocker()
+meth public boolean isWSL()
 meth public boolean isRemote()
 meth public int getAdminPort()
 meth public int getPort()
@@ -1431,6 +1433,7 @@ meth public void setAdminPort(int)
 meth public void setAdminUser(java.lang.String)
 meth public void setContainerPath(java.lang.String)
 meth public void setDocker(boolean)
+meth public void setWSL(boolean)
 meth public void setDomainName(java.lang.String)
 meth public void setDomainsFolder(java.lang.String)
 meth public void setHost(java.lang.String)
@@ -1444,7 +1447,7 @@ meth public void setUrl(java.lang.String)
 meth public void setVersion(org.netbeans.modules.payara.tooling.data.PayaraVersion)
  anno 0 java.lang.Deprecated()
 supr java.lang.Object
-hfds adminInterface,adminPassword,adminPort,adminUser,containerPath,docker,domainName,domainsFolder,host,hostPath,name,platformVersion,port,serverHome,serverRoot,url,version
+hfds adminInterface,adminPassword,adminPort,adminUser,containerPath,wsl,docker,domainName,domainsFolder,host,hostPath,name,platformVersion,port,serverHome,serverRoot,url,version
 
 CLSS public abstract interface org.netbeans.modules.payara.tooling.data.PayaraServerStatus
 meth public abstract org.netbeans.modules.payara.tooling.PayaraStatus getStatus()

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/admin/CommandException.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/admin/CommandException.java
@@ -69,6 +69,9 @@ public class CommandException extends PayaraIdeException {
 
     /** Exception message for illegal <code>Command</code> instance provided. */
     static final String ILLEGAL_COMAND_INSTANCE = "Illegal command instance provided";
+    
+    /** Exception message for application path in the mapped host path. */
+    static final String DOCKER_HOST_APPLICATION_PATH = "Application should be in same drive as docker host container path mapping";
 
     /** Exception message for illegal <code>null</code> value provided. */
     static final String ILLEGAL_NULL_VALUE

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/admin/RunnerHttpDeploy.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/admin/RunnerHttpDeploy.java
@@ -116,13 +116,24 @@ public class RunnerHttpDeploy extends RunnerHttp {
                     && !server.getHostPath().isEmpty()
                     && server.getContainerPath() != null
                     && !server.getContainerPath().isEmpty()) {
-                Path relativePath = Paths.get(server.getHostPath()).relativize(deploy.path.toPath());
-                path = Paths.get(server.getContainerPath(), relativePath.toString()).toString();
-                if (server.getContainerPath().startsWith("/")) {
-                    path = path.replace("\\", "/");
+                try {
+                    Path relativePath = Paths.get(server.getHostPath()).relativize(deploy.path.toPath());
+                    path = Paths.get(server.getContainerPath(), relativePath.toString()).toString();
+                    if (server.getContainerPath().startsWith("/")) {
+                        path = path.replace("\\", "/");
+                    }
+                } catch (IllegalArgumentException ex) {
+                    throw new CommandException(
+                            CommandException.DOCKER_HOST_APPLICATION_PATH);
                 }
             }
-            target =deploy.target;
+            if (server.isWSL()) {
+                // Replace backslashes with forward slashes
+                path = path.replace("\\", "/");
+                // Add "mnt" prefix and drive letter
+                path = "/mnt/" + path.substring(0, 1).toLowerCase() + path.substring(2);
+            }
+            target = deploy.target;
             ctxRoot = deploy.contextRoot;
             hotDeploy = Boolean.toString(deploy.hotDeploy);
         }

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/PayaraServer.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/PayaraServer.java
@@ -82,6 +82,14 @@ public interface PayaraServer {
     public boolean isDocker();
 
     /**
+     * Get information if this Payara server instance is running in WSL container.
+     * <p/>
+     * @return Value of <code>true</code> when this Payara server instance
+     *         is WSL instance or <code>false</code> otherwise.
+     */
+    public boolean isWSL();
+
+    /**
      * Get the docker host path.
      * <p/>
      * @return The dcoker volume host path.

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/PayaraServerEntity.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/PayaraServerEntity.java
@@ -63,11 +63,15 @@ public class PayaraServerEntity implements PayaraServer {
      *  (PayaraModule.DOCKER_ATTR). */
     private boolean docker;
 
-    /** Docker instance
+    /** WSL instance
+     *  (PayaraModule.WSL_ATTR). */
+    private boolean wsl;
+
+    /** Docker host path
      *  (PayaraModule.HOST_PATH_ATTR). */
     private String hostPath;
 
-    /** Docker instance
+    /** Docker container path
      *  (PayaraModule.CONTAINER_PATH_ATTR). */
     private String containerPath;
 
@@ -446,7 +450,7 @@ public class PayaraServerEntity implements PayaraServer {
      */
     @Override
     public boolean isRemote() {
-        return domainsFolder == null;
+        return domainsFolder == null || docker || wsl;
     }
 
     @Override
@@ -458,6 +462,14 @@ public class PayaraServerEntity implements PayaraServer {
         this.docker = docker;
     }
 
+    @Override
+    public boolean isWSL() {
+        return wsl;
+    }
+    
+    public void setWSL(boolean wsl) {
+        this.wsl = wsl;
+    }
     @Override
     public String getHostPath() {
         return hostPath;

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/utils/ServerUtils.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/utils/ServerUtils.java
@@ -858,7 +858,7 @@ public class ServerUtils {
         String domainsFolder = server.getDomainsFolder();
         boolean appendSeparator = domainsFolder.lastIndexOf(File.separator)
                 + OsUtils.FILE_SEPARATOR_LENGTH != domainsFolder.length();
-        StringBuilder sb = new StringBuilder(server.getDomainsFolder().length()
+        StringBuilder sb = new StringBuilder(domainsFolder.length()
                 + (appendSeparator ? OsUtils.FILE_SEPARATOR_LENGTH : 0)
                 + domainName.length());
         sb.append(domainsFolder);


### PR DESCRIPTION
This PR adds support for the Payara Server instance running on WSL. Usually, developers can register instances running on WSL as remote servers in Apache NetBeans. However, with this PR, developers can take advantage of new features that allow them to view the log file in real-time, and to auto-deploy on save action both static (.html) and dynamic (.java) applications to the Payara Server running on WSL.

To test this feature, start the server, set a password for the user, and enable the secure domain:
````
./asadmin start-domain
./asadmin change-admin-password
./asadmin enable-secure-admin
./asadmin restart-domain
````
![image](https://user-images.githubusercontent.com/15934072/228462731-bf650500-d6ed-4cdb-ab12-321da3b36cee.png)

Register the server in Apache NetBeans as Remote Server including the location of the server from the Windows disk.

![image](https://user-images.githubusercontent.com/15934072/228461026-8272ed92-2d8f-41a5-b005-772ccd89bc82.png)
![image](https://user-images.githubusercontent.com/15934072/228461177-00e7ef8a-0db3-4dcf-84a0-067618516413.png)



