### PR TITLE
Hide keybindings for NBLS

### DIFF
--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
@@ -178,4 +178,25 @@
             </folder>
         </folder>
     </folder>
+    <folder name="Editors">
+        <folder name="Keybindings">
+            <folder name="NetBeans">
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-editor-keybindings.xml_hidden"/>
+                </folder>
+            </folder>
+        </folder>
+        <folder name="text">
+            <folder name="x-java">
+                <folder name="Keybindings">
+                    <folder name="NetBeans">
+                        <folder name="Defaults">
+                            <file name="org-netbeans-modules-editor-java-keybindings.xml_hidden"/>
+                            <file name="org-netbeans-modules-editor-java-keybindings-mac.xml_hidden"/>
+                        </folder>
+                    </folder>
+                </folder>
+            </folder>
+        </folder>
+    </folder>
 </filesystem>


### PR DESCRIPTION
It doesn't make sense to have NetBeans keybindings in the NBLS. Hiding it in this PR.