### PR TITLE
Try to stabilize sealed class completion tests

### DIFF
--- a/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/CompletionTestBaseBase.java
+++ b/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/CompletionTestBaseBase.java
@@ -67,6 +67,9 @@ public class CompletionTestBaseBase extends NbTestCase {
         JavaCompletionTaskBasicTest.class.getClassLoader().setDefaultAssertionStatus(true);
         SourceUtilsTestUtil2.disableArtificalParameterNames();
         System.setProperty("org.netbeans.modules.java.source.parsing.JavacParser.no_parameter_names", "true");
+        // bump tresholds to avoid context dumps from "excessive indexing" warnings
+        System.setProperty("org.netbeans.modules.parsing.impl.indexing.LogContext$EventType.PATH.treshold", "100");
+        System.setProperty("org.netbeans.modules.parsing.impl.indexing.LogContext$EventType.MANAGER.treshold", "100");
     }
 
     static final int FINISH_OUTTIME = 5 * 60 * 1000;

--- a/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask121FeaturesTest.java
+++ b/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask121FeaturesTest.java
@@ -179,9 +179,10 @@ public class JavaCompletionTask121FeaturesTest extends CompletionTestBase {
 
     @Override
     protected void tearDown() throws Exception {
-        if (classPathRegistered != null) {
+        if (getName().startsWith("testSealed") && classPathRegistered != null) {
             GlobalPathRegistry.getDefault().unregister(ClassPath.SOURCE, new ClassPath[] {classPathRegistered});
             SourceUtils.waitScanFinished();
+            classPathRegistered = null;
         }
         super.tearDown();
     }


### PR DESCRIPTION
the new code completion tests added in https://github.com/apache/netbeans/pull/7966 have a high failure rate in CI. E.g https://github.com/apache/netbeans/actions/runs/12197542394?pr=8019 is still failing after 5 attempts.

I can't reproduce it locally unfortunately.