### PR TITLE
CI: build and start testing on JDK 24-ea

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,7 +124,7 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        java: [ '17', '21', '23' ]
+        java: [ '17', '21', '24-ea' ]
         exclude:
           - java: ${{ github.event_name == 'pull_request' && 'nothing' || '21' }}
       fail-fast: false
@@ -229,7 +229,7 @@ jobs:
         java: [ 17 ]
         include:
           - os: ubuntu-latest
-            java: 22
+            java: 23
       fail-fast: false
     steps:
 
@@ -416,29 +416,22 @@ jobs:
       - name: Build nbms
         run: ant $OPTS build-nbms
 
+      # runs only in PRs if requested; ~18 min
+      - name: Build all Tests
+        if: env.test_tests == 'true' && github.event_name == 'pull_request' && success()
+        run: ant -quiet -Dcluster.config=$CLUSTER_CONFIG test -Dtest.includes=NoTestsJustBuild
+
       # 13-14 min for javadoc; JDK version must be synced with nb-javac
-      - name: Set up JDK 23 for javadoc
+      - name: Set up JDK 24-ea for javadoc
         if: env.test_javadoc == 'true' && success()
         uses: actions/setup-java@v4
         with:
-          java-version: 23 
+          java-version: 24-ea 
           distribution: ${{ env.DEFAULT_JAVA_DISTRIBUTION }}
 
       - name: Build javadoc
         if: env.test_javadoc == 'true' && success()
         run: ant $OPTS build-javadoc
-
-      - name: Set up JDK ${{ matrix.java }} 
-        if: env.test_javadoc == 'true' && success()
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ matrix.java }} 
-          distribution: ${{ env.DEFAULT_JAVA_DISTRIBUTION }}
-
-      # runs only in PRs if requested; ~18 min
-      - name: Build all Tests
-        if: env.test_tests == 'true' && github.event_name == 'pull_request' && success()
-        run: ant -quiet -Dcluster.config=$CLUSTER_CONFIG test -Dtest.includes=NoTestsJustBuild
 
       - name: Create Test Summary
         uses: test-summary/action@v2
@@ -834,7 +827,7 @@ jobs:
     timeout-minutes: 50
     strategy:
       matrix:
-        java: [ '17', '21', '23' ]
+        java: [ '17', '21', '24-ea' ]
         exclude:
           - java: ${{ github.event_name == 'pull_request' && 'nothing' || '21' }}
       fail-fast: false
@@ -1494,7 +1487,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '17', '21', '23' ]
+        java: [ '17', '21', '24-ea' ]
         exclude:
           - java: ${{ github.event_name == 'pull_request' && 'nothing' || '21' }}
       fail-fast: false

--- a/ide/ide.kit/nbproject/project.properties
+++ b/ide/ide.kit/nbproject/project.properties
@@ -50,5 +50,5 @@ test.jms.flags=\
  --add-opens=java.desktop/javax.swing.plaf.synth=ALL-UNNAMED \
  --add-opens=java.desktop/javax.swing.text=ALL-UNNAMED \
  --add-opens=java.desktop/sun.awt=ALL-UNNAMED \
- --add-modules=jdk.jdwp.agent,jdk.attach,jdk.jdi,jdk.jshell,java.compiler,jdk.compiler,jdk.management,jdk.unsupported,jdk.internal.le,jdk.internal.ed,jdk.internal.opt,jdk.internal.jvmstat \
+ --add-modules=java.compiler \
  --add-exports=jdk.jdi/com.sun.jdi=ALL-UNNAMED

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/StatFilesTest.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/StatFilesTest.java
@@ -163,7 +163,7 @@ public class StatFilesTest extends NbTestCase {
                 expectedCount++;
                 // sun.awt.PlatformGraphicsInfo.getDefaultHeadlessProperty probes a .so or .dylib
                 // Runtime.version().feature() > 18
-                if (Integer.parseInt(System.getProperty("java.version").split("\\.")[0]) > 18) {
+                if (Integer.parseInt(System.getProperty("java.version").split("\\.")[0].split("-")[0]) > 18) {
                     expectedCount++;
                 }
             }


### PR DESCRIPTION
 - java hints job remains on 23 and has to wait for nb-javac 24
 - bump CV tests from JDK 22 to 23 (oops, nobody noticed)
 - minor cleanup (building tests after javadoc would fail if the JDK changes in between due to build jar file comparison logic - metadata changes -> lets swap the steps)

extracted from https://github.com/apache/netbeans/pull/7928