### PR TITLE
Ensure left search results panel is always visible.

### DIFF
--- a/platform/api.search/src/org/netbeans/modules/search/ui/BasicReplaceResultsPanel.java
+++ b/platform/api.search/src/org/netbeans/modules/search/ui/BasicReplaceResultsPanel.java
@@ -109,9 +109,7 @@ public class BasicReplaceResultsPanel extends BasicAbstractResultsPanel {
 
     private void initSplitDividerLocationHandling() {
         int location = FindDialogMemory.getDefault().getReplaceResultsDivider();
-        if (location > 0) {
-            splitPane.setDividerLocation(location);
-        }
+        splitPane.setDividerLocation(Math.max(location, 250));
         splitPane.addPropertyChangeListener((PropertyChangeEvent evt) -> {
             String pn = evt.getPropertyName();
             if (pn.equals(JSplitPane.DIVIDER_LOCATION_PROPERTY)) {

--- a/platform/api.search/src/org/netbeans/modules/search/ui/BasicReplaceResultsPanel.java
+++ b/platform/api.search/src/org/netbeans/modules/search/ui/BasicReplaceResultsPanel.java
@@ -22,17 +22,14 @@ import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import javax.swing.AbstractButton;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JPanel;
-import javax.swing.JSplitPane;
 import org.netbeans.modules.search.BasicComposition;
-import org.netbeans.modules.search.ContextView;
-import org.netbeans.modules.search.FindDialogMemory;
 import org.netbeans.modules.search.Manager;
 import org.netbeans.modules.search.ReplaceTask;
 import org.netbeans.modules.search.ResultModel;
@@ -43,55 +40,44 @@ import org.openide.nodes.Children;
 import org.openide.nodes.Node;
 import org.openide.util.Mutex;
 import org.openide.util.NbBundle;
-import org.openide.util.RequestProcessor;
 
 /**
  *
  * @author jhavlin
  */
-public class BasicReplaceResultsPanel extends BasicAbstractResultsPanel {
+public class BasicReplaceResultsPanel extends BasicSearchResultsPanel {
 
-    private static final RequestProcessor RP =
-            new RequestProcessor(BasicReplaceResultsPanel.class.getName());
-    private final RequestProcessor.Task SAVE_TASK = RP.create(new SaveTask());
     private JButton replaceButton;
-    private JSplitPane splitPane;
 
-    public BasicReplaceResultsPanel(ResultModel resultModel,
-            BasicComposition composition, Node infoNode) {
-        super(resultModel, composition, true,
-                new ResultsOutlineSupport(true, true, resultModel, composition,
-                infoNode));
-        init();
+    public BasicReplaceResultsPanel(ResultModel resultModel, BasicComposition composition, Node infoNode) {
+        super(resultModel, composition, true, 
+                new ResultsOutlineSupport(true, true, resultModel, composition, infoNode));
     }
 
-    private void init() {
-        JPanel leftPanel = new JPanel();
+    @Override
+    protected JComponent createLeftComponent() {
         replaceButton = new JButton();
         replaceButton.addActionListener((ActionEvent e) -> replace());
-        updateReplaceButton();
-        leftPanel.setLayout(new BoxLayout(leftPanel, BoxLayout.PAGE_AXIS));
-        JPanel buttonPanel = new JPanel();
-        buttonPanel.setLayout(new FlowLayout(FlowLayout.LEADING, 2, 1));
-        buttonPanel.add(replaceButton);
         replaceButton.setMaximumSize(replaceButton.getPreferredSize());
-        buttonPanel.setMaximumSize(new Dimension( // #225246
-                (int) buttonPanel.getMaximumSize().getWidth(),
-                (int) buttonPanel.getPreferredSize().getHeight()));
-        leftPanel.add(resultsOutlineSupport.getOutlineView());
-        leftPanel.add(buttonPanel);
-
-        this.splitPane = new JSplitPane();
-        splitPane.setLeftComponent(leftPanel);
-        splitPane.setRightComponent(new ContextView(resultModel,
-                getExplorerManager()));
-        initSplitDividerLocationHandling();
-
-        getContentPanel().add(splitPane);
-        initResultModelListener();
         replaceButton.getAccessibleContext().setAccessibleDescription(
                 NbBundle.getMessage(ResultView.class,
                 "ACS_TEXT_BUTTON_REPLACE"));                            //NOI18N
+        updateReplaceButton();
+
+        JPanel buttonPanel = new JPanel();
+        buttonPanel.setLayout(new FlowLayout(FlowLayout.LEADING, 2, 1));
+        buttonPanel.add(replaceButton);
+        buttonPanel.setMaximumSize(new Dimension( // #225246
+                (int) buttonPanel.getMaximumSize().getWidth(),
+                (int) buttonPanel.getPreferredSize().getHeight()));
+
+        JPanel leftPanel = new JPanel();
+        leftPanel.setLayout(new BoxLayout(leftPanel, BoxLayout.PAGE_AXIS));
+        leftPanel.add(resultsOutlineSupport.getOutlineView());
+        leftPanel.add(buttonPanel);
+        
+        initResultModelListener();
+        return leftPanel;
     }
 
     private void replace() {
@@ -105,17 +91,6 @@ public class BasicReplaceResultsPanel extends BasicAbstractResultsPanel {
 
     private void initResultModelListener() {
         resultModel.addPropertyChangeListener(new ModelListener());
-    }
-
-    private void initSplitDividerLocationHandling() {
-        int location = FindDialogMemory.getDefault().getReplaceResultsDivider();
-        splitPane.setDividerLocation(Math.max(location, 250));
-        splitPane.addPropertyChangeListener((PropertyChangeEvent evt) -> {
-            String pn = evt.getPropertyName();
-            if (pn.equals(JSplitPane.DIVIDER_LOCATION_PROPERTY)) {
-                SAVE_TASK.schedule(1000);
-            }
-        });
     }
 
     @Override
@@ -224,14 +199,4 @@ public class BasicReplaceResultsPanel extends BasicAbstractResultsPanel {
         });
     }
 
-    private class SaveTask implements Runnable {
-
-        @Override
-        public void run() {
-            if (splitPane != null) {
-                FindDialogMemory.getDefault().setReplaceResultsDivider(
-                        splitPane.getDividerLocation());
-            }
-        }
-    }
 }

--- a/platform/api.search/src/org/netbeans/modules/search/ui/BasicSearchResultsPanel.java
+++ b/platform/api.search/src/org/netbeans/modules/search/ui/BasicSearchResultsPanel.java
@@ -46,24 +46,17 @@ public class BasicSearchResultsPanel extends BasicAbstractResultsPanel {
     }
 
     private void init() {
-        JPanel leftPanel = new JPanel();
-        leftPanel.setLayout(new BoxLayout(leftPanel, BoxLayout.PAGE_AXIS));
-        leftPanel.add(resultsOutlineSupport.getOutlineView());
-
-        this.splitPane = new JSplitPane();
-        splitPane.setLeftComponent(leftPanel);
-        splitPane.setRightComponent(new ContextView(resultModel,
-                getExplorerManager()));
+        splitPane = new JSplitPane();
+        splitPane.setLeftComponent(resultsOutlineSupport.getOutlineView());
+        splitPane.setRightComponent(new ContextView(resultModel, getExplorerManager()));
         initSplitDividerLocationHandling();
         getContentPanel().add(splitPane);
     }
 
     private void initSplitDividerLocationHandling() {
         int location = FindDialogMemory.getDefault().getReplaceResultsDivider();
-        if (location > 0) {
-            splitPane.setDividerLocation(location);
-        }
-        splitPane.addPropertyChangeListener((PropertyChangeEvent evt) -> {
+        splitPane.setDividerLocation(Math.max(location, 250));
+        splitPane.addPropertyChangeListener(evt -> {
             String pn = evt.getPropertyName();
             if (pn.equals(JSplitPane.DIVIDER_LOCATION_PROPERTY)) {
                 SAVE_TASK.schedule(1000);


### PR DESCRIPTION
initialize divider position with a minimal value. This will always reset the value to at least 250 even if it is changed by the user to less.

fixes #8064

I could reproduce this sometimes with
 - fresh user conf (no divider location stored)
 - search something in an empty folder (e.g favorites view; ensures that the search finishes fast with no results)

I believe what happens in this case is that the divider isn't initialized (which is fine by itself) but the computed width of the left panel is 0 for some reason too (which is not ok).