### PR TITLE
Prevent NPE

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImpl.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImpl.java
@@ -68,7 +68,8 @@ public class OccurrencesFinderImpl extends OccurrencesFinder {
 
     @Override
     public Map<OffsetRange, ColoringAttributes> getOccurrences() {
-        return range2Attribs;
+        // must not return null
+        return Collections.unmodifiableMap(range2Attribs);
     }
 
     @Override
@@ -99,9 +100,11 @@ public class OccurrencesFinderImpl extends OccurrencesFinder {
             return;
         }
 
-        if (!node.getBoolean(MarkOccurencesSettings.KEEP_MARKS, true) || localRange2Attribs.size() > 0) {
-            //store the occurrences if not empty, return null in getOccurrences() otherwise
+        if (!node.getBoolean(MarkOccurencesSettings.KEEP_MARKS, true) || !localRange2Attribs.isEmpty()) {
+            //store the occurrences if not empty
             range2Attribs = localRange2Attribs;
+        } else {
+            range2Attribs = Collections.emptyMap();
         }
     }
 


### PR DESCRIPTION
- Do not return `null` in `getOccurrences()`
- See GH-8028

```diff
@@ -155,7 +146,7 @@ List<OffsetRange> processImpl(ParserResult info, Document doc, int caretPosition
 
         Map<OffsetRange, ColoringAttributes> highlights = finder.getOccurrences();
 
-        return highlights == null ? null : new ArrayList<OffsetRange>(highlights.keySet());
+        return List.copyOf(highlights.keySet());
```