### PR TITLE
LSP/Textmate: Implement multiview support for generic/textmate based syntax support

### DIFF
--- a/ide/lsp.client/nbproject/project.xml
+++ b/ide/lsp.client/nbproject/project.xml
@@ -86,6 +86,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.core.multiview</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.71</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.libs.flexmark</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/options/GenericDataObject.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/options/GenericDataObject.java
@@ -20,9 +20,7 @@ package org.netbeans.modules.lsp.client.options;
 
 import java.awt.Image;
 import java.beans.PropertyVetoException;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
@@ -30,7 +28,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.imageio.ImageIO;
+import org.netbeans.core.spi.multiview.text.MultiViewEditorElement;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataLoaderPool;
@@ -41,7 +39,7 @@ import org.openide.loaders.MultiFileLoader;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
 import org.openide.util.Exceptions;
-import org.openide.util.ImageUtilities;
+import org.openide.util.Lookup;
 
 /**
  *
@@ -57,7 +55,7 @@ public class GenericDataObject extends MultiDataObject {
     public GenericDataObject(FileObject pf, MultiFileLoader loader) throws DataObjectExistsException, IOException {
         super(pf, loader);
         this.mimeType = FileUtil.getMIMEType(pf);
-        registerEditor(mimeType, false);
+        registerEditor(mimeType, true);
         synchronized (REGISTRY) {
             REGISTRY.add(new WeakReference<>(this));
         }
@@ -144,5 +142,8 @@ public class GenericDataObject extends MultiDataObject {
             }
         };
     }
-}
 
+    public static MultiViewEditorElement createEditor(Lookup lkp) {
+        return new MultiViewEditorElement(lkp);
+    }
+}

--- a/platform/openide.filesystems/src/org/openide/filesystems/MIMESupport.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/MIMESupport.java
@@ -254,8 +254,8 @@ final class MIMESupport extends Object {
                         try {
                             // For now, just assume it has the right DTD. Could check this if desired.
                             declmimes.add(MIMEResolverImpl.forDescriptor(f)); // NOI18N
-                        } catch (IOException ex) {
-                            Exceptions.printStackTrace(ex);
+                        } catch (IOException | IllegalArgumentException ex) {
+                            ERR.log(Level.INFO, "Failed to parse declarative MIMEResolver: " + f, ex);
                         }
                     }
                 }


### PR DESCRIPTION
Multiview support for example is utilized by per-file history:

![grafik](https://github.com/user-attachments/assets/086e04d5-7be5-4ffc-832f-97eeb647836d)

In the screenshot a C# file is opened with the CSharp grammar loaded and the history of the file can be also added.

Closes: #5204