### PR TITLE
Remove java.security.manager=allow flag from windows launcher.

### DIFF
--- a/nb/ide.launcher/windows/netbeans.exe.manifest
+++ b/nb/ide.launcher/windows/netbeans.exe.manifest
@@ -20,7 +20,7 @@
 
 -->
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-<assemblyIdentity version="101.1.0.0"
+<assemblyIdentity version="101.2.0.0"
    processorArchitecture="x86"
    name="netbeans.exe"
    type="win32"/>

--- a/nb/ide.launcher/windows/netbeans64.exe.manifest
+++ b/nb/ide.launcher/windows/netbeans64.exe.manifest
@@ -22,7 +22,7 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
 <!-- Use processorArchitecture="x86", which is the value used by the 64-bit
      javaw.exe on Java 10.0.2 and Java 11ea. -->
-<assemblyIdentity version="101.1.0.0"
+<assemblyIdentity version="101.2.0.0"
    processorArchitecture="x86"
    name="netbeans64.exe"
    type="win32"/>

--- a/nb/ide.launcher/windows/version.h
+++ b/nb/ide.launcher/windows/version.h
@@ -19,9 +19,9 @@
 
 #define COMPANY ""
 #define COMPONENT "Apache NetBeans IDE Launcher"
-#define VER "101.1.0.0"
-#define FVER 101,1,0,0
-#define BUILD_ID "101100"
+#define VER "101.2.0.0"
+#define FVER 101,2,0,0
+#define BUILD_ID "101200"
 #define INTERNAL_NAME "netbeans"
 #define COPYRIGHT "Based on Apache NetBeans from the Apache Software Foundation and is licensed under Apache License Version 2.0"
 #define NAME "Apache NetBeans IDE Launcher"

--- a/platform/o.n.bootstrap/launcher/windows/jvmlauncher.cpp
+++ b/platform/o.n.bootstrap/launcher/windows/jvmlauncher.cpp
@@ -249,7 +249,7 @@ bool JvmLauncher::startInProcJvm(const char *mainClassName, const std::list<std:
             for (list<string>::const_iterator it = options.begin(); it != options.end(); ++it, ++i) {
                 const string &option = *it;
                 logMsg("\t%s", option.c_str());
-                if (option.find("-splash:") == 0 && hSplash > 0) {
+                if (option.find("-splash:") == 0 && hSplash != nullptr) {
                     const string splash = option.substr(8);
                     logMsg("splash at %s", splash.c_str());
                     

--- a/platform/o.n.bootstrap/launcher/windows/nbexec.exe.manifest
+++ b/platform/o.n.bootstrap/launcher/windows/nbexec.exe.manifest
@@ -20,7 +20,7 @@
 
 -->
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-<assemblyIdentity version="101.1.0.0"
+<assemblyIdentity version="101.2.0.0"
    processorArchitecture="X86"
    name="nbexec.exe"
    type="win32"/>

--- a/platform/o.n.bootstrap/launcher/windows/platformlauncher.cpp
+++ b/platform/o.n.bootstrap/launcher/windows/platformlauncher.cpp
@@ -52,7 +52,6 @@ const char *PlatformLauncher::OPT_NB_USERDIR = "-Dnetbeans.user=";
 const char *PlatformLauncher::OPT_DEFAULT_USERDIR_ROOT = "-Dnetbeans.default_userdir_root=";
 const char *PlatformLauncher::OPT_HEAP_DUMP = "-XX:+HeapDumpOnOutOfMemoryError";
 const char *PlatformLauncher::OPT_HEAP_DUMP_PATH = "-XX:HeapDumpPath=";
-const char *PlatformLauncher::OPT_JAVA_SECURITY_MANAGER_ALLOW = "-Djava.security.manager=allow";
 const char *PlatformLauncher::OPT_KEEP_WORKING_SET_ON_MINIMIZE = "-Dsun.awt.keepWorkingSetOnMinimize=true";
 const char *PlatformLauncher::OPT_CLASS_PATH = "-Djava.class.path=";
 const char *PlatformLauncher::OPT_SPLASH = "-splash:";
@@ -579,8 +578,6 @@ void PlatformLauncher::prepareOptions() {
     option = OPT_KEEP_WORKING_SET_ON_MINIMIZE;
     javaOptions.push_back(option);
 
-    option = OPT_JAVA_SECURITY_MANAGER_ALLOW;
-    javaOptions.push_back(option);
 }
 
 string & PlatformLauncher::constructClassPath(bool runUpdater) {

--- a/platform/o.n.bootstrap/launcher/windows/platformlauncher.h
+++ b/platform/o.n.bootstrap/launcher/windows/platformlauncher.h
@@ -42,7 +42,6 @@ class PlatformLauncher {
     static const char *OPT_DEFAULT_USERDIR_ROOT;
     static const char *OPT_HEAP_DUMP;
     static const char *OPT_HEAP_DUMP_PATH;
-    static const char *OPT_JAVA_SECURITY_MANAGER_ALLOW;
     static const char *OPT_KEEP_WORKING_SET_ON_MINIMIZE;
     static const char *OPT_CLASS_PATH;
     static const char *OPT_SPLASH;

--- a/platform/o.n.bootstrap/launcher/windows/version.h
+++ b/platform/o.n.bootstrap/launcher/windows/version.h
@@ -19,9 +19,9 @@
 
 #define COMPANY ""
 #define COMPONENT "Apache NetBeans Platform Launcher"
-#define VER "101.1.0.0"
-#define FVER 101,1,0,0
-#define BUILD_ID "101100"
+#define VER "101.2.0.0"
+#define FVER 101,2,0,0
+#define BUILD_ID "101200"
 #define INTERNAL_NAME "nbexec"
 #define COPYRIGHT "Based on Apache NetBeans from the Apache Software Foundation and is licensed under Apache License Version 2.0"
 #define NAME "Apache NetBeans Platform Launcher"


### PR DESCRIPTION
this commit implements SM removal step 1 of 3

 1) remove SM flag from windows launcher and release new launcher bits
 2) move flag to config and switch to new launcher bits
 3) implement SM removal for JDK 24 compatibility

extracted from #7928

this changes it only in the windows launcher but keeps it in the bash script. I think we should change it in the linux launcher when we move it into the config and switch to new windows launcher bits in step 2) but not here.
https://github.com/apache/netbeans/blob/4c4ed502ad7e91d74f77f01c266f7fec41a93684/platform/o.n.bootstrap/launcher/unix/nbexec#L195

this essentially reverts https://github.com/apache/netbeans-native-launchers/commit/3fea281473744df0b3f8cad0570155c9c845dac9 although the code is in a different repo now.