### PR TITLE
Update textmate support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -757,6 +757,9 @@ jobs:
       - name: ide/team.commons
         run: ant $OPTS -f ide/team.commons test
 
+      - name: ide/textmate.lexer
+        run: ant $OPTS -f ide/textmate.lexer test
+
       - name: ide/terminal.nb
         run: ant $OPTS -f ide/terminal.nb test
 

--- a/ide/libs.jcodings/external/binaries-list
+++ b/ide/libs.jcodings/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-E2C76A19F00128BB1806207E2989139BFB45F49D org.jruby.jcodings:jcodings:1.0.18
+DCE27159DC0382E5F7518D4F3E499FC8396357ED org.jruby.jcodings:jcodings:1.0.58

--- a/ide/libs.jcodings/external/jcodings-1.0.58-license.txt
+++ b/ide/libs.jcodings/external/jcodings-1.0.58-license.txt
@@ -1,5 +1,5 @@
 Name: jcodings
-Version: 1.0.18
+Version: 1.0.58
 Description: Java-based codings helper classes for Joni and JRuby
 License: MIT-nocopyright
 Origin: https://github.com/jruby/jcodings

--- a/ide/libs.jcodings/manifest.mf
+++ b/ide/libs.jcodings/manifest.mf
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
-OpenIDE-Module: org.netbeans.libs.jcodings/1
+OpenIDE-Module: org.netbeans.libs.jcodings/2
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/jcodings/Bundle.properties
-OpenIDE-Module-Specification-Version: 0.16
+OpenIDE-Module-Specification-Version: 1.0.58

--- a/ide/libs.jcodings/nbproject/org-netbeans-libs-jcodings.sig
+++ b/ide/libs.jcodings/nbproject/org-netbeans-libs-jcodings.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.15
+#Version 1.0.58
 
 CLSS public abstract interface java.io.Serializable
 
@@ -81,6 +81,37 @@ meth public void printStackTrace(java.io.PrintWriter)
 meth public void setStackTrace(java.lang.StackTraceElement[])
 supr java.lang.Object
 
+CLSS public abstract java.nio.charset.Charset
+cons protected init(java.lang.String,java.lang.String[])
+intf java.lang.Comparable<java.nio.charset.Charset>
+meth public abstract boolean contains(java.nio.charset.Charset)
+meth public abstract java.nio.charset.CharsetDecoder newDecoder()
+meth public abstract java.nio.charset.CharsetEncoder newEncoder()
+meth public boolean canEncode()
+meth public final boolean equals(java.lang.Object)
+meth public final boolean isRegistered()
+meth public final int compareTo(java.nio.charset.Charset)
+meth public final int hashCode()
+meth public final java.lang.String name()
+meth public final java.lang.String toString()
+meth public final java.nio.ByteBuffer encode(java.lang.String)
+meth public final java.nio.ByteBuffer encode(java.nio.CharBuffer)
+meth public final java.nio.CharBuffer decode(java.nio.ByteBuffer)
+meth public final java.util.Set<java.lang.String> aliases()
+meth public java.lang.String displayName()
+meth public java.lang.String displayName(java.util.Locale)
+meth public static boolean isSupported(java.lang.String)
+meth public static java.nio.charset.Charset defaultCharset()
+meth public static java.nio.charset.Charset forName(java.lang.String)
+meth public static java.util.SortedMap<java.lang.String,java.nio.charset.Charset> availableCharsets()
+supr java.lang.Object
+
+CLSS public abstract java.nio.charset.spi.CharsetProvider
+cons protected init()
+meth public abstract java.nio.charset.Charset charsetForName(java.lang.String)
+meth public abstract java.util.Iterator<java.nio.charset.Charset> charsets()
+supr java.lang.Object
+
 CLSS public abstract interface java.util.Iterator<%0 extends java.lang.Object>
 meth public abstract boolean hasNext()
 meth public abstract {java.util.Iterator%0} next()
@@ -97,13 +128,14 @@ meth public boolean isReverseMatchAllowed(byte[],int,int)
 meth public int leftAdjustCharHead(byte[],int,int,int)
 supr org.jcodings.MultiByteEncoding
 
-CLSS public org.jcodings.CaseFoldCodeItem
-cons public init(int,int,int[])
+CLSS public final org.jcodings.CaseFoldCodeItem
 fld public final int byteLen
-fld public final int codeLen
 fld public final int[] code
+fld public final static org.jcodings.CaseFoldCodeItem[] EMPTY_FOLD_CODES
+meth public static org.jcodings.CaseFoldCodeItem create(int,int)
+meth public static org.jcodings.CaseFoldCodeItem create(int,int,int)
+meth public static org.jcodings.CaseFoldCodeItem create(int,int,int,int)
 supr java.lang.Object
-hfds ENC_MAX_COMP_CASE_FOLD_CODE_LEN
 
 CLSS public abstract org.jcodings.CaseFoldMapEncoding
 cons protected init(java.lang.String,short[],byte[],int[][])
@@ -118,7 +150,7 @@ meth public void applyAllCaseFold(int,org.jcodings.ApplyAllCaseFoldFunction,java
 supr org.jcodings.SingleByteEncoding
 hfds SS
 
-CLSS public org.jcodings.CodeRange
+CLSS public final org.jcodings.CodeRange
 cons public init()
 meth public static boolean isInCodeRange(int[],int)
 meth public static boolean isInCodeRange(int[],int,int)
@@ -129,15 +161,39 @@ fld public final static boolean USE_CRNL_AS_LINE_TERMINATOR = false
 fld public final static boolean USE_UNICODE_ALL_LINE_TERMINATORS = false
 fld public final static boolean USE_UNICODE_CASE_FOLD_TURKISH_AZERI = false
 fld public final static boolean USE_UNICODE_PROPERTIES = true
-fld public final static boolean VANILLA = false
+fld public final static int CASE_ASCII_ONLY = 4194304
+fld public final static int CASE_DOWNCASE = 16384
+fld public final static int CASE_DOWN_SPECIAL = 131072
+fld public final static int CASE_FOLD = 524288
+fld public final static int CASE_FOLD_LITHUANIAN = 2097152
+fld public final static int CASE_FOLD_TURKISH_AZERI = 1048576
+fld public final static int CASE_IS_TITLECASE = 8388608
+fld public final static int CASE_MODIFIED = 262144
+fld public final static int CASE_SPECIALS = 8617984
+fld public final static int CASE_SPECIAL_OFFSET = 3
+fld public final static int CASE_TITLECASE = 32768
+fld public final static int CASE_UPCASE = 8192
+fld public final static int CASE_UP_SPECIAL = 65536
+fld public final static int CodePointMask = 7
+fld public final static int CodePointMaskWidth = 3
 fld public final static int ENC_CASE_FOLD_DEFAULT = 1073741824
 fld public final static int ENC_CASE_FOLD_MIN = 1073741824
-fld public final static int ENC_CASE_FOLD_TURKISH_AZERI = 1048576
 fld public final static int ENC_CODE_TO_MBC_MAXLEN = 7
 fld public final static int ENC_GET_CASE_FOLD_CODES_MAX_NUM = 13
 fld public final static int ENC_MAX_COMP_CASE_FOLD_CODE_LEN = 3
 fld public final static int ENC_MBC_CASE_FOLD_MAXLEN = 18
 fld public final static int INTERNAL_ENC_CASE_FOLD_MULTI_CHAR = 1073741824
+fld public final static int SpecialIndexMask = 8184
+fld public final static int SpecialIndexShift = 3
+fld public final static int SpecialIndexWidth = 10
+fld public final static int SpecialsLengthOffset = 25
+fld public final static int UNICODE_EMOJI_VERSION_MAJOR = 13
+fld public final static int UNICODE_EMOJI_VERSION_MINOR = 1
+fld public final static int UNICODE_VERSION_MAJOR = 13
+fld public final static int UNICODE_VERSION_MINOR = 0
+fld public final static int UNICODE_VERSION_TEENY = 0
+fld public final static java.lang.String UNICODE_EMOJI_VERSION_STRING = "13.1"
+fld public final static java.lang.String UNICODE_VERSION_STRING = "13.0.0"
 
 CLSS public abstract org.jcodings.Encoding
 cons protected init(java.lang.String,int,int)
@@ -154,6 +210,7 @@ meth protected final void setName(java.lang.String)
 meth public abstract boolean isCodeCType(int,int)
 meth public abstract boolean isNewLine(byte[],int,int)
 meth public abstract boolean isReverseMatchAllowed(byte[],int,int)
+meth public abstract int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 meth public abstract int codeToMbc(int,byte[],int)
 meth public abstract int codeToMbcLength(int)
 meth public abstract int leftAdjustCharHead(byte[],int,int,int)
@@ -198,7 +255,9 @@ meth public final int getIndex()
 meth public final int hashCode()
 meth public final int maxLength()
 meth public final int maxLengthDistance()
+ anno 0 java.lang.Deprecated()
 meth public final int mbcodeStartPosition()
+ anno 0 java.lang.Deprecated()
 meth public final int minLength()
 meth public final int prevCharHead(byte[],int,int,int)
 meth public final int rightAdjustCharHead(byte[],int,int,int)
@@ -221,10 +280,11 @@ meth public static byte asciiToUpper(int)
 meth public static int digitVal(int)
 meth public static int odigitVal(int)
 meth public static org.jcodings.Encoding load(java.lang.String)
+meth public static org.jcodings.Encoding load(java.lang.String,java.lang.String)
 supr java.lang.Object
-hfds charset,count,hashCode,index,isAsciiCompatible,isDummy,isFixedWidth,isSingleByte,name
+hfds charset,count,hashCode,index,isAsciiCompatible,isDummy,isFixedWidth,isSingleByte,name,stringName
 
-CLSS public org.jcodings.EncodingDB
+CLSS public final org.jcodings.EncodingDB
 cons public init()
 innr public final static Entry
 meth public final static org.jcodings.util.CaseInsensitiveBytesHash<org.jcodings.EncodingDB$Entry> getAliases()
@@ -259,6 +319,7 @@ supr org.jcodings.MultiByteEncoding
 CLSS public abstract org.jcodings.ISOEncoding
 cons protected init(java.lang.String,short[],byte[],int[][])
 cons protected init(java.lang.String,short[],byte[],int[][],boolean)
+fld public static int SHARP_s
 meth public boolean isCodeCType(int,int)
 meth public int mbcCaseFold(int,byte[],org.jcodings.IntHolder,int,byte[])
 meth public java.lang.String getCharsetName()
@@ -276,7 +337,6 @@ fld protected final int[] TransZero
 fld protected final int[][] Trans
 fld protected final static int A = -1
 fld protected final static int F = -2
-fld protected final static org.jcodings.CaseFoldCodeItem[] EMPTY_FOLD_CODES
 meth protected final boolean isCodeCTypeInternal(int,int)
 meth protected final boolean mb2IsCodeCType(int,int)
 meth protected final boolean mb4IsCodeCType(int,int)
@@ -296,12 +356,14 @@ meth protected final int safeLengthForUptoTwo(byte[],int,int)
 meth protected final org.jcodings.CaseFoldCodeItem[] asciiCaseFoldCodesByString(int,byte[],int,int)
 meth protected final void asciiApplyAllCaseFold(int,org.jcodings.ApplyAllCaseFoldFunction,java.lang.Object)
 meth public boolean isNewLine(byte[],int,int)
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 meth public int length(byte)
 meth public int mbcCaseFold(int,byte[],org.jcodings.IntHolder,int,byte[])
 meth public int propertyNameToCType(byte[],int,int)
 meth public int strCodeAt(byte[],int,int,int)
 meth public int strLength(byte[],int,int)
 meth public org.jcodings.CaseFoldCodeItem[] caseFoldCodesByString(int,byte[],int,int)
+meth public static boolean isInRange(int,int,int)
 meth public void applyAllCaseFold(int,org.jcodings.ApplyAllCaseFoldFunction,java.lang.Object)
 supr org.jcodings.Encoding
 
@@ -321,10 +383,8 @@ supr java.lang.Object
 
 CLSS public abstract org.jcodings.SingleByteEncoding
 cons protected init(java.lang.String,short[],byte[])
-cons protected init(java.lang.String,short[],byte[],int)
 fld protected final byte[] LowerCaseTable
-fld protected final static org.jcodings.CaseFoldCodeItem[] EMPTY_FOLD_CODES
-fld protected int codeSize
+fld public final static int MAX_BYTE = 255
 meth protected final boolean isCodeCTypeInternal(int,int)
 meth protected final int asciiMbcCaseFold(int,byte[],org.jcodings.IntHolder,int,byte[])
 meth protected final org.jcodings.CaseFoldCodeItem[] asciiCaseFoldCodesByString(int,byte[],int,int)
@@ -335,6 +395,7 @@ meth public final int codeToMbc(int,byte[],int)
 meth public final int leftAdjustCharHead(byte[],int,int,int)
 meth public final int strLength(byte[],int,int)
 meth public final int[] ctypeCodeRange(int,org.jcodings.IntHolder)
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 meth public int codeToMbcLength(int)
 meth public int length(byte)
 meth public int length(byte[],int,int)
@@ -375,7 +436,6 @@ fld public final static int BIT_WORD = 4096
 fld public final static int BIT_XDIGIT = 2048
 fld public final static int BLANK = 2
 fld public final static int CNTRL = 3
-fld public final static int D = 260
 fld public final static int DIGIT = 4
 fld public final static int GRAPH = 5
 fld public final static int LOWER = 6
@@ -383,11 +443,8 @@ fld public final static int MAX_STD_CTYPE = 14
 fld public final static int NEWLINE = 0
 fld public final static int PRINT = 7
 fld public final static int PUNCT = 8
-fld public final static int S = 265
 fld public final static int SPACE = 9
-fld public final static int SPECIAL_MASK = 256
 fld public final static int UPPER = 10
-fld public final static int W = 268
 fld public final static int WORD = 12
 fld public final static int XDIGIT = 11
 
@@ -400,24 +457,68 @@ supr java.lang.Object
 
 CLSS public org.jcodings.exception.CharacterPropertyException
 cons public init(java.lang.String)
+ anno 0 java.lang.Deprecated()
 cons public init(java.lang.String,byte[],int,int)
+ anno 0 java.lang.Deprecated()
 cons public init(java.lang.String,java.lang.String)
+ anno 0 java.lang.Deprecated()
+cons public init(org.jcodings.exception.EncodingError)
+cons public init(org.jcodings.exception.EncodingError,byte[],int,int)
+cons public init(org.jcodings.exception.EncodingError,java.lang.String)
 supr org.jcodings.exception.EncodingException
+
+CLSS public final !enum org.jcodings.exception.EncodingError
+fld public final static org.jcodings.exception.EncodingError ERR_COULD_NOT_REPLICATE
+fld public final static org.jcodings.exception.EncodingError ERR_ENCODING_ALIAS_ALREADY_REGISTERED
+fld public final static org.jcodings.exception.EncodingError ERR_ENCODING_ALREADY_REGISTERED
+fld public final static org.jcodings.exception.EncodingError ERR_ENCODING_CLASS_DEF_NOT_FOUND
+fld public final static org.jcodings.exception.EncodingError ERR_ENCODING_LOAD_ERROR
+fld public final static org.jcodings.exception.EncodingError ERR_ENCODING_REPLICA_ALREADY_REGISTERED
+fld public final static org.jcodings.exception.EncodingError ERR_INVALID_CHAR_PROPERTY_NAME
+fld public final static org.jcodings.exception.EncodingError ERR_INVALID_CODE_POINT_VALUE
+fld public final static org.jcodings.exception.EncodingError ERR_NO_SUCH_ENCODNG
+fld public final static org.jcodings.exception.EncodingError ERR_TOO_BIG_WIDE_CHAR_VALUE
+fld public final static org.jcodings.exception.EncodingError ERR_TOO_LONG_WIDE_CHAR_VALUE
+fld public final static org.jcodings.exception.EncodingError ERR_TRANSCODER_ALREADY_REGISTERED
+fld public final static org.jcodings.exception.EncodingError ERR_TRANSCODER_CLASS_DEF_NOT_FOUND
+fld public final static org.jcodings.exception.EncodingError ERR_TRANSCODER_LOAD_ERROR
+fld public final static org.jcodings.exception.EncodingError ERR_TYPE_BUG
+meth public int getCode()
+meth public java.lang.String getMessage()
+meth public static org.jcodings.exception.EncodingError fromCode(int)
+meth public static org.jcodings.exception.EncodingError valueOf(java.lang.String)
+meth public static org.jcodings.exception.EncodingError[] values()
+supr java.lang.Enum<org.jcodings.exception.EncodingError>
+hfds CODE_TO_ERROR,code,message
 
 CLSS public org.jcodings.exception.EncodingException
 cons public init(java.lang.String)
+ anno 0 java.lang.Deprecated()
 cons public init(java.lang.String,byte[],int,int)
+ anno 0 java.lang.Deprecated()
 cons public init(java.lang.String,java.lang.String)
+ anno 0 java.lang.Deprecated()
+cons public init(org.jcodings.exception.EncodingError)
+cons public init(org.jcodings.exception.EncodingError,byte[],int,int)
+cons public init(org.jcodings.exception.EncodingError,java.lang.String)
+meth public org.jcodings.exception.EncodingError getError()
 supr org.jcodings.exception.JCodingsException
+hfds error
 
 CLSS public abstract interface org.jcodings.exception.ErrorCodes
 fld public final static int ERR_CHAR_CLASS_VALUE_AT_END_OF_RANGE = -110
 fld public final static int ERR_CHAR_CLASS_VALUE_AT_START_OF_RANGE = -111
 fld public final static int ERR_CONTROL_CODE_SYNTAX = -109
+fld public final static int ERR_COULD_NOT_REPLICATE = -1006
 fld public final static int ERR_DEFAULT_ENCODING_IS_NOT_SET = -21
 fld public final static int ERR_EMPTY_CHAR_CLASS = -102
 fld public final static int ERR_EMPTY_GROUP_NAME = -214
 fld public final static int ERR_EMPTY_RANGE_IN_CHAR_CLASS = -203
+fld public final static int ERR_ENCODING_ALIAS_ALREADY_REGISTERED = -1003
+fld public final static int ERR_ENCODING_ALREADY_REGISTERED = -1002
+fld public final static int ERR_ENCODING_CLASS_DEF_NOT_FOUND = -1000
+fld public final static int ERR_ENCODING_LOAD_ERROR = -1001
+fld public final static int ERR_ENCODING_REPLICA_ALREADY_REGISTERED = -1004
 fld public final static int ERR_END_PATTERN_AT_CONTROL = -106
 fld public final static int ERR_END_PATTERN_AT_ESCAPE = -104
 fld public final static int ERR_END_PATTERN_AT_LEFT_BRACE = -100
@@ -447,6 +548,7 @@ fld public final static int ERR_MULTIPLEX_DEFINITION_NAME_CALL = -220
 fld public final static int ERR_NESTED_REPEAT_OPERATOR = -115
 fld public final static int ERR_NEVER_ENDING_RECURSION = -221
 fld public final static int ERR_NOT_SUPPORTED_ENCODING_COMBINATION = -402
+fld public final static int ERR_NO_SUCH_ENCODNG = -1005
 fld public final static int ERR_NUMBERED_BACKREF_OR_CALL_NOT_ALLOWED = -209
 fld public final static int ERR_PARSER_BUG = -11
 fld public final static int ERR_PREMATURE_END_OF_CHAR_CLASS = -103
@@ -463,6 +565,9 @@ fld public final static int ERR_TOO_MANY_CAPTURE_GROUPS = -224
 fld public final static int ERR_TOO_MANY_MULTI_BYTE_RANGES = -205
 fld public final static int ERR_TOO_SHORT_DIGITS = -210
 fld public final static int ERR_TOO_SHORT_MULTI_BYTE_STRING = -206
+fld public final static int ERR_TRANSCODER_ALREADY_REGISTERED = -1007
+fld public final static int ERR_TRANSCODER_CLASS_DEF_NOT_FOUND = -1008
+fld public final static int ERR_TRANSCODER_LOAD_ERROR = -1009
 fld public final static int ERR_TYPE_BUG = -6
 fld public final static int ERR_UNDEFINED_BYTECODE = -13
 fld public final static int ERR_UNDEFINED_GROUP_OPTION = -119
@@ -493,10 +598,6 @@ fld public final static java.lang.String ERR_TRANSCODER_ALREADY_REGISTERED = "tr
 fld public final static java.lang.String ERR_TRANSCODER_CLASS_DEF_NOT_FOUND = "transcoder class <%n> not found"
 fld public final static java.lang.String ERR_TRANSCODER_LOAD_ERROR = "problem loading transcoder <%n>"
 fld public final static java.lang.String ERR_TYPE_BUG = "undefined type (bug)"
-
-CLSS public org.jcodings.exception.IllegalCharacterException
-fld public final static org.jcodings.exception.IllegalCharacterException INSTANCE
-supr org.jcodings.exception.EncodingException
 
 CLSS public org.jcodings.exception.InternalException
 cons public init(java.lang.String)
@@ -542,7 +643,7 @@ meth public int mbcCaseFold(int,byte[],org.jcodings.IntHolder,int,byte[])
 meth public int mbcToCode(byte[],int,int)
 meth public int[] ctypeCodeRange(int,org.jcodings.IntHolder)
 supr org.jcodings.CanBeTrailTableEncoding
-hfds BIG5Trans,BIG5_CAN_BE_TRAIL_TABLE,transIndex
+hfds BIG5Trans,BIG5_CAN_BE_TRAIL_TABLE,TransBase
 
 CLSS public final org.jcodings.specific.Big5HKSCSEncoding
 cons protected init()
@@ -555,6 +656,22 @@ cons protected init()
 fld public final static org.jcodings.specific.Big5UAOEncoding INSTANCE
 supr org.jcodings.specific.BaseBIG5Encoding
 hfds Big5UAOEncLen
+
+CLSS public final org.jcodings.specific.CESU8Encoding
+cons protected init()
+fld public final static org.jcodings.specific.CESU8Encoding INSTANCE
+meth public boolean isNewLine(byte[],int,int)
+meth public boolean isReverseMatchAllowed(byte[],int,int)
+meth public int codeToMbc(int,byte[],int)
+meth public int codeToMbcLength(int)
+meth public int leftAdjustCharHead(byte[],int,int,int)
+meth public int length(byte[],int,int)
+meth public int mbcCaseFold(int,byte[],org.jcodings.IntHolder,int,byte[])
+meth public int mbcToCode(byte[],int,int)
+meth public int[] ctypeCodeRange(int,org.jcodings.IntHolder)
+meth public java.lang.String getCharsetName()
+supr org.jcodings.unicode.UnicodeEncoding
+hfds CESU8EncLen,CESU8Trans,INVALID_CODE_FE,INVALID_CODE_FF,USE_INVALID_CODE_SCHEME,VALID_CODE_LIMIT
 
 CLSS public final org.jcodings.specific.CP949Encoding
 cons protected init()
@@ -673,6 +790,7 @@ hfds GBK,GBKEncLen,GBKTrans,GBK_CAN_BE_TRAIL_TABLE
 CLSS public final org.jcodings.specific.ISO8859_10Encoding
 cons protected init()
 fld public final static org.jcodings.specific.ISO8859_10Encoding INSTANCE
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 supr org.jcodings.ISOEncoding
 hfds ISO8859_10CaseFoldMap,ISO8859_10CtypeTable,ISO8859_10ToLowerCaseTable
 
@@ -689,30 +807,35 @@ hfds ISO8859_11CtypeTable
 CLSS public final org.jcodings.specific.ISO8859_13Encoding
 cons protected init()
 fld public final static org.jcodings.specific.ISO8859_13Encoding INSTANCE
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 supr org.jcodings.ISOEncoding
 hfds ISO8859_13CaseFoldMap,ISO8859_13CtypeTable,ISO8859_13ToLowerCaseTable
 
 CLSS public final org.jcodings.specific.ISO8859_14Encoding
 cons protected init()
 fld public final static org.jcodings.specific.ISO8859_14Encoding INSTANCE
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 supr org.jcodings.ISOEncoding
 hfds ISO8859_14CaseFoldMap,ISO8859_14CtypeTable,ISO8859_14ToLowerCaseTable
 
 CLSS public final org.jcodings.specific.ISO8859_15Encoding
 cons protected init()
 fld public final static org.jcodings.specific.ISO8859_15Encoding INSTANCE
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 supr org.jcodings.ISOEncoding
 hfds ISO8859_15CaseFoldMap,ISO8859_15CtypeTable,ISO8859_15ToLowerCaseTable
 
 CLSS public final org.jcodings.specific.ISO8859_16Encoding
 cons protected init()
 fld public final static org.jcodings.specific.ISO8859_16Encoding INSTANCE
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 supr org.jcodings.ISOEncoding
 hfds ISO8859_16CaseFoldMap,ISO8859_16CtypeTable,ISO8859_16ToLowerCaseTable
 
 CLSS public final org.jcodings.specific.ISO8859_1Encoding
 cons protected init()
 fld public final static org.jcodings.specific.ISO8859_1Encoding INSTANCE
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 meth public org.jcodings.CaseFoldCodeItem[] caseFoldCodesByString(int,byte[],int,int)
 meth public void applyAllCaseFold(int,org.jcodings.ApplyAllCaseFoldFunction,java.lang.Object)
 supr org.jcodings.ISOEncoding
@@ -721,18 +844,21 @@ hfds ISO8859_1CaseFoldMap,ISO8859_1CtypeTable,ISO8859_1ToLowerCaseTable,ISO8859_
 CLSS public final org.jcodings.specific.ISO8859_2Encoding
 cons protected init()
 fld public final static org.jcodings.specific.ISO8859_2Encoding INSTANCE
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 supr org.jcodings.ISOEncoding
 hfds ISO8859_2CaseFoldMap,ISO8859_2CtypeTable,ISO8859_2ToLowerCaseTable
 
 CLSS public final org.jcodings.specific.ISO8859_3Encoding
 cons protected init()
 fld public final static org.jcodings.specific.ISO8859_3Encoding INSTANCE
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 supr org.jcodings.ISOEncoding
-hfds ISO8859_3CaseFoldMap,ISO8859_3CtypeTable,ISO8859_3ToLowerCaseTable
+hfds DOTLESS_i,ISO8859_3CaseFoldMap,ISO8859_3CtypeTable,ISO8859_3ToLowerCaseTable,I_WITH_DOT_ABOVE
 
 CLSS public final org.jcodings.specific.ISO8859_4Encoding
 cons protected init()
 fld public final static org.jcodings.specific.ISO8859_4Encoding INSTANCE
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 supr org.jcodings.ISOEncoding
 hfds ISO8859_4CaseFoldMap,ISO8859_4CtypeTable,ISO8859_4ToLowerCaseTable
 
@@ -740,6 +866,7 @@ CLSS public final org.jcodings.specific.ISO8859_5Encoding
 cons protected init()
 fld public final static org.jcodings.specific.ISO8859_5Encoding INSTANCE
 meth public final byte[] toLowerCaseTable()
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 meth public int mbcCaseFold(int,byte[],org.jcodings.IntHolder,int,byte[])
 supr org.jcodings.ISOEncoding
 hfds ISO8859_5CaseFoldMap,ISO8859_5CtypeTable,ISO8859_5ToLowerCaseTable
@@ -758,6 +885,7 @@ CLSS public final org.jcodings.specific.ISO8859_7Encoding
 cons protected init()
 fld public final static org.jcodings.specific.ISO8859_7Encoding INSTANCE
 meth public final byte[] toLowerCaseTable()
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 meth public int mbcCaseFold(int,byte[],org.jcodings.IntHolder,int,byte[])
 supr org.jcodings.ISOEncoding
 hfds ISO8859_7CaseFoldMap,ISO8859_7CtypeTable,ISO8859_7ToLowerCaseTable
@@ -775,8 +903,9 @@ hfds ISO8859_8CtypeTable
 CLSS public final org.jcodings.specific.ISO8859_9Encoding
 cons protected init()
 fld public final static org.jcodings.specific.ISO8859_9Encoding INSTANCE
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 supr org.jcodings.ISOEncoding
-hfds ISO8859_9CaseFoldMap,ISO8859_9CtypeTable,ISO8859_9ToLowerCaseTable
+hfds DOTLESS_i,ISO8859_9CaseFoldMap,ISO8859_9CtypeTable,ISO8859_9ToLowerCaseTable,I_WITH_DOT_ABOVE
 
 CLSS public final org.jcodings.specific.KOI8Encoding
 cons protected init()
@@ -940,6 +1069,7 @@ CLSS public final org.jcodings.specific.Windows_1250Encoding
 cons protected init()
 fld public final static org.jcodings.specific.Windows_1250Encoding INSTANCE
 meth public boolean isCodeCType(int,int)
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 meth public int mbcCaseFold(int,byte[],org.jcodings.IntHolder,int,byte[])
 supr org.jcodings.CaseFoldMapEncoding
 hfds CP1250_CaseFoldMap,CP1250_CtypeTable,CP1250_ToLowerCaseTable
@@ -948,6 +1078,7 @@ CLSS public final org.jcodings.specific.Windows_1251Encoding
 cons protected init()
 fld public final static org.jcodings.specific.Windows_1251Encoding INSTANCE
 meth public boolean isCodeCType(int,int)
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 meth public int mbcCaseFold(int,byte[],org.jcodings.IntHolder,int,byte[])
 supr org.jcodings.CaseFoldMapEncoding
 hfds CP1251_CaseFoldMap,CP1251_CtypeTable,CP1251_ToLowerCaseTable
@@ -956,9 +1087,37 @@ CLSS public final org.jcodings.specific.Windows_1252Encoding
 cons protected init()
 fld public final static org.jcodings.specific.Windows_1252Encoding INSTANCE
 meth public boolean isCodeCType(int,int)
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 meth public int mbcCaseFold(int,byte[],org.jcodings.IntHolder,int,byte[])
 supr org.jcodings.CaseFoldMapEncoding
 hfds CP1252_CaseFoldMap,CP1252_CtypeTable,CP1252_ToLowerCaseTable
+
+CLSS public final org.jcodings.specific.Windows_1253Encoding
+cons protected init()
+fld public final static org.jcodings.specific.Windows_1253Encoding INSTANCE
+meth public boolean isCodeCType(int,int)
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
+meth public int mbcCaseFold(int,byte[],org.jcodings.IntHolder,int,byte[])
+supr org.jcodings.CaseFoldMapEncoding
+hfds CP1253_CaseFoldMap,CP1253_CtypeTable,CP1253_ToLowerCaseTable
+
+CLSS public final org.jcodings.specific.Windows_1254Encoding
+cons protected init()
+fld public final static org.jcodings.specific.Windows_1254Encoding INSTANCE
+meth public boolean isCodeCType(int,int)
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
+meth public int mbcCaseFold(int,byte[],org.jcodings.IntHolder,int,byte[])
+supr org.jcodings.CaseFoldMapEncoding
+hfds CP1254_CaseFoldMap,CP1254_CtypeTable,CP1254_ToLowerCaseTable,DOTLESS_i,I_WITH_DOT_ABOVE
+
+CLSS public final org.jcodings.specific.Windows_1257Encoding
+cons protected init()
+fld public final static org.jcodings.specific.Windows_1257Encoding INSTANCE
+meth public boolean isCodeCType(int,int)
+meth public int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
+meth public int mbcCaseFold(int,byte[],org.jcodings.IntHolder,int,byte[])
+supr org.jcodings.CaseFoldMapEncoding
+hfds CP1257_CaseFoldMap,CP1257_CtypeTable,CP1257_ToLowerCaseTable,DOTLESS_i,I_WITH_DOT_ABOVE
 
 CLSS public final org.jcodings.specific.Windows_31JEncoding
 cons protected init()
@@ -973,6 +1132,21 @@ meth public int propertyNameToCType(byte[],int,int)
 meth public int[] ctypeCodeRange(int,org.jcodings.IntHolder)
 meth public java.lang.String getCharsetName()
 supr org.jcodings.CanBeTrailTableEncoding
+
+CLSS public org.jcodings.spi.Charsets
+cons public init()
+meth public java.nio.charset.Charset charsetForName(java.lang.String)
+meth public java.util.Iterator<java.nio.charset.Charset> charsets()
+supr java.nio.charset.spi.CharsetProvider
+hfds charsets
+
+CLSS public org.jcodings.spi.ISO_8859_16
+fld public final static org.jcodings.spi.ISO_8859_16 INSTANCE
+meth public boolean contains(java.nio.charset.Charset)
+meth public java.nio.charset.CharsetDecoder newDecoder()
+meth public java.nio.charset.CharsetEncoder newEncoder()
+supr java.nio.charset.Charset
+hcls Decoder,Encoder
 
 CLSS public final !enum org.jcodings.transcode.AsciiCompatibility
 fld public final static org.jcodings.transcode.AsciiCompatibility CONVERTER
@@ -1120,6 +1294,7 @@ meth public static int funSoCp5022xEncoder(byte[],byte[],int,int,byte[],int,int)
 meth public static int funSoEscapeXmlAttrQuote(byte[],byte[],int,int,byte[],int,int)
 meth public static int funSoEucjp2Sjis(byte[],byte[],int,int,byte[],int,int)
 meth public static int funSoEucjpToStatelessIso2022jp(byte[],byte[],int,int,byte[],int,int)
+meth public static int funSoFromCESU8(byte[],byte[],int,int,byte[],int,int)
 meth public static int funSoFromGB18030(byte[],byte[],int,int,byte[],int,int)
 meth public static int funSoFromUTF16(byte[],byte[],int,int,byte[],int,int)
 meth public static int funSoFromUTF16BE(byte[],byte[],int,int,byte[],int,int)
@@ -1134,6 +1309,7 @@ meth public static int funSoIso2022jpKddiDecoder(byte[],byte[],int,int,byte[],in
 meth public static int funSoIso2022jpKddiEncoder(byte[],byte[],int,int,byte[],int,int)
 meth public static int funSoSjis2Eucjp(byte[],byte[],int,int,byte[],int,int)
 meth public static int funSoStatelessIso2022jpToEucjp(byte[],byte[],int,int,byte[],int,int)
+meth public static int funSoToCESU8(byte[],byte[],int,int,byte[],int,int)
 meth public static int funSoToGB18030(byte[],byte[],int,int,byte[],int,int)
 meth public static int funSoToUTF16(byte[],byte[],int,int,byte[],int,int)
 meth public static int funSoToUTF16BE(byte[],byte[],int,int,byte[],int,int)
@@ -1248,6 +1424,7 @@ meth public static int decoratorNames(int,byte[][])
 meth public static int searchPath(byte[],byte[],org.jcodings.transcode.TranscoderDB$SearchPathCallback)
 meth public static org.jcodings.transcode.EConv alloc(int)
 meth public static org.jcodings.transcode.EConv open(byte[],byte[],int)
+meth public static org.jcodings.transcode.EConv open(java.lang.String,java.lang.String,int)
 meth public static org.jcodings.transcode.TranscoderDB$Entry getEntry(byte[],byte[])
 supr java.lang.Object
 hcls SearchPathQueue
@@ -1476,6 +1653,31 @@ meth public int startToOutput(byte[],byte[],int,int,byte[],int,int)
 supr org.jcodings.transcode.Transcoder
 
 CLSS public org.jcodings.transcode.specific.Eucjp_to_stateless_iso2022jp_Transcoder
+cons protected init()
+fld public final static int FOURbt = 6
+fld public final static int FUNii = 11
+fld public final static int FUNio = 14
+fld public final static int FUNsi = 13
+fld public final static int FUNsio = 19
+fld public final static int FUNso = 15
+fld public final static int GB4bt = 18
+fld public final static int INVALID = 7
+fld public final static int LAST = 28
+fld public final static int NOMAP = 1
+fld public final static int NOMAP_RESUME_1 = 29
+fld public final static int ONEbt = 2
+fld public final static int STR1 = 17
+fld public final static int THREEbt = 5
+fld public final static int TWObt = 3
+fld public final static int UNDEF = 9
+fld public final static int ZERObt = 10
+fld public final static int ZeroXResume_1 = 30
+fld public final static int ZeroXResume_2 = 31
+fld public final static org.jcodings.transcode.Transcoder INSTANCE
+meth public int startToOutput(byte[],byte[],int,int,byte[],int,int)
+supr org.jcodings.transcode.Transcoder
+
+CLSS public org.jcodings.transcode.specific.From_CESU_8_Transcoder
 cons protected init()
 fld public final static int FOURbt = 6
 fld public final static int FUNii = 11
@@ -1879,6 +2081,31 @@ fld public final static org.jcodings.transcode.Transcoder INSTANCE
 meth public int startToOutput(byte[],byte[],int,int,byte[],int,int)
 supr org.jcodings.transcode.Transcoder
 
+CLSS public org.jcodings.transcode.specific.To_CESU_8_Transcoder
+cons protected init()
+fld public final static int FOURbt = 6
+fld public final static int FUNii = 11
+fld public final static int FUNio = 14
+fld public final static int FUNsi = 13
+fld public final static int FUNsio = 19
+fld public final static int FUNso = 15
+fld public final static int GB4bt = 18
+fld public final static int INVALID = 7
+fld public final static int LAST = 28
+fld public final static int NOMAP = 1
+fld public final static int NOMAP_RESUME_1 = 29
+fld public final static int ONEbt = 2
+fld public final static int STR1 = 17
+fld public final static int THREEbt = 5
+fld public final static int TWObt = 3
+fld public final static int UNDEF = 9
+fld public final static int ZERObt = 10
+fld public final static int ZeroXResume_1 = 30
+fld public final static int ZeroXResume_2 = 31
+fld public final static org.jcodings.transcode.Transcoder INSTANCE
+meth public int startToOutput(byte[],byte[],int,int,byte[],int,int)
+supr org.jcodings.transcode.Transcoder
+
 CLSS public org.jcodings.transcode.specific.To_GB18030_Transcoder
 cons protected init()
 fld public final static int FOURbt = 6
@@ -2098,36 +2325,901 @@ meth public final boolean isReverseMatchAllowed(byte[],int,int)
 meth public final int codeToMbcLength(int)
 meth public final int leftAdjustCharHead(byte[],int,int,int)
 meth public final int length(byte)
-meth public final int length(byte[],int,int)
 meth public final int strCodeAt(byte[],int,int,int)
 meth public final int strLength(byte[],int,int)
 meth public final int[] ctypeCodeRange(int,org.jcodings.IntHolder)
+meth public int length(byte[],int,int)
 supr org.jcodings.unicode.UnicodeEncoding
+
+CLSS public final !enum org.jcodings.unicode.UnicodeCodeRange
+fld public final static org.jcodings.unicode.UnicodeCodeRange ADLAM
+fld public final static org.jcodings.unicode.UnicodeCodeRange ADLM
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_10_0
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_11_0
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_12_0
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_12_1
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_13_0
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_1_1
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_2_0
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_2_1
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_3_0
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_3_1
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_3_2
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_4_0
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_4_1
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_5_0
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_5_1
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_5_2
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_6_0
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_6_1
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_6_2
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_6_3
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_7_0
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_8_0
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGE_9_0
+fld public final static org.jcodings.unicode.UnicodeCodeRange AGHB
+fld public final static org.jcodings.unicode.UnicodeCodeRange AHEX
+fld public final static org.jcodings.unicode.UnicodeCodeRange AHOM
+fld public final static org.jcodings.unicode.UnicodeCodeRange ALNUM
+fld public final static org.jcodings.unicode.UnicodeCodeRange ALPHA
+fld public final static org.jcodings.unicode.UnicodeCodeRange ALPHABETIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange ANATOLIANHIEROGLYPHS
+fld public final static org.jcodings.unicode.UnicodeCodeRange ANY
+fld public final static org.jcodings.unicode.UnicodeCodeRange ARAB
+fld public final static org.jcodings.unicode.UnicodeCodeRange ARABIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange ARMENIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange ARMI
+fld public final static org.jcodings.unicode.UnicodeCodeRange ARMN
+fld public final static org.jcodings.unicode.UnicodeCodeRange ASCII
+fld public final static org.jcodings.unicode.UnicodeCodeRange ASCIIHEXDIGIT
+fld public final static org.jcodings.unicode.UnicodeCodeRange ASSIGNED
+fld public final static org.jcodings.unicode.UnicodeCodeRange AVESTAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange AVST
+fld public final static org.jcodings.unicode.UnicodeCodeRange BALI
+fld public final static org.jcodings.unicode.UnicodeCodeRange BALINESE
+fld public final static org.jcodings.unicode.UnicodeCodeRange BAMU
+fld public final static org.jcodings.unicode.UnicodeCodeRange BAMUM
+fld public final static org.jcodings.unicode.UnicodeCodeRange BASS
+fld public final static org.jcodings.unicode.UnicodeCodeRange BASSAVAH
+fld public final static org.jcodings.unicode.UnicodeCodeRange BATAK
+fld public final static org.jcodings.unicode.UnicodeCodeRange BATK
+fld public final static org.jcodings.unicode.UnicodeCodeRange BENG
+fld public final static org.jcodings.unicode.UnicodeCodeRange BENGALI
+fld public final static org.jcodings.unicode.UnicodeCodeRange BHAIKSUKI
+fld public final static org.jcodings.unicode.UnicodeCodeRange BHKS
+fld public final static org.jcodings.unicode.UnicodeCodeRange BIDIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange BIDICONTROL
+fld public final static org.jcodings.unicode.UnicodeCodeRange BLANK
+fld public final static org.jcodings.unicode.UnicodeCodeRange BOPO
+fld public final static org.jcodings.unicode.UnicodeCodeRange BOPOMOFO
+fld public final static org.jcodings.unicode.UnicodeCodeRange BRAH
+fld public final static org.jcodings.unicode.UnicodeCodeRange BRAHMI
+fld public final static org.jcodings.unicode.UnicodeCodeRange BRAI
+fld public final static org.jcodings.unicode.UnicodeCodeRange BRAILLE
+fld public final static org.jcodings.unicode.UnicodeCodeRange BUGI
+fld public final static org.jcodings.unicode.UnicodeCodeRange BUGINESE
+fld public final static org.jcodings.unicode.UnicodeCodeRange BUHD
+fld public final static org.jcodings.unicode.UnicodeCodeRange BUHID
+fld public final static org.jcodings.unicode.UnicodeCodeRange C
+fld public final static org.jcodings.unicode.UnicodeCodeRange CAKM
+fld public final static org.jcodings.unicode.UnicodeCodeRange CANADIANABORIGINAL
+fld public final static org.jcodings.unicode.UnicodeCodeRange CANS
+fld public final static org.jcodings.unicode.UnicodeCodeRange CARI
+fld public final static org.jcodings.unicode.UnicodeCodeRange CARIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange CASED
+fld public final static org.jcodings.unicode.UnicodeCodeRange CASEDLETTER
+fld public final static org.jcodings.unicode.UnicodeCodeRange CASEIGNORABLE
+fld public final static org.jcodings.unicode.UnicodeCodeRange CAUCASIANALBANIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange CC
+fld public final static org.jcodings.unicode.UnicodeCodeRange CF
+fld public final static org.jcodings.unicode.UnicodeCodeRange CHAKMA
+fld public final static org.jcodings.unicode.UnicodeCodeRange CHAM
+fld public final static org.jcodings.unicode.UnicodeCodeRange CHANGESWHENCASEFOLDED
+fld public final static org.jcodings.unicode.UnicodeCodeRange CHANGESWHENCASEMAPPED
+fld public final static org.jcodings.unicode.UnicodeCodeRange CHANGESWHENLOWERCASED
+fld public final static org.jcodings.unicode.UnicodeCodeRange CHANGESWHENTITLECASED
+fld public final static org.jcodings.unicode.UnicodeCodeRange CHANGESWHENUPPERCASED
+fld public final static org.jcodings.unicode.UnicodeCodeRange CHER
+fld public final static org.jcodings.unicode.UnicodeCodeRange CHEROKEE
+fld public final static org.jcodings.unicode.UnicodeCodeRange CHORASMIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange CHRS
+fld public final static org.jcodings.unicode.UnicodeCodeRange CI
+fld public final static org.jcodings.unicode.UnicodeCodeRange CLOSEPUNCTUATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange CN
+fld public final static org.jcodings.unicode.UnicodeCodeRange CNTRL
+fld public final static org.jcodings.unicode.UnicodeCodeRange CO
+fld public final static org.jcodings.unicode.UnicodeCodeRange COMBININGMARK
+fld public final static org.jcodings.unicode.UnicodeCodeRange COMMON
+fld public final static org.jcodings.unicode.UnicodeCodeRange CONNECTORPUNCTUATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange CONTROL
+fld public final static org.jcodings.unicode.UnicodeCodeRange COPT
+fld public final static org.jcodings.unicode.UnicodeCodeRange COPTIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange CPRT
+fld public final static org.jcodings.unicode.UnicodeCodeRange CS
+fld public final static org.jcodings.unicode.UnicodeCodeRange CUNEIFORM
+fld public final static org.jcodings.unicode.UnicodeCodeRange CURRENCYSYMBOL
+fld public final static org.jcodings.unicode.UnicodeCodeRange CWCF
+fld public final static org.jcodings.unicode.UnicodeCodeRange CWCM
+fld public final static org.jcodings.unicode.UnicodeCodeRange CWL
+fld public final static org.jcodings.unicode.UnicodeCodeRange CWT
+fld public final static org.jcodings.unicode.UnicodeCodeRange CWU
+fld public final static org.jcodings.unicode.UnicodeCodeRange CYPRIOT
+fld public final static org.jcodings.unicode.UnicodeCodeRange CYRILLIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange CYRL
+fld public final static org.jcodings.unicode.UnicodeCodeRange DASH
+fld public final static org.jcodings.unicode.UnicodeCodeRange DASHPUNCTUATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange DECIMALNUMBER
+fld public final static org.jcodings.unicode.UnicodeCodeRange DEFAULTIGNORABLECODEPOINT
+fld public final static org.jcodings.unicode.UnicodeCodeRange DEP
+fld public final static org.jcodings.unicode.UnicodeCodeRange DEPRECATED
+fld public final static org.jcodings.unicode.UnicodeCodeRange DESERET
+fld public final static org.jcodings.unicode.UnicodeCodeRange DEVA
+fld public final static org.jcodings.unicode.UnicodeCodeRange DEVANAGARI
+fld public final static org.jcodings.unicode.UnicodeCodeRange DI
+fld public final static org.jcodings.unicode.UnicodeCodeRange DIA
+fld public final static org.jcodings.unicode.UnicodeCodeRange DIACRITIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange DIAK
+fld public final static org.jcodings.unicode.UnicodeCodeRange DIGIT
+fld public final static org.jcodings.unicode.UnicodeCodeRange DIVESAKURU
+fld public final static org.jcodings.unicode.UnicodeCodeRange DOGR
+fld public final static org.jcodings.unicode.UnicodeCodeRange DOGRA
+fld public final static org.jcodings.unicode.UnicodeCodeRange DSRT
+fld public final static org.jcodings.unicode.UnicodeCodeRange DUPL
+fld public final static org.jcodings.unicode.UnicodeCodeRange DUPLOYAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange EBASE
+fld public final static org.jcodings.unicode.UnicodeCodeRange ECOMP
+fld public final static org.jcodings.unicode.UnicodeCodeRange EGYP
+fld public final static org.jcodings.unicode.UnicodeCodeRange EGYPTIANHIEROGLYPHS
+fld public final static org.jcodings.unicode.UnicodeCodeRange ELBA
+fld public final static org.jcodings.unicode.UnicodeCodeRange ELBASAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange ELYM
+fld public final static org.jcodings.unicode.UnicodeCodeRange ELYMAIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange EMOD
+fld public final static org.jcodings.unicode.UnicodeCodeRange EMOJI
+fld public final static org.jcodings.unicode.UnicodeCodeRange EMOJICOMPONENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange EMOJIMODIFIER
+fld public final static org.jcodings.unicode.UnicodeCodeRange EMOJIMODIFIERBASE
+fld public final static org.jcodings.unicode.UnicodeCodeRange EMOJIPRESENTATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange ENCLOSINGMARK
+fld public final static org.jcodings.unicode.UnicodeCodeRange EPRES
+fld public final static org.jcodings.unicode.UnicodeCodeRange ETHI
+fld public final static org.jcodings.unicode.UnicodeCodeRange ETHIOPIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange EXT
+fld public final static org.jcodings.unicode.UnicodeCodeRange EXTENDEDPICTOGRAPHIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange EXTENDER
+fld public final static org.jcodings.unicode.UnicodeCodeRange EXTPICT
+fld public final static org.jcodings.unicode.UnicodeCodeRange FINALPUNCTUATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange FORMAT
+fld public final static org.jcodings.unicode.UnicodeCodeRange GEOR
+fld public final static org.jcodings.unicode.UnicodeCodeRange GEORGIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange GLAG
+fld public final static org.jcodings.unicode.UnicodeCodeRange GLAGOLITIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange GONG
+fld public final static org.jcodings.unicode.UnicodeCodeRange GONM
+fld public final static org.jcodings.unicode.UnicodeCodeRange GOTH
+fld public final static org.jcodings.unicode.UnicodeCodeRange GOTHIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRANTHA
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPH
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMEBASE
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMECLUSTERBREAK_CONTROL
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMECLUSTERBREAK_CR
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMECLUSTERBREAK_EXTEND
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMECLUSTERBREAK_L
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMECLUSTERBREAK_LF
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMECLUSTERBREAK_LV
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMECLUSTERBREAK_LVT
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMECLUSTERBREAK_PREPEND
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMECLUSTERBREAK_REGIONALINDICATOR
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMECLUSTERBREAK_SPACINGMARK
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMECLUSTERBREAK_T
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMECLUSTERBREAK_V
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMECLUSTERBREAK_ZWJ
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMEEXTEND
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRAPHEMELINK
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRBASE
+fld public final static org.jcodings.unicode.UnicodeCodeRange GREEK
+fld public final static org.jcodings.unicode.UnicodeCodeRange GREK
+fld public final static org.jcodings.unicode.UnicodeCodeRange GREXT
+fld public final static org.jcodings.unicode.UnicodeCodeRange GRLINK
+fld public final static org.jcodings.unicode.UnicodeCodeRange GUJARATI
+fld public final static org.jcodings.unicode.UnicodeCodeRange GUJR
+fld public final static org.jcodings.unicode.UnicodeCodeRange GUNJALAGONDI
+fld public final static org.jcodings.unicode.UnicodeCodeRange GURMUKHI
+fld public final static org.jcodings.unicode.UnicodeCodeRange GURU
+fld public final static org.jcodings.unicode.UnicodeCodeRange HAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange HANG
+fld public final static org.jcodings.unicode.UnicodeCodeRange HANGUL
+fld public final static org.jcodings.unicode.UnicodeCodeRange HANI
+fld public final static org.jcodings.unicode.UnicodeCodeRange HANIFIROHINGYA
+fld public final static org.jcodings.unicode.UnicodeCodeRange HANO
+fld public final static org.jcodings.unicode.UnicodeCodeRange HANUNOO
+fld public final static org.jcodings.unicode.UnicodeCodeRange HATR
+fld public final static org.jcodings.unicode.UnicodeCodeRange HATRAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange HEBR
+fld public final static org.jcodings.unicode.UnicodeCodeRange HEBREW
+fld public final static org.jcodings.unicode.UnicodeCodeRange HEX
+fld public final static org.jcodings.unicode.UnicodeCodeRange HEXDIGIT
+fld public final static org.jcodings.unicode.UnicodeCodeRange HIRA
+fld public final static org.jcodings.unicode.UnicodeCodeRange HIRAGANA
+fld public final static org.jcodings.unicode.UnicodeCodeRange HLUW
+fld public final static org.jcodings.unicode.UnicodeCodeRange HMNG
+fld public final static org.jcodings.unicode.UnicodeCodeRange HMNP
+fld public final static org.jcodings.unicode.UnicodeCodeRange HUNG
+fld public final static org.jcodings.unicode.UnicodeCodeRange HYPHEN
+fld public final static org.jcodings.unicode.UnicodeCodeRange IDC
+fld public final static org.jcodings.unicode.UnicodeCodeRange IDCONTINUE
+fld public final static org.jcodings.unicode.UnicodeCodeRange IDEO
+fld public final static org.jcodings.unicode.UnicodeCodeRange IDEOGRAPHIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange IDS
+fld public final static org.jcodings.unicode.UnicodeCodeRange IDSB
+fld public final static org.jcodings.unicode.UnicodeCodeRange IDSBINARYOPERATOR
+fld public final static org.jcodings.unicode.UnicodeCodeRange IDST
+fld public final static org.jcodings.unicode.UnicodeCodeRange IDSTART
+fld public final static org.jcodings.unicode.UnicodeCodeRange IDSTRINARYOPERATOR
+fld public final static org.jcodings.unicode.UnicodeCodeRange IMPERIALARAMAIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INADLAM
+fld public final static org.jcodings.unicode.UnicodeCodeRange INAEGEANNUMBERS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INAHOM
+fld public final static org.jcodings.unicode.UnicodeCodeRange INALCHEMICALSYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INALPHABETICPRESENTATIONFORMS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INANATOLIANHIEROGLYPHS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INANCIENTGREEKMUSICALNOTATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange INANCIENTGREEKNUMBERS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INANCIENTSYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INARABIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INARABICEXTENDEDA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INARABICMATHEMATICALALPHABETICSYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INARABICPRESENTATIONFORMSA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INARABICPRESENTATIONFORMSB
+fld public final static org.jcodings.unicode.UnicodeCodeRange INARABICSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INARMENIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INARROWS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INAVESTAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBALINESE
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBAMUM
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBAMUMSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBASICLATIN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBASSAVAH
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBATAK
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBENGALI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBHAIKSUKI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBLOCKELEMENTS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBOPOMOFO
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBOPOMOFOEXTENDED
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBOXDRAWING
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBRAHMI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBRAILLEPATTERNS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBUGINESE
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBUHID
+fld public final static org.jcodings.unicode.UnicodeCodeRange INBYZANTINEMUSICALSYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCARIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCAUCASIANALBANIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCHAKMA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCHAM
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCHEROKEE
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCHEROKEESUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCHESSSYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCHORASMIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCJKCOMPATIBILITY
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCJKCOMPATIBILITYFORMS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCJKCOMPATIBILITYIDEOGRAPHS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCJKCOMPATIBILITYIDEOGRAPHSSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCJKRADICALSSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCJKSTROKES
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCJKSYMBOLSANDPUNCTUATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCJKUNIFIEDIDEOGRAPHS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCJKUNIFIEDIDEOGRAPHSEXTENSIONA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCJKUNIFIEDIDEOGRAPHSEXTENSIONB
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCJKUNIFIEDIDEOGRAPHSEXTENSIONC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCJKUNIFIEDIDEOGRAPHSEXTENSIOND
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCJKUNIFIEDIDEOGRAPHSEXTENSIONE
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCJKUNIFIEDIDEOGRAPHSEXTENSIONF
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCJKUNIFIEDIDEOGRAPHSEXTENSIONG
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCOMBININGDIACRITICALMARKS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCOMBININGDIACRITICALMARKSEXTENDED
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCOMBININGDIACRITICALMARKSFORSYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCOMBININGDIACRITICALMARKSSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCOMBININGHALFMARKS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCOMMONINDICNUMBERFORMS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCONTROLPICTURES
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCOPTIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCOPTICEPACTNUMBERS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCOUNTINGRODNUMERALS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCUNEIFORM
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCUNEIFORMNUMBERSANDPUNCTUATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCURRENCYSYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCYPRIOTSYLLABARY
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCYRILLIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCYRILLICEXTENDEDA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCYRILLICEXTENDEDB
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCYRILLICEXTENDEDC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INCYRILLICSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INDESERET
+fld public final static org.jcodings.unicode.UnicodeCodeRange INDEVANAGARI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INDEVANAGARIEXTENDED
+fld public final static org.jcodings.unicode.UnicodeCodeRange INDINGBATS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INDIVESAKURU
+fld public final static org.jcodings.unicode.UnicodeCodeRange INDOGRA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INDOMINOTILES
+fld public final static org.jcodings.unicode.UnicodeCodeRange INDUPLOYAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INEARLYDYNASTICCUNEIFORM
+fld public final static org.jcodings.unicode.UnicodeCodeRange INEGYPTIANHIEROGLYPHFORMATCONTROLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INEGYPTIANHIEROGLYPHS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INELBASAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INELYMAIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INEMOTICONS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INENCLOSEDALPHANUMERICS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INENCLOSEDALPHANUMERICSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INENCLOSEDCJKLETTERSANDMONTHS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INENCLOSEDIDEOGRAPHICSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INETHIOPIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INETHIOPICEXTENDED
+fld public final static org.jcodings.unicode.UnicodeCodeRange INETHIOPICEXTENDEDA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INETHIOPICSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INGENERALPUNCTUATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange INGEOMETRICSHAPES
+fld public final static org.jcodings.unicode.UnicodeCodeRange INGEOMETRICSHAPESEXTENDED
+fld public final static org.jcodings.unicode.UnicodeCodeRange INGEORGIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INGEORGIANEXTENDED
+fld public final static org.jcodings.unicode.UnicodeCodeRange INGEORGIANSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INGLAGOLITIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INGLAGOLITICSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INGOTHIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INGRANTHA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INGREEKANDCOPTIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INGREEKEXTENDED
+fld public final static org.jcodings.unicode.UnicodeCodeRange INGUJARATI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INGUNJALAGONDI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INGURMUKHI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INHALFWIDTHANDFULLWIDTHFORMS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INHANGULCOMPATIBILITYJAMO
+fld public final static org.jcodings.unicode.UnicodeCodeRange INHANGULJAMO
+fld public final static org.jcodings.unicode.UnicodeCodeRange INHANGULJAMOEXTENDEDA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INHANGULJAMOEXTENDEDB
+fld public final static org.jcodings.unicode.UnicodeCodeRange INHANGULSYLLABLES
+fld public final static org.jcodings.unicode.UnicodeCodeRange INHANIFIROHINGYA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INHANUNOO
+fld public final static org.jcodings.unicode.UnicodeCodeRange INHATRAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INHEBREW
+fld public final static org.jcodings.unicode.UnicodeCodeRange INHERITED
+fld public final static org.jcodings.unicode.UnicodeCodeRange INHIGHPRIVATEUSESURROGATES
+fld public final static org.jcodings.unicode.UnicodeCodeRange INHIGHSURROGATES
+fld public final static org.jcodings.unicode.UnicodeCodeRange INHIRAGANA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INIDEOGRAPHICDESCRIPTIONCHARACTERS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INIDEOGRAPHICSYMBOLSANDPUNCTUATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange INIMPERIALARAMAIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange ININDICSIYAQNUMBERS
+fld public final static org.jcodings.unicode.UnicodeCodeRange ININSCRIPTIONALPAHLAVI
+fld public final static org.jcodings.unicode.UnicodeCodeRange ININSCRIPTIONALPARTHIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INIPAEXTENSIONS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INITIALPUNCTUATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange INJAVANESE
+fld public final static org.jcodings.unicode.UnicodeCodeRange INKAITHI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INKANAEXTENDEDA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INKANASUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INKANBUN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INKANGXIRADICALS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INKANNADA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INKATAKANA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INKATAKANAPHONETICEXTENSIONS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INKAYAHLI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INKHAROSHTHI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INKHITANSMALLSCRIPT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INKHMER
+fld public final static org.jcodings.unicode.UnicodeCodeRange INKHMERSYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INKHOJKI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INKHUDAWADI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLAO
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLATIN1SUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLATINEXTENDEDA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLATINEXTENDEDADDITIONAL
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLATINEXTENDEDB
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLATINEXTENDEDC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLATINEXTENDEDD
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLATINEXTENDEDE
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLEPCHA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLETTERLIKESYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLIMBU
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLINEARA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLINEARBIDEOGRAMS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLINEARBSYLLABARY
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLISU
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLISUSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLOWSURROGATES
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLYCIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INLYDIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMAHAJANI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMAHJONGTILES
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMAKASAR
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMALAYALAM
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMANDAIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMANICHAEAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMARCHEN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMASARAMGONDI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMATHEMATICALALPHANUMERICSYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMATHEMATICALOPERATORS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMAYANNUMERALS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMEDEFAIDRIN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMEETEIMAYEK
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMEETEIMAYEKEXTENSIONS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMENDEKIKAKUI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMEROITICCURSIVE
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMEROITICHIEROGLYPHS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMIAO
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMISCELLANEOUSMATHEMATICALSYMBOLSA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMISCELLANEOUSMATHEMATICALSYMBOLSB
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMISCELLANEOUSSYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMISCELLANEOUSSYMBOLSANDARROWS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMISCELLANEOUSSYMBOLSANDPICTOGRAPHS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMISCELLANEOUSTECHNICAL
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMODI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMODIFIERTONELETTERS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMONGOLIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMONGOLIANSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMRO
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMULTANI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMUSICALSYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMYANMAR
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMYANMAREXTENDEDA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INMYANMAREXTENDEDB
+fld public final static org.jcodings.unicode.UnicodeCodeRange INNABATAEAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INNANDINAGARI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INNEWA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INNEWTAILUE
+fld public final static org.jcodings.unicode.UnicodeCodeRange INNKO
+fld public final static org.jcodings.unicode.UnicodeCodeRange INNOBLOCK
+fld public final static org.jcodings.unicode.UnicodeCodeRange INNUMBERFORMS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INNUSHU
+fld public final static org.jcodings.unicode.UnicodeCodeRange INNYIAKENGPUACHUEHMONG
+fld public final static org.jcodings.unicode.UnicodeCodeRange INOGHAM
+fld public final static org.jcodings.unicode.UnicodeCodeRange INOLCHIKI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INOLDHUNGARIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INOLDITALIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INOLDNORTHARABIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INOLDPERMIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INOLDPERSIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INOLDSOGDIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INOLDSOUTHARABIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INOLDTURKIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INOPTICALCHARACTERRECOGNITION
+fld public final static org.jcodings.unicode.UnicodeCodeRange INORIYA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INORNAMENTALDINGBATS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INOSAGE
+fld public final static org.jcodings.unicode.UnicodeCodeRange INOSMANYA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INOTTOMANSIYAQNUMBERS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INPAHAWHHMONG
+fld public final static org.jcodings.unicode.UnicodeCodeRange INPALMYRENE
+fld public final static org.jcodings.unicode.UnicodeCodeRange INPAUCINHAU
+fld public final static org.jcodings.unicode.UnicodeCodeRange INPHAGSPA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INPHAISTOSDISC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INPHOENICIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INPHONETICEXTENSIONS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INPHONETICEXTENSIONSSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INPLAYINGCARDS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INPRIVATEUSEAREA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INPSALTERPAHLAVI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INREJANG
+fld public final static org.jcodings.unicode.UnicodeCodeRange INRUMINUMERALSYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INRUNIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSAMARITAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSAURASHTRA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSCRIPTIONALPAHLAVI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSCRIPTIONALPARTHIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSHARADA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSHAVIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSHORTHANDFORMATCONTROLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSIDDHAM
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSINHALA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSINHALAARCHAICNUMBERS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSMALLFORMVARIANTS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSMALLKANAEXTENSION
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSOGDIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSORASOMPENG
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSOYOMBO
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSPACINGMODIFIERLETTERS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSPECIALS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSUNDANESE
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSUNDANESESUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSUPERSCRIPTSANDSUBSCRIPTS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSUPPLEMENTALARROWSA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSUPPLEMENTALARROWSB
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSUPPLEMENTALARROWSC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSUPPLEMENTALMATHEMATICALOPERATORS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSUPPLEMENTALPUNCTUATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSUPPLEMENTALSYMBOLSANDPICTOGRAPHS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSUPPLEMENTARYPRIVATEUSEAREAA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSUPPLEMENTARYPRIVATEUSEAREAB
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSUTTONSIGNWRITING
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSYLOTINAGRI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSYMBOLSANDPICTOGRAPHSEXTENDEDA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSYMBOLSFORLEGACYCOMPUTING
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSYRIAC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INSYRIACSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTAGALOG
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTAGBANWA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTAGS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTAILE
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTAITHAM
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTAIVIET
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTAIXUANJINGSYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTAKRI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTAMIL
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTAMILSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTANGUT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTANGUTCOMPONENTS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTANGUTSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTELUGU
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTHAANA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTHAI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTIBETAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTIFINAGH
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTIRHUTA
+fld public final static org.jcodings.unicode.UnicodeCodeRange INTRANSPORTANDMAPSYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INUGARITIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange INUNIFIEDCANADIANABORIGINALSYLLABICS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INUNIFIEDCANADIANABORIGINALSYLLABICSEXTENDED
+fld public final static org.jcodings.unicode.UnicodeCodeRange INVAI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INVARIATIONSELECTORS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INVARIATIONSELECTORSSUPPLEMENT
+fld public final static org.jcodings.unicode.UnicodeCodeRange INVEDICEXTENSIONS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INVERTICALFORMS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INWANCHO
+fld public final static org.jcodings.unicode.UnicodeCodeRange INWARANGCITI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INYEZIDI
+fld public final static org.jcodings.unicode.UnicodeCodeRange INYIJINGHEXAGRAMSYMBOLS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INYIRADICALS
+fld public final static org.jcodings.unicode.UnicodeCodeRange INYISYLLABLES
+fld public final static org.jcodings.unicode.UnicodeCodeRange INZANABAZARSQUARE
+fld public final static org.jcodings.unicode.UnicodeCodeRange ITAL
+fld public final static org.jcodings.unicode.UnicodeCodeRange JAVA
+fld public final static org.jcodings.unicode.UnicodeCodeRange JAVANESE
+fld public final static org.jcodings.unicode.UnicodeCodeRange JOINC
+fld public final static org.jcodings.unicode.UnicodeCodeRange JOINCONTROL
+fld public final static org.jcodings.unicode.UnicodeCodeRange KAITHI
+fld public final static org.jcodings.unicode.UnicodeCodeRange KALI
+fld public final static org.jcodings.unicode.UnicodeCodeRange KANA
+fld public final static org.jcodings.unicode.UnicodeCodeRange KANNADA
+fld public final static org.jcodings.unicode.UnicodeCodeRange KATAKANA
+fld public final static org.jcodings.unicode.UnicodeCodeRange KAYAHLI
+fld public final static org.jcodings.unicode.UnicodeCodeRange KHAR
+fld public final static org.jcodings.unicode.UnicodeCodeRange KHAROSHTHI
+fld public final static org.jcodings.unicode.UnicodeCodeRange KHITANSMALLSCRIPT
+fld public final static org.jcodings.unicode.UnicodeCodeRange KHMER
+fld public final static org.jcodings.unicode.UnicodeCodeRange KHMR
+fld public final static org.jcodings.unicode.UnicodeCodeRange KHOJ
+fld public final static org.jcodings.unicode.UnicodeCodeRange KHOJKI
+fld public final static org.jcodings.unicode.UnicodeCodeRange KHUDAWADI
+fld public final static org.jcodings.unicode.UnicodeCodeRange KITS
+fld public final static org.jcodings.unicode.UnicodeCodeRange KNDA
+fld public final static org.jcodings.unicode.UnicodeCodeRange KTHI
+fld public final static org.jcodings.unicode.UnicodeCodeRange L
+fld public final static org.jcodings.unicode.UnicodeCodeRange LANA
+fld public final static org.jcodings.unicode.UnicodeCodeRange LAO
+fld public final static org.jcodings.unicode.UnicodeCodeRange LAOO
+fld public final static org.jcodings.unicode.UnicodeCodeRange LATIN
+fld public final static org.jcodings.unicode.UnicodeCodeRange LATN
+fld public final static org.jcodings.unicode.UnicodeCodeRange LC
+fld public final static org.jcodings.unicode.UnicodeCodeRange LEPC
+fld public final static org.jcodings.unicode.UnicodeCodeRange LEPCHA
+fld public final static org.jcodings.unicode.UnicodeCodeRange LETTER
+fld public final static org.jcodings.unicode.UnicodeCodeRange LETTERNUMBER
+fld public final static org.jcodings.unicode.UnicodeCodeRange LIMB
+fld public final static org.jcodings.unicode.UnicodeCodeRange LIMBU
+fld public final static org.jcodings.unicode.UnicodeCodeRange LINA
+fld public final static org.jcodings.unicode.UnicodeCodeRange LINB
+fld public final static org.jcodings.unicode.UnicodeCodeRange LINEARA
+fld public final static org.jcodings.unicode.UnicodeCodeRange LINEARB
+fld public final static org.jcodings.unicode.UnicodeCodeRange LINESEPARATOR
+fld public final static org.jcodings.unicode.UnicodeCodeRange LISU
+fld public final static org.jcodings.unicode.UnicodeCodeRange LL
+fld public final static org.jcodings.unicode.UnicodeCodeRange LM
+fld public final static org.jcodings.unicode.UnicodeCodeRange LO
+fld public final static org.jcodings.unicode.UnicodeCodeRange LOE
+fld public final static org.jcodings.unicode.UnicodeCodeRange LOGICALORDEREXCEPTION
+fld public final static org.jcodings.unicode.UnicodeCodeRange LOWER
+fld public final static org.jcodings.unicode.UnicodeCodeRange LOWERCASE
+fld public final static org.jcodings.unicode.UnicodeCodeRange LOWERCASELETTER
+fld public final static org.jcodings.unicode.UnicodeCodeRange LT
+fld public final static org.jcodings.unicode.UnicodeCodeRange LU
+fld public final static org.jcodings.unicode.UnicodeCodeRange LYCI
+fld public final static org.jcodings.unicode.UnicodeCodeRange LYCIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange LYDI
+fld public final static org.jcodings.unicode.UnicodeCodeRange LYDIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange M
+fld public final static org.jcodings.unicode.UnicodeCodeRange MAHAJANI
+fld public final static org.jcodings.unicode.UnicodeCodeRange MAHJ
+fld public final static org.jcodings.unicode.UnicodeCodeRange MAKA
+fld public final static org.jcodings.unicode.UnicodeCodeRange MAKASAR
+fld public final static org.jcodings.unicode.UnicodeCodeRange MALAYALAM
+fld public final static org.jcodings.unicode.UnicodeCodeRange MAND
+fld public final static org.jcodings.unicode.UnicodeCodeRange MANDAIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange MANI
+fld public final static org.jcodings.unicode.UnicodeCodeRange MANICHAEAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange MARC
+fld public final static org.jcodings.unicode.UnicodeCodeRange MARCHEN
+fld public final static org.jcodings.unicode.UnicodeCodeRange MARK
+fld public final static org.jcodings.unicode.UnicodeCodeRange MASARAMGONDI
+fld public final static org.jcodings.unicode.UnicodeCodeRange MATH
+fld public final static org.jcodings.unicode.UnicodeCodeRange MATHSYMBOL
+fld public final static org.jcodings.unicode.UnicodeCodeRange MC
+fld public final static org.jcodings.unicode.UnicodeCodeRange ME
+fld public final static org.jcodings.unicode.UnicodeCodeRange MEDEFAIDRIN
+fld public final static org.jcodings.unicode.UnicodeCodeRange MEDF
+fld public final static org.jcodings.unicode.UnicodeCodeRange MEETEIMAYEK
+fld public final static org.jcodings.unicode.UnicodeCodeRange MEND
+fld public final static org.jcodings.unicode.UnicodeCodeRange MENDEKIKAKUI
+fld public final static org.jcodings.unicode.UnicodeCodeRange MERC
+fld public final static org.jcodings.unicode.UnicodeCodeRange MERO
+fld public final static org.jcodings.unicode.UnicodeCodeRange MEROITICCURSIVE
+fld public final static org.jcodings.unicode.UnicodeCodeRange MEROITICHIEROGLYPHS
+fld public final static org.jcodings.unicode.UnicodeCodeRange MIAO
+fld public final static org.jcodings.unicode.UnicodeCodeRange MLYM
+fld public final static org.jcodings.unicode.UnicodeCodeRange MN
+fld public final static org.jcodings.unicode.UnicodeCodeRange MODI
+fld public final static org.jcodings.unicode.UnicodeCodeRange MODIFIERLETTER
+fld public final static org.jcodings.unicode.UnicodeCodeRange MODIFIERSYMBOL
+fld public final static org.jcodings.unicode.UnicodeCodeRange MONG
+fld public final static org.jcodings.unicode.UnicodeCodeRange MONGOLIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange MRO
+fld public final static org.jcodings.unicode.UnicodeCodeRange MROO
+fld public final static org.jcodings.unicode.UnicodeCodeRange MTEI
+fld public final static org.jcodings.unicode.UnicodeCodeRange MULT
+fld public final static org.jcodings.unicode.UnicodeCodeRange MULTANI
+fld public final static org.jcodings.unicode.UnicodeCodeRange MYANMAR
+fld public final static org.jcodings.unicode.UnicodeCodeRange MYMR
+fld public final static org.jcodings.unicode.UnicodeCodeRange N
+fld public final static org.jcodings.unicode.UnicodeCodeRange NABATAEAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange NAND
+fld public final static org.jcodings.unicode.UnicodeCodeRange NANDINAGARI
+fld public final static org.jcodings.unicode.UnicodeCodeRange NARB
+fld public final static org.jcodings.unicode.UnicodeCodeRange NBAT
+fld public final static org.jcodings.unicode.UnicodeCodeRange NCHAR
+fld public final static org.jcodings.unicode.UnicodeCodeRange ND
+fld public final static org.jcodings.unicode.UnicodeCodeRange NEWA
+fld public final static org.jcodings.unicode.UnicodeCodeRange NEWLINE
+fld public final static org.jcodings.unicode.UnicodeCodeRange NEWTAILUE
+fld public final static org.jcodings.unicode.UnicodeCodeRange NKO
+fld public final static org.jcodings.unicode.UnicodeCodeRange NKOO
+fld public final static org.jcodings.unicode.UnicodeCodeRange NL
+fld public final static org.jcodings.unicode.UnicodeCodeRange NO
+fld public final static org.jcodings.unicode.UnicodeCodeRange NONCHARACTERCODEPOINT
+fld public final static org.jcodings.unicode.UnicodeCodeRange NONSPACINGMARK
+fld public final static org.jcodings.unicode.UnicodeCodeRange NSHU
+fld public final static org.jcodings.unicode.UnicodeCodeRange NUMBER
+fld public final static org.jcodings.unicode.UnicodeCodeRange NUSHU
+fld public final static org.jcodings.unicode.UnicodeCodeRange NYIAKENGPUACHUEHMONG
+fld public final static org.jcodings.unicode.UnicodeCodeRange OALPHA
+fld public final static org.jcodings.unicode.UnicodeCodeRange ODI
+fld public final static org.jcodings.unicode.UnicodeCodeRange OGAM
+fld public final static org.jcodings.unicode.UnicodeCodeRange OGHAM
+fld public final static org.jcodings.unicode.UnicodeCodeRange OGREXT
+fld public final static org.jcodings.unicode.UnicodeCodeRange OIDC
+fld public final static org.jcodings.unicode.UnicodeCodeRange OIDS
+fld public final static org.jcodings.unicode.UnicodeCodeRange OLCHIKI
+fld public final static org.jcodings.unicode.UnicodeCodeRange OLCK
+fld public final static org.jcodings.unicode.UnicodeCodeRange OLDHUNGARIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange OLDITALIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange OLDNORTHARABIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange OLDPERMIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange OLDPERSIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange OLDSOGDIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange OLDSOUTHARABIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange OLDTURKIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange OLOWER
+fld public final static org.jcodings.unicode.UnicodeCodeRange OMATH
+fld public final static org.jcodings.unicode.UnicodeCodeRange OPENPUNCTUATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange ORIYA
+fld public final static org.jcodings.unicode.UnicodeCodeRange ORKH
+fld public final static org.jcodings.unicode.UnicodeCodeRange ORYA
+fld public final static org.jcodings.unicode.UnicodeCodeRange OSAGE
+fld public final static org.jcodings.unicode.UnicodeCodeRange OSGE
+fld public final static org.jcodings.unicode.UnicodeCodeRange OSMA
+fld public final static org.jcodings.unicode.UnicodeCodeRange OSMANYA
+fld public final static org.jcodings.unicode.UnicodeCodeRange OTHER
+fld public final static org.jcodings.unicode.UnicodeCodeRange OTHERALPHABETIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange OTHERDEFAULTIGNORABLECODEPOINT
+fld public final static org.jcodings.unicode.UnicodeCodeRange OTHERGRAPHEMEEXTEND
+fld public final static org.jcodings.unicode.UnicodeCodeRange OTHERIDCONTINUE
+fld public final static org.jcodings.unicode.UnicodeCodeRange OTHERIDSTART
+fld public final static org.jcodings.unicode.UnicodeCodeRange OTHERLETTER
+fld public final static org.jcodings.unicode.UnicodeCodeRange OTHERLOWERCASE
+fld public final static org.jcodings.unicode.UnicodeCodeRange OTHERMATH
+fld public final static org.jcodings.unicode.UnicodeCodeRange OTHERNUMBER
+fld public final static org.jcodings.unicode.UnicodeCodeRange OTHERPUNCTUATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange OTHERSYMBOL
+fld public final static org.jcodings.unicode.UnicodeCodeRange OTHERUPPERCASE
+fld public final static org.jcodings.unicode.UnicodeCodeRange OUPPER
+fld public final static org.jcodings.unicode.UnicodeCodeRange P
+fld public final static org.jcodings.unicode.UnicodeCodeRange PAHAWHHMONG
+fld public final static org.jcodings.unicode.UnicodeCodeRange PALM
+fld public final static org.jcodings.unicode.UnicodeCodeRange PALMYRENE
+fld public final static org.jcodings.unicode.UnicodeCodeRange PARAGRAPHSEPARATOR
+fld public final static org.jcodings.unicode.UnicodeCodeRange PATSYN
+fld public final static org.jcodings.unicode.UnicodeCodeRange PATTERNSYNTAX
+fld public final static org.jcodings.unicode.UnicodeCodeRange PATTERNWHITESPACE
+fld public final static org.jcodings.unicode.UnicodeCodeRange PATWS
+fld public final static org.jcodings.unicode.UnicodeCodeRange PAUC
+fld public final static org.jcodings.unicode.UnicodeCodeRange PAUCINHAU
+fld public final static org.jcodings.unicode.UnicodeCodeRange PC
+fld public final static org.jcodings.unicode.UnicodeCodeRange PCM
+fld public final static org.jcodings.unicode.UnicodeCodeRange PD
+fld public final static org.jcodings.unicode.UnicodeCodeRange PE
+fld public final static org.jcodings.unicode.UnicodeCodeRange PERM
+fld public final static org.jcodings.unicode.UnicodeCodeRange PF
+fld public final static org.jcodings.unicode.UnicodeCodeRange PHAG
+fld public final static org.jcodings.unicode.UnicodeCodeRange PHAGSPA
+fld public final static org.jcodings.unicode.UnicodeCodeRange PHLI
+fld public final static org.jcodings.unicode.UnicodeCodeRange PHLP
+fld public final static org.jcodings.unicode.UnicodeCodeRange PHNX
+fld public final static org.jcodings.unicode.UnicodeCodeRange PHOENICIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange PI
+fld public final static org.jcodings.unicode.UnicodeCodeRange PLRD
+fld public final static org.jcodings.unicode.UnicodeCodeRange PO
+fld public final static org.jcodings.unicode.UnicodeCodeRange PREPENDEDCONCATENATIONMARK
+fld public final static org.jcodings.unicode.UnicodeCodeRange PRINT
+fld public final static org.jcodings.unicode.UnicodeCodeRange PRIVATEUSE
+fld public final static org.jcodings.unicode.UnicodeCodeRange PRTI
+fld public final static org.jcodings.unicode.UnicodeCodeRange PS
+fld public final static org.jcodings.unicode.UnicodeCodeRange PSALTERPAHLAVI
+fld public final static org.jcodings.unicode.UnicodeCodeRange PUNCT
+fld public final static org.jcodings.unicode.UnicodeCodeRange PUNCTUATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange QAAC
+fld public final static org.jcodings.unicode.UnicodeCodeRange QAAI
+fld public final static org.jcodings.unicode.UnicodeCodeRange QMARK
+fld public final static org.jcodings.unicode.UnicodeCodeRange QUOTATIONMARK
+fld public final static org.jcodings.unicode.UnicodeCodeRange RADICAL
+fld public final static org.jcodings.unicode.UnicodeCodeRange REGIONALINDICATOR
+fld public final static org.jcodings.unicode.UnicodeCodeRange REJANG
+fld public final static org.jcodings.unicode.UnicodeCodeRange RI
+fld public final static org.jcodings.unicode.UnicodeCodeRange RJNG
+fld public final static org.jcodings.unicode.UnicodeCodeRange ROHG
+fld public final static org.jcodings.unicode.UnicodeCodeRange RUNIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange RUNR
+fld public final static org.jcodings.unicode.UnicodeCodeRange S
+fld public final static org.jcodings.unicode.UnicodeCodeRange SAMARITAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange SAMR
+fld public final static org.jcodings.unicode.UnicodeCodeRange SARB
+fld public final static org.jcodings.unicode.UnicodeCodeRange SAUR
+fld public final static org.jcodings.unicode.UnicodeCodeRange SAURASHTRA
+fld public final static org.jcodings.unicode.UnicodeCodeRange SC
+fld public final static org.jcodings.unicode.UnicodeCodeRange SD
+fld public final static org.jcodings.unicode.UnicodeCodeRange SENTENCETERMINAL
+fld public final static org.jcodings.unicode.UnicodeCodeRange SEPARATOR
+fld public final static org.jcodings.unicode.UnicodeCodeRange SGNW
+fld public final static org.jcodings.unicode.UnicodeCodeRange SHARADA
+fld public final static org.jcodings.unicode.UnicodeCodeRange SHAVIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange SHAW
+fld public final static org.jcodings.unicode.UnicodeCodeRange SHRD
+fld public final static org.jcodings.unicode.UnicodeCodeRange SIDD
+fld public final static org.jcodings.unicode.UnicodeCodeRange SIDDHAM
+fld public final static org.jcodings.unicode.UnicodeCodeRange SIGNWRITING
+fld public final static org.jcodings.unicode.UnicodeCodeRange SIND
+fld public final static org.jcodings.unicode.UnicodeCodeRange SINH
+fld public final static org.jcodings.unicode.UnicodeCodeRange SINHALA
+fld public final static org.jcodings.unicode.UnicodeCodeRange SK
+fld public final static org.jcodings.unicode.UnicodeCodeRange SM
+fld public final static org.jcodings.unicode.UnicodeCodeRange SO
+fld public final static org.jcodings.unicode.UnicodeCodeRange SOFTDOTTED
+fld public final static org.jcodings.unicode.UnicodeCodeRange SOGD
+fld public final static org.jcodings.unicode.UnicodeCodeRange SOGDIAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange SOGO
+fld public final static org.jcodings.unicode.UnicodeCodeRange SORA
+fld public final static org.jcodings.unicode.UnicodeCodeRange SORASOMPENG
+fld public final static org.jcodings.unicode.UnicodeCodeRange SOYO
+fld public final static org.jcodings.unicode.UnicodeCodeRange SOYOMBO
+fld public final static org.jcodings.unicode.UnicodeCodeRange SPACE
+fld public final static org.jcodings.unicode.UnicodeCodeRange SPACESEPARATOR
+fld public final static org.jcodings.unicode.UnicodeCodeRange SPACINGMARK
+fld public final static org.jcodings.unicode.UnicodeCodeRange STERM
+fld public final static org.jcodings.unicode.UnicodeCodeRange SUND
+fld public final static org.jcodings.unicode.UnicodeCodeRange SUNDANESE
+fld public final static org.jcodings.unicode.UnicodeCodeRange SURROGATE
+fld public final static org.jcodings.unicode.UnicodeCodeRange SYLO
+fld public final static org.jcodings.unicode.UnicodeCodeRange SYLOTINAGRI
+fld public final static org.jcodings.unicode.UnicodeCodeRange SYMBOL
+fld public final static org.jcodings.unicode.UnicodeCodeRange SYRC
+fld public final static org.jcodings.unicode.UnicodeCodeRange SYRIAC
+fld public final static org.jcodings.unicode.UnicodeCodeRange TAGALOG
+fld public final static org.jcodings.unicode.UnicodeCodeRange TAGB
+fld public final static org.jcodings.unicode.UnicodeCodeRange TAGBANWA
+fld public final static org.jcodings.unicode.UnicodeCodeRange TAILE
+fld public final static org.jcodings.unicode.UnicodeCodeRange TAITHAM
+fld public final static org.jcodings.unicode.UnicodeCodeRange TAIVIET
+fld public final static org.jcodings.unicode.UnicodeCodeRange TAKR
+fld public final static org.jcodings.unicode.UnicodeCodeRange TAKRI
+fld public final static org.jcodings.unicode.UnicodeCodeRange TALE
+fld public final static org.jcodings.unicode.UnicodeCodeRange TALU
+fld public final static org.jcodings.unicode.UnicodeCodeRange TAMIL
+fld public final static org.jcodings.unicode.UnicodeCodeRange TAML
+fld public final static org.jcodings.unicode.UnicodeCodeRange TANG
+fld public final static org.jcodings.unicode.UnicodeCodeRange TANGUT
+fld public final static org.jcodings.unicode.UnicodeCodeRange TAVT
+fld public final static org.jcodings.unicode.UnicodeCodeRange TELU
+fld public final static org.jcodings.unicode.UnicodeCodeRange TELUGU
+fld public final static org.jcodings.unicode.UnicodeCodeRange TERM
+fld public final static org.jcodings.unicode.UnicodeCodeRange TERMINALPUNCTUATION
+fld public final static org.jcodings.unicode.UnicodeCodeRange TFNG
+fld public final static org.jcodings.unicode.UnicodeCodeRange TGLG
+fld public final static org.jcodings.unicode.UnicodeCodeRange THAA
+fld public final static org.jcodings.unicode.UnicodeCodeRange THAANA
+fld public final static org.jcodings.unicode.UnicodeCodeRange THAI
+fld public final static org.jcodings.unicode.UnicodeCodeRange TIBETAN
+fld public final static org.jcodings.unicode.UnicodeCodeRange TIBT
+fld public final static org.jcodings.unicode.UnicodeCodeRange TIFINAGH
+fld public final static org.jcodings.unicode.UnicodeCodeRange TIRH
+fld public final static org.jcodings.unicode.UnicodeCodeRange TIRHUTA
+fld public final static org.jcodings.unicode.UnicodeCodeRange TITLECASELETTER
+fld public final static org.jcodings.unicode.UnicodeCodeRange UGAR
+fld public final static org.jcodings.unicode.UnicodeCodeRange UGARITIC
+fld public final static org.jcodings.unicode.UnicodeCodeRange UIDEO
+fld public final static org.jcodings.unicode.UnicodeCodeRange UNASSIGNED
+fld public final static org.jcodings.unicode.UnicodeCodeRange UNIFIEDIDEOGRAPH
+fld public final static org.jcodings.unicode.UnicodeCodeRange UNKNOWN
+fld public final static org.jcodings.unicode.UnicodeCodeRange UPPER
+fld public final static org.jcodings.unicode.UnicodeCodeRange UPPERCASE
+fld public final static org.jcodings.unicode.UnicodeCodeRange UPPERCASELETTER
+fld public final static org.jcodings.unicode.UnicodeCodeRange VAI
+fld public final static org.jcodings.unicode.UnicodeCodeRange VAII
+fld public final static org.jcodings.unicode.UnicodeCodeRange VARIATIONSELECTOR
+fld public final static org.jcodings.unicode.UnicodeCodeRange VS
+fld public final static org.jcodings.unicode.UnicodeCodeRange WANCHO
+fld public final static org.jcodings.unicode.UnicodeCodeRange WARA
+fld public final static org.jcodings.unicode.UnicodeCodeRange WARANGCITI
+fld public final static org.jcodings.unicode.UnicodeCodeRange WCHO
+fld public final static org.jcodings.unicode.UnicodeCodeRange WHITESPACE
+fld public final static org.jcodings.unicode.UnicodeCodeRange WORD
+fld public final static org.jcodings.unicode.UnicodeCodeRange WSPACE
+fld public final static org.jcodings.unicode.UnicodeCodeRange XDIGIT
+fld public final static org.jcodings.unicode.UnicodeCodeRange XIDC
+fld public final static org.jcodings.unicode.UnicodeCodeRange XIDCONTINUE
+fld public final static org.jcodings.unicode.UnicodeCodeRange XIDS
+fld public final static org.jcodings.unicode.UnicodeCodeRange XIDSTART
+fld public final static org.jcodings.unicode.UnicodeCodeRange XPEO
+fld public final static org.jcodings.unicode.UnicodeCodeRange XPOSIXPUNCT
+fld public final static org.jcodings.unicode.UnicodeCodeRange XSUX
+fld public final static org.jcodings.unicode.UnicodeCodeRange YEZI
+fld public final static org.jcodings.unicode.UnicodeCodeRange YEZIDI
+fld public final static org.jcodings.unicode.UnicodeCodeRange YI
+fld public final static org.jcodings.unicode.UnicodeCodeRange YIII
+fld public final static org.jcodings.unicode.UnicodeCodeRange Z
+fld public final static org.jcodings.unicode.UnicodeCodeRange ZANABAZARSQUARE
+fld public final static org.jcodings.unicode.UnicodeCodeRange ZANB
+fld public final static org.jcodings.unicode.UnicodeCodeRange ZINH
+fld public final static org.jcodings.unicode.UnicodeCodeRange ZL
+fld public final static org.jcodings.unicode.UnicodeCodeRange ZP
+fld public final static org.jcodings.unicode.UnicodeCodeRange ZS
+fld public final static org.jcodings.unicode.UnicodeCodeRange ZYYY
+fld public final static org.jcodings.unicode.UnicodeCodeRange ZZZZ
+meth public boolean contains(int)
+meth public int getCType()
+meth public static org.jcodings.unicode.UnicodeCodeRange valueOf(java.lang.String)
+meth public static org.jcodings.unicode.UnicodeCodeRange[] values()
+supr java.lang.Enum<org.jcodings.unicode.UnicodeCodeRange>
+hfds CodeRangeTable,MAX_WORD_LENGTH,name,range,table
 
 CLSS public abstract org.jcodings.unicode.UnicodeEncoding
 cons protected init(java.lang.String,int,int,int[])
 cons protected init(java.lang.String,int,int,int[],int[][])
 meth protected final int[] ctypeCodeRange(int)
 meth public boolean isCodeCType(int,int)
+meth public final int caseMap(org.jcodings.IntHolder,byte[],org.jcodings.IntHolder,int,byte[],int,int)
 meth public int mbcCaseFold(int,byte[],org.jcodings.IntHolder,int,byte[])
 meth public int propertyNameToCType(byte[],int,int)
 meth public java.lang.String getCharsetName()
 meth public org.jcodings.CaseFoldCodeItem[] caseFoldCodesByString(int,byte[],int,int)
+meth public static boolean isInCodeRange(org.jcodings.unicode.UnicodeCodeRange,int)
 meth public void applyAllCaseFold(int,org.jcodings.ApplyAllCaseFoldFunction,java.lang.Object)
 supr org.jcodings.MultiByteEncoding
-hfds PROPERTY_NAME_MAX_SIZE,UNICODE_ISO_8859_1_CTypeTable
-hcls CTypeName,CaseFold,CaseFold11,CaseFold12,CaseFold13,CodeRangeEntry
-
-CLSS public org.jcodings.unicode.UnicodeProperties
-cons public init()
-supr java.lang.Object
-hfds CodeRangeTable
+hfds CASE_MAPPING_SLACK,DOTLESS_i,DOT_ABOVE,I_WITH_DOT_ABOVE,PROPERTY_NAME_MAX_SIZE,UNICODE_ISO_8859_1_CTypeTable
+hcls CTypeName,CaseFold,CaseMappingSpecials,CaseUnfold11,CaseUnfold12,CaseUnfold13,CodeList
 
 CLSS public org.jcodings.util.ArrayReader
 cons public init()
 meth public static byte[] readByteArray(java.lang.String)
 meth public static int[] readIntArray(java.lang.String)
 meth public static int[][] readNestedIntArray(java.lang.String)
+meth public static java.io.DataInputStream openStream(java.lang.String)
 supr java.lang.Object
 
 CLSS public final org.jcodings.util.BytesHash<%0 extends java.lang.Object>
@@ -2280,6 +3372,23 @@ CLSS public final static org.jcodings.util.IntHash$IntHashEntry<%0 extends java.
 cons public init()
 cons public init(int,org.jcodings.util.Hash$HashEntry<{org.jcodings.util.IntHash$IntHashEntry%0}>,{org.jcodings.util.IntHash$IntHashEntry%0},org.jcodings.util.Hash$HashEntry<{org.jcodings.util.IntHash$IntHashEntry%0}>)
 supr org.jcodings.util.Hash$HashEntry<{org.jcodings.util.IntHash$IntHashEntry%0}>
+
+CLSS public org.jcodings.util.Macros
+cons public init()
+fld public final static int MBCLEN_INVALID = -1
+meth public static boolean MBCLEN_CHARFOUND_P(int)
+meth public static boolean MBCLEN_INVALID_P(int)
+meth public static boolean MBCLEN_NEEDMORE_P(int)
+meth public static boolean UNICODE_VALID_CODEPOINT_P(int)
+meth public static boolean UTF16_IS_SURROGATE(int)
+meth public static boolean UTF16_IS_SURROGATE_FIRST(int)
+meth public static boolean UTF16_IS_SURROGATE_SECOND(int)
+meth public static int CONSTRUCT_MBCLEN_CHARFOUND(int)
+meth public static int CONSTRUCT_MBCLEN_INVALID()
+meth public static int CONSTRUCT_MBCLEN_NEEDMORE(int)
+meth public static int MBCLEN_CHARFOUND_LEN(int)
+meth public static int MBCLEN_NEEDMORE_LEN(int)
+supr java.lang.Object
 
 CLSS public final org.jcodings.util.ObjHash<%0 extends java.lang.Object, %1 extends java.lang.Object>
 cons public init()

--- a/ide/libs.jcodings/nbproject/project.properties
+++ b/ide/libs.jcodings/nbproject/project.properties
@@ -16,4 +16,4 @@
 # under the License.
 
 is.autoload=true
-release.external/jcodings-1.0.18.jar=modules/ext/jcodings-1.0.18.jar
+release.external/jcodings-1.0.58.jar=modules/ext/jcodings-1.0.58.jar

--- a/ide/libs.jcodings/nbproject/project.xml
+++ b/ide/libs.jcodings/nbproject/project.xml
@@ -29,8 +29,8 @@
                 <subpackages>org.jcodings</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/jcodings-1.0.18.jar</runtime-relative-path>
-                <binary-origin>external/jcodings-1.0.18.jar</binary-origin>
+                <runtime-relative-path>ext/jcodings-1.0.58.jar</runtime-relative-path>
+                <binary-origin>external/jcodings-1.0.58.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/options/LanguageStorage.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/options/LanguageStorage.java
@@ -27,15 +27,14 @@ import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.swing.event.ChangeEvent;
-import org.eclipse.tm4e.core.registry.IRegistryOptions;
-import org.eclipse.tm4e.core.registry.Registry;
+import org.eclipse.tm4e.core.internal.grammar.raw.RawGrammarReader;
+import org.eclipse.tm4e.core.registry.IGrammarSource;
 import org.netbeans.modules.textmate.lexer.TextmateTokenId;
 import org.netbeans.spi.navigator.NavigatorPanel;
 import org.openide.filesystems.FileObject;
@@ -214,23 +213,9 @@ public class LanguageStorage {
     }
 
     private static String findScope(File grammar) throws Exception {
-        IRegistryOptions opts = new IRegistryOptions() {
-            @Override
-            public String getFilePath(String scopeName) {
-                return null;
-            }
-            @Override
-            public InputStream getInputStream(String scopeName) throws IOException {
-                return null;
-            }
-            @Override
-            public Collection<String> getInjections(String scopeName) {
-                return null;
-            }
-        };
-        return new Registry(opts).loadGrammarFromPathSync(grammar).getScopeName();
+        return RawGrammarReader.readGrammar(IGrammarSource.fromFile(grammar.toPath())).getScopeName();
     }
-    
+
     public static class LanguageDescription {
 
         public String id;

--- a/ide/textmate.lexer/external/binaries-list
+++ b/ide/textmate.lexer/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-655CC3ABA1BC9DBDD653F28937BEC16F3E9C4CEC org.jruby.joni:joni:2.1.11
-109763C0803F3EAC2372B4E4A9A0D7BED9CAB5BC eu.doppel-helix.netbeans.lib.tm4e:org.eclipse.tm4e.core:0.4.1-pack1
+23D2F2EFF7FA0CDA465D86EC9D8BAB53E496D9E6 org.jruby.joni:joni:2.2.1
+9234380A35AD5C0A707E850D24031AAA158D283A https://download.eclipse.org/tm4e/releases/0.14.0/plugins/org.eclipse.tm4e.core_0.14.0.202410282056.jar org.eclipse.tm4e.core-0.14.0.jar

--- a/ide/textmate.lexer/external/joni-2.2.1-license.txt
+++ b/ide/textmate.lexer/external/joni-2.2.1-license.txt
@@ -1,5 +1,5 @@
 Name: jcodings
-Version: 2.1.11
+Version: 2.2.1
 License: MIT-jruby
 Description: Needed by TextMate support for Eclipse
 Origin: https://github.com/jruby/joni

--- a/ide/textmate.lexer/external/org.eclipse.tm4e.core-0.14.0-license.txt
+++ b/ide/textmate.lexer/external/org.eclipse.tm4e.core-0.14.0-license.txt
@@ -1,5 +1,5 @@
 Name: TextMate support for Eclipse
-Version: 0.4.1-pack1
+Version: 0.14.0
 License: EPL-v20
 Description: Used to interpret TextMate grammars
 Origin: https://github.com/eclipse/tm4e

--- a/ide/textmate.lexer/nbproject/project.properties
+++ b/ide/textmate.lexer/nbproject/project.properties
@@ -15,10 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
-release.external/joni-2.1.11.jar=modules/ext/joni-2.1.11.jar
-release.external/org.eclipse.tm4e.core-0.4.1-pack1.jar=modules/ext/org.eclipse.tm4e.core-0.4.1-pack1.jar
-spec.version.base=1.27.0
+release.external/joni-2.2.1.jar=modules/ext/joni-2.2.1.jar
+release.external/org.eclipse.tm4e.core-0.14.0.jar=modules/ext/org.eclipse.tm4e.core-0.14.0.jar
+spec.version.base=1.28.0

--- a/ide/textmate.lexer/nbproject/project.xml
+++ b/ide/textmate.lexer/nbproject/project.xml
@@ -42,8 +42,8 @@
                 <dependency>
                     <code-name-base>org.netbeans.libs.jcodings</code-name-base>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>0.1</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>1.0.58</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -200,12 +200,12 @@
                 <package>org.netbeans.modules.textmate.lexer.api</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/joni-2.1.11.jar</runtime-relative-path>
-                <binary-origin>external/joni-2.1.11.jar</binary-origin>
+                <runtime-relative-path>ext/joni-2.2.1.jar</runtime-relative-path>
+                <binary-origin>external/joni-2.2.1.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/org.eclipse.tm4e.core-0.4.1-pack1.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.tm4e.core-0.4.1-pack1.jar</binary-origin>
+                <runtime-relative-path>ext/org.eclipse.tm4e.core-0.14.0.jar</runtime-relative-path>
+                <binary-origin>external/org.eclipse.tm4e.core-0.14.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/CreateRegistrationProcessor.java
+++ b/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/CreateRegistrationProcessor.java
@@ -21,7 +21,9 @@ package org.netbeans.modules.textmate.lexer;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collection;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -37,8 +39,8 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
-import org.eclipse.tm4e.core.registry.IRegistryOptions;
-import org.eclipse.tm4e.core.registry.Registry;
+import org.eclipse.tm4e.core.internal.grammar.raw.RawGrammarReader;
+import org.eclipse.tm4e.core.registry.IGrammarSource;
 import org.openide.filesystems.annotations.LayerBuilder;
 import org.openide.filesystems.annotations.LayerGeneratingProcessor;
 import org.openide.filesystems.annotations.LayerGenerationException;
@@ -141,22 +143,21 @@ public class CreateRegistrationProcessor extends LayerGeneratingProcessor {
 
             LayerBuilder layer = layer(toRegister);
             javax.tools.FileObject file = layer.validateResource(grammar, toRegister, null, null, false);
-            try (InputStream in = file.openInputStream()) {
-                IRegistryOptions opts = new IRegistryOptions() {
+            try (InputStream in = file.openInputStream();
+                    InputStreamReader isr = new InputStreamReader(in, StandardCharsets.UTF_8)) {
+                String finalGrammar = grammar;
+                IGrammarSource referencedGrammar = new IGrammarSource() {
                     @Override
-                    public String getFilePath(String scopeName) {
-                        return null;
+                    public String getFilePath() {
+                        return finalGrammar;
                     }
+
                     @Override
-                    public InputStream getInputStream(String scopeName) throws IOException {
-                        return null;
-                    }
-                    @Override
-                    public Collection<String> getInjections(String scopeName) {
-                        return null;
+                    public Reader getReader() throws IOException {
+                        return isr;
                     }
                 };
-                String scopeName = new Registry(opts).loadGrammarFromPathSync(grammar, in).getScopeName();
+                String scopeName = RawGrammarReader.readGrammar(referencedGrammar).getScopeName();
                 String simpleName = grammar.lastIndexOf('/') != (-1) ? grammar.substring(grammar.lastIndexOf('/') + 1) : grammar;
                 layer.file("Editors" + mimeType + "/" + simpleName)
                      .url("nbresloc:/" + grammar)
@@ -191,22 +192,21 @@ public class CreateRegistrationProcessor extends LayerGeneratingProcessor {
         if (injectTo != null && grammar != null) {
             LayerBuilder layer = layer(toRegister);
             javax.tools.FileObject file = layer.validateResource(grammar, toRegister, null, null, false);
-            try (InputStream in = file.openInputStream()) {
-                IRegistryOptions opts = new IRegistryOptions() {
+            try (InputStream in = file.openInputStream();
+                    InputStreamReader isr = new InputStreamReader(in, StandardCharsets.UTF_8)) {
+                String finalGrammar = grammar;
+                IGrammarSource referencedGrammar = new IGrammarSource() {
                     @Override
-                    public String getFilePath(String scopeName) {
-                        return null;
+                    public String getFilePath() {
+                        return finalGrammar;
                     }
+
                     @Override
-                    public InputStream getInputStream(String scopeName) throws IOException {
-                        return null;
-                    }
-                    @Override
-                    public Collection<String> getInjections(String scopeName) {
-                        return null;
+                    public Reader getReader() throws IOException {
+                        return isr;
                     }
                 };
-                String scopeName = new Registry(opts).loadGrammarFromPathSync(grammar, in).getScopeName();
+                String scopeName = RawGrammarReader.readGrammar(referencedGrammar).getScopeName();
                 String simpleName = grammar.lastIndexOf('/') != (-1) ? grammar.substring(grammar.lastIndexOf('/') + 1) : grammar;
                 layer.file("Editors" + "/" + simpleName)
                      .url("nbresloc:/" + grammar)

--- a/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/FileObjectGrammarSource.java
+++ b/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/FileObjectGrammarSource.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.textmate.lexer;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import org.eclipse.tm4e.core.registry.IGrammarSource;
+import org.openide.filesystems.FileObject;
+
+public class FileObjectGrammarSource implements IGrammarSource {
+
+    private final FileObject fileObject;
+
+    public FileObjectGrammarSource(FileObject fileObject) {
+        this.fileObject = fileObject;
+    }
+
+    @Override
+    public String getFilePath() {
+        return fileObject.getPath();
+    }
+
+    @Override
+    public Reader getReader() throws IOException {
+        return new InputStreamReader(fileObject.getInputStream(), StandardCharsets.UTF_8);
+    }
+
+}

--- a/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/TextmateLexer.java
+++ b/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/TextmateLexer.java
@@ -18,14 +18,15 @@
  */
 package org.netbeans.modules.textmate.lexer;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.eclipse.tm4e.core.grammar.IGrammar;
+import org.eclipse.tm4e.core.grammar.IStateStack;
 import org.eclipse.tm4e.core.grammar.IToken;
 import org.eclipse.tm4e.core.grammar.ITokenizeLineResult;
-import org.eclipse.tm4e.core.grammar.StackElement;
 import org.netbeans.api.lexer.Token;
 import org.netbeans.spi.lexer.Lexer;
 import org.netbeans.spi.lexer.LexerInput;
@@ -42,7 +43,7 @@ public class TextmateLexer implements Lexer<TextmateTokenId>{
     private int currentOffset;
     private List<IToken> lineTokens;
     private int currentIdx;
-    private StackElement state;
+    private IStateStack state;
     private boolean forceReadLine;
 
     public TextmateLexer(LexerInput li, Object state, TokenFactory<TextmateTokenId> factory, IGrammar grammar) {
@@ -58,7 +59,7 @@ public class TextmateLexer implements Lexer<TextmateTokenId>{
             this.state = istate.state;
             this.forceReadLine = true;
         } else {
-            this.state = (StackElement) state;
+            this.state = (IStateStack) state;
         }
     }
 
@@ -72,7 +73,7 @@ public class TextmateLexer implements Lexer<TextmateTokenId>{
                 if (li.readLength() != 0) {
                     lineLen = li.readText().length();
                     currentOffset = 0;
-                    ITokenizeLineResult tokenized = grammar.tokenizeLine(li.readText().toString(), state);
+                    ITokenizeLineResult<IToken[]> tokenized = grammar.tokenizeLine(li.readText().toString(), state, Duration.ofMinutes(1));
                     lineTokens = new ArrayList<>(Arrays.asList(tokenized.getTokens()));
                     currentIdx = 0;
                     state = tokenized.getRuleStack();
@@ -124,9 +125,9 @@ public class TextmateLexer implements Lexer<TextmateTokenId>{
         private int currentOffset;
         private List<IToken> lineTokens;
         private int currentIdx;
-        private StackElement state;
+        private IStateStack state;
 
-        public IntralineState(int lineLen, int currentOffset, List<IToken> lineTokens, int currentIdx, StackElement state) {
+        public IntralineState(int lineLen, int currentOffset, List<IToken> lineTokens, int currentIdx, IStateStack state) {
             this.lineLen = lineLen;
             this.currentOffset = currentOffset;
             this.lineTokens = lineTokens;

--- a/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/TextmateTokenId.java
+++ b/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/TextmateTokenId.java
@@ -18,10 +18,9 @@
  */
 package org.netbeans.modules.textmate.lexer;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -33,6 +32,7 @@ import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.eclipse.tm4e.core.grammar.IGrammar;
+import org.eclipse.tm4e.core.registry.IGrammarSource;
 import org.eclipse.tm4e.core.registry.IRegistryOptions;
 import org.eclipse.tm4e.core.registry.Registry;
 import org.netbeans.api.editor.mimelookup.MimePath;
@@ -160,19 +160,13 @@ public enum TextmateTokenId implements TokenId {
             this.mimeType = mimeType;
             IRegistryOptions opts = new IRegistryOptions() {
                 @Override
-                public String getFilePath(String scopeName) {
+                public IGrammarSource getGrammarSource(String scopeName) {
                     synchronized (LanguageHierarchyImpl.class) {
                         FileObject file = scope2File.get(scopeName);
-                        return file != null ? file.getNameExt() : null;
+                        return file != null ? new FileObjectGrammarSource(file) : null;
                     }
                 }
-                @Override
-                public InputStream getInputStream(String scopeName) throws IOException {
-                    synchronized (LanguageHierarchyImpl.class) {
-                        FileObject file = scope2File.get(scopeName);
-                        return file != null ? file.getInputStream(): null;
-                    }
-                }
+
                 @Override
                 public Collection<String> getInjections(String scopeName) {
                     synchronized (LanguageHierarchyImpl.class) {

--- a/ide/textmate.lexer/test/unit/src/org/netbeans/modules/textmate/lexer/CreateRegistrationProcessorTest.java
+++ b/ide/textmate.lexer/test/unit/src/org/netbeans/modules/textmate/lexer/CreateRegistrationProcessorTest.java
@@ -74,9 +74,7 @@ public class CreateRegistrationProcessorTest extends NbTestCase {
                 content.append((char) read);
             }
 
-            assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                         "<!DOCTYPE filesystem PUBLIC \"-//NetBeans//DTD Filesystem 1.2//EN\"\n" +
-                         "                            \"http://www.netbeans.org/dtds/filesystem-1_2.dtd\">\n" +
+            assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE filesystem PUBLIC \"-//NetBeans//DTD Filesystem 1.2//EN\" \"http://www.netbeans.org/dtds/filesystem-1_2.dtd\">\n" +
                          "<filesystem>\n" +
                          "    <folder name=\"Editors\">\n" +
                          "        <folder name=\"text\">\n" +
@@ -122,9 +120,7 @@ public class CreateRegistrationProcessorTest extends NbTestCase {
                 content.append((char) read);
             }
 
-            assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                         "<!DOCTYPE filesystem PUBLIC \"-//NetBeans//DTD Filesystem 1.2//EN\"\n" +
-                         "                            \"http://www.netbeans.org/dtds/filesystem-1_2.dtd\">\n" +
+            assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE filesystem PUBLIC \"-//NetBeans//DTD Filesystem 1.2//EN\" \"http://www.netbeans.org/dtds/filesystem-1_2.dtd\">\n" +
                          "<filesystem>\n" +
                          "    <folder name=\"Editors\">\n" +
                          "        <file name=\"injection-grammar.json\" url=\"nbresloc:/injection-grammar.json\">\n" +

--- a/ide/textmate.lexer/test/unit/src/org/netbeans/modules/textmate/lexer/TextmateLexerTest.java
+++ b/ide/textmate.lexer/test/unit/src/org/netbeans/modules/textmate/lexer/TextmateLexerTest.java
@@ -203,7 +203,7 @@ public class TextmateLexerTest extends NbTestCase {
         assertTokenProperties(ts, "test", "ident.test");
         LexerTestUtilities.assertNextTokenEquals(ts, TextmateTokenId.TEXTMATE, "  ");
         assertTokenProperties(ts, "test");
-        LexerTestUtilities.assertNextTokenEquals(ts, TextmateTokenId.TEXTMATE, "\n");
+        LexerTestUtilities.assertNextTokenEquals(ts, TextmateTokenId.UNTOKENIZED, "\n");
         assertFalse(ts.moveNext());
     }
 

--- a/platform/openide.filesystems/nbproject/project.properties
+++ b/platform/openide.filesystems/nbproject/project.properties
@@ -30,7 +30,6 @@ test.config.stableBTD.excludes=\
     **/FileUtilTest.class,\
     **/FsMimeResolverTest.class,\
     **/JarFileSystemTest.class,\
-    **/LayerBuilderTest.class,\
     **/LayerGenerationExceptionTest.class,\
     **/LocalFileSystemTest.class,\
     **/MemoryFileSystemTest.class,\

--- a/platform/openide.filesystems/src/org/openide/filesystems/annotations/LayerBuilder.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/annotations/LayerBuilder.java
@@ -372,7 +372,14 @@ public final class LayerBuilder {
             return resource.substring(1);
         } else {
             try {
-                return new URI(null, findPackage(originatingElement).replace('.', '/') + "/", null).resolve(new URI(null, resource, null)).getPath();
+                String packagePath = findPackage(originatingElement).replace('.', '/');
+                String pathPrefix;
+                if(packagePath.isEmpty()) {
+                    pathPrefix = "";
+                } else {
+                    pathPrefix = packagePath + "/";
+                }
+                return new URI(null, pathPrefix, null).resolve(new URI(null, resource, null)).getPath();
             } catch (URISyntaxException x) {
                 throw new LayerGenerationException(x.toString(), originatingElement);
             }

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerBuilderTest.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerBuilderTest.java
@@ -28,6 +28,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
@@ -42,6 +43,7 @@ import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
+import org.junit.Assume;
 import org.netbeans.junit.NbTestCase;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.XMLFileSystem;
@@ -271,6 +273,7 @@ public class LayerBuilderTest extends NbTestCase {
      * @throws Exception 
      */
     public void testWarningsFromProcessors() throws Exception {
+        Assume.assumeTrue("Warnings are locale specific and only configured for english locales", Locale.getDefault().getLanguage().equals("en"));
         AnnotationProcessorTestUtils.makeSource(src, "p.C", "@" + A.class.getCanonicalName() + "(displayName=\"#k\") @org.openide.util.NbBundle.Messages(\"k=v\") public class C {}");
         File j = TestFileUtils.writeZipFile(new File(getWorkDir(), "cp.jar"), "other/x1:x1");
         TestFileUtils.writeFile(new File(src, "p/resources/x2"), "x2");
@@ -328,6 +331,22 @@ public class LayerBuilderTest extends NbTestCase {
         assertNotNull(f);
         assertEquals("other/x1", f.getAttribute("r1"));
         assertEquals("p/resources/x2", f.getAttribute("r2"));
+    }
+
+    public void testAbsolutizeAndValidateResourcesExistentDefaultPackage() throws Exception {
+        AnnotationProcessorTestUtils.makeSource(src, "C", "@" + V.class.getCanonicalName() + "(r1=\"other/x1\", r2=\"x2\") public class C {}");
+        File j = TestFileUtils.writeZipFile(new File(getWorkDir(), "cp.jar"), "other/x1:x1");
+        TestFileUtils.writeFile(new File(src, "x2"), "x2");
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        boolean status = AnnotationProcessorTestUtils.runJavac(src, null, dest, new File[] {j, BaseUtilities.toFile(LayerBuilderTest.class.getProtectionDomain().getCodeSource().getLocation().toURI())}, err);
+        String msgs = err.toString();
+        assertTrue(msgs, status);
+        assertTrue(msgs, msgs.contains("r1=x1"));
+        assertTrue(msgs, msgs.contains("r2=x2"));
+        FileObject f = new XMLFileSystem(BaseUtilities.toURI(new File(dest, "META-INF/generated-layer.xml")).toURL()).findResource("f");
+        assertNotNull(f);
+        assertEquals("other/x1", f.getAttribute("r1"));
+        assertEquals("x2", f.getAttribute("r2"));
     }
 
     public void testValidateResourceNonexistent() throws Exception {


### PR DESCRIPTION
It was observed, that some grammars were not accepted by the textmate grammar support. One such example was a C#-grammar. Updating textmate4eclipse, jcondings and joni fixes the issue.

Following the updates of the binaries, usesites of tm4e needed to be updated to accommodate for changed api in tm4j.

Unittests for textmate.lexer were fixed prior to update. For this the LayerBuilder needed to be fixed, as it failed for resources in the default package, which was used by the test. Slight changes to the unittests were necessary to follow the new API.