### PR TITLE
CI: Lock native binaries builds to ubuntu 22

### DIFF
--- a/.github/workflows/native-binary-build-dlight.nativeexecution.yml
+++ b/.github/workflows/native-binary-build-dlight.nativeexecution.yml
@@ -72,7 +72,7 @@ jobs:
   source:
 
     name: Build Source Zip
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
 
@@ -104,7 +104,7 @@ jobs:
   build-linux:
 
     name: Build on Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: source
 
     steps:
@@ -227,7 +227,7 @@ jobs:
   build-zip-with-build-artifacts:
 
     name: Package Native Execution Libraries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Only run when the platform specific builds are finished
     needs: [build-linux, build-macos-x64, build-macos-arm]

--- a/.github/workflows/native-binary-build-launcher.yml
+++ b/.github/workflows/native-binary-build-launcher.yml
@@ -61,7 +61,7 @@ jobs:
   source:
 
     name: Package Sources
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
 
@@ -96,7 +96,7 @@ jobs:
   build-linux:
 
     name: Build with MinGW
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: source
 
     steps:
@@ -160,7 +160,7 @@ jobs:
   build-zip-with-build-artifacts:
 
     name: Package Binaries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Only run when the platform specific builds are finished
     needs: [build-linux]

--- a/.github/workflows/native-binary-build-lib.profiler.yml
+++ b/.github/workflows/native-binary-build-lib.profiler.yml
@@ -81,7 +81,7 @@ jobs:
   source:
 
     name: Build source zip
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
 
@@ -128,7 +128,7 @@ jobs:
   build-linux:
 
     name: Build on Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: source
     
     steps:
@@ -302,7 +302,7 @@ jobs:
   build-zip-with-build-artifacts:
 
     name: Package Profiler Libraries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Only run when the platform specific builds are finished
     needs: [build-linux, build-windows, build-macos]


### PR DESCRIPTION
gh supports the last two LTS versions, ubuntu 22 would be still supported for 2 years from today.

as discussed in https://github.com/apache/netbeans/pull/8009#issuecomment-2543870834

image list: https://github.com/actions/runner-images?tab=readme-ov-file#available-images