### PR TITLE
[NETBEANS-7467] Fixing synchronization in TokenList.resetToIndex

### DIFF
--- a/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/TokenList.java
+++ b/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/TokenList.java
@@ -365,12 +365,23 @@ public class TokenList {
     }
 
     public void resetToIndex(int index) {
-        if (ts == null) {
-            return ;
-        }
+        doc.render(() -> {
+            if (cancel.get()) {
+                return ;
+            }
 
-        ts.moveIndex(index);
-        ts.moveNext();
+            if (ts == null) {
+                return ;
+            }
+
+            if (!ts.isValid()) {
+                cancel.set(true);
+                return ;
+            }
+
+            ts.moveIndex(index);
+            ts.moveNext();
+        });
     }
 
     private static List<TokenSequence<?>> embeddedTokenSequences(TokenHierarchy<Document> th, int offset) {


### PR DESCRIPTION
The overall approach is that the `TokenSequence` should only be manipulated under a (Document) read lock, which the patch is attempting to do.

Might be reasonable for NB24, but I can slip if needed.

See: https://github.com/apache/netbeans/issues/7467