### PR TITLE
LSP Server: Adding Null Checks  in  MoveRefactoring code action

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/MoveRefactoring.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/MoveRefactoring.java
@@ -420,6 +420,9 @@ public final class MoveRefactoring extends CodeRefactoring {
         }
 
         private static Project getSelectedProject(NamedPath selectedProject) {
+            if (selectedProject == null) {
+                return null;
+            }
             try {
                 String path = selectedProject.getPath();
                 return path != null ? FileOwnerQuery.getOwner(Utils.fromUri(path)) : null;
@@ -429,6 +432,9 @@ public final class MoveRefactoring extends CodeRefactoring {
         }
 
         private static FileObject getSelectedRoot(NamedPath selectedRoot) {
+            if (selectedRoot == null) {
+                return null;
+            }
             try {
                 String path = selectedRoot.getPath();
                 return path != null ? Utils.fromUri(path) : null;


### PR DESCRIPTION
- Initially when creating the refactoring web view the variables selectedProject and selectedRoot are NULL.
- getPath method called on a null results in a null pointer exception .
- Uncaught null pointer exception was leading to refactoring failing sometimes . Hence this fix is required .
