### PR TITLE
Handling Diagnostics with start position -1 while writing error/warning index.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexer.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexer.java
@@ -1321,7 +1321,7 @@ public class JavaCustomIndexer extends CustomIndexer {
         }
         @Override
         public ErrorsCache.Range getRange(Diagnostic<?> t) {
-            if (lm == null) {
+            if (lm == null || t.getStartPosition() == (-1)) {
                 return new ErrorsCache.Range(new ErrorsCache.Position((int) t.getLineNumber(), (int) t.getColumnNumber()), null);
             }
             ErrorsCache.Position endPos;


### PR DESCRIPTION
Addition to the https://github.com/apache/netbeans/pull/7983 to handle also Diagnostics with start position -1.