### PR TITLE
fixes #7879 - config set schema command for postgresql

### DIFF
--- a/ide/db/libsrc/org/netbeans/lib/ddl/resources/dbspec.plist
+++ b/ide/db/libsrc/org/netbeans/lib/ddl/resources/dbspec.plist
@@ -1798,6 +1798,12 @@
       Format = "drop index {object.name}";
     };
 
+    SetDefaultSchemaCommand = {
+      Class = org.netbeans.lib.ddl.impl.SetDefaultSchema;
+      Format = "set search_path to {schemaName}";
+      Supported = true;
+    };
+
   };
 
 //  ********************************************************************************


### PR DESCRIPTION
Postgresql configuration does simply not contain the set default schema command.

This PR tries to include this.

The most fitting command seems to be `set search_path`.