### PR TITLE
[NETBEANS-7981] Handling Diagnostics with position -1 while writing error/warning index.

### DIFF
--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskCache.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskCache.java
@@ -229,6 +229,7 @@ public class TaskCache {
                 }
             });
         } catch (IOException ex) {
+            Exceptions.attachMessage(ex, "can't dump errors for: " + String.valueOf(i));
             Exceptions.printStackTrace(ex);
         }
     }

--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexer.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexer.java
@@ -1324,9 +1324,15 @@ public class JavaCustomIndexer extends CustomIndexer {
             if (lm == null) {
                 return new ErrorsCache.Range(new ErrorsCache.Position((int) t.getLineNumber(), (int) t.getColumnNumber()), null);
             }
+            ErrorsCache.Position endPos;
+            if (t.getEndPosition() == (-1)) {
+                endPos = null;
+            } else {
+                endPos = new ErrorsCache.Position((int) lm.getLineNumber(t.getEndPosition()), (int) lm.getColumnNumber(t.getEndPosition()));
+            }
             return new ErrorsCache.Range(
                     new ErrorsCache.Position((int) lm.getLineNumber(t.getStartPosition()), (int) lm.getColumnNumber(t.getStartPosition())),
-                    new ErrorsCache.Position((int) lm.getLineNumber(t.getEndPosition()), (int) lm.getColumnNumber(t.getEndPosition()))
+                    endPos
             );
         }
         @Override


### PR DESCRIPTION
When code like:
```
package javaapplication2;

public class JavaApplication2 {

    public static void main(String[] args) {
        new G() {
            
        };
    }
    
}

class G {
    @Deprecated
    G() {}
}
```
is indexed with `-Xlint:deprecation`, writing error/warning index may fail due to an exception like:
```
java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 605
	at com.sun.tools.javac.util.Position$LineTabMapImpl.getColumnNumber(Position.java:266)
	at com.sun.tools.javac.util.Position$LineMapImpl.getColumnNumber(Position.java:236)
	at com.sun.tools.javac.util.Position$LineTabMapImpl.getColumnNumber(Position.java:253)
	at org.netbeans.modules.java.source.indexing.JavaCustomIndexer$ErrorConvertorImpl.getRange(JavaCustomIndexer.java:1329)
```

This is because the Diagnostics has end position `-1`. This patch simply proposes to treat this case as a missing end position.

Separately, it should be investigated if javac should produce errors or warnings like this.
