### PR TITLE
 Do not break additional DocumentFilters

### DIFF
--- a/platform/openide.text/src/org/openide/text/CloneableEditorSupport.java
+++ b/platform/openide.text/src/org/openide/text/CloneableEditorSupport.java
@@ -213,6 +213,7 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
     private boolean annotationsLoaded;
     
     private DocFilter docFilter;
+    private DocumentOpenClose.DocumentRef filteredDocRef;
     
     private final Object checkModificationLock = new Object();
 
@@ -493,16 +494,20 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
         if (Boolean.TRUE.equals(d.getProperty("supportsModificationListener"))) { // NOI18N
             d.putProperty("modificationListener", getListener()); // NOI18N
         }
-
-        if (d instanceof AbstractDocument) {
-            AbstractDocument aDoc = (AbstractDocument) d;
-            DocumentFilter origFilter = aDoc.getDocumentFilter();
-            docFilter = new DocFilter(origFilter);
-            aDoc.setDocumentFilter(docFilter);
-        } else { // Put property for non-AD
-            DocumentFilter origFilter = (DocumentFilter) d.getProperty(DocumentFilter.class);
-            docFilter = new DocFilter(origFilter);
-            d.putProperty(DocumentFilter.class, docFilter);
+        DocFilter df = docFilter;
+        if (df == null || df.origDocument != openClose.docRef) {
+            if (d instanceof AbstractDocument) {
+                AbstractDocument aDoc = (AbstractDocument) d;
+                DocumentFilter origFilter = aDoc.getDocumentFilter();
+                docFilter = new DocFilter(origFilter, openClose.docRef);
+                aDoc.setDocumentFilter(docFilter);
+            } else { // Put property for non-AD
+                DocumentFilter origFilter = (DocumentFilter) d.getProperty(DocumentFilter.class);
+                docFilter = new DocFilter(origFilter, openClose.docRef);
+                d.putProperty(DocumentFilter.class, docFilter);
+            }
+        } else {
+            df.docFilterDisabled = false;
         }
         d.addDocumentListener(getListener());
     }
@@ -511,15 +516,9 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
         if (Boolean.TRUE.equals(d.getProperty("supportsModificationListener"))) { // NOI18N
             d.putProperty("modificationListener", null); // NOI18N
         }
-
-        if (docFilter != null) {
-            if (d instanceof AbstractDocument) {
-                AbstractDocument aDoc = (AbstractDocument) d;
-                aDoc.setDocumentFilter(docFilter.origFilter);
-            } else { // Put property for non-AD
-                d.putProperty(DocumentFilter.class, docFilter.origFilter);
-            }
-            docFilter = null;
+        DocFilter df = docFilter;
+        if (df != null) {
+            df.docFilterDisabled = true;
         }
         d.removeDocumentListener(getListener());
     }
@@ -2325,14 +2324,17 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
     private final class DocFilter extends DocumentFilter {
         
         final DocumentFilter origFilter;
+        final Reference origDocument;
+        boolean docFilterDisabled;
         
-        DocFilter(DocumentFilter origFilter) {
+        DocFilter(DocumentFilter origFilter, Reference origDocument) {
             this.origFilter = origFilter;
+            this.origDocument = origDocument;
         }
 
         @Override
         public void insertString(FilterBypass fb, int offset, String string, AttributeSet attr) throws BadLocationException {
-            boolean origModified = checkModificationAllowed(offset);
+            boolean origModified = docFilterDisabled || checkModificationAllowed(offset);
             boolean success = false;
             try {
                 if (origFilter != null) {
@@ -2352,7 +2354,7 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
 
         @Override
         public void remove(FilterBypass fb, int offset, int length) throws BadLocationException {
-            boolean origModified = checkModificationAllowed(offset);
+            boolean origModified = docFilterDisabled || checkModificationAllowed(offset);
             boolean success = false;
             try {
                 if (origFilter != null) {
@@ -2372,7 +2374,7 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
 
         @Override
         public void replace(FilterBypass fb, int offset, int length, String text, AttributeSet attrs) throws BadLocationException {
-            boolean origModified = checkModificationAllowed(offset);
+            boolean origModified = docFilterDisabled || checkModificationAllowed(offset);
             boolean success = false;
             try {
                 if (origFilter != null) {

--- a/platform/openide.text/src/org/openide/text/DocumentOpenClose.java
+++ b/platform/openide.text/src/org/openide/text/DocumentOpenClose.java
@@ -1026,7 +1026,7 @@ final class DocumentOpenClose {
         
     }
     
-    private final class DocumentRef extends WeakReference<StyledDocument> implements Runnable {
+    final class DocumentRef extends WeakReference<StyledDocument> implements Runnable {
 
         public DocumentRef(StyledDocument doc) {
             super(doc, org.openide.util.Utilities.activeReferenceQueue());


### PR DESCRIPTION
This PR improves behaviour of `CloneableEditorSupport` in that it will not break additional `DocumentFilter`s which may be attached to the AbstractDocument.

If a plugin registers a filter for a document, the `CloneableEditorSupport` will erase that filter on document's reload, basically at some unexpected and uncontrolled point. This PR changes the impl so it will not *remove* the DocumentFilter which would unset the client's DocumentFilter and breaks the pass-through chain), but rather **disables**  it.

When the document is listened on again, and it's the same document (!) as the existing filter works with, the filter is re-enabled.

If the document reference changes, a new filter is created; the user must detect that and restore its own filter as the old Document is gone. This should happen mainly if the Document expires and is garbage-collected and is loaded again.