### PR TITLE
Switch SVG loading from the Batik library to JSVG

### DIFF
--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -189,6 +189,7 @@ nb.cluster.platform=\
         libs.jna,\
         libs.jna.platform,\
         libs.jsr223,\
+        libs.jsvg,\
         libs.junit4,\
         libs.junit5,\
         libs.osgi,\

--- a/nbbuild/licenses/MIT-jsvg
+++ b/nbbuild/licenses/MIT-jsvg
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021-2024 Jannis Weis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nbbuild/licenses/names.properties
+++ b/nbbuild/licenses/names.properties
@@ -69,6 +69,7 @@ MIT-phpstan=MIT license PHPStan variant
 MIT-validator=MIT license validator variant
 MIT-vscode=MIT license for VSCode
 MIT-vscode-ext=MIT license VS Code variant
+MIT-jsvg=MIT license JSVG variant
 MPL-1.0=MPL 1.0 license
 CDDL-SPL=CDDL 1.0 + SPL 1.0
 W3C2=W3C Software and Document Notice and License

--- a/platform/libs.jsvg/build.xml
+++ b/platform/libs.jsvg/build.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<!-- You may freely edit this file. See harness/README in the NetBeans platform -->
+<!-- for some information on what you could do (e.g. targets to override). -->
+<!-- If you delete this file and reopen the project it will be recreated. -->
+<project name="platform/libs.jsvg" default="build" basedir=".">
+    <description>Builds the JSVG library wrapper module.</description>
+    <import file="../../nbbuild/templates/projectized.xml"/>
+</project>

--- a/platform/libs.jsvg/external/binaries-list
+++ b/platform/libs.jsvg/external/binaries-list
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+A84D34480044DB51A1448E9C0E32BD284B797288 com.github.weisj:jsvg:1.6.1

--- a/platform/libs.jsvg/external/jsvg-1.6.1-license.txt
+++ b/platform/libs.jsvg/external/jsvg-1.6.1-license.txt
@@ -1,0 +1,29 @@
+Name: JSVG
+Version: 1.6.1
+Description: JSVG - A Java SVG implementation
+License: MIT-jsvg
+Origin: JSVG
+URL: https://github.com/weisJ/jsvg
+Files: jsvg-1.6.1.jar
+
+MIT License
+
+Copyright (c) 2021-2024 Jannis Weis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/platform/libs.jsvg/manifest.mf
+++ b/platform/libs.jsvg/manifest.mf
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+OpenIDE-Module: org.netbeans.libs.jsvg
+OpenIDE-Module-Implementation-Version: 1
+OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/jsvg/Bundle.properties
+AutoUpdate-Show-In-Client: false

--- a/platform/libs.jsvg/nbproject/project.properties
+++ b/platform/libs.jsvg/nbproject/project.properties
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+file.reference.jsvg-1.6.1.jar=external/jsvg-1.6.1.jar
+release.external/jsvg-1.6.1.jar=modules/ext/jsvg-1.6.1.jar
+
+is.autoload=true
+javac.source=1.8
+
+nbm.homepage=https://github.com/weisJ/jsvg
+sigtest.gen.fail.on.error=false
+spec.version.base=1.22.0

--- a/platform/libs.jsvg/nbproject/project.xml
+++ b/platform/libs.jsvg/nbproject/project.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.apisupport.project</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/nb-module-project/2">
+            <code-name-base>org.netbeans.libs.jsvg</code-name-base>
+            <module-dependencies/>
+            <public-packages>
+                <package>com.github.weisj.jsvg</package>
+                <package>com.github.weisj.jsvg.attributes</package>
+                <package>com.github.weisj.jsvg.attributes.filter</package>
+                <package>com.github.weisj.jsvg.attributes.font</package>
+                <package>com.github.weisj.jsvg.attributes.paint</package>
+                <package>com.github.weisj.jsvg.attributes.stroke</package>
+                <package>com.github.weisj.jsvg.attributes.text</package>
+                <package>com.github.weisj.jsvg.geometry</package>
+                <package>com.github.weisj.jsvg.geometry.mesh</package>
+                <package>com.github.weisj.jsvg.geometry.noise</package>
+                <package>com.github.weisj.jsvg.geometry.path</package>
+                <package>com.github.weisj.jsvg.geometry.size</package>
+                <package>com.github.weisj.jsvg.geometry.util</package>
+                <package>com.github.weisj.jsvg.nodes</package>
+                <package>com.github.weisj.jsvg.nodes.animation</package>
+                <package>com.github.weisj.jsvg.nodes.container</package>
+                <package>com.github.weisj.jsvg.nodes.filter</package>
+                <package>com.github.weisj.jsvg.nodes.mesh</package>
+                <package>com.github.weisj.jsvg.nodes.prototype</package>
+                <package>com.github.weisj.jsvg.nodes.prototype.spec</package>
+                <package>com.github.weisj.jsvg.nodes.text</package>
+                <package>com.github.weisj.jsvg.parser</package>
+                <package>com.github.weisj.jsvg.parser.css</package>
+                <package>com.github.weisj.jsvg.parser.resources</package>
+                <package>com.github.weisj.jsvg.renderer</package>
+                <package>com.github.weisj.jsvg.renderer.awt</package>
+                <package>com.github.weisj.jsvg.renderer.jdk</package>
+                <package>com.github.weisj.jsvg.util</package>
+            </public-packages>
+            <class-path-extension>
+                <runtime-relative-path>ext/jsvg-1.6.1.jar</runtime-relative-path>
+                <binary-origin>external/jsvg-1.6.1.jar</binary-origin>
+            </class-path-extension>
+        </data>
+    </configuration>
+</project>

--- a/platform/libs.jsvg/src/org/netbeans/libs/jsvg/Bundle.properties
+++ b/platform/libs.jsvg/src/org/netbeans/libs/jsvg/Bundle.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+OpenIDE-Module-Name=JSVG Library
+OpenIDE-Module-Short-Description=JSVG Library
+OpenIDE-Module-Long-Description=Contains the JSVG library, for reading and painting SVG files.
+OpenIDE-Module-Display-Category=Libraries

--- a/platform/openide.util.ui.svg/nbproject/project.xml
+++ b/platform/openide.util.ui.svg/nbproject/project.xml
@@ -26,7 +26,7 @@
             <code-name-base>org.openide.util.ui.svg</code-name-base>
             <module-dependencies>
                 <dependency>
-                    <code-name-base>org.netbeans.libs.batik.read</code-name-base>
+                    <code-name-base>org.netbeans.libs.jsvg</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>

--- a/platform/openide.util.ui.svg/src/org/openide/util/svg/DenyingElementLoader.java
+++ b/platform/openide.util.ui.svg/src/org/openide/util/svg/DenyingElementLoader.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.openide.util.svg;
+
+import com.github.weisj.jsvg.attributes.AttributeParser;
+import com.github.weisj.jsvg.parser.ElementLoader;
+import com.github.weisj.jsvg.parser.ParsedDocument;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+class DenyingElementLoader implements ElementLoader {
+    private final Set<String> attemptedExternalURLsLoaded = new LinkedHashSet<>();
+
+    public Set<String> getAttemptedExternalURLsLoaded() {
+        return Collections.unmodifiableSet(attemptedExternalURLsLoaded);
+    }
+
+    @Override
+    public <T> T loadElement(Class<T> type, String value,
+            ParsedDocument document, AttributeParser attributeParser)
+    {
+        /* Same logic as in com.github.weisj.jsvg.parser.DefaultElementLoader for the
+        AllowExternalResources.DENY case, but gathering up the attempted externally loaded URLs so
+        we can make the whole loading operation fail and make testLoadImageWithExternalUseXlinkHref
+        pass. */
+        String url = attributeParser.parseUrl(value);
+        if (url == null) {
+            return null;
+        }
+        if (url.contains("#")) {
+            String[] parts = url.split("#", 2);
+            String name = parts[0];
+            if (!name.isEmpty()) {
+                attemptedExternalURLsLoaded.add(value);
+                return null;
+            }
+            return document.getElementById(type, parts[1]);
+        } else {
+            return document.getElementById(type, url);
+        }
+    }
+}

--- a/platform/openide.util.ui.svg/test/unit/src/org/openide/util/svg/SVGLoaderImplTest.java
+++ b/platform/openide.util.ui.svg/test/unit/src/org/openide/util/svg/SVGLoaderImplTest.java
@@ -44,7 +44,19 @@ public class SVGLoaderImplTest extends NbTestCase {
         assertNotNull("Image must not load", im);
     }
     
-    public void testLoadImageWithExternalHref() throws Exception {
+    public void testLoadImageWithExternalUseHrefXlink() throws Exception {
+      testLoadImageWithExternalHref("org/openide/util/svg/externalHref.svg");
+    }
+
+    public void testLoadImageWithExternalImageHrefXLink() throws Exception {
+      testLoadImageWithExternalHref("org/openide/util/svg/externalImageHrefXLink.svg");
+    }
+
+    public void testLoadImageWithExternalImageHref() throws Exception {
+      testLoadImageWithExternalHref("org/openide/util/svg/externalImageHref.svg");
+    }
+
+    public void testLoadImageWithExternalHref(String image) throws Exception {
         class H extends Handler {
             List<LogRecord> recorded = new ArrayList<>();
 
@@ -64,7 +76,7 @@ public class SVGLoaderImplTest extends NbTestCase {
         H h = new H();
         Logger.getLogger(ImageUtilities.class.getName()).addHandler(h);
         try {
-            Image im = ImageUtilities.loadImage("org/openide/util/svg/externalHref.svg", false); // NOI18N
+            Image im = ImageUtilities.loadImage(image, false); // NOI18N
             assertNull("Image must not load", im);
         } finally {
             Logger.getLogger(ImageUtilities.class.getName()).removeHandler(h);

--- a/platform/openide.util.ui.svg/test/unit/src/org/openide/util/svg/externalImageHref.svg
+++ b/platform/openide.util.ui.svg/test/unit/src/org/openide/util/svg/externalImageHref.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN"
+   "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+
+<!--
+
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100" viewBox="0 0 100 100">
+    <image href="https://example.com/image.png" x="10" y="10" height="160" width="380"/>
+</svg>

--- a/platform/openide.util.ui.svg/test/unit/src/org/openide/util/svg/externalImageHrefXLink.svg
+++ b/platform/openide.util.ui.svg/test/unit/src/org/openide/util/svg/externalImageHrefXLink.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN"
+   "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+
+<!--
+
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100" viewBox="0 0 100 100">
+    <image xlink:href="https://example.com/image.png" x="10" y="10" height="160" width="380"/>
+</svg>


### PR DESCRIPTION
Per our discussion in https://github.com/apache/netbeans/pull/7463#issuecomment-2252299955 and https://github.com/apache/netbeans/pull/7938 , here is a PR that switches SVG loading routine in ImageUtilities from the Batik library to the much more lightweight JSVG library.

It's a draft that needs more testing, so I have added the do-not-merge label for now. But I'm leaving the work here since it might benefit https://github.com/apache/netbeans/pull/7938.