### PR TITLE
Small improvements to the “Show parent folder name in tab title” option

### DIFF
--- a/platform/core.multitabs/nbproject/project.properties
+++ b/platform/core.multitabs/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=11
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 nbm.needs.restart=true

--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/Settings.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/Settings.java
@@ -88,6 +88,10 @@ public final class Settings {
         return impl.isTabRowPerProject();
     }
 
+    public boolean isShowFolderName() {
+        return impl.isShowFolderName();
+    }
+
     /**
      * @return Maximum tab row count.
      */

--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/DocumentSwitcherTable.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/DocumentSwitcherTable.java
@@ -63,18 +63,26 @@ class DocumentSwitcherTable extends SwitcherTable {
 
     private final JButton btnClose;
     private final Controller controller;
-    private final ProjectColorTabDecorator decorator;
+    private final ProjectColorTabDecorator projectColorTabDecorator;
+    private final FolderNameTabDecorator folderNameDecorator;
     private final ItemBorder ITEM_BORDER = new ItemBorder();
     private final Border SEPARATOR_BORDER = BorderFactory.createEmptyBorder( 2, 2, 0, 5 );
+
+    private String itemText;
 
     public DocumentSwitcherTable( Controller controller, SwitcherTableItem[] items, int y ) {
         super( items, y );
         this.controller = controller;
         btnClose = createCloseButton();
         if( Settings.getDefault().isSameProjectSameColor() ) {
-            decorator = new ProjectColorTabDecorator();
+            projectColorTabDecorator = new ProjectColorTabDecorator();
         } else {
-            decorator = null;
+            projectColorTabDecorator = null;
+        }
+        if( Settings.getDefault().isShowFolderName() ) {
+            folderNameDecorator = new FolderNameTabDecorator(this);
+        } else {
+            folderNameDecorator = null;
         }
         ToolTipManager.sharedInstance().registerComponent( this );
     }
@@ -103,6 +111,13 @@ class DocumentSwitcherTable extends SwitcherTable {
                 lbl.setIcon( null );
                 lbl.setText( item.getHtmlName() );
             } else {
+                if(null != folderNameDecorator && null != item) {
+                    TabData tab = item.getTabData();
+                    if(null != tab) {
+                        itemText = folderNameDecorator.getText(tab) + (item.isActive() ? " ←" : ""); //NOI18N
+                        lbl.setText(itemText);
+                    }
+                }
                 lbl.setBorder( ITEM_BORDER );
             }
         }
@@ -115,10 +130,10 @@ class DocumentSwitcherTable extends SwitcherTable {
             res.setBackground( renComponent.getBackground() );
             return res;
         }
-        if( null != decorator && null != item && !selected ) {
+        if( null != projectColorTabDecorator && null != item && !selected ) {
             TabData tab = item.getTabData();
             if( null != tab ) {
-                ITEM_BORDER.color = decorator.getBackground( tab, selected);
+                ITEM_BORDER.color = projectColorTabDecorator.getBackground( tab, selected);
             }
         }
         return renComponent;

--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/FolderNameTabDecorator.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/FolderNameTabDecorator.java
@@ -21,14 +21,19 @@ package org.netbeans.core.multitabs.impl;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Rectangle;
+import java.io.File;
 import javax.swing.Icon;
+import javax.swing.UIManager;
 import org.netbeans.core.multitabs.TabDecorator;
 import org.netbeans.core.multitabs.prefs.SettingsImpl;
+import org.netbeans.swing.popupswitcher.SwitcherTable;
 import org.netbeans.swing.tabcontrol.TabData;
 import org.openide.filesystems.FileObject;
 import org.openide.loaders.DataObject;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.windows.TopComponent;
+
+import static java.util.Objects.requireNonNullElse;
 
 /**
  * Show the name of parent folder in tab's title.
@@ -40,7 +45,27 @@ import org.openide.windows.TopComponent;
 public class FolderNameTabDecorator extends TabDecorator {
 
     private final SettingsImpl settings = new SettingsImpl();
-    private static final String pathSeparator = System.getProperty( "file.separator", "/" ); //NOI18N
+    private final String fadeColor;
+    private final boolean isTab;
+
+    /**
+     * Decorator used for tabs
+     */
+    public FolderNameTabDecorator() {
+        fadeColor = fadeColor(
+            requireNonNullElse(UIManager.getColor("nb.multitabs.foreground"), UIManager.getColor("TabbedPane.foreground")), //NOI18N
+            requireNonNullElse(UIManager.getColor("nb.multitabs.background"), UIManager.getColor("TabbedPane.background")) //NOI18N
+        );
+        isTab = true;
+    }
+
+    /**
+     * Decorator used for switcher
+     */
+    FolderNameTabDecorator(SwitcherTable switcher) {
+        fadeColor = fadeColor(switcher.getForeground(), switcher.getBackground());
+        isTab = false;
+    }
 
     @Override
     public String getText( TabData tab ) {
@@ -54,10 +79,14 @@ public class FolderNameTabDecorator extends TabDecorator {
                 if( fo.isData() ) {
                     FileObject folder = fo.getParent();
                     if( null != folder ) {
-                        String folderName = folder.getNameExt() + pathSeparator;
-                        String defaultText = tab.getText();
-
-                        return merge( folderName, defaultText );
+                        String folderName = folder.getNameExt() + File.separator;
+                        // don't use faded colors in tabs when colored tabs are active
+                        // since it is difficult to get right with so many colors and shades involved
+                        // the switcher uses a line as marker instead of bg change and can continue using fade colors
+                        if (!(isTab && settings.isSameProjectSameColor())) {
+                            folderName = "<font color=\"" + fadeColor + "\">" + folderName + "</font>"; //NOI18N
+                        }
+                        return merge(folderName, tab.getText());
                     }
                 }
             }
@@ -100,4 +129,17 @@ public class FolderNameTabDecorator extends TabDecorator {
 
         return res.toString();
     }
+
+    private String fadeColor(Color f, Color b) {
+        float a = isDarkLaF() ? 0.7f : 0.6f;
+        return String.format("#%02x%02x%02x", //NOI18N
+                 (int)(b.getRed()   + a * (f.getRed()   - b.getRed())),
+                 (int)(b.getGreen() + a * (f.getGreen() - b.getGreen())),
+                 (int)(b.getBlue()  + a * (f.getBlue()  - b.getBlue())));
+    }
+
+    private static boolean isDarkLaF() {
+        return UIManager.getBoolean("nb.dark.theme"); //NOI18N 
+    }
+
 }


### PR DESCRIPTION
Small improvements to the “Show parent folder name in tab title” option:
- parent folder name is displayed in opened documents list;
- parent folder name is displayed in a different color from the file name.

Before:
![before_2](https://github.com/user-attachments/assets/7a0a7d47-0621-4531-bfe4-b35240dcca7b)




After:
![after_3](https://github.com/user-attachments/assets/2ecfd0c9-25a5-4336-b092-4470e704e27a)




After dark theme:
![after_dark_3](https://github.com/user-attachments/assets/f08b92aa-e3c1-4ceb-a5fe-abce8d35022f)











