### PR TITLE
output window: better warning color for FlatLaf light

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
@@ -80,3 +80,4 @@ nb.quicksearch.border=1,1,1,1,@background
 
 # output
 nb.output.selectionBackground=#89BCED
+nb.output.warning.foreground=#FF9900


### PR DESCRIPTION
current default is often hard to read on white background

before (`Color.ORANGE`):
![image](https://github.com/user-attachments/assets/2822326b-6963-4ffb-8efe-b62e025807b6)

after:
![image](https://github.com/user-attachments/assets/b300aaac-fd10-4368-bda0-56abff8cf187)

fixes #7911

targets delivery since trivial