### PR TITLE
JS CDT Debugger: Improve path handling and remember connection settings

### DIFF
--- a/webcommon/javascript.cdtdebug.ui/nbproject/project.properties
+++ b/webcommon/javascript.cdtdebug.ui/nbproject/project.properties
@@ -19,4 +19,4 @@ javac.release=11
 javadoc.arch=${basedir}/arch.xml
 
 is.eager=true
-spec.version.base=1.3.0
+spec.version.base=1.4.0

--- a/webcommon/javascript.cdtdebug.ui/nbproject/project.xml
+++ b/webcommon/javascript.cdtdebug.ui/nbproject/project.xml
@@ -48,8 +48,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.0</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/javascript.cdtdebug.ui/src/org/netbeans/modules/javascript/cdtdebug/ui/annotation/CallStackAnnotationListener.java
+++ b/webcommon/javascript.cdtdebug.ui/src/org/netbeans/modules/javascript/cdtdebug/ui/annotation/CallStackAnnotationListener.java
@@ -184,7 +184,7 @@ public final class CallStackAnnotationListener extends DebuggerManagerAdapter
                 return ;
             }
             topFrameShown = false;
-            EditorUtils.showFrameLine(dbg, cf, true);
+            annotationProcessor.execute(() -> EditorUtils.showFrameLine(dbg, cf, true));
         }
 
         @Override

--- a/webcommon/javascript.cdtdebug.ui/src/org/netbeans/modules/javascript/cdtdebug/ui/models/DebuggingModel.java
+++ b/webcommon/javascript.cdtdebug.ui/src/org/netbeans/modules/javascript/cdtdebug/ui/models/DebuggingModel.java
@@ -22,6 +22,8 @@ package org.netbeans.modules.javascript.cdtdebug.ui.models;
 import java.awt.datatransfer.Transferable;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import org.netbeans.lib.chrome_devtools_protocol.debugger.CallFrame;
 import org.netbeans.modules.javascript.cdtdebug.CDTDebugger;
@@ -189,7 +191,16 @@ public class DebuggingModel extends ViewModelSupport implements TreeModel, Exten
     static String getScriptName(ScriptsHandler scriptsHandler, CallFrame cf) {
         CDTScript script = scriptsHandler.getScript(cf.getLocation().getScriptId());
         if (script != null) {
-            String scriptName = script.getUrl().getPath();
+            String urlString = script.getUrl();
+            String scriptName = urlString;
+            try {
+                URI url = new URI(urlString);
+                if(url.getPath() != null) {
+                    scriptName = url.getPath();
+                }
+            } catch (URISyntaxException ex) {
+                return urlString;
+            }
             if (scriptName == null) {
                 return null;
             }

--- a/webcommon/javascript.cdtdebug/nbproject/project.properties
+++ b/webcommon/javascript.cdtdebug/nbproject/project.properties
@@ -19,4 +19,4 @@ javac.release=11
 javadoc.arch=${basedir}/arch.xml
 
 is.autoload=true
-spec.version.base=1.3.0
+spec.version.base=1.4.0

--- a/webcommon/javascript.cdtdebug/nbproject/project.xml
+++ b/webcommon/javascript.cdtdebug/nbproject/project.xml
@@ -56,8 +56,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.0</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/javascript.cdtdebug/src/org/netbeans/modules/javascript/cdtdebug/CDTScript.java
+++ b/webcommon/javascript.cdtdebug/src/org/netbeans/modules/javascript/cdtdebug/CDTScript.java
@@ -18,14 +18,13 @@
  */
 package org.netbeans.modules.javascript.cdtdebug;
 
-import java.net.URI;
 import java.util.Objects;
 import org.netbeans.lib.chrome_devtools_protocol.debugger.ScriptFailedToParse;
 import org.netbeans.lib.chrome_devtools_protocol.debugger.ScriptParsed;
 
 public class CDTScript {
     private final String scriptId;
-    private final URI url;
+    private final String url;
     private final int startLine;
     private final int startColumn;
     private final int endLine;
@@ -59,7 +58,7 @@ public class CDTScript {
         return scriptId;
     }
 
-    public URI getUrl() {
+    public String getUrl() {
         return url;
     }
 

--- a/webcommon/javascript.cdtdebug/src/org/netbeans/modules/javascript/cdtdebug/sources/ChangeLiveSupport.java
+++ b/webcommon/javascript.cdtdebug/src/org/netbeans/modules/javascript/cdtdebug/sources/ChangeLiveSupport.java
@@ -120,15 +120,13 @@ public final class ChangeLiveSupport {
                 continue;
             }
             String path = fo.getPath();
-            String serverPath;
-            try {
-                serverPath = sh.getServerPath(path);
-            } catch (ScriptsHandler.OutOfScope ex) {
+            String serverPath = sh.getServerPath(fo);
+            if(serverPath == null) {
                 continue;
             }
             CDTScript script = null;
             for (CDTScript s : scripts) {
-                if (serverPath.equals(s.getUrl().getPath())) {
+                if (serverPath.equals(s.getUrl())) {
                     script = s;
                     break;
                 }
@@ -158,7 +156,7 @@ public final class ChangeLiveSupport {
                         return null;
                     });
 
-            LOG.log(Level.FINE, "Running ChangeLive command for script {0}", script.getUrl().toASCIIString());
+            LOG.log(Level.FINE, "Running ChangeLive command for script {0}", script.getUrl());
         }
         phaser.arriveAndAwaitAdvance();
     }

--- a/webcommon/lib.chrome_devtools_protocol/manifest.mf
+++ b/webcommon/lib.chrome_devtools_protocol/manifest.mf
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
-OpenIDE-Module: org.netbeans.lib.chrome_devtools_protocol/1
+OpenIDE-Module: org.netbeans.lib.chrome_devtools_protocol/2
 OpenIDE-Module-Localizing-Bundle: org/netbeans/lib/chrome_devtools_protocol/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.3
+OpenIDE-Module-Specification-Version: 2.0

--- a/webcommon/lib.chrome_devtools_protocol/nbproject/org-netbeans-lib-chrome_devtools_protocol.sig
+++ b/webcommon/lib.chrome_devtools_protocol/nbproject/org-netbeans-lib-chrome_devtools_protocol.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.1
+#Version 2.0
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable
@@ -64,6 +64,7 @@ meth public void setStackTrace(java.lang.StackTraceElement[])
 supr java.lang.Object
 
 CLSS public abstract org.netbeans.lib.chrome_devtools_protocol.CDTUtil
+meth public static java.lang.String toNodeUrl(java.lang.String)
 meth public static java.net.URI toNodeUrl(java.net.URI)
 supr java.lang.Object
 
@@ -165,9 +166,9 @@ meth public int hashCode()
 meth public java.lang.Boolean getCanBeRestarted()
 meth public java.lang.String getCallFrameId()
 meth public java.lang.String getFunctionName()
-meth public java.lang.String toString()
-meth public java.net.URI getUrl()
+meth public java.lang.String getUrl()
  anno 0 java.lang.Deprecated(boolean forRemoval=false, java.lang.String since="")
+meth public java.lang.String toString()
 meth public java.util.List<org.netbeans.lib.chrome_devtools_protocol.debugger.Scope> getScopeChain()
 meth public org.netbeans.lib.chrome_devtools_protocol.debugger.Location getFunctionLocation()
 meth public org.netbeans.lib.chrome_devtools_protocol.debugger.Location getLocation()
@@ -181,7 +182,7 @@ meth public void setLocation(org.netbeans.lib.chrome_devtools_protocol.debugger.
 meth public void setReturnValue(org.netbeans.lib.chrome_devtools_protocol.runtime.RemoteObject)
 meth public void setScopeChain(java.util.List<org.netbeans.lib.chrome_devtools_protocol.debugger.Scope>)
 meth public void setThisObject(org.netbeans.lib.chrome_devtools_protocol.runtime.RemoteObject)
-meth public void setUrl(java.net.URI)
+meth public void setUrl(java.lang.String)
  anno 0 java.lang.Deprecated(boolean forRemoval=false, java.lang.String since="")
 supr java.lang.Object
 hfds callFrameId,canBeRestarted,functionLocation,functionName,location,returnValue,scopeChain,thisObject,url
@@ -458,9 +459,9 @@ meth public java.lang.String getEmbedderName()
 meth public java.lang.String getHash()
 meth public java.lang.String getScriptId()
 meth public java.lang.String getScriptLanguage()
+meth public java.lang.String getUrl()
 meth public java.lang.String toString()
 meth public java.net.URI getSourceMapURL()
-meth public java.net.URI getUrl()
 meth public org.netbeans.lib.chrome_devtools_protocol.runtime.StackTrace getStackTrace()
 meth public void setCodeOffset(java.lang.Integer)
 meth public void setEmbedderName(java.lang.String)
@@ -478,7 +479,7 @@ meth public void setSourceMapURL(java.net.URI)
 meth public void setStackTrace(org.netbeans.lib.chrome_devtools_protocol.runtime.StackTrace)
 meth public void setStartColumn(int)
 meth public void setStartLine(int)
-meth public void setUrl(java.net.URI)
+meth public void setUrl(java.lang.String)
 supr java.lang.Object
 hfds codeOffset,embedderName,endColumn,endLine,executionContextAuxData,executionContextId,hasSourceURL,hash,isModule,length,scriptId,scriptLanguage,sourceMapURL,stackTrace,startColumn,startLine,url
 
@@ -501,9 +502,9 @@ meth public java.lang.String getEmbedderName()
 meth public java.lang.String getHash()
 meth public java.lang.String getScriptId()
 meth public java.lang.String getScriptLanguage()
+meth public java.lang.String getUrl()
 meth public java.lang.String toString()
 meth public java.net.URI getSourceMapURL()
-meth public java.net.URI getUrl()
 meth public org.netbeans.lib.chrome_devtools_protocol.debugger.DebugSymbols getDebugSymbols()
 meth public org.netbeans.lib.chrome_devtools_protocol.runtime.StackTrace getStackTrace()
 meth public void setCodeOffset(java.lang.Integer)
@@ -524,7 +525,7 @@ meth public void setSourceMapURL(java.net.URI)
 meth public void setStackTrace(org.netbeans.lib.chrome_devtools_protocol.runtime.StackTrace)
 meth public void setStartColumn(int)
 meth public void setStartLine(int)
-meth public void setUrl(java.net.URI)
+meth public void setUrl(java.lang.String)
 supr java.lang.Object
 hfds codeOffset,debugSymbols,embedderName,endColumn,endLine,executionContextAuxData,executionContextId,hasSourceURL,hash,isLiveEdit,isModule,length,scriptId,scriptLanguage,sourceMapURL,stackTrace,startColumn,startLine,url
 
@@ -601,14 +602,14 @@ meth public int hashCode()
 meth public java.lang.Integer getColumnNumber()
 meth public java.lang.String getCondition()
 meth public java.lang.String getScriptHash()
+meth public java.lang.String getUrl()
 meth public java.lang.String getUrlRegex()
 meth public java.lang.String toString()
-meth public java.net.URI getUrl()
 meth public void setColumnNumber(java.lang.Integer)
 meth public void setCondition(java.lang.String)
 meth public void setLineNumber(int)
 meth public void setScriptHash(java.lang.String)
-meth public void setUrl(java.net.URI)
+meth public void setUrl(java.lang.String)
 meth public void setUrlRegex(java.lang.String)
 supr java.lang.Object
 hfds columnNumber,condition,lineNumber,scriptHash,url,urlRegex
@@ -857,13 +858,13 @@ meth public int getLineNumber()
 meth public int hashCode()
 meth public java.lang.String getFunctionName()
 meth public java.lang.String getScriptId()
+meth public java.lang.String getUrl()
 meth public java.lang.String toString()
-meth public java.net.URI getUrl()
 meth public void setColumnNumber(int)
 meth public void setFunctionName(java.lang.String)
 meth public void setLineNumber(int)
 meth public void setScriptId(java.lang.String)
-meth public void setUrl(java.net.URI)
+meth public void setUrl(java.lang.String)
 supr java.lang.Object
 hfds columnNumber,functionName,lineNumber,scriptId,url
 

--- a/webcommon/lib.chrome_devtools_protocol/src/org/netbeans/lib/chrome_devtools_protocol/CDTUtil.java
+++ b/webcommon/lib.chrome_devtools_protocol/src/org/netbeans/lib/chrome_devtools_protocol/CDTUtil.java
@@ -46,4 +46,24 @@ public abstract class CDTUtil {
             return uri;
         }
     }
+
+    /**
+     * Java created file URIs in the style "file:/PATH" by default, but Node
+     * only accepts the form "file:///PATH";
+     *
+     * @param uri
+     * @return
+     */
+    public static String toNodeUrl(String uri) {
+        try {
+            URI parsedUri = new URI(uri);
+            if("file".equals(parsedUri.getScheme())) {
+                return toNodeUrl(parsedUri).toString();
+            } else {
+                return uri;
+            }
+        } catch (URISyntaxException ex) {
+            return uri;
+        }
+    }
 }

--- a/webcommon/lib.chrome_devtools_protocol/src/org/netbeans/lib/chrome_devtools_protocol/debugger/CallFrame.java
+++ b/webcommon/lib.chrome_devtools_protocol/src/org/netbeans/lib/chrome_devtools_protocol/debugger/CallFrame.java
@@ -19,7 +19,6 @@
 package org.netbeans.lib.chrome_devtools_protocol.debugger;
 
 import com.google.gson.annotations.SerializedName;
-import java.net.URI;
 import java.util.List;
 import java.util.Objects;
 import org.netbeans.lib.chrome_devtools_protocol.runtime.RemoteObject;
@@ -32,7 +31,7 @@ public final class CallFrame {
     private String functionName;
     private Location functionLocation;
     private Location location;
-    private URI url;
+    private String url;
     private List<Scope> scopeChain;
     @SerializedName("this")
     private RemoteObject thisObject;
@@ -106,7 +105,7 @@ public final class CallFrame {
      * Debugger.scriptParsed event.
      */
     @Deprecated
-    public URI getUrl() {
+    public String getUrl() {
         return url;
     }
 
@@ -116,7 +115,7 @@ public final class CallFrame {
      * Debugger.scriptParsed event.
      */
     @Deprecated
-    public void setUrl(URI url) {
+    public void setUrl(String url) {
         this.url = url;
     }
 

--- a/webcommon/lib.chrome_devtools_protocol/src/org/netbeans/lib/chrome_devtools_protocol/debugger/ScriptFailedToParse.java
+++ b/webcommon/lib.chrome_devtools_protocol/src/org/netbeans/lib/chrome_devtools_protocol/debugger/ScriptFailedToParse.java
@@ -27,7 +27,7 @@ import org.netbeans.lib.chrome_devtools_protocol.runtime.StackTrace;
  */
 public final class ScriptFailedToParse {
     private String scriptId;
-    private URI url;
+    private String url;
     private int startLine;
     private int startColumn;
     private int endLine;
@@ -64,14 +64,14 @@ public final class ScriptFailedToParse {
     /**
      * URL or name of the script parsed (if any).
      */
-    public URI getUrl() {
+    public String getUrl() {
         return url;
     }
 
     /**
      * URL or name of the script parsed (if any).
      */
-    public void setUrl(URI url) {
+    public void setUrl(String url) {
         this.url = url;
     }
 

--- a/webcommon/lib.chrome_devtools_protocol/src/org/netbeans/lib/chrome_devtools_protocol/debugger/ScriptParsed.java
+++ b/webcommon/lib.chrome_devtools_protocol/src/org/netbeans/lib/chrome_devtools_protocol/debugger/ScriptParsed.java
@@ -27,7 +27,7 @@ import org.netbeans.lib.chrome_devtools_protocol.runtime.StackTrace;
  */
 public final class ScriptParsed {
     private String scriptId;
-    private URI url;
+    private String url;
     private int startLine;
     private int startColumn;
     private int endLine;
@@ -66,14 +66,14 @@ public final class ScriptParsed {
     /**
      * URL or name of the script parsed (if any).
      */
-    public URI getUrl() {
+    public String getUrl() {
         return url;
     }
 
     /**
      * URL or name of the script parsed (if any).
      */
-    public void setUrl(URI url) {
+    public void setUrl(String url) {
         this.url = url;
     }
 

--- a/webcommon/lib.chrome_devtools_protocol/src/org/netbeans/lib/chrome_devtools_protocol/debugger/SetBreakpointByUrlRequest.java
+++ b/webcommon/lib.chrome_devtools_protocol/src/org/netbeans/lib/chrome_devtools_protocol/debugger/SetBreakpointByUrlRequest.java
@@ -18,12 +18,11 @@
  */
 package org.netbeans.lib.chrome_devtools_protocol.debugger;
 
-import java.net.URI;
 import java.util.Objects;
 
 public final class SetBreakpointByUrlRequest {
     private int lineNumber;
-    private URI url;
+    private String url;
     private String urlRegex;
     private String scriptHash;
     private Integer columnNumber;
@@ -49,14 +48,14 @@ public final class SetBreakpointByUrlRequest {
     /**
      * URL of the resources to set breakpoint on.
      */
-    public URI getUrl() {
+    public String getUrl() {
         return url;
     }
 
     /**
      * URL of the resources to set breakpoint on.
      */
-    public void setUrl(URI url) {
+    public void setUrl(String url) {
         this.url = url;
     }
 

--- a/webcommon/lib.chrome_devtools_protocol/src/org/netbeans/lib/chrome_devtools_protocol/runtime/CallFrame.java
+++ b/webcommon/lib.chrome_devtools_protocol/src/org/netbeans/lib/chrome_devtools_protocol/runtime/CallFrame.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.lib.chrome_devtools_protocol.runtime;
 
-import java.net.URI;
 import java.util.Objects;
 
 /**
@@ -27,7 +26,7 @@ import java.util.Objects;
 public final class CallFrame {
     private String functionName;
     private String scriptId;
-    private URI url;
+    private String url;
     private int lineNumber;
     private int columnNumber;
 
@@ -65,14 +64,14 @@ public final class CallFrame {
     /**
      * JavaScript script name or url.
      */
-    public URI getUrl() {
+    public String getUrl() {
         return url;
     }
 
     /**
      * JavaScript script name or url.
      */
-    public void setUrl(URI url) {
+    public void setUrl(String url) {
         this.url = url;
     }
 


### PR DESCRIPTION
- JS CDT Debugger: Remember connection settings for remote attach
- JS CDT Debugger: Improve handling of paths
- CDT Protocol allows to store "names" in url fields, which ware not URL compatible and thus break parsing

Closes: #7797