### PR TITLE
Inlining values inside debugger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1563,8 +1563,8 @@ jobs:
 #      - name: debugger.jpda.truffle
 #        run: ant $OPTS -f java/debugger.jpda.truffle test
 
-#      - name: debugger.jpda.ui
-#        run: ant $OPTS -f java/debugger.jpda.ui test
+      - name: debugger.jpda.ui
+        run: ant $OPTS -f java/debugger.jpda.ui test-unit
 
       - name: Create Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4

--- a/ide/api.lsp/apichanges.xml
+++ b/ide/api.lsp/apichanges.xml
@@ -51,6 +51,19 @@
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
 <changes>
+    <change id="InlineValuesProvider">
+        <api name="LSP_API"/>
+        <summary>Adding InlineValue and InlineValuesProvider</summary>
+        <version major="1" minor="35"/>
+        <date day="23" month="4" year="2025"/>
+        <author login="jlahoda"/>
+        <compatibility binary="compatible" source="compatible" addition="yes" deletion="no" />
+        <description>
+            The <code>InlineValuesProvider</code> is introduced to provide debugger
+            inline values in the the LSP protocol.
+        </description>
+        <class package="org.netbeans.spi.lsp" name="InlineValuesProvider"/>
+    </change>
     <change id="InlayHintsProvider">
         <api name="LSP_API"/>
         <summary>Adding InlayHintsProvider</summary>

--- a/ide/api.lsp/manifest.mf
+++ b/ide/api.lsp/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.api.lsp/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/api/lsp/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.34
+OpenIDE-Module-Specification-Version: 1.35
 AutoUpdate-Show-In-Client: false

--- a/ide/api.lsp/nbproject/project.properties
+++ b/ide/api.lsp/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.release=11
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.name=LSP APIs
 javadoc.title=LSP APIs

--- a/ide/api.lsp/src/org/netbeans/api/lsp/InlineValue.java
+++ b/ide/api.lsp/src/org/netbeans/api/lsp/InlineValue.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.api.lsp;
+
+/**
+ * An expression whose value may be shown inline while debugging.
+ *
+ * @since 1.35
+ */
+public final class InlineValue {
+    private final Range range;
+    private final String expression;
+
+    private InlineValue(Range range, String expression) {
+        this.range = range;
+        this.expression = expression;
+    }
+
+    /**
+     * {@return Range to which the inline value applies}
+     */
+    public Range getRange() {
+        return range;
+    }
+
+    /**
+     * {@return The expression of that should be evaluated for the inline value.}
+     */
+    public String getExpression() {
+        return expression;
+    }
+
+    /**
+     * {@return a new instance of {@code InlineValue}, based on the provided information.}
+     *
+     * @param range range to which the inline value should apply
+     * @param expression expression that should be evaluted
+     */
+    public static InlineValue createInlineVariable(Range range, String expression) {
+        return new InlineValue(range, expression);
+    }
+}

--- a/ide/api.lsp/src/org/netbeans/spi/lsp/InlineValuesProvider.java
+++ b/ide/api.lsp/src/org/netbeans/spi/lsp/InlineValuesProvider.java
@@ -16,22 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.netbeans.modules.editor.actions;
+package org.netbeans.spi.lsp;
 
-import java.awt.event.ActionEvent;
-import javax.swing.AbstractAction;
-import org.netbeans.api.editor.EditorActionRegistration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.api.lsp.InlineValue;
+import org.openide.filesystems.FileObject;
 
-@EditorActionRegistration(name="toggle-lines-view",
-                          menuPath="View",
-                          menuPosition=895,
-                          preferencesKey=ShowLinesAction.KEY_LINES,
-                          preferencesDefault=ShowLinesAction.DEF_LINES)
-public class ShowLinesAction extends AbstractAction {
-    public static final String KEY_LINES = "enable.guide.lines";
-    public static final boolean DEF_LINES = true;
-    @Override
-    public void actionPerformed(ActionEvent e) {
-    }
-    
+/**
+ * Compute {@link InlineValue}s for the given file and offset.
+ *
+ * @since 1.35
+ */
+public interface InlineValuesProvider {
+
+    /**
+     * Compute {@linkplain InlineValue}s for the given file and location.
+     *
+     * @param file file for which the inline values should be computed
+     * @param currentExecutionPosition position for which the inline values should be computed
+     * @return the computed inline values
+     */
+    public CompletableFuture<List<? extends InlineValue>> inlineValues(@NonNull FileObject file, int currentExecutionPosition);
 }

--- a/ide/editor.actions/src/org/netbeans/modules/editor/actions/ShowInlineHintsAction.java
+++ b/ide/editor.actions/src/org/netbeans/modules/editor/actions/ShowInlineHintsAction.java
@@ -24,7 +24,7 @@ import org.netbeans.api.editor.EditorActionRegistration;
 
 @EditorActionRegistration(name="toggle-inline-hints",
                           menuPath="View",
-                          menuPosition=899,
+                          menuPosition=897,
                           preferencesKey=ShowInlineHintsAction.KEY_LINES,
                           preferencesDefault=ShowInlineHintsAction.DEF_LINES)
 public class ShowInlineHintsAction extends AbstractAction {

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsList.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsList.java
@@ -121,7 +121,7 @@ public final class HighlightsList {
      * @param usePrependText reflect the prepended text setting.
      * @return either simple or compound attribute set.
      */
-    public AttributeSet cutSameFont(Font defaultFont, int maxEndOffset, int wsEndOffset, CharSequence docText, boolean usePrependText) {
+    public AttributeSet cutSameFont(Font defaultFont, int maxEndOffset, int wsEndOffset, CharSequence docText) {
         assert (maxEndOffset <= endOffset()) :
                 "maxEndOffset=" + maxEndOffset + " > endOffset()=" + endOffset() + ", " + this; // NOI18N
         HighlightItem item = get(0);
@@ -159,13 +159,13 @@ public final class HighlightsList {
 
         // Extends beyond first highlight
         Font firstFont = ViewUtils.getFont(firstAttrs, defaultFont);
-        Object firstPrependText = usePrependText && firstAttrs != null ? firstAttrs.getAttribute(ViewUtils.KEY_VIRTUAL_TEXT_PREPEND) : null;
+        Object firstPrependText = firstAttrs != null ? firstAttrs.getAttribute(ViewUtils.KEY_VIRTUAL_TEXT_PREPEND) : null;
         int index = 1;
         while (true) {
             item = get(index);
             AttributeSet attrs = item.getAttributes();
             Font font = ViewUtils.getFont(attrs, defaultFont);
-            Object prependText = usePrependText && attrs != null ? attrs.getAttribute(ViewUtils.KEY_VIRTUAL_TEXT_PREPEND) : null;
+            Object prependText = attrs != null ? attrs.getAttribute(ViewUtils.KEY_VIRTUAL_TEXT_PREPEND) : null;
             if (!font.equals(firstFont) || !Objects.equals(firstPrependText, prependText)) { // Stop at itemEndOffset
                 if (index == 1) { // Just single attribute set
                     cutStartItems(1);

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
@@ -317,7 +317,6 @@ public final class DocumentViewOp
     boolean asTextField;
     
     private boolean guideLinesEnable;
-    private boolean inlineHintsEnable;
     
     private int indentLevelSize;
     
@@ -924,13 +923,10 @@ public final class DocumentViewOp
         // Line height correction
         float lineHeightCorrectionOrig = rowHeightCorrection;
         rowHeightCorrection = prefs.getFloat(SimpleValueNames.LINE_HEIGHT_CORRECTION, 1.0f);
-        boolean inlineHintsEnableOrig = inlineHintsEnable;
-        inlineHintsEnable = prefs.getBoolean("enable.inline.hints", false); // NOI18N
         boolean updateMetrics = (rowHeightCorrection != lineHeightCorrectionOrig);
         boolean releaseChildren = nonInitialUpdate && 
                 ((nonPrintableCharactersVisible != nonPrintableCharactersVisibleOrig) ||
-                 (rowHeightCorrection != lineHeightCorrectionOrig) ||
-                 (inlineHintsEnable != inlineHintsEnableOrig));
+                 (rowHeightCorrection != lineHeightCorrectionOrig));
         indentLevelSize = getIndentSize();
         tabSize = prefs.getInt(SimpleValueNames.TAB_SIZE, EditorPreferencesDefaults.defaultTabSize);
         if (updateMetrics) {
@@ -1170,10 +1166,6 @@ public final class DocumentViewOp
     
     public boolean isGuideLinesEnable() {
         return guideLinesEnable && !asTextField;
-    }
-
-    public boolean isInlineHintsEnable() {
-        return inlineHintsEnable;
     }
 
     public int getIndentLevelSize() {

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/HighlightsViewFactory.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/HighlightsViewFactory.java
@@ -218,8 +218,7 @@ public final class HighlightsViewFactory extends EditorViewFactory implements Hi
                     }
                             
                 }
-                boolean inlineHints = documentView().op.isInlineHintsEnable();
-                AttributeSet attrs = hList.cutSameFont(defaultFont, limitOffset, wsEndOffset, docText, inlineHints);
+                AttributeSet attrs = hList.cutSameFont(defaultFont, limitOffset, wsEndOffset, docText);
                 int length = hList.startOffset() - startOffset;
                 EditorView view = wrapWithPrependedText(new HighlightsView(length, attrs), attrs);
                 EditorView origViewUnwrapped = origView instanceof PrependedTextView ? ((PrependedTextView) origView).getDelegate() : origView;
@@ -255,9 +254,7 @@ public final class HighlightsViewFactory extends EditorViewFactory implements Hi
     }
 
     private @NonNull EditorView wrapWithPrependedText(@NonNull EditorView origView, @NullAllowed AttributeSet attrs) {
-        boolean inlineHints = documentView().op.isInlineHintsEnable();
-
-        if (attrs != null && inlineHints && attrs.getAttribute(ViewUtils.KEY_VIRTUAL_TEXT_PREPEND) instanceof String) {
+        if (attrs != null && attrs.getAttribute(ViewUtils.KEY_VIRTUAL_TEXT_PREPEND) instanceof String) {
             return new PrependedTextView(documentView().op, attrs, origView);
         }
 

--- a/ide/editor.lib2/src/org/netbeans/spi/editor/highlighting/support/HighlightsContainers.java
+++ b/ide/editor.lib2/src/org/netbeans/spi/editor/highlighting/support/HighlightsContainers.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.spi.editor.highlighting.support;
+
+import java.util.prefs.PreferenceChangeEvent;
+import java.util.prefs.PreferenceChangeListener;
+import java.util.prefs.Preferences;
+import javax.swing.text.Document;
+import org.netbeans.api.editor.mimelookup.MimeLookup;
+import org.netbeans.lib.editor.util.swing.DocumentUtilities;
+import org.netbeans.spi.editor.highlighting.HighlightsContainer;
+import org.netbeans.spi.editor.highlighting.HighlightsSequence;
+import org.openide.util.WeakListeners;
+
+public class HighlightsContainers {
+    public static HighlightsContainer inlineHintsSettingAwareContainer(Document doc, HighlightsContainer delegate) {
+        class InlineHintsSettingsAwareContainer extends AbstractHighlightsContainer implements PreferenceChangeListener {
+            private static final String KEY_ENABLE_INLINE_HINTS = "enable.inline.hints";
+
+            private final Preferences prefs;
+            private boolean enabled;
+
+            public InlineHintsSettingsAwareContainer() {
+                String mimeType = DocumentUtilities.getMimeType(doc);
+                prefs = MimeLookup.getLookup(mimeType).lookup(Preferences.class);
+                prefs.addPreferenceChangeListener(WeakListeners.create(PreferenceChangeListener.class, this, prefs));
+                inlineSettingChanged();
+            }
+
+            @Override
+            public HighlightsSequence getHighlights(int startOffset, int endOffset) {
+                synchronized (this) {
+                    if (!enabled) {
+                        return HighlightsSequence.EMPTY;
+                    }
+                }
+                return delegate.getHighlights(startOffset, endOffset);
+            }
+
+            @Override
+            public void preferenceChange(PreferenceChangeEvent evt) {
+                if (KEY_ENABLE_INLINE_HINTS.equals(evt.getKey())) {
+                    inlineSettingChanged();
+                }
+            }
+
+            private void inlineSettingChanged() {
+                synchronized (this) {
+                    boolean newValue = prefs.getBoolean(KEY_ENABLE_INLINE_HINTS, false);
+
+                    if (enabled == newValue) {
+                        return ;
+                    }
+
+                    enabled = newValue;
+                }
+
+                fireHighlightsChange(0, doc.getLength());
+            }
+        }
+
+        return new InlineHintsSettingsAwareContainer();
+    }
+}

--- a/ide/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsListTest.java
+++ b/ide/editor.lib2/test/unit/src/org/netbeans/modules/editor/lib2/highlighting/HighlightsListTest.java
@@ -68,7 +68,7 @@ public class HighlightsListTest {
 
         HighlightsList hList = highlightsListSimple(doc);
         // Fetch first
-        AttributeSet attrs = hList.cutSameFont(defaultFont, 10, 10, null, false);
+        AttributeSet attrs = hList.cutSameFont(defaultFont, 10, 10, null);
         assert (attrs instanceof CompoundAttributes) : "Non-CompoundAttributes attrs=" + attrs;
         CompoundAttributes cAttrs = (CompoundAttributes) attrs;
         assert (cAttrs.startOffset() == 0) : "startOffset=" + cAttrs.startOffset();
@@ -79,21 +79,21 @@ public class HighlightsListTest {
         assertItem(items[2], 6, null);
         // Fetch next
         assert (hList.startOffset() == 6);
-        attrs = hList.cutSameFont(defaultFont, 10, 10, null, false);
+        attrs = hList.cutSameFont(defaultFont, 10, 10, null);
         assert !(attrs instanceof CompoundAttributes);
         assert attrs == attrSets[1];
         assert (hList.startOffset() == 8);
-        attrs = hList.cutSameFont(defaultFont, 10, 10, null, false);
+        attrs = hList.cutSameFont(defaultFont, 10, 10, null);
         assert !(attrs instanceof CompoundAttributes);
         assert (attrs == null);
         assert (hList.startOffset() == 10);
         
         
         hList = highlightsListSimple(doc);
-        attrs = hList.cutSameFont(defaultFont, 2, 2, null, false);
+        attrs = hList.cutSameFont(defaultFont, 2, 2, null);
         assert !(attrs instanceof CompoundAttributes);
         assert (attrs == null);
-        attrs = hList.cutSameFont(defaultFont, 10, 10, null, false);
+        attrs = hList.cutSameFont(defaultFont, 10, 10, null);
         assert (hList.startOffset() == 6);
         assert (attrs instanceof CompoundAttributes) : "Non-CompoundAttributes attrs=" + attrs;
         cAttrs = (CompoundAttributes) attrs;
@@ -104,7 +104,7 @@ public class HighlightsListTest {
         assertItem(items[1], 6, null);
         
         hList = highlightsListSimple(doc);
-        attrs = hList.cutSameFont(defaultFont, 3, 3, null, false);
+        attrs = hList.cutSameFont(defaultFont, 3, 3, null);
         cAttrs = (CompoundAttributes) attrs;
         assert (cAttrs.startOffset() == 0) : "startOffset=" + cAttrs.startOffset();
         items = cAttrs.highlightItems();
@@ -112,7 +112,7 @@ public class HighlightsListTest {
         assertItem(items[0], 2, null);
         assertItem(items[1], 3, attrSets[0]);
         // Next
-        attrs = hList.cutSameFont(defaultFont, 5, 5, null, false);
+        attrs = hList.cutSameFont(defaultFont, 5, 5, null);
         cAttrs = (CompoundAttributes) attrs;
         assert (cAttrs.startOffset() == 3) : "startOffset=" + cAttrs.startOffset();
         items = cAttrs.highlightItems();
@@ -120,22 +120,22 @@ public class HighlightsListTest {
         assertItem(items[0], 4, attrSets[0]);
         assertItem(items[1], 5, null);
         // Next
-        attrs = hList.cutSameFont(defaultFont, 7, 7, null, false);
+        attrs = hList.cutSameFont(defaultFont, 7, 7, null);
         assert !(attrs instanceof CompoundAttributes);
         assert (attrs == null);
         assert (hList.startOffset() == 6);
         // Next
-        attrs = hList.cutSameFont(defaultFont, 7, 7, null, false);
+        attrs = hList.cutSameFont(defaultFont, 7, 7, null);
         assert !(attrs instanceof CompoundAttributes);
         assert (attrs == attrSets[1]);
         assert (hList.startOffset() == 7);
         // Next
-        attrs = hList.cutSameFont(defaultFont, 10, 10, null, false);
+        attrs = hList.cutSameFont(defaultFont, 10, 10, null);
         assert !(attrs instanceof CompoundAttributes);
         assert (attrs == attrSets[1]);
         assert (hList.startOffset() == 8);
         // Next
-        attrs = hList.cutSameFont(defaultFont, 10, 10, null, false);
+        attrs = hList.cutSameFont(defaultFont, 10, 10, null);
         assert !(attrs instanceof CompoundAttributes);
         assert (attrs == null);
         assert (hList.startOffset() == 10);
@@ -182,7 +182,7 @@ public class HighlightsListTest {
         HighlightsList hList = reader.highlightsList();
 
         // Fetch first
-        AttributeSet attrs = hList.cutSameFont(defaultFont, end, end, null, false);
+        AttributeSet attrs = hList.cutSameFont(defaultFont, end, end, null);
         assert (attrs instanceof CompoundAttributes) : "Non-CompoundAttributes attrs=" + attrs;
         CompoundAttributes cAttrs = (CompoundAttributes) attrs;
         assert (cAttrs.startOffset() == 0) : "startOffset=" + cAttrs.startOffset();
@@ -194,11 +194,11 @@ public class HighlightsListTest {
         assertItem(items[3], 8, null);
         // Fetch next
         assert (hList.startOffset() == 8);
-        attrs = hList.cutSameFont(defaultFont, end, end, null, false);
+        attrs = hList.cutSameFont(defaultFont, end, end, null);
         assert !(attrs instanceof CompoundAttributes);
         assert attrs == attrs3;
         assert (hList.startOffset() == 10);
-        attrs = hList.cutSameFont(defaultFont, end, end, null, false);
+        attrs = hList.cutSameFont(defaultFont, end, end, null);
         assert !(attrs instanceof CompoundAttributes);
         assert (attrs == null);
         assert (hList.startOffset() == 14);
@@ -210,15 +210,15 @@ public class HighlightsListTest {
         HighlightsList hList = reader.highlightsList();
 
         // Fetch first
-        AttributeSet attrs = hList.cutSameFont(defaultFont, end, end, null, true);
+        AttributeSet attrs = hList.cutSameFont(defaultFont, end, end, null);
         assert !(attrs instanceof CompoundAttributes) : "CompoundAttributes attrs=" + attrs;
         assert attrs == attrs1;
         assert (hList.startOffset() == 2);
-        attrs = hList.cutSameFont(defaultFont, end, end, null, true);
+        attrs = hList.cutSameFont(defaultFont, end, end, null);
         assert !(attrs instanceof CompoundAttributes);
         assert (attrs == attrs2);
         assert (hList.startOffset() == 4);
-        attrs = hList.cutSameFont(defaultFont, end, end, null, true);
+        attrs = hList.cutSameFont(defaultFont, end, end, null);
         assert (attrs instanceof CompoundAttributes) : "Non-CompoundAttributes attrs=" + attrs;
         CompoundAttributes cAttrs = (CompoundAttributes) attrs;
         assert (cAttrs.startOffset() == 4) : "startOffset=" + cAttrs.startOffset();
@@ -228,11 +228,11 @@ public class HighlightsListTest {
         assertItem(items[1], 8, null);
         // Fetch next
         assert (hList.startOffset() == 8);
-        attrs = hList.cutSameFont(defaultFont, end, end, null, true);
+        attrs = hList.cutSameFont(defaultFont, end, end, null);
         assert !(attrs instanceof CompoundAttributes);
         assert attrs == attrs3;
         assert (hList.startOffset() == 10);
-        attrs = hList.cutSameFont(defaultFont, end, end, null, true);
+        attrs = hList.cutSameFont(defaultFont, end, end, null);
         assert !(attrs instanceof CompoundAttributes);
         assert (attrs == null);
         assert (hList.startOffset() == 14);

--- a/ide/spi.debugger.ui/apichanges.xml
+++ b/ide/spi.debugger.ui/apichanges.xml
@@ -51,6 +51,23 @@
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
 <changes>
+    <change id="inline-values-setting-keys">
+        <api name="DebuggerCoreSPI"/>
+        <summary><code>Constants</code> class enhanced with constants for inline values.</summary>
+        <version major="2" minor="88"/>
+        <date day="8" month="4" year="2025"/>
+        <author login="jlahoda"/>
+        <compatibility binary="compatible" source="compatible" modification="yes" semantic="compatible"/>
+        <description>
+            <p>
+                Two new constants are added to <code>Constants</code>:
+                <span><b>KEY_INLINE_VALUES</b>: the <code>Preferences</code> key for the inline value setting.</span>
+                <span><b>DEF_INLINE_VALUES</b>: the default value of the inline value setting.</span>
+            </p>
+        </description>
+        <class package="org.netbeans.spi.debugger.ui" name="Constants"/>
+    </change>
+
     <change id="annotation-to-breakpoint">
         <api name="DebuggerCoreSPI"/>
         <summary><code>BreakpointAnnotation</code> class added.</summary>
@@ -209,7 +226,7 @@
         <api name="DebuggerCoreSPI"/>
         <summary>A method for retrieving a set of language MIME types on a line in a document is added.</summary>
         <version major="2" minor="50"/>
-        <date day="20" month="04" year="2015"/>
+        <date day="20" month="4" year="2015"/>
         <author login="mentlicher"/>
         <compatibility binary="compatible" source="compatible" addition="yes" semantic="compatible"/>
         <description>
@@ -248,7 +265,7 @@
         <api name="DebuggerCoreSPI"/>
         <summary>Frames added into DebuggingView.</summary>
         <version major="2" minor="65"/>
-        <date day="09" month="10" year="2020"/>
+        <date day="9" month="10" year="2020"/>
         <author login="mentlicher"/>
         <compatibility binary="compatible" source="compatible" addition="yes" semantic="compatible"/>
         <description>
@@ -280,7 +297,7 @@
         <api name="DebuggerCoreSPI"/>
         <summary>Add a way not to persist breakpoints and watches.</summary>
         <version major="2" minor="72"/>
-        <date day="04" month="10" year="2021"/>
+        <date day="4" month="10" year="2021"/>
         <author login="entlicher"/>
         <compatibility binary="compatible" source="compatible" addition="yes" semantic="compatible"/>
 	<description>

--- a/ide/spi.debugger.ui/manifest.mf
+++ b/ide/spi.debugger.ui/manifest.mf
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.spi.debugger.ui/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/debugger/ui/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/debugger/resources/mf-layer.xml
-OpenIDE-Module-Specification-Version: 2.87
+OpenIDE-Module-Specification-Version: 2.88
 OpenIDE-Module-Provides: org.netbeans.spi.debugger.ui
 OpenIDE-Module-Install: org/netbeans/modules/debugger/ui/DebuggerModule.class

--- a/ide/spi.debugger.ui/nbproject/project.properties
+++ b/ide/spi.debugger.ui/nbproject/project.properties
@@ -19,6 +19,7 @@ is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
+javadoc.apichanges=${basedir}/apichanges.xml
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/ShowInlineValuesAction.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/ShowInlineValuesAction.java
@@ -16,22 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.netbeans.modules.editor.actions;
+package org.netbeans.modules.debugger.ui.actions;
 
 import java.awt.event.ActionEvent;
 import javax.swing.AbstractAction;
 import org.netbeans.api.editor.EditorActionRegistration;
+import org.netbeans.spi.debugger.ui.Constants;
+import org.openide.util.NbBundle.Messages;
 
-@EditorActionRegistration(name="toggle-lines-view",
+@EditorActionRegistration(name="toggle-inline-values",
                           menuPath="View",
-                          menuPosition=895,
-                          preferencesKey=ShowLinesAction.KEY_LINES,
-                          preferencesDefault=ShowLinesAction.DEF_LINES)
-public class ShowLinesAction extends AbstractAction {
-    public static final String KEY_LINES = "enable.guide.lines";
-    public static final boolean DEF_LINES = true;
+                          menuPosition=899,
+                          preferencesKey=Constants.KEY_INLINE_VALUES,
+                          preferencesDefault=Constants.DEF_INLINE_VALUES)
+@Messages({
+    "toggle-inline-values=Show Inline Values",
+    "toggle-inline-values_menu_text=Show Inline V&alues"
+})
+public class ShowInlineValuesAction extends AbstractAction {
     @Override
     public void actionPerformed(ActionEvent e) {
     }
-    
+
 }

--- a/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/Constants.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/Constants.java
@@ -149,4 +149,16 @@ public interface Constants {
      * @see org.netbeans.spi.viewmodel.ColumnModel#getNextColumnID
      */
     public static final String SESSION_LANGUAGE_COLUMN_ID = "SessionLanguage";
+
+    /**Should the inline values be visible - preferences key.
+     *
+     * @since 2.88
+     */
+    public static final String KEY_INLINE_VALUES = "enable.inline.values";
+
+    /**Should the inline values be visible - default value.
+     *
+     * @since 2.88
+     */
+    public static final boolean DEF_INLINE_VALUES = true;
 }

--- a/java/debugger.jpda.ui/nbproject/project.properties
+++ b/java/debugger.jpda.ui/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 cp.extra=${tools.jar}
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 requires.nb.javac=true
 

--- a/java/debugger.jpda.ui/nbproject/project.xml
+++ b/java/debugger.jpda.ui/nbproject/project.xml
@@ -61,6 +61,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.api.lsp</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.31</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.api.progress</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -138,6 +147,24 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.editor.settings</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.84</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.editor.util</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.92</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.java.preprocessorbridge</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -177,6 +204,15 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>1.0</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.parsing.api</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>9.34</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -341,6 +377,45 @@
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
+                    </test-dependency>
+                </test-type>
+                <test-type>
+                    <name>unit</name>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.junit4</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.editor.mimelookup</code-name-base>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.java.j2seplatform</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.java.source.base</code-name-base>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.parsing.indexing</code-name-base>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.parsing.nb</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
+                        <compile-dependency/>
                     </test-dependency>
                 </test-type>
             </test-dependencies>

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/InlineValueComputerImpl.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/InlineValueComputerImpl.java
@@ -1,0 +1,463 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.debugger.jpda.ui.models;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.prefs.PreferenceChangeEvent;
+import java.util.prefs.PreferenceChangeListener;
+import java.util.prefs.Preferences;
+import java.util.stream.Collectors;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.Document;
+import org.netbeans.api.debugger.DebuggerManagerAdapter;
+import org.netbeans.api.debugger.LazyDebuggerManagerListener;
+import org.netbeans.api.debugger.Session;
+import org.netbeans.api.debugger.jpda.CallStackFrame;
+import org.netbeans.api.debugger.jpda.InvalidExpressionException;
+import org.netbeans.api.debugger.jpda.JPDAClassType;
+import org.netbeans.api.debugger.jpda.JPDADebugger;
+import org.netbeans.api.debugger.jpda.ObjectVariable;
+import org.netbeans.api.debugger.jpda.Variable;
+import org.netbeans.api.editor.mimelookup.MimeLookup;
+import org.netbeans.api.editor.mimelookup.MimeRegistration;
+import org.netbeans.api.editor.settings.AttributesUtilities;
+import org.netbeans.api.java.source.CancellableTask;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.JavaSource.Phase;
+import org.netbeans.api.java.source.JavaSource.Priority;
+import org.netbeans.api.java.source.JavaSourceTaskFactory;
+import org.netbeans.modules.debugger.jpda.JPDADebuggerImpl;
+import org.netbeans.modules.debugger.jpda.expr.formatters.Formatters;
+import org.netbeans.modules.debugger.jpda.expr.formatters.FormattersLoopControl;
+import org.netbeans.modules.debugger.jpda.expr.formatters.VariablesFormatter;
+import org.netbeans.modules.debugger.jpda.jdi.InternalExceptionWrapper;
+import org.netbeans.modules.debugger.jpda.jdi.InvalidStackFrameExceptionWrapper;
+import org.netbeans.modules.debugger.jpda.jdi.ObjectCollectedExceptionWrapper;
+import org.netbeans.modules.debugger.jpda.jdi.VMDisconnectedExceptionWrapper;
+import org.netbeans.modules.debugger.jpda.ui.values.ComputeInlineValues;
+import org.netbeans.modules.debugger.jpda.ui.values.ComputeInlineValues.InlineVariable;
+import org.netbeans.modules.parsing.spi.TaskIndexingMode;
+import org.netbeans.spi.debugger.DebuggerServiceRegistration;
+import org.netbeans.spi.debugger.ui.Constants;
+import org.netbeans.spi.editor.highlighting.HighlightsLayer;
+import org.netbeans.spi.editor.highlighting.HighlightsLayerFactory;
+import org.netbeans.spi.editor.highlighting.ZOrder;
+import org.netbeans.spi.editor.highlighting.support.OffsetsBag;
+import org.openide.cookies.EditorCookie;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.URLMapper;
+import org.openide.util.Exceptions;
+import org.openide.util.Lookup;
+import org.openide.util.RequestProcessor;
+import org.openide.util.WeakListeners;
+import org.openide.util.lookup.ServiceProvider;
+import org.openide.util.lookup.ServiceProviders;
+
+
+public class InlineValueComputerImpl implements PreferenceChangeListener, PropertyChangeListener {
+
+    private static final Logger LOG = Logger.getLogger(InlineValueComputerImpl.class.getName());
+    private static final RequestProcessor EVALUATOR = new RequestProcessor(InlineValueComputerImpl.class.getName(), 1, false, false);
+    private static final String JAVA_STRATUM = "Java"; //XXX: this is probably already defined somewhere
+    private final JPDADebuggerImpl debugger;
+    private final Preferences prefs;
+    private TaskDescription currentTask;
+
+    private InlineValueComputerImpl(Session session) {
+        debugger = (JPDADebuggerImpl) session.lookupFirst(null, JPDADebugger.class);
+        debugger.addPropertyChangeListener(this);
+        prefs = MimeLookup.getLookup("text/x-java").lookup(Preferences.class);
+        prefs.addPreferenceChangeListener(WeakListeners.create(PreferenceChangeListener.class, this, prefs));
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (JPDADebugger.PROP_STATE.equals(evt.getPropertyName()) &&
+            debugger.getState() == JPDADebugger.STATE_DISCONNECTED) {
+            setNewTask(null);
+        }
+
+        if (JPDADebugger.PROP_CURRENT_CALL_STACK_FRAME.equals(evt.getPropertyName())) {
+            refreshVariables();
+        }
+    }
+
+    @Override
+    public void preferenceChange(PreferenceChangeEvent evt) {
+        refreshVariables();
+    }
+
+    private void refreshVariables() {
+        CallStackFrame frame = debugger.getCurrentCallStackFrame();
+
+        FileObject frameFile = null;
+        int frameLineNumber = -1;
+        Document frameDocument = null;
+
+        if (prefs.getBoolean(Constants.KEY_INLINE_VALUES, Constants.DEF_INLINE_VALUES) &&
+            frame != null && !frame.isObsolete() &&
+            frame.getThread().isSuspended() &&
+            JAVA_STRATUM.equals(frame.getDefaultStratum())) {
+            try {
+                String url = debugger.getEngineContext().getURL(frame, JAVA_STRATUM);
+                frameFile = url != null ? URLMapper.findFileObject(URI.create(url).toURL()) : null;
+                if (frameFile != null) {
+                    frameLineNumber = frame.getLineNumber(JAVA_STRATUM);
+                    EditorCookie ec = frameFile.getLookup().lookup(EditorCookie.class);
+                    frameDocument = ec != null ? ec.getDocument() : null;
+                }
+            } catch (InternalExceptionWrapper | InvalidStackFrameExceptionWrapper | ObjectCollectedExceptionWrapper | VMDisconnectedExceptionWrapper | MalformedURLException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        }
+
+        TaskDescription newTask;
+
+        if (frameFile != null && frameDocument != null) {
+            newTask = new TaskDescription(frameFile, frameLineNumber, frameDocument);
+        } else {
+            newTask = null;
+        }
+
+        if (setNewTask(newTask)) {
+            return;
+        }
+
+        if (newTask != null) {
+            CountDownLatch computationDone = new CountDownLatch(1);
+
+            newTask.addCancelCallback(computationDone::countDown);
+
+            AtomicReference<Collection<InlineVariable>> values = new AtomicReference<>();
+
+            EVALUATOR.post(() -> {
+                OffsetsBag runningBag = new OffsetsBag(newTask.frameDocument);
+
+                Lookup.getDefault().lookup(ComputeInlineVariablesFactory.class).set(newTask.frameFile, newTask.frameLineNumber, variables -> {
+                    values.set(variables);
+                    computationDone.countDown();
+                });
+
+                try {
+                    computationDone.await();
+                } catch (InterruptedException ex) {
+                    Exceptions.printStackTrace(ex);
+                }
+
+                if (newTask.isCancelled()) {
+                    return ;
+                }
+
+                Collection<InlineVariable> variables = values.get();
+
+                if (variables == null) {
+                    return ;
+                }
+
+                Map<String, Variable> expression2Value = new HashMap<>();
+                Map<Integer, Map<String, String>> line2Values = new HashMap<>();
+
+                for (InlineVariable v : variables) {
+                    if (newTask.isCancelled()) {
+                        return ;
+                    }
+
+                    Variable value = expression2Value.computeIfAbsent(v.expression(), expr -> {
+                        try {
+                            return debugger.evaluate(expr);
+                        } catch (InvalidExpressionException ex) {
+                            //the variable may not exist
+                            LOG.log(Level.FINE, null, ex);
+                            return null;
+                        }
+                    });
+                    if (value != null) {
+                        String valueText;
+                        if (value instanceof ObjectVariable ov) {
+                            valueText = toValue(ov).replace("\n", "\\n");
+                        } else {
+                            valueText = value.getValue();
+                        }
+                        line2Values.computeIfAbsent(v.lineEnd(), __ -> new LinkedHashMap<>())
+                                   .putIfAbsent(v.expression(), v.expression() + " = " + valueText);
+                        String mergedValues = line2Values.get(v.lineEnd()).values().stream().collect(Collectors.joining(", ", "  ", ""));
+                        AttributeSet attrs = AttributesUtilities.createImmutable("virtual-text-prepend", mergedValues);
+
+                        runningBag.addHighlight(v.lineEnd(), v.lineEnd() + 1, attrs);
+
+                        setHighlights(newTask, runningBag);
+                    }
+                }
+            });
+        }
+    }
+
+    private String toValue(ObjectVariable variable) {
+        //mostly copied from the VariablesFormatterFilter.getValueAt:
+        FormattersLoopControl formattersLoop = new FormattersLoopControl();
+        String type = variable.getType ();
+        ObjectVariable ov = (ObjectVariable) variable;
+        JPDAClassType ct = ov.getClassType();
+        if (ct == null) {
+            return ov.getValue();
+        }
+        VariablesFormatter f = Formatters.getFormatterForType(ct, formattersLoop.getFormatters());
+        String[] formattersInLoopRef = new String[] { null };
+        if (f != null && formattersLoop.canUse(f, ct.getName(), formattersInLoopRef)) {
+            String code = f.getValueFormatCode();
+            if (code != null && code.length() > 0) {
+                try {
+                    java.lang.reflect.Method evaluateMethod = ov.getClass().getMethod("evaluate", String.class);
+                    evaluateMethod.setAccessible(true);
+                    Variable ret = (Variable) evaluateMethod.invoke(ov, code);
+                    if (ret == null) {
+                        return null;
+                    }
+                    return ret.getValue();
+                } catch (java.lang.reflect.InvocationTargetException itex) {
+                    Throwable t = itex.getTargetException();
+                    if (t instanceof InvalidExpressionException) {
+                        return ov.getValue();
+                    } else {
+                        Exceptions.printStackTrace(t);
+                    }
+                } catch (ReflectiveOperationException ex) {
+                    Exceptions.printStackTrace(ex);
+                }
+            }
+        } else if (formattersInLoopRef[0] != null) {
+            //ignore loops(?)
+        }
+        if (VariablesFormatterFilter.isToStringValueType(type)) {
+            try {
+                return "\""+ov.getToStringValue ()+"\"";
+            } catch (InvalidExpressionException ex) {
+                // Not a supported operation (e.g. J2ME, see #45543)
+                // Or missing context or any other reason
+                Logger.getLogger(VariablesFormatterFilter.class.getName()).fine("getToStringValue() "+ex.getLocalizedMessage());
+                if (ex.getTargetException () instanceof UnsupportedOperationException) {
+                    // PATCH for J2ME. see 45543
+                    return ov.getValue();
+                }
+                return ex.getLocalizedMessage ();
+            }
+        }
+        return ov.getValue();
+    }
+
+    private synchronized boolean setNewTask(TaskDescription newTask) {
+        if (Objects.equals(currentTask, newTask)) {
+            return true; //nothing changed, nothing to do
+        }
+
+        if (currentTask != null) {
+            currentTask.cancel();
+            getHighlightsBag(currentTask.frameDocument).clear();
+        }
+
+        currentTask = newTask;
+
+        return false;
+    }
+
+    private synchronized void setHighlights(TaskDescription task, OffsetsBag highlights) {
+        if (!task.isCancelled()) {
+            getHighlightsBag(currentTask.frameDocument).setHighlights(highlights);
+        }
+    }
+
+    @DebuggerServiceRegistration(types=LazyDebuggerManagerListener.class)
+    public static final class Init extends DebuggerManagerAdapter {
+        @Override
+        public void sessionAdded(Session session) {
+            new InlineValueComputerImpl(session);
+        }
+    }
+
+    @ServiceProviders({
+        @ServiceProvider(service=JavaSourceTaskFactory.class),
+        @ServiceProvider(service=ComputeInlineVariablesFactory.class)
+    })
+    public static final class ComputeInlineVariablesFactory extends JavaSourceTaskFactory {
+
+        private FileObject currentFile;
+        private int currentLineNumber;
+        private Consumer<Collection<InlineVariable>> currentTarget;
+
+        public ComputeInlineVariablesFactory() {
+            super(Phase.UP_TO_DATE, Priority.NORMAL, TaskIndexingMode.ALLOWED_DURING_SCAN);
+        }
+
+        @Override
+        protected CancellableTask<CompilationInfo> createTask(FileObject file) {
+            return new CancellableTask<CompilationInfo>() {
+                private final AtomicBoolean cancel = new AtomicBoolean();
+
+                @Override
+                public void cancel() {
+                    cancel.set(true);
+                }
+
+                @Override
+                public void run(CompilationInfo info) throws Exception {
+                    cancel.set(false);
+
+                    int line;
+                    Consumer<Collection<InlineVariable>> target;
+
+                    synchronized (ComputeInlineVariablesFactory.this) {
+                        if (!info.getFileObject().equals(currentFile)) {
+                            return ;
+                        }
+                        line = currentLineNumber;
+                        target = currentTarget;
+                    }
+
+                    Collection<InlineVariable> variables = ComputeInlineValues.computeVariables(info, line, 1, cancel);
+
+                    target.accept(variables);
+                }
+            };
+        }
+
+        @Override
+        protected synchronized Collection<FileObject> getFileObjects() {
+            return currentFile != null ? List.of(currentFile) : List.of();
+        }
+
+        public synchronized void set(FileObject currentFile, int lineNumber, Consumer<Collection<InlineVariable>> target) {
+            this.currentFile = currentFile;
+            this.currentLineNumber = lineNumber;
+            this.currentTarget = target;
+            fileObjectsChanged();
+            if (currentFile != null) {
+                reschedule(currentFile);
+            }
+        }
+    }
+
+    private static final class TaskDescription {
+        public final FileObject frameFile;
+        public final int frameLineNumber;
+        public final Document frameDocument;
+        private final AtomicBoolean cancelled = new AtomicBoolean();
+        private final List<Runnable> cancelCallbacks =
+                Collections.synchronizedList(new ArrayList<>());
+
+        public TaskDescription(FileObject frameFile, int frameLineNumber, Document frameDocument) {
+            this.frameFile = frameFile;
+            this.frameLineNumber = frameLineNumber;
+            this.frameDocument = frameDocument;
+        }
+
+        public void cancel() {
+            cancelled.set(true);
+
+            List<Runnable> callbacks;
+
+            synchronized (cancelCallbacks) {
+                callbacks = new ArrayList<>(cancelCallbacks);
+            }
+
+            for (Runnable r : callbacks) {
+                r.run();
+            }
+        }
+
+        public void addCancelCallback(Runnable r) {
+            cancelCallbacks.add(r);
+
+            if (cancelled.get()) {
+                r.run();
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 7;
+            hash = 53 * hash + Objects.hashCode(this.frameFile);
+            hash = 53 * hash + this.frameLineNumber;
+            hash = 53 * hash + System.identityHashCode(this.frameDocument);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final TaskDescription other = (TaskDescription) obj;
+            if (this.frameLineNumber != other.frameLineNumber) {
+                return false;
+            }
+            if (!Objects.equals(this.frameFile, other.frameFile)) {
+                return false;
+            }
+            return this.frameDocument == other.frameDocument;
+        }
+
+        public boolean isCancelled() {
+            return cancelled.get();
+        }
+
+    }
+    @MimeRegistration(mimeType="text/x-java", service=HighlightsLayerFactory.class)
+    public static HighlightsLayerFactory createHighlightsLayerFactory() {
+        return new HighlightsLayerFactory() {
+            @Override
+            public HighlightsLayer[] createLayers(HighlightsLayerFactory.Context context) {
+                return new HighlightsLayer[] {
+                    HighlightsLayer.create(InlineValueComputerImpl.class.getName(), ZOrder.SYNTAX_RACK.forPosition(1400), false, getHighlightsBag(context.getDocument()))
+                };
+            }
+        };
+    }
+
+    private static OffsetsBag getHighlightsBag(Document doc) {
+        OffsetsBag bag = (OffsetsBag) doc.getProperty(InlineValueComputerImpl.class);
+        if (bag == null) {
+            doc.putProperty(InlineValueComputerImpl.class, bag = new OffsetsBag(doc, true));
+        }
+        return bag;
+    }
+
+}

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesFormatterFilter.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesFormatterFilter.java
@@ -584,7 +584,7 @@ public class VariablesFormatterFilter extends VariablesFilterAdapter {
     }
     
     private static HashSet toStringValueType;
-    private static boolean isToStringValueType (String type) {
+    static boolean isToStringValueType (String type) {
         if (toStringValueType == null) {
             toStringValueType = new HashSet ();
             toStringValueType.add ("java.lang.StringBuffer");

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/values/ComputeInlineValues.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/values/ComputeInlineValues.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.debugger.jpda.ui.values;
+
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.LineMap;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePath;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.TreeUtilities;
+import org.netbeans.api.java.source.support.CancellableTreePathScanner;
+
+public class ComputeInlineValues {
+
+    public static Collection<InlineVariable> computeVariables(CompilationInfo info, int stackLine, int stackCol, AtomicBoolean cancel) {
+        int donePos = (int) info.getCompilationUnit().getLineMap().getPosition(stackLine, stackCol);
+        int upcomingPos = (int) info.getCompilationUnit().getLineMap().getStartPosition(stackLine + 1);
+        TreePath relevantPoint = info.getTreeUtilities().pathFor(donePos + 1);
+        OUTER: while (relevantPoint != null) {
+            Tree leaf = relevantPoint.getLeaf();
+            switch (leaf.getKind()) {
+                case ANNOTATION_TYPE, CLASS, ENUM, INTERFACE, RECORD:
+                case METHOD, LAMBDA_EXPRESSION: break OUTER;
+                case BLOCK:
+                    if (relevantPoint.getParentPath() != null && TreeUtilities.CLASS_TREE_KINDS.contains(relevantPoint.getParentPath().getLeaf().getKind())) {
+                        break OUTER;
+                    }
+            }
+            relevantPoint = relevantPoint.getParentPath();
+        }
+        if (relevantPoint == null) {
+            return List.of();
+        }
+        Collection<InlineVariable> result = new ArrayList<>();
+        LineMap lm = info.getCompilationUnit().getLineMap();
+        new CancellableTreePathScanner<Void, Tree>(cancel) {
+            @Override
+            public Void visitVariable(VariableTree node, Tree relevantPointTree) {
+                int end = (int) info.getTrees().getSourcePositions().getEndPosition(info.getCompilationUnit(), node);
+                if (end < donePos) {
+                    int[] span = info.getTreeUtilities().findNameSpan(node);
+
+                    if (span != null) {
+                        int lineEnd = (int) (lm.getStartPosition(lm.getLineNumber(span[1]) + 1) - 1);
+
+                        result.add(new InlineVariable(span[0], span[1], lineEnd, node.getName().toString()));
+                    }
+                }
+                return super.visitVariable(node, relevantPointTree);
+            }
+
+            @Override
+            public Void visitIdentifier(IdentifierTree node, Tree relevantPointTree) {
+                Element el = info.getTrees().getElement(getCurrentPath());
+
+                if (el != null && el.getKind().isVariable() &&
+                    el.getKind() != ElementKind.ENUM_CONSTANT) {
+                    int start = (int) info.getTrees().getSourcePositions().getStartPosition(info.getCompilationUnit(), node);
+                    int end = (int) info.getTrees().getSourcePositions().getEndPosition(info.getCompilationUnit(), node);
+
+                    if (start != (-1) && end != (-1)) {
+                        int lineEnd = (int) (lm.getStartPosition(lm.getLineNumber(end) + 1) - 1);
+
+                        result.add(new InlineVariable(start, end, lineEnd, node.getName().toString()));
+                    }
+                }
+
+                return super.visitIdentifier(node, relevantPointTree);
+            }
+
+            @Override
+            public Void visitClass(ClassTree node, Tree relevantPointTree) {
+                if (node == relevantPointTree) {
+                    return super.visitClass(node, relevantPointTree);
+                }
+                return null;
+            }
+
+            @Override
+            public Void visitLambdaExpression(LambdaExpressionTree node, Tree relevantPointTree) {
+                return null;
+            }
+
+            @Override
+            public Void scan(Tree tree, Tree relevantPointTree) {
+                if (tree != null) {
+                    int start = (int) info.getTrees().getSourcePositions().getStartPosition(info.getCompilationUnit(), tree);
+
+                    if (start > upcomingPos) {
+                        return null;
+                    }
+                }
+                return super.scan(tree, relevantPointTree);
+            }
+
+        }.scan(relevantPoint, relevantPoint.getLeaf());
+
+        return result;
+    }
+
+    public record InlineVariable(int start, int end, int lineEnd, String expression) {}
+
+}

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/values/InlineValueProviderImpl.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/values/InlineValueProviderImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.debugger.jpda.ui.values;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.netbeans.api.editor.mimelookup.MimeRegistration;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.lsp.InlineValue;
+import org.netbeans.api.lsp.Range;
+import org.netbeans.spi.lsp.InlineValuesProvider;
+import org.openide.filesystems.FileObject;
+
+@MimeRegistration(mimeType = "text/x-java", service = InlineValuesProvider.class)
+public final class InlineValueProviderImpl implements InlineValuesProvider {
+
+    @Override
+    public CompletableFuture<List<? extends InlineValue>> inlineValues(FileObject file, int currentExecutionPosition) {
+        //TODO: proper cancellability
+        JavaSource js = JavaSource.forFileObject(file);
+        CompletableFuture<List<? extends InlineValue>> result = new CompletableFuture<>();
+        List<InlineValue> resultValues = new ArrayList<>();
+        if (js != null) {
+            try {
+                js.runUserActionTask(cc -> {
+                    cc.toPhase(JavaSource.Phase.RESOLVED);
+                    int stackLine = (int) cc.getCompilationUnit().getLineMap().getLineNumber(currentExecutionPosition);
+                    int stackCol = (int) cc.getCompilationUnit().getLineMap().getColumnNumber(currentExecutionPosition);
+                    for (ComputeInlineValues.InlineVariable var : ComputeInlineValues.computeVariables(cc, stackLine, stackCol, new AtomicBoolean())) {
+                        resultValues.add(InlineValue.createInlineVariable(new Range(var.start(), var.end()), var.expression()));
+                    }
+                }, true);
+            } catch (IOException ex) {
+                result.completeExceptionally(ex);
+                return result;
+            }
+        }
+        result.complete(resultValues);
+        return result;
+    }
+
+}

--- a/java/debugger.jpda.ui/test/unit/src/org/netbeans/modules/debugger/jpda/ui/values/ComputeInlineValuesTest.java
+++ b/java/debugger.jpda.ui/test/unit/src/org/netbeans/modules/debugger/jpda/ui/values/ComputeInlineValuesTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.debugger.jpda.ui.values;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.SourceUtilsTestUtil;
+import org.netbeans.api.java.source.TestUtilities;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.debugger.jpda.ui.values.ComputeInlineValues.InlineVariable;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class ComputeInlineValuesTest extends NbTestCase {
+
+    private FileObject srcDir;
+
+    public ComputeInlineValuesTest(String name) {
+        super(name);
+    }
+
+    protected void setUp() throws Exception {
+        SourceUtilsTestUtil.prepareTest(new String[0], new Object[0]);
+
+        clearWorkDir();
+
+        FileObject wd = FileUtil.toFileObject(getWorkDir());
+
+        srcDir = FileUtil.createFolder(wd, "src");
+
+        FileObject buildDir = FileUtil.createFolder(wd, "build");
+        FileObject cacheDir = FileUtil.createFolder(wd, "cache");
+
+        SourceUtilsTestUtil.prepareTest(srcDir, buildDir, cacheDir);
+    }
+
+    public void testSimpleComputeInlineVariables() throws Exception {
+        runCompileInlineVariablesTest("""
+                                      public class Test {
+                                          private void test(String /param/) {
+                                              int /i1/ = 0;
+                                              |int i2 = /i1/;
+                                              int i3 = 1;
+                                          }
+                                      }
+                                      """);
+    }
+
+    public void testNestedMethodsComputeInlineVariables() throws Exception {
+        runCompileInlineVariablesTest("""
+                                      public class Test {
+                                          private void test(String /param/) {
+                                              int /i1/ = 0;
+                                              Runnable /r1/ = new Runnable() {
+                                                  public void run() {
+                                                      int n = 0;
+                                                  }
+                                              };
+                                              Runnable /r2/ = () -> {
+                                                  int n = 0;
+                                              };
+                                              |int i2 = /i1/;
+                                              int i3 = 1;
+                                          }
+                                      }
+                                      """);
+    }
+
+    public void testNoEnumConstants() throws Exception {
+        runCompileInlineVariablesTest("""
+                                      package test;
+                                      import static test.Test.E.*;
+                                      public class Test {
+                                          private void test(String /param/) {
+                                              E /e/ = A;
+                                              |E e2 = /e/;
+                                          }
+                                          public enum E {
+                                              A, B, C;
+                                          }
+                                      }
+                                      """);
+    }
+
+    public void testDeclarationAndUseOnTheSameLine() throws Exception {
+        runCompileInlineVariablesTest("""
+                                      public class Test {
+                                          private void test(String /param/) {
+                                              int /i1/ = 0;
+                                              |for (int j = 0; /j/ < 10; /j/++) {
+                                              }
+                                          }
+                                      }
+                                      """);
+    }
+
+    public void testFields() throws Exception {
+        runCompileInlineVariablesTest("""
+                                      public class Test {
+                                          int /i1/ = 0;
+                                          |int j = /i1/;
+                                      }
+                                      """);
+    }
+
+    public void testClassNoCrash() throws Exception {
+        runCompileInlineVariablesTest("""
+                                      |public class Test {
+                                      }
+                                      """);
+    }
+
+    private void runCompileInlineVariablesTest(String codeResultAndPos) throws Exception {
+        FileObject source = FileUtil.createData(srcDir, "Test.java");
+        int pos = codeResultAndPos.replace("/", "").indexOf("|");
+        int idx = 0;
+        List<String> parts = new ArrayList<>(List.of(codeResultAndPos.replace("|", "").split("/")));
+        Set<String> expectedSpans = new HashSet<>();
+
+        while (parts.size() > 1) {
+            int start = idx += parts.remove(0).length();
+            int end = idx += parts.remove(0).length();
+
+            expectedSpans.add("" + start + "-" + end);
+        }
+
+        String code = codeResultAndPos.replace("/", "").replace("|", "");
+
+        TestUtilities.copyStringToFile(source, code);
+        CompilationInfo info =
+                SourceUtilsTestUtil.getCompilationInfo(JavaSource.forFileObject(source),
+                                                       JavaSource.Phase.RESOLVED);
+        int stackLine = (int) info.getCompilationUnit().getLineMap().getLineNumber(pos);
+        Collection<InlineVariable> computedVariables = ComputeInlineValues.computeVariables(info, stackLine, 0, new AtomicBoolean());
+
+        for (InlineVariable var : computedVariables) {
+            String snippet = code.substring(var.start(), var.end());
+
+            assertEquals(snippet, var.expression());
+            assertFalse(code.substring(var.end(), var.lineEnd()).contains("\n"));
+            assertEquals('\n', code.charAt(var.lineEnd()));
+
+            if (!expectedSpans.remove("" + var.start() + "-" + var.end())) {
+                throw new AssertionError("Returned span: " + var.start() + "-" + var.end() + " (" + snippet + "), but it is not among the expected spans.");
+            }
+        }
+
+        if (!expectedSpans.isEmpty()) {
+            throw new AssertionError("Spans not found: " + expectedSpans);
+        }
+    }
+
+}

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/formatters/VariablesFormatter.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/formatters/VariablesFormatter.java
@@ -301,6 +301,8 @@ public final class VariablesFormatter implements Cloneable {
                         "MSG_EnumFormatter=Default Enum Formatter",
                         "MSG_BigDecimalFormatter=Default BigDecimal Formatter",
                         "MSG_BigIntegerFormatter=Default BigInteger Formatter",
+                        "MSG_JavadocASTFormatter=Default com.sun.source.doctree.DocTree Formatter",
+                        "MSG_JavacASTFormatter=Default com.sun.source.tree.Tree Formatter",
                         })
     private static VariablesFormatter[] createDefaultFormatters() {
         VariablesFormatter charSequence = new VariablesFormatter(Bundle.MSG_CharSequenceFormatter());
@@ -354,8 +356,20 @@ public final class VariablesFormatter implements Cloneable {
         bigIntegerFormatter.setValueFormatCode("toString()");
         bigIntegerFormatter.isDefault = true;
 
+        VariablesFormatter javadocASTFormatter = new VariablesFormatter(Bundle.MSG_JavadocASTFormatter());
+        javadocASTFormatter.setClassTypes("com.sun.source.doctree.DocTree");
+        javadocASTFormatter.setIncludeSubTypes(true);
+        javadocASTFormatter.setValueFormatCode("toString()");
+        javadocASTFormatter.isDefault = true;
+
+        VariablesFormatter javacASTFormatter = new VariablesFormatter(Bundle.MSG_JavacASTFormatter());
+        javacASTFormatter.setClassTypes("com.sun.source.tree.Tree");
+        javacASTFormatter.setIncludeSubTypes(true);
+        javacASTFormatter.setValueFormatCode("toString()");
+        javacASTFormatter.isDefault = true;
+
         return new VariablesFormatter[] { charSequence, collection, map, mapEntry, enumFormatter,
-            bigDecimalFormatter, bigIntegerFormatter };
+            bigDecimalFormatter, bigIntegerFormatter, javadocASTFormatter, javacASTFormatter };
     }
 
 

--- a/java/java.editor/src/org/netbeans/modules/java/editor/semantic/HighlightsLayerFactoryImpl.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/semantic/HighlightsLayerFactoryImpl.java
@@ -23,6 +23,7 @@ import org.netbeans.spi.editor.highlighting.HighlightsLayer;
 import org.netbeans.spi.editor.highlighting.HighlightsLayerFactory;
 import org.netbeans.spi.editor.highlighting.HighlightsLayerFactory.Context;
 import org.netbeans.spi.editor.highlighting.ZOrder;
+import org.netbeans.spi.editor.highlighting.support.HighlightsContainers;
 
 /**
  *
@@ -38,7 +39,7 @@ public class HighlightsLayerFactoryImpl implements HighlightsLayerFactory {
         return new HighlightsLayer[] {
             HighlightsLayer.create(SemanticHighlighter.class.getName() + "-1", ZOrder.SYNTAX_RACK.forPosition(1000), false,semantic),
             HighlightsLayer.create(SemanticHighlighter.class.getName() + "-2", ZOrder.SYNTAX_RACK.forPosition(1500), false, SemanticHighlighter.getImportHighlightsBag(context.getDocument())),
-            HighlightsLayer.create(SemanticHighlighter.class.getName() + "-3", ZOrder.SYNTAX_RACK.forPosition(1600), false, SemanticHighlighter.getPreTextBag(context.getDocument())),
+            HighlightsLayer.create(SemanticHighlighter.class.getName() + "-3", ZOrder.SYNTAX_RACK.forPosition(1600), false, HighlightsContainers.inlineHintsSettingAwareContainer(context.getDocument(), SemanticHighlighter.getPreTextBag(context.getDocument()))),
             //the mark occurrences layer should be "above" current row and "below" the search layers:
             HighlightsLayer.create(MarkOccurrencesHighlighter.class.getName(), ZOrder.SHOW_OFF_RACK.forPosition(20), true, MarkOccurrencesHighlighter.getHighlightsBag(context.getDocument())),
             //"above" mark occurrences, "below" search layers:

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -892,6 +892,7 @@ public final class Server {
                 capabilities.setDocumentFormattingProvider(true);
                 capabilities.setDocumentRangeFormattingProvider(true);
                 capabilities.setReferencesProvider(true);
+                capabilities.setInlineValueProvider(true);
 
                 CallHierarchyRegistrationOptions chOpts = new CallHierarchyRegistrationOptions();
                 chOpts.setWorkDoneProgress(true);


### PR DESCRIPTION
This is a prototype of a feature to show variable values directly in the editor, as permitted by the LSP protocol.

It looks like this inside VS Code:
![inline-values-vscode](https://github.com/user-attachments/assets/726395f1-5de0-415a-a7bc-e602dc6026ec)

and inside NetBeans:
![inline-values-nb](https://github.com/user-attachments/assets/b72c2a7a-1a59-4472-beca-5929eef335fe)
