### PR TITLE
update formatter to handle record closing braces correctly

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
@@ -947,7 +947,7 @@ public class Reformatter implements ReformatTask {
                     }
                     List<? extends Tree> perms = node.getPermitsClause();
                     if (perms != null && !perms.isEmpty()) {
-                        wrapToken(cs.wrapExtendsImplementsKeyword(), 1, EXTENDS); 
+                        wrapToken(cs.wrapExtendsImplementsKeyword(), 1, EXTENDS);
                         wrapList(cs.wrapExtendsImplementsList(), cs.alignMultilineImplements(), true, COMMA, perms);
                     }
                 } finally {
@@ -1352,6 +1352,7 @@ public class Reformatter implements ReformatTask {
                 if (!recParams.isEmpty()) {
                     spaces(cs.spaceWithinMethodDeclParens() ? 1 : 0, true);
                     wrapList(cs.wrapMethodParams(), cs.alignMultilineMethodParams(), false, COMMA, recParams);
+                    spaces(cs.spaceWithinMethodDeclParens() ? 1 : 0, true); // solves #7403
                 }
                 accept(RPAREN);
                 List<? extends Tree> impls = node.getImplementsClause();
@@ -1398,8 +1399,6 @@ public class Reformatter implements ReformatTask {
                                 isFirstMember = false;
                             }
                         }
-
-                        spaces(cs.spaceWithinMethodDeclParens() ? 1 : 0, true);
                     }
                 } finally {
                     indent = oldIndent;
@@ -5425,7 +5424,7 @@ public class Reformatter implements ReformatTask {
         }
 
         /**
-         * 
+         *
          * @see <a href="https://docs.oracle.com/en/java/javase/22/docs/specs/javadoc/doc-comment-spec.html#Where%20Tags%20Can%20Be%20Used">for more info on inline tags check documentation here.</a>
          * @return returns true if has inline tag prefix like "{+@tagname"
          */

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
@@ -3525,9 +3525,9 @@ public class FormatingTest extends NbTestCase {
 
     public void testAnnotatedRecord() throws Exception {
         try {
-            SourceVersion.valueOf("RELEASE_19"); //NOI18N
+            SourceVersion.valueOf("RELEASE_17"); //NOI18N
         } catch (IllegalArgumentException ex) {
-            //OK, no RELEASE_19, skip test
+            //OK, no RELEASE_17, skip test
             return;
         }
         testFile = new File(getWorkDir(), "Test.java");
@@ -6683,6 +6683,61 @@ public class FormatingTest extends NbTestCase {
                 + "}\n";
         reformat(doc, content, golden);
     }
+
+    // verify closing '}' position during record formatting
+    public void testRecordClosingBrace7043() throws Exception {
+        try {
+            SourceVersion.valueOf("RELEASE_17"); //NOI18N
+        } catch (IllegalArgumentException ex) {
+            //OK, no RELEASE_17, skip test
+            return;
+        }
+        sourceLevel = "17";
+        JavacParser.DISABLE_SOURCE_LEVEL_DOWNGRADE = true;
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile, "");
+        FileObject testSourceFO = FileUtil.toFileObject(testFile);
+        DataObject testSourceDO = DataObject.find(testSourceFO);
+        EditorCookie ec = (EditorCookie) testSourceDO.getCookie(EditorCookie.class);
+        final Document doc = ec.openDocument();
+        doc.putProperty(Language.class, JavaTokenId.language());
+        
+        Preferences preferences = MimeLookup.getLookup(JavaTokenId.language().mimeType()).lookup(Preferences.class);
+        preferences.putBoolean("spaceWithinMethodDeclParens", true);
+        preferences.putInt("blankLinesAfterClassHeader", 0);
+
+        String content ="""
+                        package test;
+                        record Student(int id,String lastname,String firstname) implements Serializable {
+                        int m(int x){ 
+                        return id+x;
+                        }
+                        } // should stay flush to left margin
+                        """;
+        String golden = """
+                        package test;
+
+                        record Student( int id, String lastname, String firstname ) implements Serializable {
+                            int m( int x ) {
+                                return id + x;
+                            }
+                        } // should stay flush to left margin
+                        """;
+        reformat(doc, content, golden);
+
+        preferences.putBoolean("spaceWithinMethodDeclParens", false);
+        golden =        """
+                        package test;
+
+                        record Student(int id, String lastname, String firstname) implements Serializable {
+                            int m(int x) {
+                                return id + x;
+                            }
+                        } // should stay flush to left margin
+                        """;
+        reformat(doc, content, golden);
+    }
+    
     @ServiceProvider(service = CompilerOptionsQueryImplementation.class, position = 100)
     public static class TestCompilerOptionsQueryImplementation implements CompilerOptionsQueryImplementation {
 

--- a/java/java.source/src/org/netbeans/modules/java/ui/Bundle.properties
+++ b/java/java.source/src/org/netbeans/modules/java/ui/Bundle.properties
@@ -497,6 +497,10 @@ default\:\
 public int add(int a, int b) {\
     return a + b;\
 }\
+public record ARecord(String name, int age){\
+}\
+}\
+record TopLevelRecord(String name, double value){\
 }
 
 #do not translate


### PR DESCRIPTION
alternative to https://github.com/apache/netbeans/pull/8101 contributed by @homberghp, 

rebased and moves the new regression test to `FormattingTest`.

 - adds tests to show the error
 - adds inner and outer record in ui template text for setting java format spaces
 - solves the error by moving `spaces(cs.spaceWithinMethodDeclParens() ? 1 : 0, true);`  to the correct place.

fixes #7043