### PR TITLE
Java Platform Libraries: Support source archives with multiple modules

### DIFF
--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SEVolumeCustomizer.form
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SEVolumeCustomizer.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
 


### PR DESCRIPTION
The OpenJFX SDK and OpenJDK itself provide src.zip files, where the source is not located at the toplevel directory, but an intermediate level with one folder per module is used.

Closes: #7888