### PR TITLE
Robustness of the "Goto Type Dialog"

### DIFF
--- a/ide/jumpto/src/org/netbeans/modules/jumpto/type/GoToTypeAction.java
+++ b/ide/jumpto/src/org/netbeans/modules/jumpto/type/GoToTypeAction.java
@@ -613,6 +613,8 @@ public class GoToTypeAction extends AbstractAction implements GoToPanel.ContentP
                     final TypeProvider.Result result = TypeProviderAccessor.DEFAULT.createResult(items, message, context);
                     provider.computeTypeNames(context, result);
                     retry[0] = mergeRetryTimeOut(retry[0], TypeProviderAccessor.DEFAULT.getRetry(result));
+                } catch (Exception ex) {
+                    LOGGER.log(Level.SEVERE, "Provider ''" + provider.getDisplayName() + "'' yields an exception", ex);
                 } finally {
                     current = null;
                 }


### PR DESCRIPTION
I started to see following exception when using the _"GoTo Type Dialog"_ and the dialog stop showing anything:
```
java.lang.UnsupportedOperationException
        // deep stack skipped
        at org.netbeans.modules.lsp.client.bindings.TypeProviderImpl.computeTypeNames(TypeProviderImpl.java:54)
        at org.netbeans.modules.jumpto.type.GoToTypeAction$Worker.getTypeNames(GoToTypeAction.java:614)
        at org.netbeans.modules.jumpto.type.GoToTypeAction$Worker.run(GoToTypeAction.java:522)
        at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1403)
        at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
        at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
        at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2018)
```
It is not good when a single broken provider brakes everything. This PR catches exceptions from each provider, logs the exception coming from `TypeProvider.computeTypeNames` and goes on and querying the other providers. With this fix I see the exception in the log, but _"Goto Type Dialog" continues to work as expected.

