### PR TITLE
Disable JDK 23 line-doc comments for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -416,10 +416,24 @@ jobs:
       - name: Build nbms
         run: ant $OPTS build-nbms
 
-      # 13-14 min
+      # 13-14 min for javadoc; JDK version must be synced with nb-javac
+      - name: Set up JDK 23 for javadoc
+        if: env.test_javadoc == 'true' && success()
+        uses: actions/setup-java@v4
+        with:
+          java-version: 23 
+          distribution: ${{ env.DEFAULT_JAVA_DISTRIBUTION }}
+
       - name: Build javadoc
         if: env.test_javadoc == 'true' && success()
         run: ant $OPTS build-javadoc
+
+      - name: Set up JDK ${{ matrix.java }} 
+        if: env.test_javadoc == 'true' && success()
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }} 
+          distribution: ${{ env.DEFAULT_JAVA_DISTRIBUTION }}
 
       # runs only in PRs if requested; ~18 min
       - name: Build all Tests

--- a/nbbuild/javadoctools/template.xml
+++ b/nbbuild/javadoctools/template.xml
@@ -321,6 +321,9 @@ cause it to fail.
             <bottom>${javadoc.footer}</bottom>
             <!-- Avoid timestamp comments in _all_ html generated files, to reduce unnecessary git commits -->
             <arg value="-notimestamp" />
+            <!-- codebase has many occurrences of '///' which were never meant to appear in javadoc
+                 this disables JDK 23+ "line doc comments" for now  -->
+            <arg value="--disable-line-doc-comments" />
             <arg value="-Xdoclint:all" />
             <arg value="-Xdoclint:-missing" />
         </javadoc>


### PR DESCRIPTION
 - codebase has many occurrences of '///' which were never meant to appear in javadoc
 - this disables JDK 23+ "line doc comments" for now ([JEP 467](https://openjdk.org/jeps/467))
 - javadoc CI step should run on JDK 23 (like on jenkins) to be able to resolve nb-javac classes (and understand the new flag)

```
ag -l -E java ///
```
lists about 1k files, this would be too much work to clean up for little gain atm

targets delivery