### PR TITLE
Fix nanoid and revert default VSIX version

### DIFF
--- a/java/java.lsp.server/vscode/package-lock.json
+++ b/java/java.lsp.server/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "apache-netbeans-java",
-	"version": "99.99.9",
+	"version": "0.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "apache-netbeans-java",
-			"version": "99.99.9",
+			"version": "0.1.0",
 			"license": "Apache 2.0",
 			"dependencies": {
 				"@vscode/debugadapter": "1.55.1",
@@ -1210,7 +1210,7 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "4.2.1",
 				"ms": "2.1.3",
-				"nanoid": "3.3.1",
+				"nanoid": "3.3.8",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -1255,10 +1255,17 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-			"integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+			"version": "3.3.8",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+			"integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -2454,7 +2461,7 @@
 				"log-symbols": "4.1.0",
 				"minimatch": "4.2.1",
 				"ms": "2.1.3",
-				"nanoid": "3.3.1",
+				"nanoid": "3.3.8",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -2485,9 +2492,9 @@
 			"dev": true
 		},
 		"nanoid": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-			"integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+			"version": "3.3.8",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+			"integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
 			"dev": true
 		},
 		"neo-async": {

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -4,7 +4,7 @@
 	"description": "Apache NetBeans Language Server Extension for Visual Studio Code",
 	"author": "Apache NetBeans",
 	"license": "Apache 2.0",
-	"version": "99.99.9",
+	"version": "0.1.0",
 	"preview": false,
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Fix nanoid npm version to 3.3.8 due to https://github.com/advisories/GHSA-mwcw-c2x4-8c55 keeping mocha version the same. Revert back default VSIX version to 0.1.0.