### PR TITLE
Support for UserQuestionException during reloads

### DIFF
--- a/platform/openide.text/apichanges.xml
+++ b/platform/openide.text/apichanges.xml
@@ -25,6 +25,20 @@
 <apidef name="text">Text API</apidef>
 </apidefs>
 <changes>
+    <change id="DocumentOpenClose.ReloadAutomaticUserAnswers">
+        <api name="text"/>
+        <summary>DocumentFilter can block a reload, UserQuestionExceptions can be branded to true or false.</summary>
+        <version major="6" minor="96"/>
+        <date day="24" month="10" year="2024"/>
+        <author login="sdedic"/>
+        <compatibility addition="yes" binary="compatible" source="compatible"
+                       semantic="compatible" deletion="no"
+                       modification="no"/>
+        <description>
+            The implementation handles <code>UserQuestionException</code> during reload, which means a DocumentFilter
+            may block document reload. Support for automatic UserQuestionException handling was added as branding API
+        </description>
+    </change>
     <change id="EditorCookie.Observable.PROP_RELOADING">
         <api name="text"/>
         <summary>Added EditorCookie.Observable.PROP_RELOADING and associated begin/end events</summary>

--- a/platform/openide.text/arch.xml
+++ b/platform/openide.text/arch.xml
@@ -437,6 +437,15 @@ in methods
     <code>org/netbeans/modules/openide/text/Bundle.properties</code>
     to <code>yes</code> or <code>no</code> in a branding file in your application.
 </api>
+<api name="org.netbeans.modules.openide.text.UserQuestionAnswer" group="branding" type="export" category="devel">
+    Controls handling of UserQuestionExceptions thrown during document I/O by 
+    <a href="@TOP@/org/openide/text/CloneableEditorSupport.html">CloneableEditorSupport</a>
+    Specific classes can be branded to result in 
+    "yes" (reload without asking) or "no" (cancel the re/load operation). If unspecified or set to any other value, the
+    user will be asked the question (this is the default behaviour).
+    <p/>
+    The support is available from version 6.96
+</api>
 </answer>
 
 

--- a/platform/openide.text/manifest.mf
+++ b/platform/openide.text/manifest.mf
@@ -2,5 +2,4 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.openide.text
 OpenIDE-Module-Localizing-Bundle: org/openide/text/Bundle.properties
 AutoUpdate-Essential-Module: true
-OpenIDE-Module-Specification-Version: 6.95
-
+OpenIDE-Module-Specification-Version: 6.96

--- a/platform/openide.text/src/org/netbeans/modules/openide/text/AskEditorQuestions.java
+++ b/platform/openide.text/src/org/netbeans/modules/openide/text/AskEditorQuestions.java
@@ -18,12 +18,47 @@
  */
 package org.netbeans.modules.openide.text;
 
+import java.util.MissingResourceException;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.util.NbBundle;
+import org.openide.util.UserQuestionException;
 
 public final class AskEditorQuestions {
+    public enum QuestionResult {
+        /**
+         * The implementation should ask the user. The default, if no
+         * value is present in the resource bundle.
+         */
+        ASK_USER,
+        
+        /**
+         * Assume yes, do not ask the user, proceed immediately.
+         */
+        YES,
+        
+        /**
+         * Assume no, do not ask the user, proceed immediately.
+         */
+        NO,
+    }
     private AskEditorQuestions() {
+    }
+    
+    public static QuestionResult askUserQuestion(UserQuestionException uqe) {
+        String key = "UserQuestionAnswer_" + uqe.getClass().getName();
+        try {
+            String ask = NbBundle.getMessage(AskEditorQuestions.class, key); // NOI18N
+            if ("yes".equals(ask)) {
+                return QuestionResult.YES;
+            }
+            if ("no".equals(ask)) {
+                return QuestionResult.NO;
+            }
+        } catch (MissingResourceException ex) {
+            // expected
+        }
+        return QuestionResult.ASK_USER;
     }
 
     public static boolean askReloadDocument(String localizedMessage) {

--- a/platform/openide.text/src/org/openide/text/DocumentOpenClose.java
+++ b/platform/openide.text/src/org/openide/text/DocumentOpenClose.java
@@ -729,6 +729,9 @@ final class DocumentOpenClose {
                                 loadDoc.remove(0, loadDoc.getLength());
                             }
                         } catch (BadLocationException ex) {
+                            if (ex.getCause() instanceof IOException) {
+                                throw (IOException)ex.getCause();
+                            }
                             LOG.log(Level.INFO, null, ex);
                         }
                     }


### PR DESCRIPTION
This PR allows to step in even during reload, by throwing `BadLocationException` with a wrapped `UserQuestionException` - will result in the question dialog for the user.

For LSP/headless operation, a branding API is introduced that allows to skip question for **specified subclass* of UserQuestionException - either always permit or always deny. Applications/distributions can control that using branding.
