### PR TITLE
[Groovy] Prevent NPE for mark occurrences

### DIFF
--- a/groovy/groovy.editor/nbproject/project.properties
+++ b/groovy/groovy.editor/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/MarkOccurrencesHighlighter.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/MarkOccurrencesHighlighter.java
@@ -146,6 +146,14 @@ public final class MarkOccurrencesHighlighter extends ParserResultTask<ParserRes
 
         Map<OffsetRange, ColoringAttributes> highlights = finder.getOccurrences();
 
+        // Many implementatios of the OccurencesFinder don't follow the contract,
+        // that getOccurrences must not return null. Instead of blowing up with
+        // a NullPointer exception, log that problem and continue execution.
+        if (highlights == null) {
+            LOG.log(Level.WARNING, "org.netbeans.modules.csl.api.OccurrencesFinder.getOccurrences() non-null contract violation by {0}", language.getMimeType());
+            highlights = Map.of();
+        }
+
         return List.copyOf(highlights.keySet());
     }
     


### PR DESCRIPTION
- Update OccurrencesFinder for Groovy to honor contract to not return null for `getOccurences`
- Don't raise a `NullPointerException` after PR #8028, but log warning