### PR TITLE
Fix MacOS tests failures in java.hints

### DIFF
--- a/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testShortErrors5-nonmac.pass
+++ b/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testShortErrors5-nonmac.pass
@@ -1,3 +1,0 @@
-5:8-5:14:error:cannot find symbol
-  symbol:method create()
-  location:class TestShortErrors5

--- a/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testShortErrors5.pass
+++ b/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testShortErrors5.pass
@@ -1,1 +1,3 @@
-5:8-5:14:error:compiler message file broken:key=compiler.err.cant.resolve.location.args arguments=method, create, , , class, javahints.TestShortErrors5, {6}, {7}
+5:8-5:14:error:cannot find symbol
+  symbol:method create()
+  location:class TestShortErrors5

--- a/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testTestShortErrorsSVUIDWarning-nonmac.pass
+++ b/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testTestShortErrorsSVUIDWarning-nonmac.pass
@@ -1,1 +1,0 @@
-2:13-2:40:warning:[serial] serializable class TestShortErrorsSVUIDWarning has no definition of serialVersionUID

--- a/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testTestShortErrorsSVUIDWarning.pass
+++ b/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testTestShortErrorsSVUIDWarning.pass
@@ -1,1 +1,1 @@
-2:13-2:40:warning:serializable class javahints.TestShortErrorsSVUIDWarning has no definition of serialVersionUID
+2:13-2:40:warning:[serial] serializable class TestShortErrorsSVUIDWarning has no definition of serialVersionUID

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest.java
@@ -180,7 +180,7 @@ public class ErrorHintsProviderTest extends NbTestCase {
     }
     
     public void testShortErrors5() throws Exception {
-        performTest("TestShortErrors5", true);
+        performTest("TestShortErrors5", false);
     }
     
     public void testShortErrors6() throws Exception {
@@ -228,7 +228,7 @@ public class ErrorHintsProviderTest extends NbTestCase {
         TestCompilerSettings.commandLine = "-Xlint:serial";
 
         try {
-            performTest("TestShortErrorsSVUIDWarning", true);
+            performTest("TestShortErrorsSVUIDWarning", false);
         } finally {
             TestCompilerSettings.commandLine = null;
         }


### PR DESCRIPTION
The javac outputs of the following tests in java/java.hints ErrorHintsProviderTest were updated for non-mac OSes due to changes in JDK 7 updates:
- testShortErrors5: [jdk-6968793](https://github.com/openjdk/jdk/commit/b77effad6c6)
- testTestShortErrorsSVUIDWarning: [jdk-6957438](https://github.com/openjdk/jdk/commit/1c75e97108)

Since Apple JDK was present only up till JDK 6, we no longer require the special case for MacOS since JDK 8.

Thus, making the test argument value `specialMacTreatment = false` for these two tests, and renaming the corresponding goldenfiles from *"-nonmac.pass"* suffix to *".pass"* suffix, while retaining the original mac goldenfiles with the *"-oldmac.pass"* suffix.
