### PR TITLE
[NETBEANS-7069] Support Nashorn 15.x for JDK >= 15

### DIFF
--- a/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/JSUtils.java
+++ b/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/JSUtils.java
@@ -27,7 +27,12 @@ public class JSUtils {
     public static final String JS_MIME_TYPE = "text/javascript";    // NOI18N
     public static final String JS_STRATUM = "JS";                   // NOI18N
     
-    public static final String NASHORN_SCRIPT = "jdk.nashorn.internal.scripts.Script$";     // NOI18N
+    // Script class for Nashorn built in JDK
+    public static final String NASHORN_SCRIPT_JDK = "jdk.nashorn.internal.scripts.Script$";     // NOI18N
+    // avoid API type removed warning, but do not use this constant, use explicitly _JDK or _EXT suffixes
+    public static final String NASHORN_SCRIPT = NASHORN_SCRIPT_JDK;
+    // Script class for external Nashorn
+    public static final String NASHORN_SCRIPT_EXT = "org.openjdk.nashorn.internal.scripts.Script$";     // NOI18N
     
     public static final String VAR_THIS = ":this";     // NOI18N
     public static final String VAR_SCOPE = ":scope";   // NOI18N

--- a/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/source/Source.java
+++ b/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/source/Source.java
@@ -50,7 +50,8 @@ public final class Source {
     
     private static final Logger LOG = Logger.getLogger(Source.class.getName());
     
-    private static final String SOURCE_CLASS = "jdk.nashorn.internal.runtime.Source";   // NOI18N
+    private static final String SOURCE_CLASS_JDK = "jdk.nashorn.internal.runtime.Source";   // NOI18N
+    private static final String SOURCE_CLASS_EXT = "org.openjdk.nashorn.internal.runtime.Source";   // NOI18N
     private static final String SOURCE_FIELD = "source";    // NOI18N
     
     private static final String SOURCE_VAR_NAME = "name";   // NOI18N
@@ -227,7 +228,7 @@ public final class Source {
         for (Field sf : staticFields) {
             if (sf instanceof ObjectVariable &&
                 SOURCE_FIELD.equals(sf.getName()) &&
-                SOURCE_CLASS.equals(sf.getType())) {
+                (SOURCE_CLASS_JDK.equals(sf.getType()) || SOURCE_CLASS_EXT.equals(sf.getType()))) {
                 
                 return (ObjectVariable) sf;
             }

--- a/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/DebuggerSupport.java
+++ b/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/DebuggerSupport.java
@@ -50,26 +50,39 @@ import org.openide.util.Exceptions;
  * @author Martin
  */
 public final class DebuggerSupport {
-    
-    public  static final String DEBUGGER_SUPPORT_CLASS = "jdk.nashorn.internal.runtime.DebuggerSupport";    // NOI18N
-    private static final String DEBUGGER_SUPPORT_VALUE_DESC_CLASS = "jdk.nashorn.internal.runtime.DebuggerSupport$DebuggerValueDesc"; // NOI18N
-    private static final String CONTEXT_CLASS = "jdk.nashorn.internal.runtime.Context";    // NOI18N
+
+    public  static final String DEBUGGER_SUPPORT_CLASS_JDK = "jdk.nashorn.internal.runtime.DebuggerSupport";    // NOI18N
+    // avoid API type removed warning, but do not use this constant, use explicitly _JDK or _EXT suffixes
+    public  static final String DEBUGGER_SUPPORT_CLASS = DEBUGGER_SUPPORT_CLASS_JDK;
+    private static final String DEBUGGER_SUPPORT_VALUE_DESC_CLASS_JDK = "jdk.nashorn.internal.runtime.DebuggerSupport$DebuggerValueDesc"; // NOI18N
+    private static final String CONTEXT_CLASS_JDK = "jdk.nashorn.internal.runtime.Context";    // NOI18N
+
+    public  static final String DEBUGGER_SUPPORT_CLASS_EXT = "org.openjdk.nashorn.internal.runtime.DebuggerSupport";    // NOI18N
+    private static final String DEBUGGER_SUPPORT_VALUE_DESC_CLASS_EXT = "org.openjdk.nashorn.internal.runtime.DebuggerSupport$DebuggerValueDesc"; // NOI18N
+    private static final String CONTEXT_CLASS_EXT = "org.openjdk.nashorn.internal.runtime.Context";    // NOI18N
     
     private static final String METHOD_VALUE_INFO  = "valueInfo";       // NOI18N
-    private static final String SIGNAT_VALUE_INFO  = "(Ljava/lang/String;Ljava/lang/Object;Z)Ljdk/nashorn/internal/runtime/DebuggerSupport$DebuggerValueDesc;"; // NOI18N
+    private static final String SIGNAT_VALUE_INFO_JDK  = "(Ljava/lang/String;Ljava/lang/Object;Z)Ljdk/nashorn/internal/runtime/DebuggerSupport$DebuggerValueDesc;"; // NOI18N
+    private static final String SIGNAT_VALUE_INFO_EXT  = "(Ljava/lang/String;Ljava/lang/Object;Z)Lorg/openjdk/nashorn/internal/runtime/DebuggerSupport$DebuggerValueDesc;"; // NOI18N
     private static final String METHOD_VALUE_INFOS = "valueInfos";      // NOI18N
-    private static final String SIGNAT_VALUE_INFOS = "(Ljava/lang/Object;Z)[Ljdk/nashorn/internal/runtime/DebuggerSupport$DebuggerValueDesc;";  // NOI18N
+    private static final String SIGNAT_VALUE_INFOS_JDK = "(Ljava/lang/Object;Z)[Ljdk/nashorn/internal/runtime/DebuggerSupport$DebuggerValueDesc;";  // NOI18N
+    private static final String SIGNAT_VALUE_INFOS_EXT = "(Ljava/lang/Object;Z)[Lorg/openjdk/nashorn/internal/runtime/DebuggerSupport$DebuggerValueDesc;";  // NOI18N
     private static final String METHOD_EVAL        = "eval";            // NOI18N
-    private static final String SIGNAT_EVAL        = "(Ljdk/nashorn/internal/runtime/ScriptObject;Ljava/lang/Object;Ljava/lang/String;Z)Ljava/lang/Object;";    // NOI18N
+    private static final String SIGNAT_EVAL_JDK        = "(Ljdk/nashorn/internal/runtime/ScriptObject;Ljava/lang/Object;Ljava/lang/String;Z)Ljava/lang/Object;";    // NOI18N
+    private static final String SIGNAT_EVAL_EXT        = "(Lorg/openjdk/nashorn/internal/runtime/ScriptObject;Ljava/lang/Object;Ljava/lang/String;Z)Ljava/lang/Object;";    // NOI18N
     private static final String METHOD_FROM_CLASS  = "fromClass";       // NOI18N
-    private static final String SIGNAT_FROM_CLASS  = "(Ljava/lang/Class;)Ljdk/nashorn/internal/runtime/Context;";   // NOI18N
+    private static final String SIGNAT_FROM_CLASS_JDK  = "(Ljava/lang/Class;)Ljdk/nashorn/internal/runtime/Context;";   // NOI18N
+    private static final String SIGNAT_FROM_CLASS_EXT  = "(Ljava/lang/Class;)Lorg/openjdk/nashorn/internal/runtime/Context;";   // NOI18N
     private static final String METHOD_CONTEXT_EVAL= "eval";            // NOI18N
-    private static final String SIGNAT_CONTEXT_EVAL= "(Ljdk/nashorn/internal/runtime/ScriptObject;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";  // NOI18N
-    private static final String SIGNAT_CONTEXT_EVAL_OLD = "(Ljdk/nashorn/internal/runtime/ScriptObject;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Z)Ljava/lang/Object;";  // NOI18N
+    private static final String SIGNAT_CONTEXT_EVAL_JDK= "(Ljdk/nashorn/internal/runtime/ScriptObject;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";  // NOI18N
+    private static final String SIGNAT_CONTEXT_EVAL_OLD_JDK = "(Ljdk/nashorn/internal/runtime/ScriptObject;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Z)Ljava/lang/Object;";  // NOI18N
+    private static final String SIGNAT_CONTEXT_EVAL_EXT= "(Lorg/openjdk/nashorn/internal/runtime/ScriptObject;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";  // NOI18N
+    private static final String SIGNAT_CONTEXT_EVAL_OLD_EXT = "(Lorg/openjdk/nashorn/internal/runtime/ScriptObject;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Z)Ljava/lang/Object;";  // NOI18N
     private static final String METHOD_VALUE_AS_STRING = "valueAsString";       // NOI18N
     private static final String SIGNAT_VALUE_AS_STRING = "(Ljava/lang/Object;)Ljava/lang/String;";  // NOI18N
     private static final String METHOD_SOURCE_INFO = "getSourceInfo";   // NOI18N
-    private static final String SIGNAT_SOURCE_INFO = "(Ljava/lang/Class;)Ljdk/nashorn/internal/runtime/DebuggerSupport$SourceInfo;";    // NOI18N
+    private static final String SIGNAT_SOURCE_INFO_JDK = "(Ljava/lang/Class;)Ljdk/nashorn/internal/runtime/DebuggerSupport$SourceInfo;";    // NOI18N
+    private static final String SIGNAT_SOURCE_INFO_EXT = "(Ljava/lang/Class;)Lorg/openjdk/nashorn/internal/runtime/DebuggerSupport$SourceInfo;";    // NOI18N
     
     private static final String FIELD_DESC_VALUE_AS_STRING = "valueAsString";   // NOI18N
     private static final String FIELD_DESC_KEY             = "key";             // NOI18N
@@ -86,7 +99,7 @@ public final class DebuggerSupport {
     private DebuggerSupport() {}
     
     static Variable getValueInfoDesc(JPDADebugger debugger, String name, Variable value, boolean all) {
-        List<JPDAClassType> supportClasses = debugger.getClassesByName(DEBUGGER_SUPPORT_CLASS);
+        List<JPDAClassType> supportClasses = getSupportDebuggerClasses(debugger);
         if (supportClasses.isEmpty()) {
             return null;
         }
@@ -96,7 +109,7 @@ public final class DebuggerSupport {
             args[0] = debugger.createMirrorVar(name);
             args[1] = value;
             args[2] = debugger.createMirrorVar(all, true);
-            return supportClass.invokeMethod(METHOD_VALUE_INFO, SIGNAT_VALUE_INFO, args);
+            return supportClass.invokeMethod(METHOD_VALUE_INFO, isLegacyNashorn(supportClass) ? SIGNAT_VALUE_INFO_JDK : SIGNAT_VALUE_INFO_EXT, args);
         } catch (InvalidObjectException | InvalidExpressionException iex) {
             return null;
         } catch (NoSuchMethodException nsmex) {
@@ -132,7 +145,7 @@ public final class DebuggerSupport {
     }
     
     static Variable[] getValueInfos(JPDADebugger debugger, Variable scope, boolean all) {
-        List<JPDAClassType> supportClasses = debugger.getClassesByName(DEBUGGER_SUPPORT_CLASS);
+        List<JPDAClassType> supportClasses = getSupportDebuggerClasses(debugger);
         if (supportClasses.isEmpty()) {
             return null;
         }
@@ -141,7 +154,7 @@ public final class DebuggerSupport {
         try {
             args[0] = scope;
             args[1] = debugger.createMirrorVar(all, true);
-            ObjectVariable infosVar = (ObjectVariable) supportClass.invokeMethod(METHOD_VALUE_INFOS, SIGNAT_VALUE_INFOS, args);
+            ObjectVariable infosVar = (ObjectVariable) supportClass.invokeMethod(METHOD_VALUE_INFOS, isLegacyNashorn(supportClass) ? SIGNAT_VALUE_INFOS_JDK : SIGNAT_VALUE_INFOS_EXT, args);
             return infosVar.getFields(0, Integer.MAX_VALUE);
         } catch (InvalidObjectException ioex) {
             return null;
@@ -154,14 +167,14 @@ public final class DebuggerSupport {
     }
     
     public static boolean hasSourceInfo(JPDADebugger debugger) {
-        List<JPDAClassType> supportClasses = debugger.getClassesByName(DEBUGGER_SUPPORT_CLASS);
+        List<JPDAClassType> supportClasses = getSupportDebuggerClasses(debugger);
         if (supportClasses.isEmpty()) {
             return false;
         }
         JPDAClassType supportClass = supportClasses.get(0);
         try {
             ReferenceType supportType = (ReferenceType) supportClass.getClass().getMethod("getType").invoke(supportClass);
-            Method getSourceInfoMethod = ((ClassType) supportType).concreteMethodByName(METHOD_SOURCE_INFO, SIGNAT_SOURCE_INFO);
+            Method getSourceInfoMethod = ((ClassType) supportType).concreteMethodByName(METHOD_SOURCE_INFO, isLegacyNashorn(supportClass) ? SIGNAT_SOURCE_INFO_JDK : SIGNAT_SOURCE_INFO_EXT);
             return getSourceInfoMethod != null;
         } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
             Exceptions.printStackTrace(ex);
@@ -172,13 +185,13 @@ public final class DebuggerSupport {
     }
     
     public static Variable getSourceInfo(JPDADebugger debugger, JPDAClassType classType) {
-        List<JPDAClassType> supportClasses = debugger.getClassesByName(DEBUGGER_SUPPORT_CLASS);
+        List<JPDAClassType> supportClasses = getSupportDebuggerClasses(debugger);
         if (supportClasses.isEmpty()) {
             return null;
         }
         JPDAClassType supportClass = supportClasses.get(0);
         try {
-            Variable sourceInfo = supportClass.invokeMethod(METHOD_SOURCE_INFO, SIGNAT_SOURCE_INFO, new Variable[] { classType.classObject() });
+            Variable sourceInfo = supportClass.invokeMethod(METHOD_SOURCE_INFO, isLegacyNashorn(supportClass) ? SIGNAT_SOURCE_INFO_JDK : SIGNAT_SOURCE_INFO_EXT, new Variable[] { classType.classObject() });
             return sourceInfo;
         } catch (NoSuchMethodException | InvalidExpressionException ex) {
             return null;
@@ -208,7 +221,7 @@ public final class DebuggerSupport {
     }
     
     private static Variable doEvaluate(JPDADebugger debugger, CallStackFrame frame, String expression, ObjectVariable contextVar) throws InvalidExpressionException {
-        List<JPDAClassType> supportClasses = debugger.getClassesByName(DEBUGGER_SUPPORT_CLASS);
+        List<JPDAClassType> supportClasses = getSupportDebuggerClasses(debugger);
         if (supportClasses.isEmpty()) {
             return null;
         }
@@ -244,14 +257,14 @@ public final class DebuggerSupport {
         // Evaluate on the current class' context:
         Source source = Source.getSource(frame);
         JPDAClassType sourceClassType = source.getClassType();
+        final boolean legacyNashorn = isLegacyNashorn(supportClass);
         // Call Context.fromClass(clazz):
-        List<JPDAClassType> contextClassesByName = debugger.getClassesByName(CONTEXT_CLASS);
+        List<JPDAClassType> contextClassesByName = debugger.getClassesByName(legacyNashorn ? CONTEXT_CLASS_JDK : CONTEXT_CLASS_EXT);
         JPDAClassType contextClass = contextClassesByName.get(0);
         Variable contextObj = null;
         try {
-            contextObj = contextClass.invokeMethod(
-                    METHOD_FROM_CLASS,
-                    SIGNAT_FROM_CLASS,
+            contextObj = contextClass.invokeMethod(METHOD_FROM_CLASS,
+                    legacyNashorn ? SIGNAT_FROM_CLASS_JDK : SIGNAT_FROM_CLASS_EXT,
                     new Variable[] { sourceClassType.classObject() });
         } catch (NoSuchMethodException nsmex) {
             Exceptions.printStackTrace(nsmex);
@@ -270,9 +283,8 @@ public final class DebuggerSupport {
                         Exceptions.printStackTrace(ioex);
                         throw new InvalidExpressionException(ioex);
                     }
-                    return ((ObjectVariable) contextObj).invokeMethod(
-                            METHOD_CONTEXT_EVAL,
-                            SIGNAT_CONTEXT_EVAL,
+                    return ((ObjectVariable) contextObj).invokeMethod(METHOD_CONTEXT_EVAL,
+                            legacyNashorn ? SIGNAT_CONTEXT_EVAL_JDK : SIGNAT_CONTEXT_EVAL_EXT,
                             args);
                 } catch (NoSuchMethodException nsmex) {
                     oldEval = true;
@@ -293,9 +305,8 @@ public final class DebuggerSupport {
                         Exceptions.printStackTrace(ioex);
                         throw new InvalidExpressionException(ioex);
                     }
-                    return ((ObjectVariable) contextObj).invokeMethod(
-                            METHOD_CONTEXT_EVAL,
-                            SIGNAT_CONTEXT_EVAL_OLD,
+                    return ((ObjectVariable) contextObj).invokeMethod(METHOD_CONTEXT_EVAL,
+                            legacyNashorn ? SIGNAT_CONTEXT_EVAL_OLD_JDK : SIGNAT_CONTEXT_EVAL_OLD_EXT,
                             args);
                 } catch (NoSuchMethodException nsmex) {
                     Exceptions.printStackTrace(nsmex);
@@ -309,7 +320,7 @@ public final class DebuggerSupport {
             args[1] = contextVar;
             args[2] = debugger.createMirrorVar(expression);
             args[3] = debugger.createMirrorVar(false, true);
-            return supportClass.invokeMethod(METHOD_EVAL, SIGNAT_EVAL, args);
+            return supportClass.invokeMethod(METHOD_EVAL, legacyNashorn ? SIGNAT_EVAL_JDK : SIGNAT_EVAL_EXT, args);
         } catch (InvalidObjectException ioex) {
             Exceptions.printStackTrace(ioex);
             throw new InvalidExpressionException(ioex);
@@ -334,11 +345,33 @@ public final class DebuggerSupport {
     private static void setOldEval(JPDADebugger debugger) {
         hasOldEval.add(new WeakReference<>(debugger));
     }
+
+    /**
+     * Tries to find Nashorn debugger classes either in built-in JDK or external Nashorn
+     * @param debugger
+     * @return debugger classes list (or empty list)
+     */
+    public static List<JPDAClassType> getSupportDebuggerClasses(JPDADebugger debugger) {
+        List<JPDAClassType> supportClasses = debugger.getClassesByName(DEBUGGER_SUPPORT_CLASS_JDK);
+        if (supportClasses.isEmpty()) {
+            // if not in JDK, look for External Nashorn
+            supportClasses = debugger.getClassesByName(DEBUGGER_SUPPORT_CLASS_EXT);
+        }
+        return supportClasses;
+    }
+    
+    /**
+     * @param classType returned from getSupportDebuggerClasses()
+     * @return true when classTYpe belongs to the legacy JDK Nashorn, false otherwise
+     */
+    public static boolean isLegacyNashorn(JPDAClassType classType) {
+        return classType.getName().startsWith("jdk.nashorn.internal.");
+    }
     
     public static String getVarValue(JPDADebugger debugger, Variable var) {
         if (var instanceof ObjectVariable) {
             ObjectVariable ov = (ObjectVariable) var;
-            List<JPDAClassType> supportClasses = debugger.getClassesByName(DEBUGGER_SUPPORT_CLASS);
+            List<JPDAClassType> supportClasses = getSupportDebuggerClasses(debugger);
             JPDAClassType ct;
             if (supportClasses.isEmpty() ||
                 ((ct = ov.getClassType()) != null && String.class.getCanonicalName().equals(ct.getName()))) {
@@ -375,7 +408,7 @@ public final class DebuggerSupport {
     }
     
     public static Variable getVarStringValueAsVar(JPDADebugger debugger, ObjectVariable ov) {
-        List<JPDAClassType> supportClasses = debugger.getClassesByName(DEBUGGER_SUPPORT_CLASS);
+        List<JPDAClassType> supportClasses = getSupportDebuggerClasses(debugger);
         if (supportClasses.isEmpty()) {
             return ov;
         }

--- a/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/JSVariable.java
+++ b/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/vars/JSVariable.java
@@ -52,7 +52,7 @@ public class JSVariable {
                 JPDAClassType classType = ((ObjectVariable) valueObjectVar).getClassType();
                 if (classType != null) {
                     String className = classType.getName();
-                    if (!className.startsWith("jdk.nashorn") && !String.class.getName().equals(className)) {   // NOI18N
+                    if (!className.startsWith("jdk.nashorn") && !className.startsWith("org.openjdk.nashorn") && !String.class.getName().equals(className)) {   // NOI18N
                         // Not a Nashorn's script class
                         valueObject = (ObjectVariable) valueObjectVar;
                     }
@@ -101,7 +101,8 @@ public class JSVariable {
         if (classType == null) {
             return null;
         }
-        boolean isScript = classType.isInstanceOf("jdk.nashorn.internal.runtime.ScriptObject"); // NOI18N
+        boolean isScript = classType.isInstanceOf("jdk.nashorn.internal.runtime.ScriptObject") ||  // NOI18N
+                classType.isInstanceOf("org.openjdk.nashorn.internal.runtime.ScriptObject"); // NOI18N
         if (!isScript) {
             return null;
         }

--- a/java/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSActionsProvider.java
+++ b/java/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSActionsProvider.java
@@ -242,8 +242,10 @@ public class DebuggingJSActionsProvider implements NodeActionsProviderFilter {
                     JSStackFrame jsframe = (JSStackFrame) ch;
                     frame = jsframe.getJavaFrame();
                     String cName = frame.getClassName();
-                    if (cName.startsWith(JSUtils.NASHORN_SCRIPT)) {
-                        cName = cName.substring(JSUtils.NASHORN_SCRIPT.length());
+                    if (cName.startsWith(JSUtils.NASHORN_SCRIPT_JDK)) {
+                        cName = cName.substring(JSUtils.NASHORN_SCRIPT_JDK.length());
+                    } else if (cName.startsWith(JSUtils.NASHORN_SCRIPT_EXT)) {
+                        cName = cName.substring(JSUtils.NASHORN_SCRIPT_EXT.length());
                     }
                     frameStr.append("\tat ");
                     frameStr.append(cName);

--- a/java/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSNodeModel.java
+++ b/java/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSNodeModel.java
@@ -108,7 +108,13 @@ public class DebuggingJSNodeModel implements ExtendedNodeModelFilter {
             CallStackFrame javaFrame = ((JSStackFrame) node).getJavaFrame();
             descr = original.getDisplayName(javaFrame);
             //System.out.println("ORIG descr = '"+descr+"'");
-            int i = descr.indexOf(JSUtils.NASHORN_SCRIPT);
+            String nashornScriptClass = JSUtils.NASHORN_SCRIPT_JDK;
+            int i = descr.indexOf(nashornScriptClass);
+            if (i < 0) {
+                // if Legacy JDK not found, search for external Nashorn
+                nashornScriptClass = JSUtils.NASHORN_SCRIPT_EXT;
+                i = descr.indexOf(nashornScriptClass);
+            }
             int i2 = 0;
             if (i < 0) {
                 if (descr.startsWith(SCRIPT_CLASS_PREFIX)) {
@@ -122,7 +128,7 @@ public class DebuggingJSNodeModel implements ExtendedNodeModelFilter {
                     }
                 }
             } else {
-                i2 = i + JSUtils.NASHORN_SCRIPT.length();
+                i2 = i + nashornScriptClass.length();
             }
             if (i >= 0) {
                 descr = descr.substring(0, i) + descr.substring(i2);

--- a/java/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSTreeExpansionModelFilter.java
+++ b/java/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSTreeExpansionModelFilter.java
@@ -136,7 +136,7 @@ public class DebuggingJSTreeExpansionModelFilter implements TreeExpansionModelFi
     }
 
     private void currentStackFrameChanged(CallStackFrame csf) {
-        if (csf != null && csf.getClassName().startsWith(JSUtils.NASHORN_SCRIPT)) {
+        if (csf != null && (csf.getClassName().startsWith(JSUtils.NASHORN_SCRIPT_JDK) || csf.getClassName().startsWith(JSUtils.NASHORN_SCRIPT_EXT))) {
             JPDAThread thread = csf.getThread();
             suspendedNashornThread = new WeakReference<>(thread);
             try {

--- a/java/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSTreeModel.java
+++ b/java/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSTreeModel.java
@@ -67,7 +67,7 @@ public class DebuggingJSTreeModel implements TreeModelFilter {
             Object ch = children[i];
             if (ch instanceof CallStackFrame) {
                 CallStackFrame csf = (CallStackFrame) ch;
-                if (csf.getClassName().startsWith(JSUtils.NASHORN_SCRIPT)) {
+                if (csf.getClassName().startsWith(JSUtils.NASHORN_SCRIPT_JDK) || csf.getClassName().startsWith(JSUtils.NASHORN_SCRIPT_EXT)) {
                     if (!isJSStack) {
                         Object[] children2 = new Object[children.length];
                         System.arraycopy(children, 0, children2, 0, children.length);

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/CallStackFrameImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/CallStackFrameImpl.java
@@ -314,7 +314,9 @@ public class CallStackFrameImpl implements CallStackFrame {
             } else {
                 // Check Nashorn:
                 String sourcePath = getSourcePath(null);
-                if (sourcePath.startsWith("jdk/nashorn/internal/scripts/") ||       // NOI18N
+                if (sourcePath.startsWith("org/openjdk/nashorn/internal/scripts/") ||       // NOI18N
+                    sourcePath.startsWith("org\\openjdk\\nashorn\\internal\\scripts\\") ||   // NOI18N
+                    sourcePath.startsWith("jdk/nashorn/internal/scripts/") ||       // NOI18N
                     sourcePath.startsWith("jdk\\nashorn\\internal\\scripts\\")) {   // NOI18N
                     s = "JS";                                                   // NOI18N
                     as = Collections.singletonList(s);


### PR DESCRIPTION
Netbeans does support debugging of legacy Nashorn JavaScript engine bundled with OpenJDK < 15.0. It does not support the the most recent Nashorn 15.4 extracted from OpenJDK, that has different package name.

Change allows debugging both legacy Nashorn JavaScript and also extracted Nashorn with new org.openjdk.nashorn package name.

See issue https://github.com/apache/netbeans/issues/7069