### PR TITLE
fixes #7996 - space after comma (css)

### DIFF
--- a/ide/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/BreadCrumbComponent.java
+++ b/ide/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/BreadCrumbComponent.java
@@ -351,7 +351,7 @@ public class BreadCrumbComponent<T extends JLabel&Renderer> extends JComponent i
             renderer.setText(html);
         } else {
             renderer.setHtml(false);
-            renderer.setText(node.getDisplayName());
+            renderer.setText(node.getDisplayName().replace('\n', ' '));
         }
         renderer.setFont(getFont());
     }


### PR DESCRIPTION
Those CSS rule names were separated by a linefeed

.css_one,
.css_two {
}

The linefeed was not displayed and since breadcrumbs are displayed in a single line, it transformed to `.css_one,.css_two`.

So this PR simply replaces linefeeds with a space.