### PR TITLE
Remove unnecessary continue/return hint should handle rule cases and switch expressions.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/control/RemoveUnnecessary.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/control/RemoveUnnecessary.java
@@ -143,21 +143,38 @@ public class RemoveUnnecessary {
                 }
                 case BLOCK: statements = ((BlockTree) tp.getLeaf()).getStatements(); break;
                 case CASE: {
-                    if (tp.getParentPath().getLeaf().getKind() == Kind.SWITCH) {
-                        List<? extends CaseTree> cases = ((SwitchTree) tp.getParentPath().getLeaf()).getCases();
-                        List<StatementTree> locStatements = new ArrayList<>();
+                    switch (tp.getParentPath().getLeaf().getKind()) {
+                        case SWITCH -> {
+                            CaseTree ct = (CaseTree) tp.getLeaf();
+                            if (ct.getCaseKind() == CaseTree.CaseKind.RULE) {
+                                if (ExpressionTree.class.isAssignableFrom(ct.getBody().getKind().asInterface())) {
+                                    //TODO: anything that can be done here?
+                                    return null;
+                                } else {
+                                    statements = List.of((StatementTree) ct.getBody());
+                                }
+                            } else {
+                                List<? extends CaseTree> cases = ((SwitchTree) tp.getParentPath().getLeaf()).getCases();
+                                List<StatementTree> locStatements = new ArrayList<>();
 
-                        for (int i = cases.indexOf(tp.getLeaf()); i < cases.size(); i++) {
-                            List<? extends StatementTree> list = cases.get(i).getStatements();
-                            if (list != null) {
-                                locStatements.addAll(list);
+                                for (int i = cases.indexOf(tp.getLeaf()); i < cases.size(); i++) {
+                                    List<? extends StatementTree> list = cases.get(i).getStatements();
+                                    if (list != null) {
+                                        locStatements.addAll(list);
+                                    }
+                                }
+
+                                statements = locStatements;
                             }
                         }
-
-                        statements = locStatements;
-                    } else {
-                        //???
-                        statements = ((CaseTree) tp.getLeaf()).getStatements();
+                        case SWITCH_EXPRESSION -> {
+                            //jumps out of switch expressions are illegal, ignore:
+                            return null;
+                        }
+                        default -> {
+                            //???
+                            statements = ((CaseTree) tp.getLeaf()).getStatements();
+                        }
                     }
                     break;
                 }

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/control/RemoveUnnecessaryTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/control/RemoveUnnecessaryTest.java
@@ -468,4 +468,64 @@ public class RemoveUnnecessaryTest extends NbTestCase {
                 .run(RemoveUnnecessary.class)
                 .assertWarnings();
     }
+
+    public void testRuleSwitch1() throws Exception {
+        HintTest.create()
+                .input("""
+                       package test;
+                       public class Test {
+                           public void testContinue(int i) {
+                               switch (i) {
+                                   case 0 -> { return ; }
+                                   case 1 -> { return ; }
+                                   default -> { }
+                               }
+                               System.err.println("not end");
+                           }
+                       }
+                       """)
+                .sourceLevel("17")
+                .run(RemoveUnnecessary.class)
+                .assertWarnings();
+    }
+
+    public void testRuleSwitch2() throws Exception {
+        HintTest.create()
+                .input("""
+                       package test;
+                       public class Test {
+                           public void testContinue(int i) {
+                               switch (i) {
+                                   case 0 -> { return ; }
+                                   case 1 -> { return ; }
+                                   default -> { }
+                               }
+                           }
+                       }
+                       """)
+                .sourceLevel("17")
+                .run(RemoveUnnecessary.class)
+                .assertWarnings("4:24-4:32:verifier:Unnecessary return statement",
+                                "5:24-5:32:verifier:Unnecessary return statement");
+    }
+
+    public void testRuleSwitchExpression() throws Exception {
+        HintTest.create()
+                .input("""
+                       package test;
+                       public class Test {
+                           public int testContinue(int i) {
+                               return switch (i) {
+                                   case 0 -> { return 0; } //illegal
+                                   case 1 -> { return 0; } //illegal
+                                   default -> -1;
+                               };
+                           }
+                       }
+                       """,
+                       false)
+                .sourceLevel("17")
+                .run(RemoveUnnecessary.class)
+                .assertWarnings();
+    }
 }


### PR DESCRIPTION
The `RemoveUnnecessary` hint crashes on code like:
```
switch (...) {
   case 0 -> { return ; }
}
```
with exceptions like:
```
Caused by: java.lang.AssertionError
	at org.netbeans.modules.java.hints.control.RemoveUnnecessary.unnecessaryReturnContinue(RemoveUnnecessary.java:175)
	at org.netbeans.modules.java.hints.control.RemoveUnnecessary.unnecessaryReturn(RemoveUnnecessary.java:99)
```

This patch adds handling for rule cases and switch expressions.