### PR TITLE
Prevent NPE

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImpl.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImpl.java
@@ -69,7 +69,9 @@ public class OccurrencesFinderImpl extends OccurrencesFinder {
     @Override
     public Map<OffsetRange, ColoringAttributes> getOccurrences() {
         // must not return null
-        return Collections.unmodifiableMap(range2Attribs);
+        return range2Attribs != null
+                ? Collections.unmodifiableMap(range2Attribs)
+                : Collections.emptyMap();
     }
 
     @Override


### PR DESCRIPTION
- Add `null` check because it may be `null` when the mark occurrences feature is canceled

My consideration was missing, sorry.