### PR TITLE
Better change tracking for Semantic highlighting for CSL

### DIFF
--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/ColoringManager.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/ColoringManager.java
@@ -34,8 +34,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.text.AttributeSet;
-import javax.swing.text.Document;
-import javax.swing.text.JTextComponent;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.editor.mimelookup.MimePath;
@@ -64,10 +62,6 @@ import org.openide.util.NbBundle;
 public final class ColoringManager {
     private final String mimeType;
     private final Map<Set<ColoringAttributes>, String> type2Coloring;
-    
-    //private static final Font ITALIC = SettingsDefaults.defaultFont.deriveFont(Font.ITALIC);
-    //private static final Font BOLD = SettingsDefaults.defaultFont.deriveFont(Font.BOLD);
-
     
     public ColoringManager(String mimeType) {
         this.mimeType = mimeType;
@@ -159,11 +153,9 @@ public final class ColoringManager {
         es.addAll(colorings);
         
         if (colorings.contains(UNUSED)) {
-            attribs.add(AttributesUtilities.createImmutable(EditorStyleConstants.Tooltip, new UnusedTooltipResolver()));
+            attribs.add(AttributesUtilities.createImmutable(EditorStyleConstants.Tooltip, UNUSED_TOOLTIP_RESOLVER));
             attribs.add(AttributesUtilities.createImmutable("unused-browseable", Boolean.TRUE));
         }
-        
-        //colorings = colorings.size() > 0 ? EnumSet.copyOf(colorings) : EnumSet.noneOf(ColoringAttributes.class);
         
         for (Entry<Set<ColoringAttributes>, String> attribs2Colorings : type2Coloring.entrySet()) {
             if (es.containsAll(attribs2Colorings.getKey())) {
@@ -204,12 +196,8 @@ public final class ColoringManager {
         
         return AttributesUtilities.createImmutable(attrs.toArray());
     }
-    
-    private final class UnusedTooltipResolver implements HighlightAttributeValue<String> {
 
-        @Override
-        public String getValue(JTextComponent component, Document document, Object attributeKey, int startOffset, final int endOffset) {
-            return NbBundle.getMessage(ColoringManager.class, "LBL_UNUSED");
-        }
-    }
+    private static final HighlightAttributeValue<String> UNUSED_TOOLTIP_RESOLVER =
+            (component, document, attributeKey, startOffset, endOffset) -> NbBundle.getMessage(ColoringManager.class, "LBL_UNUSED");
+
 }

--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/GsfSemanticLayer.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/GsfSemanticLayer.java
@@ -26,15 +26,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.Document;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.editor.mimelookup.MimePath;
 import org.netbeans.api.editor.settings.FontColorSettings;
-import org.netbeans.lib.editor.util.swing.DocumentListenerPriority;
-import org.netbeans.lib.editor.util.swing.DocumentUtilities;
 import org.netbeans.modules.csl.core.Language;
 import org.netbeans.modules.csl.api.ColoringAttributes.Coloring;
 import org.netbeans.spi.editor.highlighting.HighlightsSequence;
@@ -49,10 +45,9 @@ import org.openide.util.WeakListeners;
  * 
  * @author Tor Norbye
  */
-public final class GsfSemanticLayer extends AbstractHighlightsContainer implements DocumentListener {
+public final class GsfSemanticLayer extends AbstractHighlightsContainer {
     
     private List<SequenceElement> colorings = List.of();
-    private List<Edit> edits;
     private final Map<Language,Map<Coloring, AttributeSet>> cache = new HashMap<>();
     private final Document doc;
 
@@ -81,12 +76,8 @@ public final class GsfSemanticLayer extends AbstractHighlightsContainer implemen
         doc.render(() -> {
             synchronized (GsfSemanticLayer.this) {
                 GsfSemanticLayer.this.colorings = List.copyOf(colorings);
-                GsfSemanticLayer.this.edits = new ArrayList<>();
 
                 fireHighlightsChange(0, doc.getLength()); //XXX: locking
-                
-                DocumentUtilities.removeDocumentListener(doc, GsfSemanticLayer.this, DocumentListenerPriority.LEXER);
-                DocumentUtilities.addDocumentListener(doc, GsfSemanticLayer.this, DocumentListenerPriority.LEXER);
             }
         });
     }
@@ -131,56 +122,7 @@ public final class GsfSemanticLayer extends AbstractHighlightsContainer implemen
         );
         coloringListeners.add(l);
     }
-
-    @Override
-    public void insertUpdate(DocumentEvent e) {
-        synchronized (GsfSemanticLayer.this) {
-            edits.add(new Edit(e.getOffset(), e.getLength(), true));
-        }
-    }
-
-    @Override
-    public void removeUpdate(DocumentEvent e) {
-        synchronized (GsfSemanticLayer.this) {
-            edits.add(new Edit(e.getOffset(), e.getLength(), false));
-        }
-    }
-
-    @Override
-    public void changedUpdate(DocumentEvent e) {
-    }
-    
-    // Compute an adjusted offset
-    public int getShiftedPos(int pos) {
-        int ret = pos;
-
-        for (Edit edit: edits) {
-            if (ret > edit.offset()) {
-                if (edit.insert()) {
-                    ret += edit.len();
-                } else if (ret < edit.offset() + edit.len()) {
-                    ret = edit.offset();
-                } else {
-                    ret -= edit.len();
-                }
-            }
-        }
-        return ret;
-    }
-    
-    /**
-     * An Edit is a modification (insert/remove) we've been notified about from the document
-     * since the last time we updated our "colorings" object.
-     * The list of Edits lets me quickly compute the current position of an original
-     * position in the "colorings" object. This is typically going to involve only a couple
-     * of edits (since the colorings object is updated as soon as the user stops typing).
-     * This is probably going to be more efficient than updating all the colorings offsets
-     * every time the document is updated, since the colorings object can contain thousands
-     * of ranges (e.g. for every highlight in the whole document) whereas asking for the
-     * current positions is typically only done for the highlights visible on the screen.
-     */
-    private record Edit(int offset, int len, boolean insert) {}
-    
+ 
     /**
      * An implementation of a HighlightsSequence which can show OffsetRange
      * sections and keep them up to date during edits.
@@ -197,18 +139,27 @@ public final class GsfSemanticLayer extends AbstractHighlightsContainer implemen
 
         @Override
         public boolean moveNext() {
-            element = iterator.hasNext() ? iterator.next() : null;
-            return element != null;
+            while (iterator.hasNext()) {
+                SequenceElement i = iterator.next();
+                // Skip empty highlights, the editor can handle them, though not happy about it
+                // this could happen on deleting large portion of code
+                if (i.start().getOffset() != i.end().getOffset()) {
+                    element = i;
+                    return true;
+                }
+            }
+            element = null;
+            return false;
         }
 
         @Override
         public int getStartOffset() {
-            return getShiftedPos(element.range().getStart());
+            return element.start().getOffset();
         }
 
         @Override
         public int getEndOffset() {
-            return getShiftedPos(element.range().getEnd());
+            return element.end().getOffset();
         }
 
         @Override
@@ -233,7 +184,7 @@ public final class GsfSemanticLayer extends AbstractHighlightsContainer implemen
         while (low <= high) {
             int mid = (low + high) >>> 1;
             SequenceElement midVal = l.get(mid);
-            int cmp = midVal.range().getStart() - offset;
+            int cmp = midVal.start().getOffset() - offset;
 
             if (cmp == 0) {
                 return mid;

--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/HighlightsLayerFactoryImpl.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/HighlightsLayerFactoryImpl.java
@@ -44,7 +44,6 @@ public class HighlightsLayerFactoryImpl implements HighlightsLayerFactory {
         
         return new HighlightsLayer[] {
             HighlightsLayer.create(SemanticHighlighter.class.getName() + "-1", ZOrder.SYNTAX_RACK.forPosition(1000), false, semantic),
-//            HighlightsLayer.create(SemanticHighlighter.class.getName() + "-2", ZOrder.SYNTAX_RACK.forPosition(1500), false, SemanticHighlighter.getImportHighlightsBag(context.getDocument())),
             //the mark occurrences layer should be "above" current row and "below" the search layers:
             HighlightsLayer.create(MarkOccurrencesHighlighter.class.getName(), ZOrder.CARET_RACK.forPosition(50), false, occurrences),
             //"above" mark occurrences, "below" search layers:

--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/MarkOccurrencesHighlighter.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/MarkOccurrencesHighlighter.java
@@ -25,6 +25,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.modules.csl.api.OffsetRange;
@@ -116,10 +117,13 @@ public final class MarkOccurrencesHighlighter extends ParserResultTask<ParserRes
             GsfSemanticLayer layer = GsfSemanticLayer.getLayer(MarkOccurrencesHighlighter.class, doc);
             SortedSet seqs = new TreeSet<SequenceElement>();
 
-            bag.stream()
-                    .filter(range -> range != OffsetRange.NONE)
-                    .forEach(range -> seqs.add(new SequenceElement(language, range, MO)));
-        
+            for (OffsetRange range : bag) {
+                if (range != OffsetRange.NONE) {
+                    try {
+                        seqs.add(new SequenceElement(language, doc.createPosition(range.getStart()), doc.createPosition(range.getEnd()), MO));
+                    } catch (BadLocationException ex) {}
+                }
+            }
             layer.setColorings(seqs);
 
             OccurrencesMarkProvider.get(doc).setOccurrences(OccurrencesMarkProvider.createMarks(doc, bag, ES_COLOR, NbBundle.getMessage(MarkOccurrencesHighlighter.class, "LBL_ES_TOOLTIP")));

--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/SequenceElement.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/SequenceElement.java
@@ -19,9 +19,10 @@
 
 package org.netbeans.modules.csl.editor.semantic;
 
+import java.util.Comparator;
+import javax.swing.text.Position;
 import org.netbeans.modules.csl.core.Language;
 import org.netbeans.modules.csl.api.ColoringAttributes.Coloring;
-import org.netbeans.modules.csl.api.OffsetRange;
 
 /**
  * Each SequeneceElement represents a OffsetRange/Coloring/Language tuple that
@@ -30,24 +31,9 @@ import org.netbeans.modules.csl.api.OffsetRange;
  *
  * @author Tor Norbye
  */
-record SequenceElement(Language language, OffsetRange range, Coloring coloring) implements Comparable<SequenceElement> {
+record SequenceElement(Language language, Position start, Position end, Coloring coloring) {
 
-    @Override
-    public int compareTo(SequenceElement o) {
-        assert o.range() != null;
-        return range.compareTo(o.range());
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof SequenceElement other) {
-            return range.equals(other.range());
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        return range.hashCode();
-    }
+    public static final Comparator<? super SequenceElement> POSITION_ORDER =
+            (e1, e2) -> e1.start.getOffset() != e2.start.getOffset() ? e1.start.getOffset() - e2.start.getOffset()
+                : e1.end.getOffset() - e2.end.getOffset();
 }


### PR DESCRIPTION
Instead of tracking changes in a series of `Edit` records between parsing there could be Document `Position`  used, which automatically track the offset changes in the edited document.

This version further simplifies the highlighter.

Also resolves a minor issue, that would not extend the previous highlight when the new text is just appended after a whole token. 

Before:
[Screencast From 2024-12-29 15-53-25.webm](https://github.com/user-attachments/assets/489e6cff-7b16-4aa8-9576-d32955284ab4)

After:
[Screencast From 2024-12-29 15-50-57.webm](https://github.com/user-attachments/assets/3351505d-a1df-4aa9-8096-aaa869a2708f)


This may have better performance as well. There was some minor flickering on highlights when the edit list grew "large" (basically that needed a lot of monkey style keyboard clamping, to be noticeable)

I have a minor aversion to put Position which is a mutable thing info the `SequenceElement`record, though it is used  to grouping data together, also changes in the document, shall not change the order of the instances when put in a collection, so I could live with that. Please tell me if you have something better in mind. 
