### PR TITLE
Increasing hash key length

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/ProjectTrust.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ProjectTrust.java
@@ -48,6 +48,7 @@ import org.openide.util.NbPreferences;
 public class ProjectTrust {
     private static final Logger LOG = Logger.getLogger(ProjectTrust.class.getName());
     
+    private static final int KEY_LENGTH = 64;
     private static final String KEY_SALT     = "secret";     //NOI18N
     private static final String NODE_PROJECT = "projects"; //NOI18N
     private static final String NODE_TRUST   = "trust";    //NOI18N
@@ -68,7 +69,7 @@ public class ProjectTrust {
     ProjectTrust(Preferences prefs) {
         byte[] buf = prefs.getByteArray(KEY_SALT, null);
         if (buf == null) {
-            buf = new byte[16];
+            buf = new byte[KEY_LENGTH];
             new SecureRandom().nextBytes(buf);
             prefs.putByteArray(KEY_SALT, buf);
         }

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/CLIHandlerTest.java
@@ -274,14 +274,14 @@ public class CLIHandlerTest extends NbTestCase {
         File f = runner.resultFile();
         byte[] arr = new byte[(int)f.length()];
         int len = arr.length;
-        assertTrue("We know that the size of the file should be int + key_length + 4 for ip address: ", len >=14 && len <= 18);
+        assertTrue("We know that the size of the file should be int + key_length + 4 for ip address: ", len >=68 && len <= 72);
         FileInputStream is = new FileInputStream(f);
         assertEquals("Fully read", arr.length, is.read(arr));
         is.close();
         
-        byte[] altarr = new byte[18];
-        for (int i = 0; i < 18; i++) {
-            altarr[i] = i<14? arr[i]: 1;
+        byte[] altarr = new byte[72];
+        for (int i = 0; i < 72; i++) {
+            altarr[i] = i<68? arr[i]: 1;
         }
         
         // change the IP at the end of the file

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/CLIHowHardIsToGuessKeyTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/CLIHowHardIsToGuessKeyTest.java
@@ -107,14 +107,14 @@ public class CLIHowHardIsToGuessKeyTest extends NbTestCase {
         LOG.info("lock file exists" + lock);
         for (int i = 0; i < 500; i++) {
             LOG.info(i + ": testing its size: " + lock.length());
-            if (lock.length() >= 14) {
+            if (lock.length() >= 68) {
                 break;
             }
             Thread.sleep(500);
         }
-        assertTrue("Lock must contain the key now: " + lock.length(), lock.length() >= 14);//fail("Ok");
+        assertTrue("Lock must contain the key now: " + lock.length(), lock.length() >= 68);//fail("Ok");
         
-        final byte[] arr = new byte[10]; // CLIHandler.KEY_LENGTH
+        final byte[] arr = new byte[64]; // CLIHandler.KEY_LENGTH
         DataInputStream is = new DataInputStream(new FileInputStream(lock));
         final int port = is.readInt();
         int read = is.read(arr);


### PR DESCRIPTION
### Issue
Hash key length is different in different sections of project. We are increasing two of them to 64
### Changes
Increased hash key length to 64 in below projects
Bootstrap/org.netbeans.CLIHandler and 
Gradle-Projects/org.netbeans.modules.gradle.ProjectTrust

