### PR TITLE
OutputWindow: text selection can start at index 0.

### DIFF
--- a/platform/core.output2/src/org/netbeans/core/output2/ui/AbstractOutputPane.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/ui/AbstractOutputPane.java
@@ -198,7 +198,7 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
         int start = getSelectionStart();
         int end = getSelectionEnd();
         String str = null;
-        if (start > 0 && end > start) {
+        if (start >= 0 && end > start) {
             try {
                 str = getDocument().getText(start, end - start);
             } catch (BadLocationException ex) {


### PR DESCRIPTION
trivial fix.

`AbstractOutputPane#getSelection()` is only called from within [`OutputTab#actionPerformed`](https://github.com/apache/netbeans/blob/7d89336259b840ce53709cbc8240c88e32fd6ea1/platform/core.output2/src/org/netbeans/core/output2/OutputTab.java#L1127) and isn't public API. This should make this fix local and low risk since it doesn't affect anything outside of the _find_ and _filter_ actions of the same module.

targets delivery

closes #7942