### PR TITLE
Downgrade CI jobs to JDK 23

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -428,11 +428,11 @@ jobs:
         run: ant -quiet -Dcluster.config=$CLUSTER_CONFIG test -Dtest.includes=NoTestsJustBuild
 
       # 13-14 min for javadoc; JDK version must be synced with nb-javac
-      - name: Set up JDK 24-ea for javadoc
+      - name: Set up JDK 23 for javadoc
         if: env.test_javadoc == 'true' && success()
         uses: actions/setup-java@v4
         with:
-          java-version: 24-ea 
+          java-version: 23 
           distribution: ${{ env.DEFAULT_JAVA_DISTRIBUTION }}
 
       - name: Build javadoc
@@ -833,7 +833,7 @@ jobs:
     timeout-minutes: 50
     strategy:
       matrix:
-        java: [ '17', '21', '24-ea' ]
+        java: [ '17', '21', '23' ]
         exclude:
           - java: ${{ github.event_name == 'pull_request' && 'nothing' || '21' }}
       fail-fast: false
@@ -1493,7 +1493,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '17', '21', '24-ea' ]
+        java: [ '17', '21', '23' ]
         exclude:
           - java: ${{ github.event_name == 'pull_request' && 'nothing' || '21' }}
       fail-fast: false


### PR DESCRIPTION
CI has to wait for the PRs which handle the JDK SM removal.

additionally, the [javadoc step](https://github.com/apache/netbeans/actions/runs/12349897791/job/34471244486#step:18:350) did start failing with:
```
 BUILD FAILED
/home/runner/work/netbeans/netbeans/nbbuild/build.xml:407: The following error occurred while executing this line:
/home/runner/work/netbeans/netbeans/nbbuild/javadoctools/build.xml:43: The following error occurred while executing this line:
/home/runner/work/netbeans/netbeans/nbbuild/templates/projectized.xml:409: The following error occurred while executing this line:
/home/runner/work/netbeans/netbeans/nbbuild/javadoctools/replaces.xml:75: JAXP00010004: The accumulated size of entities is "100,029" that exceeded the "100,000" limit set by "jdk.xml.totalEntitySizeLimit".
```

this is partially reverting https://github.com/apache/netbeans/pull/7974, only build remains on JDK 24