### PR TITLE
Upgrading nb-javac to JDK 24b29.

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/ElementUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ElementUtilities.java
@@ -61,6 +61,8 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -489,7 +491,7 @@ public final class ElementUtilities {
         for (CompilationUnitTree unit : Collections.singletonList(info.getCompilationUnit())) {
             TreePath path = new TreePath(unit);
             Scope scope = trees.getScope(path);
-            while (scope instanceof JavacScope && !((JavacScope)scope).isStarImportScope()) {
+            while (scope instanceof JavacScope && ((JavacScope)scope).getScopeType() == ORDINARY_SCOPE_TYPE) {
                 for (Element local : scope.getLocalElements()) {
                     if (local.getKind().isClass() || local.getKind().isInterface()) {
                         if (acceptor.accept(local, null)) {
@@ -519,6 +521,21 @@ public final class ElementUtilities {
             }
         }
         return membersList;
+    }
+
+    private static final Object ORDINARY_SCOPE_TYPE;
+    private static final Logger LOG = Logger.getLogger(ElementUtilities.class.getName());
+
+    static {
+        Object ordinary = null;
+
+        try {
+            ordinary = Enum.valueOf((Class<Enum>) Class.forName("com.sun.tools.javac.api.JavacScope$ScopeType"), "ORDINARY");
+        } catch (ClassNotFoundException ex) {
+            LOG.log(Level.FINE, null, ex);
+        }
+
+        ORDINARY_SCOPE_TYPE = ordinary;
     }
 
     /**Filter {@link Element}s

--- a/java/java.source.base/src/org/netbeans/api/java/source/TypeMirrorHandle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TypeMirrorHandle.java
@@ -426,7 +426,7 @@ public final class TypeMirrorHandle<T extends TypeMirror> {
 
         @Override
         public TypeTag getTag() {
-            return TypeTag.UNKNOWN;
+            return TypeTag.NONE;
         }
 
         @Override

--- a/java/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
@@ -34,7 +34,7 @@ import org.openide.modules.OnStart;
  */
 public class NoJavacHelper {
 
-    public static final int REQUIRED_JAVAC_VERSION = 23; // <- TODO: increment on every release
+    public static final int REQUIRED_JAVAC_VERSION = 24; // <- TODO: increment on every release
     private static final boolean HAS_WORKING_JAVAC;
 
     static {

--- a/java/libs.javacapi/external/binaries-list
+++ b/java/libs.javacapi/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-1B70EC8A5230901C0EEE6EDF9829B43EAFAE9CC9 com.dukescript.nbjavac:nb-javac:jdk-23+35
-B3CB7A425EC7AAADA60754E6DF2E5E2D990E91AE com.dukescript.nbjavac:nb-javac:jdk-23+35:api
+3AA17DB68CB7E39E9DE17F566FCD1787BDD03E16 com.dukescript.nbjavac:nb-javac:jdk-24+29
+92F6565B6FB8F397CEB90308A47202E30E27A167 com.dukescript.nbjavac:nb-javac:jdk-24+29:api

--- a/java/libs.javacapi/external/nb-javac-jdk-24+29-license.txt
+++ b/java/libs.javacapi/external/nb-javac-jdk-24+29-license.txt
@@ -1,7 +1,7 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Version: 23+35
-Files: nb-javac-jdk-23+35-api.jar nb-javac-jdk-23+35.jar
+Version: 24+29
+Files: nb-javac-jdk-24+29-api.jar nb-javac-jdk-24+29.jar
 License: GPL-2-CP
 Origin: OpenJDK (https://github.com/openjdk/jdk)
 Source: https://github.com/openjdk/jdk

--- a/java/libs.javacapi/nbproject/project.xml
+++ b/java/libs.javacapi/nbproject/project.xml
@@ -40,11 +40,11 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-jdk-23+35-api.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-24+29-api.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-jdk-23+35.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-24+29.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/libs.nbjavacapi/external/binaries-list
+++ b/java/libs.nbjavacapi/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-1B70EC8A5230901C0EEE6EDF9829B43EAFAE9CC9 com.dukescript.nbjavac:nb-javac:jdk-23+35
-B3CB7A425EC7AAADA60754E6DF2E5E2D990E91AE com.dukescript.nbjavac:nb-javac:jdk-23+35:api
+3AA17DB68CB7E39E9DE17F566FCD1787BDD03E16 com.dukescript.nbjavac:nb-javac:jdk-24+29
+92F6565B6FB8F397CEB90308A47202E30E27A167 com.dukescript.nbjavac:nb-javac:jdk-24+29:api

--- a/java/libs.nbjavacapi/external/nb-javac-jdk-24+29-license.txt
+++ b/java/libs.nbjavacapi/external/nb-javac-jdk-24+29-license.txt
@@ -1,7 +1,7 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Version: 23+35
-Files: nb-javac-jdk-23+35-api.jar nb-javac-jdk-23+35.jar
+Version: 24+29
+Files: nb-javac-jdk-24+29-api.jar nb-javac-jdk-24+29.jar
 License: GPL-2-CP
 Origin: OpenJDK (https://github.com/openjdk/jdk)
 Source: https://github.com/openjdk/jdk

--- a/java/libs.nbjavacapi/nbproject/project.properties
+++ b/java/libs.nbjavacapi/nbproject/project.properties
@@ -18,8 +18,8 @@
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 license.file.override=${nb_all}/nbbuild/licenses/GPL-2-CP
-release.external/nb-javac-jdk-23+35-api.jar=modules/ext/nb-javac-jdk-23-30-api.jar
-release.external/nb-javac-jdk-23+35.jar=modules/ext/nb-javac-jdk-23-30.jar
+release.external/nb-javac-jdk-24+29-api.jar=modules/ext/nb-javac-jdk-24-29-api.jar
+release.external/nb-javac-jdk-24+29.jar=modules/ext/nb-javac-jdk-24-29.jar
 
 # for tests
 requires.nb.javac=true

--- a/java/libs.nbjavacapi/nbproject/project.xml
+++ b/java/libs.nbjavacapi/nbproject/project.xml
@@ -45,12 +45,12 @@
             </test-dependencies>
             <public-packages/>
             <class-path-extension>
-                <runtime-relative-path>ext/nb-javac-jdk-23-30-api.jar</runtime-relative-path>
-                <binary-origin>external/nb-javac-jdk-23+35-api.jar</binary-origin>
+                <runtime-relative-path>ext/nb-javac-jdk-24-29-api.jar</runtime-relative-path>
+                <binary-origin>external/nb-javac-jdk-24+29-api.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/nb-javac-jdk-23-30.jar</runtime-relative-path>
-                <binary-origin>external/nb-javac-jdk-23+35.jar</binary-origin>
+                <runtime-relative-path>ext/nb-javac-jdk-24-29.jar</runtime-relative-path>
+                <binary-origin>external/nb-javac-jdk-24+29.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/libs.nbjavacapi/src/org/netbeans/modules/nbjavac/api/Bundle.properties
+++ b/java/libs.nbjavacapi/src/org/netbeans/modules/nbjavac/api/Bundle.properties
@@ -18,6 +18,6 @@
 OpenIDE-Module-Display-Category=Java
 OpenIDE-Module-Long-Description=\
     This library provides a Java language parser for the IDE. \
-    Supports JDK-23 features.
+    Supports JDK-24 features.
 OpenIDE-Module-Name=The nb-javac Java editing support library
 OpenIDE-Module-Short-Description=The nb-javac Java editing support library

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -96,8 +96,8 @@ nb/ide.launcher/external/launcher-external-binaries-1-94a19f0.zip platform/o.n.b
 nb/ide.launcher/external/launcher-external-binaries-1-94a19f0.zip harness/apisupport.harness/external/launcher-external-binaries-1-94a19f0.zip
 
 # only one is part of the product:
-java/libs.javacapi/external/nb-javac-jdk-23+35-api.jar java/libs.nbjavacapi/external/nb-javac-jdk-23+35-api.jar
-java/libs.javacapi/external/nb-javac-jdk-23+35.jar java/libs.nbjavacapi/external/nb-javac-jdk-23+35.jar
+java/libs.javacapi/external/nb-javac-jdk-24+29-api.jar java/libs.nbjavacapi/external/nb-javac-jdk-24+29-api.jar
+java/libs.javacapi/external/nb-javac-jdk-24+29.jar java/libs.nbjavacapi/external/nb-javac-jdk-24+29.jar
 
 # Used only in unittests for mysql db specific tests
 ide/db.metadata.model/external/mysql-connector-j-8.0.31.jar ide/db.mysql/external/mysql-connector-j-8.0.31.jar


### PR DESCRIPTION
A first sketch (so far) to attempt to (nb-)javac from JDK 24.
