### PR TITLE
Avoid remaining trivial uses of new ImageIcon(Image), for HiDPI icons

### DIFF
--- a/contrib/groovy.grailsproject/src/org/netbeans/modules/groovy/grailsproject/GrailsProject.java
+++ b/contrib/groovy.grailsproject/src/org/netbeans/modules/groovy/grailsproject/GrailsProject.java
@@ -158,8 +158,7 @@ public final class GrailsProject implements Project {
 
         @Override
         public Icon getIcon() {
-            Image image = ImageUtilities.loadImage(GrailsConstants.GRAILS_ICON_16x16);
-            return image == null ? null : new ImageIcon(image);
+            return ImageUtilities.loadIcon(GrailsConstants.GRAILS_ICON_16x16);
         }
 
         @Override

--- a/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/ui/LogicalViewNode.java
+++ b/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/ui/LogicalViewNode.java
@@ -78,8 +78,8 @@ public final class LogicalViewNode extends AbstractNode {
     static synchronized Icon getFolderIcon (boolean opened) {
         if (openedFolderIconCache == null) {
             Node n = DataFolder.findFolder(FileUtil.getConfigRoot()).getNodeDelegate();
-            openedFolderIconCache = new ImageIcon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
-            folderIconCache = new ImageIcon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
+            openedFolderIconCache = ImageUtilities.image2Icon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
+            folderIconCache = ImageUtilities.image2Icon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
         }
         if (opened) {
             return openedFolderIconCache;

--- a/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/ddloaders/multiview/CustomSectionNodePanel.java
+++ b/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/ddloaders/multiview/CustomSectionNodePanel.java
@@ -41,8 +41,7 @@ public class CustomSectionNodePanel extends SectionNodePanel {
     }
     
     public void setTitleIcon(String iconBase) {
-        Image iconImage = ImageUtilities.loadImage(iconBase, true);
-        getTitleButton().setIcon(iconImage != null ? new ImageIcon(iconImage) : null);
+        getTitleButton().setIcon(ImageUtilities.loadImageIcon(iconBase, true));
     }
 
 //    @Override

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ChangelogWildflyPlugin.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/ChangelogWildflyPlugin.java
@@ -23,7 +23,6 @@ import java.util.MissingResourceException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.Preferences;
-import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import org.openide.awt.NotificationDisplayer;
 import org.openide.awt.NotificationDisplayer.Category;
@@ -44,7 +43,7 @@ public class ChangelogWildflyPlugin {
             int version = Integer.parseInt(NbBundle.getMessage(ChangelogWildflyPlugin.class, VERSION_PREF));
             if (prefs.getInt(VERSION_PREF, 5) < version) {
                 NotificationDisplayer.getDefault().notify(NbBundle.getMessage(ChangelogWildflyPlugin.class, "MSG_CHANGES_TITLE"),
-                        new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/javaee/wildfly/resources/wildfly.png")),
+                        ImageUtilities.loadImageIcon("org/netbeans/modules/javaee/wildfly/resources/wildfly.png", false),
                         new JLabel(NbBundle.getMessage(ChangelogWildflyPlugin.class, "MSG_CHANGES_SUMMARY")),
                         new JLabel(NbBundle.getMessage(ChangelogWildflyPlugin.class, "MSG_CHANGES_DESC")),
                         NotificationDisplayer.Priority.NORMAL, Category.INFO);

--- a/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/nodes/JaxWsClientRootNode.java
+++ b/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/nodes/JaxWsClientRootNode.java
@@ -78,8 +78,8 @@ public class JaxWsClientRootNode extends AbstractNode {
     private Icon getFolderIcon (boolean opened) {
         if (openedFolderIconCache == null) {
             Node n = DataFolder.findFolder(FileUtil.getConfigRoot()).getNodeDelegate();
-            openedFolderIconCache = new ImageIcon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
-            folderIconCache = new ImageIcon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
+            openedFolderIconCache = ImageUtilities.image2Icon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
+            folderIconCache = ImageUtilities.image2Icon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
         }
         if (opened) {
             return openedFolderIconCache;

--- a/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/nodes/JaxWsRootNode.java
+++ b/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/nodes/JaxWsRootNode.java
@@ -78,8 +78,8 @@ public class JaxWsRootNode extends AbstractNode {
     private Icon getFolderIcon (boolean opened) {
         if (openedFolderIconCache == null) {
             Node n = DataFolder.findFolder(FileUtil.getConfigRoot()).getNodeDelegate();
-            openedFolderIconCache = new ImageIcon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
-            folderIconCache = new ImageIcon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
+            openedFolderIconCache = ImageUtilities.image2Icon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
+            folderIconCache = ImageUtilities.image2Icon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
         }
         if (opened) {
             return openedFolderIconCache;

--- a/enterprise/web.jsf.navigation/src/org/netbeans/modules/web/jsf/navigation/PageFlowToolbarUtilities.java
+++ b/enterprise/web.jsf.navigation/src/org/netbeans/modules/web/jsf/navigation/PageFlowToolbarUtilities.java
@@ -28,7 +28,6 @@
 package org.netbeans.modules.web.jsf.navigation;
 
 import java.awt.Dimension;
-import java.awt.Image;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.MouseAdapter;
@@ -44,7 +43,7 @@ import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import javax.swing.ImageIcon;
+import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import org.openide.util.ImageUtilities;
@@ -194,7 +193,7 @@ public class PageFlowToolbarUtilities {
         scopeBox = comboBox;
         return comboBox;
     }
-    private static final Image LAYOUT_ICON = ImageUtilities.loadImage("org/netbeans/modules/web/jsf/navigation/resources/navigation.gif"); // NOI18N
+    private static final Icon LAYOUT_ICON = ImageUtilities.loadIcon("org/netbeans/modules/web/jsf/navigation/resources/navigation.gif"); // NOI18N
     private JButton layoutButton = null;
 
     /**
@@ -209,7 +208,7 @@ public class PageFlowToolbarUtilities {
             return layoutButton;
         }
 
-        layoutButton = new JButton(new ImageIcon(LAYOUT_ICON));
+        layoutButton = new JButton(LAYOUT_ICON);
         //Set the appropriate size of the combo box so it doesn't take up the whole page.
         //        Dimension prefSize = layoutButton.getPreferredSize();
         //        layoutButton.setMinimumSize(prefSize);

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/ProjectWebServiceNodeFactory.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/ProjectWebServiceNodeFactory.java
@@ -320,8 +320,8 @@ public class ProjectWebServiceNodeFactory implements NodeFactory {
         private Icon getFolderIcon(boolean opened) {
             if (openedFolderIconCache == null) {
                 Node n = DataFolder.findFolder(FileUtil.getConfigRoot()).getNodeDelegate();
-                openedFolderIconCache = new ImageIcon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
-                folderIconCache = new ImageIcon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
+                openedFolderIconCache = ImageUtilities.image2Icon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
+                folderIconCache = ImageUtilities.image2Icon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
             }
             if (opened) {
                 return openedFolderIconCache;

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/nodes/JaxWsClientRootNode.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/nodes/JaxWsClientRootNode.java
@@ -82,8 +82,8 @@ public class JaxWsClientRootNode extends AbstractNode {
     private Icon getFolderIcon (boolean opened) {
         if (openedFolderIconCache == null) {
             Node n = DataFolder.findFolder(FileUtil.getConfigRoot()).getNodeDelegate();
-            openedFolderIconCache = new ImageIcon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
-            folderIconCache = new ImageIcon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
+            openedFolderIconCache = ImageUtilities.image2Icon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
+            folderIconCache = ImageUtilities.image2Icon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
         }
         if (opened) {
             return openedFolderIconCache;

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/nodes/JaxWsRootNode.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/nodes/JaxWsRootNode.java
@@ -95,8 +95,8 @@ public class JaxWsRootNode extends AbstractNode implements PropertyChangeListene
     private Icon getFolderIcon (boolean opened) {
         if (openedFolderIconCache == null) {
             Node n = DataFolder.findFolder(FileUtil.getConfigRoot()).getNodeDelegate();
-            openedFolderIconCache = new ImageIcon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
-            folderIconCache = new ImageIcon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
+            openedFolderIconCache = ImageUtilities.image2Icon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
+            folderIconCache = ImageUtilities.image2Icon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
         }
         if (opened) {
             return openedFolderIconCache;

--- a/enterprise/websvc.design/src/org/netbeans/modules/websvc/design/view/ZoomManager.java
+++ b/enterprise/websvc.design/src/org/netbeans/modules/websvc/design/view/ZoomManager.java
@@ -20,7 +20,6 @@
 package org.netbeans.modules.websvc.design.view;
 
 import java.awt.Dimension;
-import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
@@ -30,7 +29,7 @@ import java.util.EventObject;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.DefaultComboBoxModel;
-import javax.swing.ImageIcon;
+import javax.swing.Icon;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JScrollPane;
@@ -41,7 +40,6 @@ import javax.swing.event.EventListenerList;
 import org.netbeans.api.visual.widget.Scene;
 import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
-import org.openide.util.Utilities;
 
 /**
  * Manages the zoom level for a particular Scene instance.
@@ -497,9 +495,9 @@ public class ZoomManager {
             this.manager = manager;
             String path = NbBundle.getMessage(FitDiagramAction.class,
                     "IMG_FitDiagramAction");
-            Image img = ImageUtilities.loadImage(path);
-            if (img != null) {
-                putValue(Action.SMALL_ICON, new ImageIcon(img));
+            Icon icon = ImageUtilities.loadIcon(path);
+            if (icon != null) {
+                putValue(Action.SMALL_ICON, icon);
             }
             String desc = NbBundle.getMessage(FitDiagramAction.class,
                     "LBL_FitDiagramAction");
@@ -543,9 +541,9 @@ public class ZoomManager {
             this.manager = manager;
             String path = NbBundle.getMessage(FitWidthAction.class,
                     "IMG_FitWidthAction");
-            Image img = ImageUtilities.loadImage(path);
-            if (img != null) {
-                putValue(Action.SMALL_ICON, new ImageIcon(img));
+            Icon icon = ImageUtilities.loadIcon(path);
+            if (icon != null) {
+                putValue(Action.SMALL_ICON, icon);
             }
             String desc = NbBundle.getMessage(FitWidthAction.class,
                     "LBL_FitWidthAction");
@@ -586,9 +584,9 @@ public class ZoomManager {
             this.manager = manager;
             String path = NbBundle.getMessage(ZoomDefaultAction.class,
                     "IMG_ZoomDefaultAction");
-            Image img = ImageUtilities.loadImage(path);
-            if (img != null) {
-                putValue(Action.SMALL_ICON, new ImageIcon(img));
+            Icon icon = ImageUtilities.loadIcon(path);
+            if (icon != null) {
+                putValue(Action.SMALL_ICON, icon);
             }
             String desc = NbBundle.getMessage(ZoomDefaultAction.class,
                     "LBL_ZoomDefaultAction");
@@ -618,9 +616,9 @@ public class ZoomManager {
             this.manager = manager;
             String path = NbBundle.getMessage(ZoomInAction.class,
                     "IMG_ZoomInAction");
-            Image img = ImageUtilities.loadImage(path);
-            if (img != null) {
-                putValue(Action.SMALL_ICON, new ImageIcon(img));
+            Icon icon = ImageUtilities.loadIcon(path);
+            if (icon != null) {
+                putValue(Action.SMALL_ICON, icon);
             }
             String desc = NbBundle.getMessage(ZoomInAction.class,
                     "LBL_ZoomInAction");
@@ -657,9 +655,9 @@ public class ZoomManager {
             this.manager = manager;
             String path = NbBundle.getMessage(ZoomOutAction.class,
                     "IMG_ZoomOutAction");
-            Image img = ImageUtilities.loadImage(path);
-            if (img != null) {
-                putValue(Action.SMALL_ICON, new ImageIcon(img));
+            Icon icon = ImageUtilities.loadIcon(path);
+            if (icon != null) {
+                putValue(Action.SMALL_ICON, icon);
             }
             String desc = NbBundle.getMessage(ZoomOutAction.class,
                     "LBL_ZoomOutAction");

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/nodes/HttpMethodsNode.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/nodes/HttpMethodsNode.java
@@ -67,8 +67,8 @@ public class HttpMethodsNode extends AbstractNode {
     static synchronized Icon getFolderIcon (boolean opened) {
         if (openedFolderIconCache == null) {
             Node n = DataFolder.findFolder(FileUtil.getConfigRoot()).getNodeDelegate();
-            openedFolderIconCache = new ImageIcon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
-            folderIconCache = new ImageIcon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
+            openedFolderIconCache = ImageUtilities.image2Icon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
+            folderIconCache = ImageUtilities.image2Icon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
         }
         if (opened) {
             return openedFolderIconCache;

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/nodes/RestServicesNode.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/nodes/RestServicesNode.java
@@ -73,8 +73,8 @@ public class RestServicesNode extends AbstractNode { //implements PropertyChange
     static synchronized Icon getFolderIcon(boolean opened) {
         if (openedFolderIconCache == null) {
             Node n = DataFolder.findFolder(FileUtil.getConfigRoot()).getNodeDelegate();
-            openedFolderIconCache = new ImageIcon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
-            folderIconCache = new ImageIcon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
+            openedFolderIconCache = ImageUtilities.image2Icon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
+            folderIconCache = ImageUtilities.image2Icon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
         }
         if (opened) {
             return openedFolderIconCache;

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/nodes/SubResourceLocatorsNode.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/nodes/SubResourceLocatorsNode.java
@@ -67,8 +67,8 @@ public class SubResourceLocatorsNode extends AbstractNode { //implements Propert
     static synchronized Icon getFolderIcon (boolean opened) {
         if (openedFolderIconCache == null) {
             Node n = DataFolder.findFolder(FileUtil.getConfigRoot()).getNodeDelegate();
-            openedFolderIconCache = new ImageIcon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
-            folderIconCache = new ImageIcon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
+            openedFolderIconCache = ImageUtilities.image2Icon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
+            folderIconCache = ImageUtilities.image2Icon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
         }
         if (opened) {
             return openedFolderIconCache;

--- a/groovy/groovy.refactoring/src/org/netbeans/modules/groovy/refactoring/ui/WhereUsedPanel.java
+++ b/groovy/groovy.refactoring/src/org/netbeans/modules/groovy/refactoring/ui/WhereUsedPanel.java
@@ -206,7 +206,7 @@ public class WhereUsedPanel extends JPanel implements CustomRefactoringPanel {
             } catch (DataObjectNotFoundException ex) {
             } // Not important, only for Icon.
             customScope = new JLabel(NbBundle.getMessage(WhereUsedPanel.class, "LBL_CustomScope"), pi.getIcon(), SwingConstants.LEFT); //NOI18N
-            currentFile = new JLabel(NbBundle.getMessage(WhereUsedPanel.class, "LBL_CurrentFile", fo.getNameExt()), currentFileDo != null ? new ImageIcon(currentFileDo.getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16)) : pi.getIcon(), SwingConstants.LEFT); //NOI18N
+            currentFile = new JLabel(NbBundle.getMessage(WhereUsedPanel.class, "LBL_CurrentFile", fo.getNameExt()), currentFileDo != null ? ImageUtilities.image2Icon(currentFileDo.getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16)) : pi.getIcon(), SwingConstants.LEFT); //NOI18N
             currentPackage = new JLabel(NbBundle.getMessage(WhereUsedPanel.class, "LBL_CurrentPackage", packageName), ImageUtilities.loadImageIcon(PACKAGE, false), SwingConstants.LEFT); //NOI18N
             currentProject = new JLabel(NbBundle.getMessage(WhereUsedPanel.class, "LBL_CurrentProject", pi.getDisplayName()), pi.getIcon(), SwingConstants.LEFT); //NOI18N
             allProjects = new JLabel(NbBundle.getMessage(WhereUsedPanel.class, "LBL_AllProjects"), pi.getIcon(), SwingConstants.LEFT); //NOI18N

--- a/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueTable.java
+++ b/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueTable.java
@@ -174,7 +174,7 @@ public class IssueTable implements MouseListener, AncestorListener, KeyListener,
         if (borderColor == null) borderColor = UIManager.getColor("controlShadow"); // NOI18N
         tableScrollPane.setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, borderColor));
 
-        ImageIcon ic = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/bugtracking/commons/resources/columns_16.png", true)); // NOI18N
+        ImageIcon ic = ImageUtilities.loadImageIcon("org/netbeans/modules/bugtracking/commons/resources/columns_16.png", true); // NOI18N
         colsButton = new javax.swing.JButton(ic);
         colsButton.getAccessibleContext().setAccessibleName(NbBundle.getMessage(TreeTableView.class, "ACN_ColumnsSelector")); //NOI18N
         colsButton.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(TreeTableView.class, "ACD_ColumnsSelector")); //NOI18N

--- a/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/QueryTableCellRenderer.java
+++ b/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/QueryTableCellRenderer.java
@@ -54,7 +54,7 @@ public class QueryTableCellRenderer extends DefaultTableCellRenderer {
     private final IssueTable issueTable;
 
     private static final int VISIBLE_START_CHARS = 0;
-    private static final Icon seenValueIcon = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/bugtracking/commons/resources/seen-value.png")); // NOI18N
+    private static final Icon seenValueIcon = ImageUtilities.loadIcon("org/netbeans/modules/bugtracking/commons/resources/seen-value.png"); // NOI18N
 
     private static final MessageFormat issueNewFormat       = getFormat("issueNewFormat", UIUtils.getTaskNewColor()); //NOI18N
     private static final MessageFormat issueObsoleteFormat  = getFormat("issueObsoleteFormat", UIUtils.getTaskObsoleteColor()); //NOI18N

--- a/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/QueryTableHeaderRenderer.java
+++ b/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/QueryTableHeaderRenderer.java
@@ -33,7 +33,7 @@ class QueryTableHeaderRenderer extends DefaultTableCellRenderer {
 
     private final JLabel seenCell = new JLabel();
 
-    private static final Icon seenHeaderIcon = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/bugtracking/commons/resources/seen-header.png")); // NOI18N
+    private static final Icon seenHeaderIcon = ImageUtilities.loadIcon("org/netbeans/modules/bugtracking/commons/resources/seen-header.png"); // NOI18N
     private final TableCellRenderer delegate;
     private final IssueTable issueTable;
     private boolean isSaved;

--- a/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/TableSorter.java
+++ b/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/TableSorter.java
@@ -118,8 +118,8 @@ public final class TableSorter extends AbstractTableModel {
         }
     };
 
-    private final Icon ICON_ASCENDING = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/openide/explorer/columnsSortedAsc.gif", true)); // NOI18N
-    private final Icon ICON_DESCENDING = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/openide/explorer/columnsSortedDesc.gif", true)); // NOI18N
+    private final Icon ICON_ASCENDING = ImageUtilities.loadImageIcon("org/netbeans/modules/openide/explorer/columnsSortedAsc.gif", true); // NOI18N
+    private final Icon ICON_DESCENDING = ImageUtilities.loadImageIcon("org/netbeans/modules/openide/explorer/columnsSortedDesc.gif", true); // NOI18N
     
     private Row[] viewToModel;
     private int[] modelToView;

--- a/ide/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/ErrorNode.java
+++ b/ide/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/ErrorNode.java
@@ -51,7 +51,7 @@ public class ErrorNode extends LeafNode {
         this.defaultAction = refreshAction;
         btnRefresh = new LinkButton(NbBundle.getMessage(ErrorNode.class, "LBL_Retry"), refreshAction); //NOI18N
         lblMessage = new TreeLabel(text);
-        lblMessage.setIcon(new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/bugtracking/tasks/resources/error.png"))); //NOI18N
+        lblMessage.setIcon(ImageUtilities.loadImageIcon("org/netbeans/modules/bugtracking/tasks/resources/error.png", false)); //NOI18N
     }
 
     @Override

--- a/ide/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/RepositoryNode.java
+++ b/ide/bugtracking/src/org/netbeans/modules/bugtracking/tasks/dashboard/RepositoryNode.java
@@ -324,15 +324,13 @@ public class RepositoryNode extends AsynchronousNode<Collection<QueryImpl>> impl
         return repository.getQueries();
     }
 
-    ImageIcon getIcon() {
+    Icon getIcon() {
         Image icon = repository.getIcon();
-        ImageIcon imageIcon;
         if (icon == null) {
-            imageIcon = ImageUtilities.loadImageIcon("org/netbeans/modules/bugtracking/tasks/resources/remote_repo.png", true);
+            return ImageUtilities.loadImageIcon("org/netbeans/modules/bugtracking/tasks/resources/remote_repo.png", true);
         } else {
-            imageIcon = new ImageIcon(icon);
+            return ImageUtilities.image2Icon(icon);
         }
-        return imageIcon;
     }
 
     @Override

--- a/ide/bugtracking/src/org/netbeans/modules/bugtracking/ui/repository/RepositoryComboRenderer.java
+++ b/ide/bugtracking/src/org/netbeans/modules/bugtracking/ui/repository/RepositoryComboRenderer.java
@@ -24,11 +24,11 @@ import java.awt.Font;
 import java.awt.Image;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import org.netbeans.modules.bugtracking.RepositoryImpl;
 import org.netbeans.modules.bugtracking.api.Repository;
+import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
 
 /**
@@ -85,7 +85,7 @@ public class RepositoryComboRenderer extends DefaultListCellRenderer {
                 if(icon instanceof Icon) {
                     label.setIcon((Icon) icon);
                 } else if(icon instanceof Image) {
-                    label.setIcon(new ImageIcon(icon));
+                    label.setIcon(ImageUtilities.image2Icon(icon));
                 }
             } else {
                 Font font = label.getFont();

--- a/ide/bugtracking/src/org/netbeans/modules/bugtracking/ui/selectors/RepositoryFormPanel.java
+++ b/ide/bugtracking/src/org/netbeans/modules/bugtracking/ui/selectors/RepositoryFormPanel.java
@@ -91,8 +91,8 @@ public class RepositoryFormPanel extends JPanel {
 
         errorLabel = new JLabel();
         errorLabel.setForeground(ERROR_COLOR);
-        errorLabel.setIcon(new ImageIcon(ImageUtilities.loadImage(
-                "org/netbeans/modules/bugtracking/ui/resources/error.gif")));   //NOI18N
+        errorLabel.setIcon(ImageUtilities.loadImageIcon(
+                "org/netbeans/modules/bugtracking/ui/resources/error.gif", false));   //NOI18N
         errorText = new JTextArea();
         errorText.setForeground(ERROR_COLOR);
         errorText.setBackground(errorLabel.getBackground());

--- a/ide/bugtracking/src/org/netbeans/modules/bugtracking/ui/selectors/RepositorySelectorBuilder.java
+++ b/ide/bugtracking/src/org/netbeans/modules/bugtracking/ui/selectors/RepositorySelectorBuilder.java
@@ -38,8 +38,6 @@ import javax.swing.Box;
 import javax.swing.BoxLayout;
 import static javax.swing.BoxLayout.X_AXIS;
 import static javax.swing.BoxLayout.Y_AXIS;
-import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import static javax.swing.JComponent.LEFT_ALIGNMENT;
@@ -67,6 +65,7 @@ import org.netbeans.modules.bugtracking.api.Repository;
 import org.openide.DialogDescriptor;
 import org.openide.awt.Mnemonics;
 import org.openide.util.HelpCtx;
+import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
 
 /**
@@ -766,7 +765,7 @@ public final class RepositorySelectorBuilder implements ItemListener,
                                                                          cellHasFocus);
             if (r instanceof JLabel) {
                 JLabel label = (JLabel) r;
-                label.setIcon(new ImageIcon(icon));
+                label.setIcon(ImageUtilities.image2Icon(icon));
             }
             return r;
         }

--- a/ide/bugzilla/src/org/netbeans/modules/bugzilla/issue/IssuePanel.java
+++ b/ide/bugzilla/src/org/netbeans/modules/bugzilla/issue/IssuePanel.java
@@ -123,7 +123,6 @@ import org.netbeans.modules.bugzilla.util.NbBugzillaConstants;
 import org.netbeans.modules.mylyn.util.NbDateRange;
 import org.netbeans.modules.spellchecker.api.Spellchecker;
 import org.netbeans.modules.team.ide.spi.IDEServices;
-import org.netbeans.modules.team.spi.TeamAccessorUtils;
 import org.openide.awt.HtmlBrowser;
 import org.openide.filesystems.FileUtil;
 import org.openide.nodes.Node;
@@ -1480,25 +1479,25 @@ public class IssuePanel extends javax.swing.JPanel {
             JLabel noSummaryLabel = new JLabel();
             noSummaryLabel.setText(NbBundle.getMessage(IssuePanel.class, "IssuePanel.noSummary")); // NOI18N
             String icon = issue.isNew() ? "org/netbeans/modules/bugzilla/resources/info.png" : "org/netbeans/modules/bugzilla/resources/error.gif"; // NOI18N
-            noSummaryLabel.setIcon(new ImageIcon(ImageUtilities.loadImage(icon)));
+            noSummaryLabel.setIcon(ImageUtilities.loadImageIcon(icon, false));
             messagePanel.add(noSummaryLabel);
         }
         if (cyclicDependency) {
             JLabel cyclicDependencyLabel = new JLabel();
             cyclicDependencyLabel.setText(NbBundle.getMessage(IssuePanel.class, "IssuePanel.cyclicDependency")); // NOI18N
-            cyclicDependencyLabel.setIcon(new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/bugzilla/resources/error.gif"))); // NOI18N
+            cyclicDependencyLabel.setIcon(ImageUtilities.loadImageIcon("org/netbeans/modules/bugzilla/resources/error.gif", false)); // NOI18N
             messagePanel.add(cyclicDependencyLabel);
         }
         if (invalidKeyword) {
             JLabel invalidKeywordLabel = new JLabel();
             invalidKeywordLabel.setText(NbBundle.getMessage(IssuePanel.class, "IssuePanel.invalidKeyword")); // NOI18N
-            invalidKeywordLabel.setIcon(new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/bugzilla/resources/error.gif"))); // NOI18N
+            invalidKeywordLabel.setIcon(ImageUtilities.loadImageIcon("org/netbeans/modules/bugzilla/resources/error.gif", false)); // NOI18N
             messagePanel.add(invalidKeywordLabel);
         }
         if (noDuplicateId) {
             JLabel noDuplicateLabel = new JLabel();
             noDuplicateLabel.setText(NbBundle.getMessage(IssuePanel.class, "IssuePanel.noDuplicateId")); // NOI18N
-            noDuplicateLabel.setIcon(new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/bugzilla/resources/error.gif"))); // NOI18N
+            noDuplicateLabel.setIcon(ImageUtilities.loadImageIcon("org/netbeans/modules/bugzilla/resources/error.gif", false)); // NOI18N
             messagePanel.add(noDuplicateLabel);
         }
         if (noSummary || cyclicDependency || invalidKeyword || noComponent || noVersion || noTargetMilestione || noDuplicateId || (noReproducibility && issue.isNew())) {
@@ -1530,7 +1529,7 @@ public class IssuePanel extends javax.swing.JPanel {
         JLabel messageLabel = new JLabel();
         messageLabel.setText(NbBundle.getMessage(IssuePanel.class, messageKey));
         String icon = issue.isNew() ? "org/netbeans/modules/bugzilla/resources/info.png" : "org/netbeans/modules/bugzilla/resources/error.gif"; // NOI18N
-        messageLabel.setIcon(new ImageIcon(ImageUtilities.loadImage(icon)));
+        messageLabel.setIcon(ImageUtilities.loadImageIcon(icon, false));
         messagePanel.add(messageLabel);
     }
 

--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/completion/GsfCompletionItem.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/completion/GsfCompletionItem.java
@@ -41,7 +41,6 @@ import org.netbeans.lib.editor.codetemplates.api.CodeTemplateManager;
 import org.netbeans.modules.csl.api.CodeCompletionResult;
 import org.netbeans.modules.csl.api.ElementKind;
 import org.netbeans.modules.csl.spi.DefaultCompletionProposal;
-import org.netbeans.modules.csl.spi.DefaultCompletionResult;
 import org.netbeans.spi.editor.completion.CompletionDocumentation;
 import org.netbeans.spi.editor.completion.CompletionItem;
 import org.netbeans.spi.editor.completion.CompletionResultSet;
@@ -390,7 +389,7 @@ public abstract class GsfCompletionItem implements CompletionItem {
         }
         @Override
         protected ImageIcon getIcon() {
-            return new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/csl/editor/completion/warning.png")); // NOI18N
+            return ImageUtilities.loadImageIcon("org/netbeans/modules/csl/editor/completion/warning.png", false); // NOI18N
         }
 
         public int getSortPriority() {

--- a/ide/csl.api/src/org/netbeans/modules/csl/navigation/ClassMemberFilters.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/navigation/ClassMemberFilters.java
@@ -147,28 +147,28 @@ public final class ClassMemberFilters {
                 NbBundle.getMessage(ClassMemberFilters.class, "LBL_ShowInherited"),     //NOI18N
                 NbBundle.getMessage(ClassMemberFilters.class, "LBL_ShowInheritedTip"),     //NOI18N
                 false,
-                new ImageIcon (ImageUtilities.loadImage("org/netbeans/modules/csl/navigation/resources/filterHideInherited.png")), //NOI18N
+                ImageUtilities.loadImageIcon("org/netbeans/modules/csl/navigation/resources/filterHideInherited.png", false), //NOI18N
                 null
         );
         desc.addFilter(SHOW_FIELDS,
                 NbBundle.getMessage(ClassMemberFilters.class, "LBL_ShowFields"),     //NOI18N
                 NbBundle.getMessage(ClassMemberFilters.class, "LBL_ShowFieldsTip"),     //NOI18N
                 true,
-                new ImageIcon (ImageUtilities.loadImage("org/netbeans/modules/csl/navigation/resources/filterHideFields.gif")), //NOI18N
+                ImageUtilities.loadImageIcon("org/netbeans/modules/csl/navigation/resources/filterHideFields.gif", false), //NOI18N
                 null
         );
         desc.addFilter(SHOW_STATIC,
                 NbBundle.getMessage(ClassMemberFilters.class, "LBL_ShowStatic"),     //NOI18N
                 NbBundle.getMessage(ClassMemberFilters.class, "LBL_ShowStaticTip"),     //NOI18N
                 true,
-                new ImageIcon (ImageUtilities.loadImage("org/netbeans/modules/csl/navigation/resources/filterHideStatic.png")), //NOI18N
+                ImageUtilities.loadImageIcon("org/netbeans/modules/csl/navigation/resources/filterHideStatic.png", false), //NOI18N
                 null
         );
         desc.addFilter(SHOW_NON_PUBLIC,
                 NbBundle.getMessage(ClassMemberFilters.class, "LBL_ShowNonPublic"),     //NOI18N
                 NbBundle.getMessage(ClassMemberFilters.class, "LBL_ShowNonPublicTip"),     //NOI18N
                 true,
-                new ImageIcon (ImageUtilities.loadImage("org/netbeans/modules/csl/navigation/resources/filterHideNonPublic.png")), //NOI18N
+                ImageUtilities.loadImageIcon("org/netbeans/modules/csl/navigation/resources/filterHideNonPublic.png", false), //NOI18N
                 null
         );
         

--- a/ide/csl.api/src/org/netbeans/modules/csl/navigation/ElementScanningTask.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/navigation/ElementScanningTask.java
@@ -421,7 +421,7 @@ public abstract class ElementScanningTask extends IndexingAwareParserResultTask<
 
         public ImageIcon getCustomIcon() {
             String iconBase = language.getIconBase();
-            return iconBase == null ? null : new ImageIcon(ImageUtilities.loadImage(iconBase));
+            return iconBase == null ? null : ImageUtilities.loadImageIcon(iconBase, false);
         }
     }
 }    

--- a/ide/csl.api/src/org/netbeans/modules/csl/navigation/Icons.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/navigation/Icons.java
@@ -18,9 +18,9 @@
  */
 package org.netbeans.modules.csl.navigation;
 
-import java.awt.Image;
 import java.util.Collection;
 import java.util.Collections;
+import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import org.netbeans.modules.csl.api.ElementKind;
 import org.netbeans.modules.csl.api.Modifier;
@@ -47,121 +47,66 @@ public final class Icons {
     private Icons() {
     }
 
-//    public static Icon getBusyIcon() {
-//        Image img = Utilities.loadImage(WAIT);
-//
-//        if (img == null) {
-//            return null;
-//        } else {
-//            return new ImageIcon(img);
-//        }
-//    }
-//
-//    public static Icon getMethodIcon() {
-//        // TODO - consider modifiers
-//        Image img =
-//            Utilities.loadImage(ICON_BASE + "method" + "Public" + PNG_EXTENSION);
-//
-//        if (img == null) {
-//            return null;
-//        } else {
-//            return new ImageIcon(img);
-//        }
-//    }
-//
-//    public static Icon getFieldIcon() {
-//        // TODO - consider modifiers
-//        Image img =
-//            Utilities.loadImage(ICON_BASE + "field" + "Public" + PNG_EXTENSION);
-//
-//        if (img == null) {
-//            return null;
-//        } else {
-//            return new ImageIcon(img);
-//        }
-//    }
-//
-//    public static Icon getClassIcon() {
-//        Image img = Utilities.loadImage(ICON_BASE + "class" + PNG_EXTENSION);
-//
-//        if (img == null) {
-//            return null;
-//        } else {
-//            return new ImageIcon(img);
-//        }
-//    }
-//
-//    public static Icon getModuleIcon() {
-//        Image img =
-//            Utilities.loadImage(ICON_BASE + "package"  + GIF_EXTENSION);
-//
-//        if (img == null) {
-//            return null;
-//        } else {
-//            return new ImageIcon(img);
-//        }
-//    }
-
     public static ImageIcon getElementIcon( ElementKind elementKind, Collection<Modifier> modifiers ) {
     
         if ( modifiers == null ) {
             modifiers = Collections.<Modifier>emptyList();
         }
     
-        Image img = null;
+        Icon icon = null;
     
         switch( elementKind ) {
         case FILE:
-            img = ImageUtilities.loadImage( ICON_BASE + "emptyfile-icon" + PNG_EXTENSION );
+            icon = ImageUtilities.loadIcon( ICON_BASE + "emptyfile-icon" + PNG_EXTENSION );
             break;
         case ERROR:
-            img = ImageUtilities.loadImage( ICON_BASE + "error-glyph" + GIF_EXTENSION );
+            icon = ImageUtilities.loadIcon( ICON_BASE + "error-glyph" + GIF_EXTENSION );
             break;
         case PACKAGE:
         case MODULE:
-            img = ImageUtilities.loadImage( ICON_BASE + "package" + GIF_EXTENSION );
+            icon = ImageUtilities.loadIcon( ICON_BASE + "package" + GIF_EXTENSION );
             break;
         case TEST:
-            img = ImageUtilities.loadImage( ICON_BASE + "test" + PNG_EXTENSION );
+            icon = ImageUtilities.loadIcon( ICON_BASE + "test" + PNG_EXTENSION );
             break;
         case CLASS:
         case INTERFACE:
-            img = ImageUtilities.loadImage( ICON_BASE + "class" + PNG_EXTENSION );
+            icon = ImageUtilities.loadIcon( ICON_BASE + "class" + PNG_EXTENSION );
             break;
         case TAG:
-            img = ImageUtilities.loadImage( ICON_BASE + "html_element" + PNG_EXTENSION );
+            icon = ImageUtilities.loadIcon( ICON_BASE + "html_element" + PNG_EXTENSION );
             break;
         case RULE:
-            img = ImageUtilities.loadImage( ICON_BASE + "rule" + PNG_EXTENSION );
+            icon = ImageUtilities.loadIcon( ICON_BASE + "rule" + PNG_EXTENSION );
             break;
         case VARIABLE:
         case PROPERTY:
         case GLOBAL:
         case ATTRIBUTE:
         case FIELD:
-            img = ImageUtilities.loadImage( getIconName( ICON_BASE + "field", PNG_EXTENSION, modifiers ) );
+            icon = ImageUtilities.loadIcon( getIconName( ICON_BASE + "field", PNG_EXTENSION, modifiers ) );
             break;
         case PARAMETER:
         case CONSTANT:
-            img = ImageUtilities.loadImage(getIconName(ICON_BASE + "constant", PNG_EXTENSION, modifiers)); // NOI18N
-            if (img == null) {
-                img = ImageUtilities.loadImage(ICON_BASE + "constantPublic" + PNG_EXTENSION); // NOI18N
+            icon = ImageUtilities.loadIcon(getIconName(ICON_BASE + "constant", PNG_EXTENSION, modifiers)); // NOI18N
+            if (icon == null) {
+                icon = ImageUtilities.loadIcon(ICON_BASE + "constantPublic" + PNG_EXTENSION); // NOI18N
             }
             break;
         case CONSTRUCTOR:
-            img = ImageUtilities.loadImage( getIconName( ICON_BASE + "constructor", PNG_EXTENSION, modifiers ) );
+            icon = ImageUtilities.loadIcon( getIconName( ICON_BASE + "constructor", PNG_EXTENSION, modifiers ) );
             break;
         case METHOD:
-            img = ImageUtilities.loadImage( getIconName( ICON_BASE + "method", PNG_EXTENSION, modifiers ) );
+            icon = ImageUtilities.loadIcon( getIconName( ICON_BASE + "method", PNG_EXTENSION, modifiers ) );
             break;
         case DB:
-            img = ImageUtilities.loadImage(ICON_BASE + "database" + GIF_EXTENSION);
+            icon = ImageUtilities.loadIcon(ICON_BASE + "database" + GIF_EXTENSION);
             break;
         default:   
-                img = null;
+                icon = null;
         }
     
-        return img == null ? null : new ImageIcon (img);
+        return icon == null ? null : ImageUtilities.icon2ImageIcon (icon);
     }
         
     // Private Methods ---------------------------------------------------------

--- a/ide/css.prep/src/org/netbeans/modules/css/prep/editor/CPCategoryStructureItem.java
+++ b/ide/css.prep/src/org/netbeans/modules/css/prep/editor/CPCategoryStructureItem.java
@@ -136,7 +136,7 @@ public abstract class CPCategoryStructureItem implements StructureItem {
     @NbBundle.Messages("navigator.item.name.variables=Variables")
     public static class Variables extends ChildrenSetStructureItem {
 
-        private static final ImageIcon ICON = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/css/prep/editor/resources/variables.gif")); //NOI18N
+        private static final ImageIcon ICON = ImageUtilities.loadImageIcon("org/netbeans/modules/css/prep/editor/resources/variables.gif", false); //NOI18N
 
         public Variables(Set<StructureItem> children, FeatureContext context) {
             super(new DummyElementHandle(context.getFileObject(), Bundle.navigator_item_name_variables()), children);
@@ -151,7 +151,7 @@ public abstract class CPCategoryStructureItem implements StructureItem {
     @NbBundle.Messages("navigator.item.name.mixins=Mixins")
     public static class Mixins extends ChildrenSetStructureItem {
 
-        private static final ImageIcon ICON = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/css/prep/editor/resources/methods.gif")); //NOI18N
+        private static final ImageIcon ICON = ImageUtilities.loadImageIcon("org/netbeans/modules/css/prep/editor/resources/methods.gif", false); //NOI18N
 
         private final FeatureContext context;
 

--- a/ide/css.prep/src/org/netbeans/modules/css/prep/editor/VariableCompletionItem.java
+++ b/ide/css.prep/src/org/netbeans/modules/css/prep/editor/VariableCompletionItem.java
@@ -33,7 +33,7 @@ import org.openide.util.ImageUtilities;
  */
 public class VariableCompletionItem extends CPCompletionItem {
 
-    private static final ImageIcon LOCAL_VAR_ICON = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/css/prep/editor/resources/localVariable.gif")); //NOI18N
+    private static final ImageIcon LOCAL_VAR_ICON = ImageUtilities.loadImageIcon("org/netbeans/modules/css/prep/editor/resources/localVariable.gif", false); //NOI18N
 
     /**
      * 

--- a/ide/css.visual/src/org/netbeans/modules/css/visual/RuleEditorPanel.java
+++ b/ide/css.visual/src/org/netbeans/modules/css/visual/RuleEditorPanel.java
@@ -115,8 +115,8 @@ public class RuleEditorPanel extends JPanel {
     
     static RequestProcessor RP = new RequestProcessor(CssCaretAwareSourceTask.class);
     
-    private static final Icon ERROR_ICON = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/css/visual/resources/error-glyph.gif")); //NOI18N
-    private static final Icon APPLIED_ICON = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/css/visual/resources/database.gif")); //NOI18N
+    private static final Icon ERROR_ICON = ImageUtilities.loadIcon("org/netbeans/modules/css/visual/resources/error-glyph.gif"); //NOI18N
+    private static final Icon APPLIED_ICON = ImageUtilities.loadIcon("org/netbeans/modules/css/visual/resources/database.gif"); //NOI18N
     
     private final JLabel errorLabel, appliedLabel;
 

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/ui/ConnectionStatusPanel.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/ui/ConnectionStatusPanel.java
@@ -25,19 +25,14 @@
 package org.netbeans.modules.db.sql.visualeditor.ui;
 
 import org.netbeans.modules.db.sql.visualeditor.Log;
-import java.awt.Image;
 import java.awt.event.ActionListener;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JDialog;
-import org.openide.NotifyDescriptor;
 import org.openide.DialogDisplayer;
 import org.openide.DialogDescriptor;
 import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
-import org.openide.util.HelpCtx;
-import org.openide.util.Utilities;
 /**
  *  Shows the status of a connction in a dialog.
  *  This just presentss the results of a testConnection(), it
@@ -52,11 +47,9 @@ public class ConnectionStatusPanel extends javax.swing.JPanel {
 
     private JButton okButton = new JButton(NbBundle.getMessage(ConnectionStatusPanel.class, "OK")); // NOI18N
 
-    // private Image conGood = Utilities.loadImage("org/netbeans/modules/db/sql/visualeditor/resources/started.png");  // NOI18N
-    // private Image conFailed = Utilities.loadImage("org/netbeans/modules/db/sql/visualeditor/resources/disconnected.png");  // NOI18N
-    private Image conGood = ImageUtilities.loadImage("org/netbeans/modules/db/sql/visualeditor/resources/ok.gif");  // NOI18N
-    private Image conFailed = ImageUtilities.loadImage("org/netbeans/modules/db/sql/visualeditor/resources/error.gif");  // NOI18N
-    private Image conWarning = ImageUtilities.loadImage("org/netbeans/modules/db/sql/visualeditor/resources/warning.gif");  // NOI18N
+    private Icon conGood = ImageUtilities.loadIcon("org/netbeans/modules/db/sql/visualeditor/resources/ok.gif");  // NOI18N
+    private Icon conFailed = ImageUtilities.loadIcon("org/netbeans/modules/db/sql/visualeditor/resources/error.gif");  // NOI18N
+    private Icon conWarning = ImageUtilities.loadIcon("org/netbeans/modules/db/sql/visualeditor/resources/warning.gif");  // NOI18N
     /** Creates new form ConnectionStatusDialog */
     public ConnectionStatusPanel() {
         initComponents();
@@ -127,28 +120,28 @@ public class ConnectionStatusPanel extends javax.swing.JPanel {
         /* calculate the displayd values based on this method's input parameters.
          */
         if ( connected ) {
-            connectionStatusIcon.setIcon( new ImageIcon(conGood) ) ;
+            connectionStatusIcon.setIcon( conGood ) ;
             connectionStatusText.setText(getMsg("ConStat_succeeded_msg")) ; // NOI18N
             connectionStatusMessage.setVisible(false) ;
             validationInfo.setVisible(true) ;
             if ( sqlException == null ) {
                 valStatusText.setText(getMsg("ConStat_rows_selected_msg", tableName, Integer.valueOf(rows)) ) ; // NOI18N
-                valStatusIcon.setIcon( new ImageIcon(conGood) ) ;
+                valStatusIcon.setIcon( conGood ) ;
                 String valMsg ;
                 if (rows > 1 ) {
                     
                     valMsg = getMsg("ConStat_valtable_bad_msg") ;// NOI18N
-                    valStatusMessageIcon.setIcon( new ImageIcon(conWarning) ) ;
+                    valStatusMessageIcon.setIcon( conWarning ) ;
                 } else {
                     valMsg = getMsg("ConStat_valtable_good_msg") ;// NOI18N
-                    valStatusMessageIcon.setIcon( new ImageIcon(conGood) ) ;
+                    valStatusMessageIcon.setIcon( conGood ) ;
                 }
                 valMsg = valMsg + "\n" + getMsg("ConStat_validationTableInfo") ; // NOI18N
                 valStatusMessage.setText(valMsg) ;
                 
             } else if (tableName != null) {
                 // validation table test failed.
-                valStatusIcon.setIcon( new ImageIcon(conFailed) ) ;
+                valStatusIcon.setIcon( conFailed ) ;
 
                 // validation failed.
                 valStatusText.setText(getMsg("ConStat_failed_msg")) ;// NOI18N
@@ -168,7 +161,7 @@ public class ConnectionStatusPanel extends javax.swing.JPanel {
             }
         } else {
             // connection failed.
-            connectionStatusIcon.setIcon( new ImageIcon(conFailed) ) ;
+            connectionStatusIcon.setIcon( conFailed ) ;
             connectionStatusText.setText(getMsg("ConStat_failed_msg")) ;// NOI18N
             connectionStatusMessage.setText(sqlException) ;
             validationInfo.setVisible(false) ;

--- a/ide/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergePanel.java
+++ b/ide/diff/src/org/netbeans/modules/merge/builtin/visualizer/MergePanel.java
@@ -118,8 +118,6 @@ public class MergePanel extends javax.swing.JPanel implements java.awt.event.Act
         lastConflictButton.setVisible(false);
         prevConflictButton.setIcon(ImageUtilities.loadImageIcon("org/netbeans/modules/diff/builtin/visualizer/prev.gif", true));
         nextConflictButton.setIcon(ImageUtilities.loadImageIcon("org/netbeans/modules/diff/builtin/visualizer/next.gif", true));
-        //prevConflictButton.setIcon(new ImageIcon(getClass().getResource("/org/netbeans/modules/diff/builtin/visualizer/prev.gif")));
-        //nextConflictButton.setIcon(new ImageIcon(getClass().getResource("/org/netbeans/modules/diff/builtin/visualizer/next.gif")));
         //setTitle(org.openide.util.NbBundle.getBundle(DiffComponent.class).getString("DiffComponent.title"));
         //setName(org.openide.util.NbBundle.getMessage(MergePanel.class, "MergePanel.title"));
         //HelpCtx.setHelpIDString (getRootPane (), DiffComponent.class.getName ());

--- a/ide/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageReportTopComponent.java
+++ b/ide/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageReportTopComponent.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.swing.GroupLayout.Alignment;
-import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JScrollPane;
@@ -60,6 +59,7 @@ import org.openide.loaders.DataObject;
 import org.openide.loaders.DataObjectNotFoundException;
 import org.openide.nodes.Node;
 import org.openide.util.Exceptions;
+import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
 import org.openide.windows.TopComponent;
@@ -548,7 +548,7 @@ final class CoverageReportTopComponent extends TopComponent {
                     DataObject dobj = DataObject.find(file);
                     Node node = dobj.getNodeDelegate();
                     Image icon = node.getIcon(BeanInfo.ICON_COLOR_32x32);
-                    setIcon(new ImageIcon(icon));
+                    setIcon(ImageUtilities.image2Icon(icon));
                 } catch (DataObjectNotFoundException ex) {
                     Exceptions.printStackTrace(ex);
                 }

--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/StatisticsPanel.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/StatisticsPanel.java
@@ -85,10 +85,10 @@ public final class StatisticsPanel extends JPanel {
     private static final Icon alwaysOpenNewTabIcon = ImageUtilities.loadImageIcon("org/netbeans/modules/gsf/testrunner/resources/newTab.png", true);
 
     private static final Icon rerunIcon = ImageUtilities.loadImageIcon("org/netbeans/modules/gsf/testrunner/resources/rerun.png", true);
-    private static final Icon rerunFailedIcon = ImageUtilities.image2Icon(ImageUtilities.mergeImages(
-                            ImageUtilities.loadImage("org/netbeans/modules/gsf/testrunner/resources/rerun.png"), //NOI18N
-                            ImageUtilities.loadImage("org/netbeans/modules/gsf/testrunner/resources/error-badge.gif"), //NOI18N
-                            8, 8));
+    private static final Icon rerunFailedIcon = ImageUtilities.mergeIcons(
+                            ImageUtilities.loadIcon("org/netbeans/modules/gsf/testrunner/resources/rerun.png"), //NOI18N
+                            ImageUtilities.loadIcon("org/netbeans/modules/gsf/testrunner/resources/error-badge.gif"), //NOI18N
+                            8, 8);
 
     private static final boolean isMacLaf = "Aqua".equals(UIManager.getLookAndFeel().getID());
     private static final Color macBackground = UIManager.getColor("NbExplorerView.background");

--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/Manager.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/Manager.java
@@ -419,7 +419,7 @@ public final class Manager {
                         if (window.isOpened() && !isInSlidingMode) {
                             window.promote();
                         } else if (!window.isOpened() || (window.isOpened() && !window.isShowing() && isInSlidingMode)) {
-                            Icon icon = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/gsf/testrunner/ui/resources/testResults.png"));   //NOI18N
+                            Icon icon = ImageUtilities.loadIcon("org/netbeans/modules/gsf/testrunner/ui/resources/testResults.png");   //NOI18N
                             String projectname = ProjectUtils.getInformation(session.getProject()).getDisplayName();
                             int total = displayHandler.getTotalTests();
                             String title = total == 0 ? Bundle.LBL_NotificationDisplayer_NoTestsExecuted_title(projectname) : Bundle.LBL_NotificationDisplayer_title(total, projectname);

--- a/ide/jumpto/src/org/netbeans/modules/jumpto/file/FileDescription.java
+++ b/ide/jumpto/src/org/netbeans/modules/jumpto/file/FileDescription.java
@@ -22,7 +22,6 @@
 
 package org.netbeans.modules.jumpto.file;
 
-import java.awt.Image;
 import java.beans.BeanInfo;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -93,10 +92,12 @@ public class FileDescription extends FileDescriptor {
         Icon res = icon;
         if (res == null) {
             final DataObject od = getDataObject();
-            final Image img = od == null ? // #187973
-                UNKNOWN_PROJECT_ICON.getImage() :
-                od.getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16);
-            res = icon = new ImageIcon(img);
+            if (od == null) { // #187973
+                res = UNKNOWN_PROJECT_ICON;
+            } else {
+                res = ImageUtilities.image2Icon(od.getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16));
+            }
+            icon = res;
         }
         return res;
     }

--- a/ide/languages.toml/src/org/netbeans/modules/languages/toml/structure/TomlStructureItem.java
+++ b/ide/languages.toml/src/org/netbeans/modules/languages/toml/structure/TomlStructureItem.java
@@ -121,7 +121,7 @@ public final class TomlStructureItem implements StructureItem, ElementHandle {
     @Override
     public ImageIcon getCustomIcon() {
         String iconBase = getIconBase();
-        return new ImageIcon(ImageUtilities.loadImage(iconBase));
+        return ImageUtilities.loadImageIcon(iconBase, false);
     }
 
     private String getIconBase() {

--- a/ide/languages/src/org/netbeans/modules/languages/features/CompletionSupport.java
+++ b/ide/languages/src/org/netbeans/modules/languages/features/CompletionSupport.java
@@ -61,14 +61,13 @@ public class CompletionSupport implements org.netbeans.spi.editor.completion.Com
         if (resourceName == null)
             resourceName = "org/netbeans/modules/languages/resources/node.gif";
         if (!icons.containsKey (resourceName)) {
-            Image image = ImageUtilities.loadImage (resourceName);
-            if (image == null)
-                image = ImageUtilities.loadImage (
-                    "org/netbeans/modules/languages/resources/node.gif"
-                );
+            ImageIcon icon = ImageUtilities.loadImageIcon (resourceName, false);
+            if (icon == null)
+                icon = ImageUtilities.loadImageIcon (
+                    "org/netbeans/modules/languages/resources/node.gif", false);
             icons.put (
                 resourceName,
-                new ImageIcon (image)
+                icon
             );
         }
         return icons.get (resourceName);

--- a/ide/languages/src/org/netbeans/modules/languages/features/LanguagesNavigator.java
+++ b/ide/languages/src/org/netbeans/modules/languages/features/LanguagesNavigator.java
@@ -272,14 +272,13 @@ public class LanguagesNavigator implements NavigatorPanel {
         private static Icon getCIcon (String resourceName) {
             if (resourceName == null) return null;
             if (!icons.containsKey (resourceName)) {
-                Image image = ImageUtilities.loadImage (resourceName);
-                if (image == null)
-                    image = ImageUtilities.loadImage (
-                        "org/netbeans/modules/languages/resources/node.gif"
-                    );
+                ImageIcon icon = ImageUtilities.loadImageIcon (resourceName, false);
+                if (icon == null)
+                    icon = ImageUtilities.loadImageIcon (
+                        "org/netbeans/modules/languages/resources/node.gif", false);
                 icons.put (
                     resourceName,
-                    new ImageIcon (image)
+                    icon
                 );
             }
             return icons.get (resourceName);

--- a/ide/localtasks/src/org/netbeans/modules/localtasks/task/TaskPanel.java
+++ b/ide/localtasks/src/org/netbeans/modules/localtasks/task/TaskPanel.java
@@ -927,7 +927,7 @@ final class TaskPanel extends javax.swing.JPanel {
             JLabel noSummaryLabel = new JLabel();
             noSummaryLabel.setText(Bundle.IssuePanel_noSummary());
             String icon = "org/netbeans/modules/localtasks/resources/error.gif"; //NOI18N
-            noSummaryLabel.setIcon(new ImageIcon(ImageUtilities.loadImage(icon)));
+            noSummaryLabel.setIcon(ImageUtilities.loadIcon(icon));
             messagePanel.add(noSummaryLabel);
         }
         if (noSummary) {

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/Icons.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/Icons.java
@@ -42,22 +42,21 @@ public final class Icons {
     }
     
     public static Icon getCompletionIcon(CompletionItemKind completionKind) {
-        Image img = null;
+        Icon icon = null;
 
         if (completionKind != null) {
-            img = ImageUtilities.loadImage(ICON_BASE + completionKind.name().toLowerCase(Locale.US) + PNG_EXTENSION);
+            icon = ImageUtilities.loadIcon(ICON_BASE + completionKind.name().toLowerCase(Locale.US) + PNG_EXTENSION);
 
-            if (img == null) {
-                img = ImageUtilities.loadImage(ICON_BASE + completionKind.name().toLowerCase(Locale.US) + GIF_EXTENSION);
+            if (icon == null) {
+                icon = ImageUtilities.loadIcon(ICON_BASE + completionKind.name().toLowerCase(Locale.US) + GIF_EXTENSION);
             }
         }
         
-        if (img == null) {
-            img = ImageUtilities.loadImage(ICON_BASE + "variable" + GIF_EXTENSION);
+        if (icon == null) {
+            icon = ImageUtilities.loadIcon(ICON_BASE + "variable" + GIF_EXTENSION);
         }
         
-	return img == null ? null : new ImageIcon (img);
-        
+        return icon;
     }
     
     public static String getSymbolIconBase(Enum<?> symbolKind) {

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/refactoring/tree/FileTreeElement.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/refactoring/tree/FileTreeElement.java
@@ -33,6 +33,7 @@ import org.openide.loaders.DataObjectNotFoundException;
 import org.openide.text.Line;
 import org.openide.text.NbDocument;
 import org.openide.util.Exceptions;
+import org.openide.util.ImageUtilities;
 
 /**Copied from refactoring.java, and simplified.
  *
@@ -65,8 +66,7 @@ public class FileTreeElement implements TreeElement, Openable {
     @Override
     public Icon getIcon() {
         try {
-            ImageIcon imageIcon = new ImageIcon(DataObject.find(fo).getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16));
-            return imageIcon;
+            return ImageUtilities.image2Icon(DataObject.find(fo).getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16));
         } catch (DataObjectNotFoundException ex) {
             return null;
         }

--- a/ide/notifications/test/unit/src/org/netbeans/modules/notifications/center/NotificationCenterManagerTest.java
+++ b/ide/notifications/test/unit/src/org/netbeans/modules/notifications/center/NotificationCenterManagerTest.java
@@ -141,7 +141,7 @@ public class NotificationCenterManagerTest extends NbTestCase {
     private Notification createNotification(Category category, String title) {
         String dummyText = "<html>The Netbeans IDE has detected that your system is using most of your available system resources. We recommend shutting down other applications and windows.</html>";
         return NotificationDisplayerImpl.getInstance().notify(title,
-                new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/notifications/resources/filter.png")),
+                ImageUtilities.loadIcon("org/netbeans/modules/notifications/resources/filter.png"),
                 new JLabel(dummyText), new JLabel(dummyText),
                 NotificationDisplayer.Priority.NORMAL,
                 category);

--- a/ide/projectui/src/org/netbeans/modules/project/ui/ExitDialog.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/ExitDialog.java
@@ -46,6 +46,7 @@ import org.openide.awt.Mnemonics;
 import org.openide.cookies.SaveCookie;
 import org.openide.loaders.DataObject;
 import org.openide.nodes.Node;
+import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
 
 
@@ -333,7 +334,7 @@ public final class ExitDialog extends JPanel implements ActionListener {
 
             Node node = obj.getNodeDelegate();
 
-            ImageIcon icon = new ImageIcon(node.getIcon(BeanInfo.ICON_COLOR_16x16));
+            Icon icon = ImageUtilities.image2Icon(node.getIcon(BeanInfo.ICON_COLOR_16x16));
             super.setIcon(icon);
 
             setText(node.getDisplayName());

--- a/ide/spellchecker/src/org/netbeans/modules/spellchecker/options/SpellcheckerOptionsPanel.java
+++ b/ide/spellchecker/src/org/netbeans/modules/spellchecker/options/SpellcheckerOptionsPanel.java
@@ -83,7 +83,7 @@ public class SpellcheckerOptionsPanel extends javax.swing.JPanel {
     private List<DictionaryDescription> addedDictionaries = new ArrayList<DictionaryDescription>();
 
     private SpellcheckerOptionsPanelController c;
-    private static final Icon errorIcon = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/spellchecker/resources/error.gif"));
+    private static final Icon errorIcon = ImageUtilities.loadIcon("org/netbeans/modules/spellchecker/resources/error.gif");
     
     /**
      * Creates new form SpellcheckerOptionsPanel

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/ViewModelListener.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/ViewModelListener.java
@@ -38,7 +38,6 @@ import java.util.prefs.PreferenceChangeEvent;
 import java.util.prefs.PreferenceChangeListener;
 import java.util.prefs.Preferences;
 import javax.swing.AbstractButton;
-import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 import javax.swing.JMenuItem;
 import javax.swing.SwingConstants;
@@ -83,6 +82,7 @@ import org.netbeans.spi.viewmodel.TreeModel;
 import org.netbeans.spi.viewmodel.TreeModelFilter;
 import org.netbeans.spi.viewmodel.UnknownTypeException;
 import org.openide.util.Exceptions;
+import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
 import org.openide.util.NbPreferences;
 import org.openide.util.RequestProcessor;
@@ -770,7 +770,7 @@ public class ViewModelListener extends DebuggerManagerAdapter {
 
     private javax.swing.JButton createSessionsSwitchButton() {
         final javax.swing.JButton b = VariablesViewButtons.createButton(
-                new ImageIcon(viewIcon),
+                ImageUtilities.image2Icon(viewIcon),
                 NbBundle.getMessage(ViewModelListener.class, "Tooltip_SelectSrc"));
         b.addActionListener(new ActionListener() {
             @Override

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/InfoPanel.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/InfoPanel.java
@@ -31,13 +31,11 @@ import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JMenuItem;
@@ -51,7 +49,6 @@ import javax.swing.Timer;
 import javax.swing.UIManager;
 import javax.swing.border.EmptyBorder;
 import org.netbeans.api.debugger.Breakpoint;
-import org.netbeans.api.debugger.DebuggerManager;
 import org.netbeans.api.debugger.Session;
 import org.netbeans.spi.debugger.ui.DebuggingView.DVSupport;
 import org.netbeans.spi.debugger.ui.DebuggingView.DVThread;
@@ -60,7 +57,6 @@ import org.openide.util.Exceptions;
 import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
-import org.openide.util.Utilities;
 
 /**
  *
@@ -213,7 +209,7 @@ public class InfoPanel extends javax.swing.JPanel {
     private JMenuItem createMenuItem(final DVSupport dvs, final DVThread thread) {
         String displayName = dvs.getDisplayName(thread);
         Image image = dvs.getIcon(thread);
-        Icon icon = image != null ? new ImageIcon(image) : null;
+        Icon icon = image != null ? ImageUtilities.image2Icon(image) : null;
         JMenuItem item = new JMenuItem(displayName, icon);
         item.addActionListener(new ActionListener() {
 

--- a/ide/spi.palette/src/org/netbeans/modules/palette/ui/CategoryList.java
+++ b/ide/spi.palette/src/org/netbeans/modules/palette/ui/CategoryList.java
@@ -25,7 +25,6 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.FocusTraversalPolicy;
-import java.awt.Font;
 import java.awt.Image;
 import java.awt.Insets;
 import java.awt.KeyboardFocusManager;
@@ -41,10 +40,8 @@ import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.ActionMap;
 import javax.swing.BorderFactory;
-import javax.swing.ImageIcon;
 import javax.swing.InputMap;
 import javax.swing.JComponent;
-import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JPopupMenu;
 import javax.swing.JToggleButton;
@@ -63,6 +60,7 @@ import org.netbeans.modules.palette.Category;
 import org.netbeans.modules.palette.Item;
 import org.netbeans.modules.palette.Utils;
 import org.openide.nodes.Node;
+import org.openide.util.ImageUtilities;
 import org.openide.util.Utilities;
 
 /**
@@ -298,7 +296,7 @@ public class CategoryList extends JList implements Autoscroll {
             Item item = (Item) value;
             Image icon = item.getIcon (iconSize);
             if (icon != null) {
-                button.setIcon (new ImageIcon (icon));
+                button.setIcon (ImageUtilities.image2Icon(icon));
             }
 
             button.setText (showNames ? item.getDisplayName () : null);

--- a/ide/tasklist.ui/src/org/netbeans/modules/tasklist/ui/ScopeButton.java
+++ b/ide/tasklist.ui/src/org/netbeans/modules/tasklist/ui/ScopeButton.java
@@ -22,12 +22,12 @@ package org.netbeans.modules.tasklist.ui;
 import java.awt.event.ActionEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import javax.swing.ImageIcon;
 import javax.swing.JToggleButton;
 import javax.swing.ToolTipManager;
 import org.netbeans.modules.tasklist.impl.Accessor;
 import org.netbeans.modules.tasklist.impl.TaskManagerImpl;
 import org.netbeans.spi.tasklist.TaskScanningScope;
+import org.openide.util.ImageUtilities;
 
 /**
  *
@@ -43,7 +43,7 @@ class ScopeButton extends JToggleButton implements PropertyChangeListener {
         this.tm = tm;
         this.scope = scope;
         setText( null );
-        setIcon( new ImageIcon( Accessor.getIcon( scope ) ) );
+        setIcon( ImageUtilities.image2Icon( Accessor.getIcon( scope ) ) );
         ToolTipManager.sharedInstance().registerComponent(this);
         setFocusable( false );
     }

--- a/ide/tasklist.ui/src/org/netbeans/modules/tasklist/ui/TaskListTable.java
+++ b/ide/tasklist.ui/src/org/netbeans/modules/tasklist/ui/TaskListTable.java
@@ -334,7 +334,7 @@ class TaskListTable extends JTable {
     private static final Icon openedIcon = (Icon)UIManager.get("Tree.expandedIcon"); // NOI18N
     private static final Icon closedIcon = (Icon)UIManager.get("Tree.collapsedIcon"); // NOI18N
     
-    private static Map<Image, ImageIcon> iconCache = new HashMap<Image, ImageIcon>(10);
+    private static Map<Image, Icon> iconCache = new HashMap<Image, Icon>(10);
     
     private class TaskGroupRenderer extends DefaultTableCellRenderer {
         
@@ -347,9 +347,9 @@ class TaskListTable extends JTable {
                     TaskGroup tg = (TaskGroup)value;
                     JLabel renderer = (JLabel)res;
                     renderer.setText( null );
-                    ImageIcon icon = iconCache.get( tg.getIcon() );
+                    Icon icon = iconCache.get( tg.getIcon() );
                     if( null == icon ) {
-                        icon = new ImageIcon( tg.getIcon() );
+                        icon = ImageUtilities.image2Icon( tg.getIcon() );
                         iconCache.put( tg.getIcon(), icon );
                     }
                     renderer.setIcon( icon );

--- a/ide/tasklist.ui/src/org/netbeans/modules/tasklist/ui/Util.java
+++ b/ide/tasklist.ui/src/org/netbeans/modules/tasklist/ui/Util.java
@@ -23,13 +23,13 @@ import java.awt.event.ActionEvent;
 import javax.swing.AbstractAction;
 import org.netbeans.modules.tasklist.impl.*;
 import javax.swing.Action;
-import javax.swing.ImageIcon;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenu;
 import javax.swing.JPopupMenu;
 import javax.swing.JRadioButtonMenuItem;
 import org.netbeans.spi.tasklist.Task;
 import org.netbeans.spi.tasklist.TaskScanningScope;
+import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
 
 /**
@@ -118,7 +118,7 @@ class Util {
     private static class SwitchScopeAction extends AbstractAction {
         private TaskScanningScope scope;
         public SwitchScopeAction( TaskScanningScope scope ) {
-            super( Accessor.getDisplayName( scope ), new ImageIcon( Accessor.getIcon( scope ) ) );
+            super( Accessor.getDisplayName( scope ), ImageUtilities.image2Icon( Accessor.getIcon( scope ) ) );
             this.scope = scope;
         }
     

--- a/ide/team.commons/src/org/netbeans/modules/bugtracking/commons/SaveQueryPanel.java
+++ b/ide/team.commons/src/org/netbeans/modules/bugtracking/commons/SaveQueryPanel.java
@@ -26,8 +26,7 @@
 package org.netbeans.modules.bugtracking.commons;
 
 import java.awt.Color;
-import java.awt.Image;
-import javax.swing.ImageIcon;
+import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.UIManager;
 import javax.swing.event.DocumentEvent;
@@ -61,8 +60,8 @@ public class SaveQueryPanel extends javax.swing.JPanel implements DocumentListen
         queryNameTextField.getDocument().addDocumentListener(this);
 
         saveErrorLabel.setForeground(ERROR_COLOR);
-        Image img = ImageUtilities.loadImage("org/netbeans/modules/bugtracking/ui/resources/error.gif"); //NOI18N
-        saveErrorLabel.setIcon( new ImageIcon(img) );
+        Icon icon = ImageUtilities.loadIcon("org/netbeans/modules/bugtracking/ui/resources/error.gif"); //NOI18N
+        saveErrorLabel.setIcon( icon );
         saveErrorLabel.setVisible(false);
     }
 

--- a/ide/team.commons/src/org/netbeans/modules/team/commons/treelist/AsynchronousNode.java
+++ b/ide/team.commons/src/org/netbeans/modules/team/commons/treelist/AsynchronousNode.java
@@ -22,7 +22,6 @@ import org.netbeans.modules.team.commons.ColorManager;
 import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.awt.Image;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.util.MissingResourceException;
@@ -268,8 +267,8 @@ public abstract class AsynchronousNode<T> extends TreeListNode {
             lblLoading.setForeground(ColorManager.getDefault().getDisabledColor());
             lblError = new TreeLabel(NbBundle.getMessage(AsynchronousNode.class, "LBL_NotResponding")); //NOI18N
             lblError.setForeground(ColorManager.getDefault().getErrorColor());
-            Image img = ImageUtilities.loadImage("org/netbeans/modules/team/commons/resources/error.png"); //NOI18N
-            lblError.setIcon(new ImageIcon(img));
+            Icon icon = ImageUtilities.loadIcon("org/netbeans/modules/team/commons/resources/error.png"); //NOI18N
+            lblError.setIcon(icon);
             lblFill = new JLabel();
             btnRetry = new LinkButton(NbBundle.getMessage(AsynchronousNode.class, "LBL_Retry"), new AbstractAction() { //NOI18N
                 @Override

--- a/ide/utilities/src/org/netbeans/modules/openfile/RecentFiles.java
+++ b/ide/utilities/src/org/netbeans/modules/openfile/RecentFiles.java
@@ -305,7 +305,7 @@ public final class RecentFiles {
             }
             i = dObj == null
                     ? null
-                    : new ImageIcon(dObj.getNodeDelegate().getIcon(
+                    : ImageUtilities.image2Icon(dObj.getNodeDelegate().getIcon(
                     BeanInfo.ICON_COLOR_16x16));
         }
         return i;

--- a/ide/utilities/src/org/netbeans/modules/url/URLPresenter.java
+++ b/ide/utilities/src/org/netbeans/modules/url/URLPresenter.java
@@ -27,20 +27,17 @@ import java.beans.BeanInfo;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import javax.swing.AbstractButton;
-import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JMenuItem;
 import org.openide.awt.Mnemonics;
 import org.openide.cookies.OpenCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileStateInvalidException;
-import org.openide.filesystems.FileSystem;
 import org.openide.filesystems.FileUIUtils;
 import org.openide.loaders.DataObject;
 import org.openide.nodes.Node;
 import org.openide.util.HelpCtx;
 import org.openide.util.ImageUtilities;
-import org.openide.util.Utilities;
 import org.openide.util.WeakListeners;
 import org.openide.util.actions.Presenter;
 
@@ -108,7 +105,7 @@ final class URLPresenter implements Presenter.Menu,
             } catch (FileStateInvalidException fsie) {
                 // OK, so we use the default icon
             }
-            presenter.setIcon(new ImageIcon(icon));
+            presenter.setIcon(ImageUtilities.image2Icon(icon));
         }
 
         /* set the presenter's text and ensure it is maintained up-to-date: */

--- a/ide/versioning.util/src/org/netbeans/modules/versioning/util/common/FileTreeView.java
+++ b/ide/versioning.util/src/org/netbeans/modules/versioning/util/common/FileTreeView.java
@@ -50,7 +50,6 @@ import java.util.logging.Logger;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
@@ -680,7 +679,7 @@ public abstract class FileTreeView<T extends VCSStatusNode> implements FileViewC
         @Override
         public Icon getIcon (Object o) {
             Node n = Visualizer.findNode(o);
-            return new ImageIcon(n.getIcon(java.beans.BeanInfo.ICON_COLOR_16x16));
+            return ImageUtilities.image2Icon(n.getIcon(java.beans.BeanInfo.ICON_COLOR_16x16));
         }
 
         private boolean isModified (T node) {

--- a/ide/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/CompletionQuery.java
+++ b/ide/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/CompletionQuery.java
@@ -381,8 +381,8 @@ public class CompletionQuery extends AsyncCompletionQuery {
     private FileObject primaryFile;
     private CompletionContextImpl context;
     
-    private static final ImageIcon LOADING_ICON = new ImageIcon(ImageUtilities.loadImage(
-            "org/netbeans/modules/xml/schema/completion/resources/element.png")); // NOI18N
+    private static final ImageIcon LOADING_ICON = ImageUtilities.loadImageIcon(
+            "org/netbeans/modules/xml/schema/completion/resources/element.png", false); // NOI18N
 
     private static final class FinishDownloadItem implements CompletionItem {
         @Override

--- a/ide/xml.text/src/org/netbeans/modules/xml/text/navigator/NavigatorTreeCellRenderer.java
+++ b/ide/xml.text/src/org/netbeans/modules/xml/text/navigator/NavigatorTreeCellRenderer.java
@@ -19,9 +19,7 @@
 
 package org.netbeans.modules.xml.text.navigator;
 import java.awt.Component;
-import java.awt.Image;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeCellRenderer;
@@ -45,12 +43,12 @@ public class NavigatorTreeCellRenderer extends DefaultTreeCellRenderer {
     
     private static final String ERROR_16 = "org/netbeans/modules/xml/text/navigator/resources/badge_error.png";
     
-    private final Image ERROR_IMAGE = ImageUtilities.loadImage(ERROR_16, true);
+    private final Icon ERROR_ICON = ImageUtilities.loadIcon(ERROR_16, true);
    
-    private final Icon[] TAG_ICON = new Icon[]{getImageIcon(TAG_16, false), getImageIcon(TAG_16, true)};
-    private final Icon[] PI_ICON = new Icon[]{getImageIcon(PI_16, false), getImageIcon(PI_16, true)};
-    private final Icon[] DOCTYPE_ICON = new Icon[]{getImageIcon(DOCTYPE_16, false), getImageIcon(DOCTYPE_16, true)};
-    private final Icon[] CDATA_ICON = new Icon[]{getImageIcon(CDATA_16, false), getImageIcon(CDATA_16, true)};
+    private final Icon[] TAG_ICON = new Icon[]{getIcon(TAG_16, false), getIcon(TAG_16, true)};
+    private final Icon[] PI_ICON = new Icon[]{getIcon(PI_16, false), getIcon(PI_16, true)};
+    private final Icon[] DOCTYPE_ICON = new Icon[]{getIcon(DOCTYPE_16, false), getIcon(DOCTYPE_16, true)};
+    private final Icon[] CDATA_ICON = new Icon[]{getIcon(CDATA_16, false), getIcon(CDATA_16, true)};
      
     private HtmlRenderer.Renderer renderer;
     
@@ -91,12 +89,13 @@ public class NavigatorTreeCellRenderer extends DefaultTreeCellRenderer {
         renderer.setIcon(icons[containsError ? 1 : 0]);
     }
     
-    private ImageIcon getImageIcon(String name, boolean error){
-        ImageIcon icon = ImageUtilities.loadImageIcon(name, false);
-        if(error)
-            return new ImageIcon(ImageUtilities.mergeImages( icon.getImage(), ERROR_IMAGE, 15, 7 ));
-        else
+    private Icon getIcon(String name, boolean error){
+        Icon icon = ImageUtilities.loadIcon(name);
+        if (error) {
+            return ImageUtilities.mergeIcons(icon, ERROR_ICON, 15, 7);
+        } else {
             return icon;
+        }
     }
     
 }

--- a/java/form/src/org/netbeans/modules/form/FormToolBar.java
+++ b/java/form/src/org/netbeans/modules/form/FormToolBar.java
@@ -82,7 +82,7 @@ final class FormToolBar {
         listener = new Listener();
 
         // selection button
-        selectionButton = new JToggleButton(new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/form/resources/selection_mode.png", true)), // NOI18N
+        selectionButton = new JToggleButton(ImageUtilities.loadImageIcon("org/netbeans/modules/form/resources/selection_mode.png", true), // NOI18N
                                             false);
         selectionButton.addActionListener(listener);
         selectionButton.addMouseListener(listener);
@@ -93,7 +93,7 @@ final class FormToolBar {
         initButton(selectionButton);
 
         // connection button
-        connectionButton = new JToggleButton(new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/form/resources/connection_mode.png", true)), // NOI18N
+        connectionButton = new JToggleButton(ImageUtilities.loadImageIcon("org/netbeans/modules/form/resources/connection_mode.png", true), // NOI18N
                                              false);
         connectionButton.addActionListener(listener);
         connectionButton.addMouseListener(listener);
@@ -213,7 +213,7 @@ final class FormToolBar {
             PaletteItem item = PaletteUtils.getSelectedItem();
             if (item != null && mode == FormDesigner.MODE_ADD) {
                 addLabel.setIcon(
-                    new ImageIcon(item.getNode().getIcon(BeanInfo.ICON_COLOR_16x16)));
+                    ImageUtilities.image2Icon(item.getNode().getIcon(BeanInfo.ICON_COLOR_16x16)));
                 addLabel.setText(item.getNode().getDisplayName());
             }
             else {

--- a/java/form/src/org/netbeans/modules/form/HandleLayer.java
+++ b/java/form/src/org/netbeans/modules/form/HandleLayer.java
@@ -3410,7 +3410,7 @@ public class HandleLayer extends JPanel implements MouseListener, MouseMotionLis
                 } else {
                     icon = node.getIcon(java.beans.BeanInfo.ICON_COLOR_16x16);
                 }
-                showingComponents[0] = new JLabel(new ImageIcon(icon));
+                showingComponents[0] = new JLabel(ImageUtilities.image2Icon(icon));
                 Dimension dim = showingComponents[0].getPreferredSize();
                 hotSpot = new Point(dim.width/2, dim.height/2);
                 if (hotSpot.x < 0) {

--- a/java/form/src/org/netbeans/modules/form/NonVisualTray.java
+++ b/java/form/src/org/netbeans/modules/form/NonVisualTray.java
@@ -28,6 +28,7 @@ import org.openide.nodes.*;
 import org.openide.actions.*;
 import org.openide.explorer.*;
 import org.openide.explorer.view.*;
+import org.openide.util.ImageUtilities;
 
 /**
  * A component that displays non visual beans.
@@ -141,7 +142,7 @@ public class NonVisualTray extends JPanel implements ExplorerManager.Provider {
         public Component getListCellRendererComponent(JList list,
             Object value, int index, boolean isSelected, boolean cellHasFocus) {
             Node node = Visualizer.findNode(value);
-            ImageIcon icon = new ImageIcon(node.getIcon(java.beans.BeanInfo.ICON_COLOR_32x32));
+            Icon icon = ImageUtilities.image2Icon(node.getIcon(java.beans.BeanInfo.ICON_COLOR_32x32));
             button.setIcon(icon);
             String text = node.getShortDescription();
             button.setText(text);

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/customizer/SourceSetPanel.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/customizer/SourceSetPanel.java
@@ -68,7 +68,7 @@ public class SourceSetPanel extends javax.swing.JPanel {
     private static final String PROJECT_ICON = "org.netbeans.modules/gradle/resources/gradle.png"; //NOI18N
     private static final String ARTIFACT_ICON = "org.netbeans.modules/gradle/resources/module-artifact.png"; //NOI18N
 
-    final Icon folderIcon = new ImageIcon(NodeUtils.getTreeFolderIcon(false));
+    final Icon folderIcon = ImageUtilities.image2Icon(NodeUtils.getTreeFolderIcon(false));
     final Icon projectIcon = ImageUtilities.loadImageIcon(PROJECT_ICON, false);
     final Icon artifactIcon = ImageUtilities.loadImageIcon(ARTIFACT_ICON, false);
 

--- a/java/i18n/src/org/netbeans/modules/i18n/wizard/ResourceWizardPanel.java
+++ b/java/i18n/src/org/netbeans/modules/i18n/wizard/ResourceWizardPanel.java
@@ -56,6 +56,7 @@ import org.netbeans.modules.i18n.SelectorUtils;
 
 import org.openide.WizardValidationException;
 import org.openide.loaders.DataObject;
+import org.openide.util.ImageUtilities;
 import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
 import org.openide.filesystems.FileObject;
@@ -154,7 +155,7 @@ final class ResourceWizardPanel extends JPanel {
                     }
 
                     label.setText(name); // NOI18N
-                    label.setIcon(new ImageIcon(dataObject.getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16)));
+                    label.setIcon(ImageUtilities.image2Icon(dataObject.getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16)));
                 } else {
                     label.setText(""); // NOI18N
                     label.setIcon(null);

--- a/java/i18n/src/org/netbeans/modules/i18n/wizard/SourceWizardPanel.java
+++ b/java/i18n/src/org/netbeans/modules/i18n/wizard/SourceWizardPanel.java
@@ -50,6 +50,7 @@ import org.openide.nodes.NodeAcceptor;
 import org.openide.nodes.NodeOperation;
 import org.openide.util.HelpCtx;
 import org.openide.util.UserCancelException;
+import org.openide.util.ImageUtilities;
 import org.netbeans.modules.i18n.SelectorUtils;
 import org.openide.WizardDescriptor;
 
@@ -313,7 +314,7 @@ final class SourceWizardPanel extends JPanel {
                 } else {
                     label.setText(cp.getResourceName(dataObject.getPrimaryFile(), '.', false )); // NOI18N
                 }
-                label.setIcon(new ImageIcon(dataObject.getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16)));
+                label.setIcon(ImageUtilities.image2Icon(dataObject.getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16)));
             } else {
                 label.setText(""); // NOI18N
                 label.setIcon(null);

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/CCPaintComponent.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/CCPaintComponent.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.swing.BorderFactory;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JPanel;
 import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
@@ -317,7 +316,7 @@ public class CCPaintComponent extends JPanel {
         
         @Override
         protected void draw(Graphics g){
-            drawIcon(g, new ImageIcon(ImageUtilities.loadImage(COLUMN_ICON)));
+            drawIcon(g, ImageUtilities.loadIcon(COLUMN_ICON));
             drawString(g, tableName+".", Color.BLACK);
             drawString(g, columnName, Color.BLACK, getDrawFont().deriveFont(Font.BOLD), false);
         }
@@ -334,7 +333,7 @@ public class CCPaintComponent extends JPanel {
         
         @Override
         protected void draw(Graphics g){
-            drawIcon(g, new ImageIcon(ImageUtilities.loadImage(TABLE_ICON)));
+            drawIcon(g, ImageUtilities.loadIcon(TABLE_ICON));
             drawString(g, tableName, Color.BLACK, getDrawFont().deriveFont(Font.BOLD), false);
         }
         
@@ -350,7 +349,7 @@ public class CCPaintComponent extends JPanel {
         
         @Override
         protected void draw(Graphics g){
-            drawIcon(g, new ImageIcon(ImageUtilities.loadImage(PU_ICON)));
+            drawIcon(g, ImageUtilities.loadIcon(PU_ICON));
             drawString(g, puName, Color.BLACK, getDrawFont().deriveFont(Font.BOLD), false);
         }
         
@@ -365,7 +364,7 @@ public class CCPaintComponent extends JPanel {
         
         @Override
         protected void draw(Graphics g){
-            drawIcon(g, new ImageIcon(ImageUtilities.loadImage(PU_ICON)));
+            drawIcon(g, ImageUtilities.loadIcon(PU_ICON));
             drawString(g, puName, Color.BLACK, getDrawFont().deriveFont(Font.BOLD), false);
         }
         
@@ -381,7 +380,7 @@ public class CCPaintComponent extends JPanel {
         
         @Override
         protected void draw(Graphics g){
-            drawIcon(g, new ImageIcon(ImageUtilities.loadImage(PU_ICON)));
+            drawIcon(g, ImageUtilities.loadIcon(PU_ICON));
             drawString(g, elName, Color.BLACK, getDrawFont().deriveFont(Font.BOLD), false);
         }
         
@@ -391,7 +390,7 @@ public class CCPaintComponent extends JPanel {
         
         @Override
         protected void draw(Graphics g){
-            drawIcon(g, new ImageIcon(ImageUtilities.loadImage(NOCONNECTION_ICON)));
+            drawIcon(g, ImageUtilities.loadIcon(NOCONNECTION_ICON));
             drawString(g, NbBundle.getMessage(CCPaintComponent.class, "LBL_ConnectToDatabase"), Color.RED, getDrawFont().deriveFont(Font.BOLD), false);
         }
 
@@ -400,7 +399,7 @@ public class CCPaintComponent extends JPanel {
         
         @Override
         protected void draw(Graphics g){
-            drawIcon(g, new ImageIcon(ImageUtilities.loadImage(CONNECTION_ICON)));
+            drawIcon(g, ImageUtilities.loadIcon(CONNECTION_ICON));
             drawString(g, NbBundle.getMessage(CCPaintComponent.class, "LBL_AddConnection"), Color.BLACK, getDrawFont().deriveFont(Font.BOLD), false);
         }
 

--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/LibrariesNode.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/LibrariesNode.java
@@ -559,8 +559,8 @@ public final class LibrariesNode extends AbstractNode {
     static synchronized Icon getFolderIcon (boolean opened) {
         if (openedFolderIconCache == null) {
             Node n = DataFolder.findFolder(FileUtil.getConfigRoot()).getNodeDelegate();
-            openedFolderIconCache = new ImageIcon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
-            folderIconCache = new ImageIcon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
+            openedFolderIconCache = ImageUtilities.image2Icon(n.getOpenedIcon(BeanInfo.ICON_COLOR_16x16));
+            folderIconCache = ImageUtilities.image2Icon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
         }
         if (opened) {
             return openedFolderIconCache;

--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/ClassPathListCellRenderer.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/ClassPathListCellRenderer.java
@@ -29,7 +29,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JList;
 import javax.swing.JTable;
 import javax.swing.JTree;
@@ -66,11 +65,10 @@ public class ClassPathListCellRenderer extends DefaultListCellRenderer {
     private static final Pattern FOREIGN_PLAIN_FILE_REFERENCE = Pattern.compile("\\$\\{file\\.reference\\.([^${}]+)\\}"); // NOI18N
     private static final Pattern UNKNOWN_FILE_REFERENCE = Pattern.compile("\\$\\{([^${}]+)\\}"); // NOI18N
 
-    private static ImageIcon ICON_FOLDER = null;
-
-    private static ImageIcon ICON_BROKEN_JAR;
-    private static ImageIcon ICON_BROKEN_LIBRARY;
-    private static ImageIcon ICON_BROKEN_ARTIFACT;
+    private static Icon ICON_FOLDER = null;
+    private static Icon ICON_BROKEN_JAR;
+    private static Icon ICON_BROKEN_LIBRARY;
+    private static Icon ICON_BROKEN_ARTIFACT;
 
     private PropertyEvaluator evaluator;
     private FileObject projectFolder;
@@ -199,7 +197,7 @@ public class ClassPathListCellRenderer extends DefaultListCellRenderer {
             case ClassPathSupport.Item.TYPE_LIBRARY:
                 if ( item.isBroken() ) {
                     if ( ICON_BROKEN_LIBRARY == null ) {
-                        ICON_BROKEN_LIBRARY = new ImageIcon( ImageUtilities.mergeImages( ProjectProperties.ICON_LIBRARY.getImage(), ProjectProperties.ICON_BROKEN_BADGE.getImage(), 7, 7 ) );
+                        ICON_BROKEN_LIBRARY = ImageUtilities.mergeIcons( ProjectProperties.ICON_LIBRARY, ProjectProperties.ICON_BROKEN_BADGE, 7, 7 );
                     }
                     return ICON_BROKEN_LIBRARY;
                 }
@@ -209,7 +207,7 @@ public class ClassPathListCellRenderer extends DefaultListCellRenderer {
             case ClassPathSupport.Item.TYPE_ARTIFACT:
                 if ( item.isBroken() ) {
                     if ( ICON_BROKEN_ARTIFACT == null ) {
-                        ICON_BROKEN_ARTIFACT = new ImageIcon( ImageUtilities.mergeImages( ProjectProperties.ICON_ARTIFACT.getImage(), ProjectProperties.ICON_BROKEN_BADGE.getImage(), 7, 7 ) );
+                        ICON_BROKEN_ARTIFACT = ImageUtilities.mergeIcons(ProjectProperties.ICON_ARTIFACT, ProjectProperties.ICON_BROKEN_BADGE, 7, 7 );
                     }
                     return ICON_BROKEN_ARTIFACT;
                 }
@@ -224,18 +222,18 @@ public class ClassPathListCellRenderer extends DefaultListCellRenderer {
             case ClassPathSupport.Item.TYPE_JAR:
                 if ( item.isBroken() ) {
                     if ( ICON_BROKEN_JAR == null ) {
-                        ICON_BROKEN_JAR = new ImageIcon( ImageUtilities.mergeImages( ProjectProperties.ICON_JAR.getImage(), ProjectProperties.ICON_BROKEN_BADGE.getImage(), 7, 7 ) );
+                        ICON_BROKEN_JAR = ImageUtilities.mergeIcons(ProjectProperties.ICON_JAR, ProjectProperties.ICON_BROKEN_BADGE, 7, 7);
                     }
                     return ICON_BROKEN_JAR;
                 }
                 else {
                     File file = item.getResolvedFile();
-                    ImageIcon icn = file.isDirectory() ? getFolderIcon() : ProjectProperties.ICON_JAR;
+                    Icon icn = file.isDirectory() ? getFolderIcon() : ProjectProperties.ICON_JAR;
                     if (item.getSourceFilePath() != null) {
-                        icn =  new ImageIcon( ImageUtilities.mergeImages( icn.getImage(), ProjectProperties.ICON_SOURCE_BADGE.getImage(), 8, 8 ));
+                        icn = ImageUtilities.mergeIcons(icn, ProjectProperties.ICON_SOURCE_BADGE, 8, 8 );
                     }
                     if (item.getJavadocFilePath() != null) {
-                        icn =  new ImageIcon( ImageUtilities.mergeImages( icn.getImage(), ProjectProperties.ICON_JAVADOC_BADGE.getImage(), 8, 0 ));
+                        icn = ImageUtilities.mergeIcons(icn, ProjectProperties.ICON_JAVADOC_BADGE, 8, 0 );
                     }
                     return icn;
                 }
@@ -274,13 +272,11 @@ public class ClassPathListCellRenderer extends DefaultListCellRenderer {
         return null;
     }
 
-    private static ImageIcon getFolderIcon() {
-
+    private static Icon getFolderIcon() {
         if ( ICON_FOLDER == null ) {
             DataFolder dataFolder = DataFolder.findFolder( FileUtil.getConfigRoot() );
-            ICON_FOLDER = new ImageIcon( dataFolder.getNodeDelegate().getIcon( BeanInfo.ICON_COLOR_16x16 ) );
+            ICON_FOLDER = ImageUtilities.image2Icon(dataFolder.getNodeDelegate().getIcon( BeanInfo.ICON_COLOR_16x16 ) );
         }
-
         return ICON_FOLDER;
     }
 

--- a/java/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/CheckRenderer.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/codegen/ui/CheckRenderer.java
@@ -29,7 +29,6 @@ import java.beans.BeanInfo;
 import java.util.List;
 import javax.swing.ButtonGroup;
 import javax.swing.ButtonModel;
-import javax.swing.ImageIcon;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JList;
@@ -39,6 +38,7 @@ import javax.swing.event.ChangeListener;
 import javax.swing.tree.TreeCellRenderer;
 import org.openide.explorer.view.Visualizer;
 import org.openide.nodes.Node;
+import org.openide.util.ImageUtilities;
 
 /**
  * @author Petr Hrebejk
@@ -99,7 +99,7 @@ class CheckRenderer extends JPanel implements TreeCellRenderer {
         }
 
         label.setText( n.getHtmlDisplayName() );
-        label.setIcon( new ImageIcon( n.getIcon(BeanInfo.ICON_COLOR_16x16) ) ); // XXX Ask description directly
+        label.setIcon( ImageUtilities.image2Icon( n.getIcon(BeanInfo.ICON_COLOR_16x16) ) ); // XXX Ask description directly
 
         panel.add(check, BorderLayout.WEST );
         panel.add(label, BorderLayout.CENTER );

--- a/java/java.editor/src/org/netbeans/modules/java/editor/overridden/ElementDescription.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/overridden/ElementDescription.java
@@ -169,17 +169,17 @@ public class ElementDescription {
     }
 
     public Icon getIcon() {
-        Image badge;
+        Icon badge;
 
         if (overriddenFlag) {
-            badge = ImageUtilities.loadImage("org/netbeans/modules/java/editor/resources/is-overridden-badge.png");
+            badge = ImageUtilities.loadIcon("org/netbeans/modules/java/editor/resources/is-overridden-badge.png");
         } else {
-            badge = ImageUtilities.loadImage("org/netbeans/modules/java/editor/resources/overrides-badge.png");
+            badge = ImageUtilities.loadIcon("org/netbeans/modules/java/editor/resources/overrides-badge.png");
         }
 
-        Image icon = ImageUtilities.icon2Image(ElementIcons.getElementIcon(imageKind, modifiers));
+        Icon icon = ElementIcons.getElementIcon(imageKind, modifiers);
 
-        return ImageUtilities.image2Icon(ImageUtilities.mergeImages(icon, badge, 16, 0));
+        return ImageUtilities.mergeIcons(icon, badge, 16, 0);
     }
 
     public boolean isOverridden() {

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
@@ -185,7 +185,7 @@ public class InspectAndRefactorPanel extends javax.swing.JPanel implements Popup
         customScopeLab = new JLabel(NbBundle.getMessage(InspectAndRefactorPanel.class, "LBL_CustomScope"), prj , SwingConstants.LEFT); //NOI18N
         if (fileObject!=null) {
             if (!fileObject.isFolder())
-                currentFile = new JLabel(NbBundle.getMessage(InspectAndRefactorPanel.class, "LBL_CurrentFile", fileObject.getNameExt()), new ImageIcon(dob.getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16)), SwingConstants.LEFT);
+                currentFile = new JLabel(NbBundle.getMessage(InspectAndRefactorPanel.class, "LBL_CurrentFile", fileObject.getNameExt()), ImageUtilities.image2Icon(dob.getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16)), SwingConstants.LEFT);
             String packageName = getPackageName(fileObject);
             if (packageName!=null)
                 currentPackage = new JLabel(NbBundle.getMessage(InspectAndRefactorPanel.class, "LBL_CurrentPackage", packageName), ImageUtilities.loadImageIcon(PACKAGE, false), SwingConstants.LEFT);

--- a/java/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/CheckRenderer.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/analyzer/ui/CheckRenderer.java
@@ -26,10 +26,8 @@ import java.awt.event.ItemListener;
 import java.awt.event.MouseListener;
 import java.beans.BeanInfo;
 import java.util.Collection;
-import java.util.List;
 import javax.swing.ButtonGroup;
 import javax.swing.ButtonModel;
-import javax.swing.ImageIcon;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JList;
@@ -39,6 +37,7 @@ import javax.swing.event.ChangeListener;
 import javax.swing.tree.TreeCellRenderer;
 import org.openide.explorer.view.Visualizer;
 import org.openide.nodes.Node;
+import org.openide.util.ImageUtilities;
 
 /**
  * @author Petr Hrebejk
@@ -106,7 +105,7 @@ class CheckRenderer extends JPanel implements TreeCellRenderer {
         }
         
         label.setText( displayName );
-        label.setIcon( new ImageIcon( n.getIcon(BeanInfo.ICON_COLOR_16x16) ) ); // XXX Ask description directly
+        label.setIcon( ImageUtilities.image2Icon( n.getIcon(BeanInfo.ICON_COLOR_16x16) ) ); // XXX Ask description directly
         
         return this;
         

--- a/java/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/ui/CreateJREPanel.java
+++ b/java/java.j2seembedded/src/org/netbeans/modules/java/j2seembedded/ui/CreateJREPanel.java
@@ -604,8 +604,8 @@ public class CreateJREPanel extends javax.swing.JPanel {
     }
 
     private static final class EJDKFileView extends FileView {
-        private static final Image BADGE = ImageUtilities.loadImage("org/netbeans/modules/java/j2seembedded/resources/ejdkBadge.gif", false); // NOI18N
-        private static final ImageIcon EMPTY = ImageUtilities.loadImageIcon("org/netbeans/modules/java/j2seembedded/resources/empty.gif", false); // NOI18N
+        private static final Icon BADGE = ImageUtilities.loadIcon("org/netbeans/modules/java/j2seembedded/resources/ejdkBadge.gif"); // NOI18N
+        private static final Icon EMPTY = ImageUtilities.loadIcon("org/netbeans/modules/java/j2seembedded/resources/empty.gif"); // NOI18N
 
         private final FileSystemView fsv;
         private Icon lastOrig;
@@ -628,11 +628,11 @@ public class CreateJREPanel extends javax.swing.JPanel {
                     assert lastMerged != null;
                     return lastMerged;
                 }
-                lastMerged = ImageUtilities.image2Icon(ImageUtilities.mergeImages(
-                        ImageUtilities.icon2Image(original),
+                lastMerged = ImageUtilities.mergeIcons(
+                        original,
                         BADGE,
-                        original.getIconWidth() - BADGE.getWidth(null),
-                        original.getIconHeight()- BADGE.getHeight(null)));
+                        original.getIconWidth() - BADGE.getIconWidth(),
+                        original.getIconHeight()- BADGE.getIconHeight());
                 lastOrig = original;
                 return lastMerged;
             } else {

--- a/java/java.navigation/src/org/netbeans/modules/java/navigation/base/Icons.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/navigation/base/Icons.java
@@ -19,11 +19,8 @@
 
 package org.netbeans.modules.java.navigation.base;
 
-import java.awt.Image;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import org.openide.util.ImageUtilities;
-import org.openide.util.Utilities;
 
 /** Capable of serving incns for the navigator modules. Notice that it is not
  * used for Element icons. May not be necessary an may be removed later.
@@ -41,13 +38,7 @@ public class Icons {
     }
     
     public static Icon getBusyIcon () {
-        Image img = ImageUtilities.loadImage (WAIT);
-        if (img == null) {
-            return null;
-        }
-        else {
-            return new ImageIcon (img);
-        }
+        return ImageUtilities.loadIcon (WAIT);
     }
     
 }

--- a/java/java.project.ui/src/org/netbeans/spi/java/project/support/ui/PackageView.java
+++ b/java/java.project.ui/src/org/netbeans/spi/java/project/support/ui/PackageView.java
@@ -38,7 +38,6 @@ import javax.swing.Action;
 import javax.swing.ComboBoxModel;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.ListCellRenderer;
@@ -63,6 +62,7 @@ import org.openide.loaders.DataObjectNotFoundException;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.FilterNode;
 import org.openide.nodes.Node;
+import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.Parameters;
 import org.openide.util.WeakListeners;
@@ -374,7 +374,7 @@ public class PackageView {
                 Image image = PackageDisplayUtils.getIcon(pkg, empty);
                 icon = image2icon.get(image);
                 if ( icon == null ) {            
-                    icon = new ImageIcon( image );
+                    icon = ImageUtilities.image2Icon( image );
                     image2icon.put( image, icon );
                 }
             }

--- a/java/maven/src/org/netbeans/modules/maven/problems/BatchProblemNotifier.java
+++ b/java/maven/src/org/netbeans/modules/maven/problems/BatchProblemNotifier.java
@@ -197,9 +197,9 @@ public class BatchProblemNotifier {
             this.root = root;
             n = NotificationDisplayer.getDefault().notify(
                 build_title(root.getName()),
-                ImageUtilities.image2Icon(ImageUtilities.mergeImages(
-                    ImageUtilities.loadImage(IconResources.MAVEN_ICON, true),
-                    ImageUtilities.loadImage(IconResources.BROKEN_PROJECT_BADGE_ICON, true), 8, 0)),
+                ImageUtilities.mergeIcons(
+                    ImageUtilities.loadIcon(IconResources.MAVEN_ICON, true),
+                    ImageUtilities.loadIcon(IconResources.BROKEN_PROJECT_BADGE_ICON, true), 8, 0),
                 build_details(root), this);
             LOG.log(Level.FINE, "created for {0}", root);
         }

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/WhereUsedBinaryElement.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/WhereUsedBinaryElement.java
@@ -18,10 +18,8 @@
  */
 package org.netbeans.modules.refactoring.java;
 
-import java.awt.Image;
 import java.beans.BeanInfo;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import org.netbeans.modules.refactoring.java.spi.JavaWhereUsedFilters;
 import org.netbeans.modules.refactoring.java.ui.tree.ElementGripFactory;
 import org.netbeans.modules.refactoring.spi.FiltersManager;
@@ -64,14 +62,12 @@ public class WhereUsedBinaryElement extends SimpleRefactoringElementImplementati
     public Lookup getLookup() {
         Icon icon = null;
         try {
-            ImageIcon imageIcon = new ImageIcon(DataObject.find(fo).getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16));
+            icon = ImageUtilities.image2Icon(DataObject.find(fo).getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16));
             Boolean inTestFile = ElementGripFactory.getDefault().inTestFile(fo);
             if (Boolean.TRUE == inTestFile) {
-                Image mergeImages = ImageUtilities.mergeImages(imageIcon.getImage(),
-                        ImageUtilities.loadImageIcon("org/netbeans/modules/refactoring/java/resources/found_item_test.png", false).getImage(), 4, 4);
-                imageIcon = new ImageIcon(mergeImages);
+                icon = ImageUtilities.mergeIcons(icon,
+                        ImageUtilities.loadIcon("org/netbeans/modules/refactoring/java/resources/found_item_test.png"), 4, 4);
             }
-            icon = imageIcon;
         } catch (DataObjectNotFoundException ex) {
             // ignore
         }

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/Call.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/Call.java
@@ -192,12 +192,12 @@ final class Call implements CallDescriptor {
 
         if (isCallerGraph) {
             if (parent != null) {
-                c.icon = ImageUtilities.image2Icon(ImageUtilities.mergeImages(ImageUtilities.icon2Image(i), ImageUtilities.loadImage("org/netbeans/modules/refactoring/java/resources/up.png"), 0, 0));
+                c.icon = ImageUtilities.mergeIcons(i, ImageUtilities.loadIcon("org/netbeans/modules/refactoring/java/resources/up.png"), 0, 0);
             } else {
                 c.icon = i;
             }
         } else {
-            c.icon = ImageUtilities.image2Icon(ImageUtilities.mergeImages(ImageUtilities.icon2Image(i), ImageUtilities.loadImage("org/netbeans/modules/refactoring/java/resources/down.png"), 0, 0));
+            c.icon = ImageUtilities.mergeIcons(i, ImageUtilities.loadIcon("org/netbeans/modules/refactoring/java/resources/down.png"), 0, 0);
         }
 
         c.selection = TreePathHandle.create(selection, javac);

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveClassPanel.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/MoveClassPanel.java
@@ -63,6 +63,7 @@ import org.openide.explorer.view.NodeRenderer;
 import org.openide.filesystems.FileObject;
 import org.openide.nodes.Node;
 import org.openide.util.Exceptions;
+import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 
@@ -739,7 +740,7 @@ private void bypassRefactoringCheckBoxItemStateChanged(java.awt.event.ItemEvent 
             } else if (value instanceof Node) {
                 Node node = (Node) value;
                 setText(node.getHtmlDisplayName());
-                setIcon(new ImageIcon(node.getIcon(BeanInfo.ICON_COLOR_16x16)));
+                setIcon(ImageUtilities.image2Icon(node.getIcon(BeanInfo.ICON_COLOR_16x16)));
             } else {
                 // #49954: render a specially inserted class somehow.
                 String item = (String) value;

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CurrentFileScopeProvider.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CurrentFileScopeProvider.java
@@ -22,13 +22,13 @@ import java.beans.BeanInfo;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import org.netbeans.modules.refactoring.api.Scope;
 import org.netbeans.modules.refactoring.spi.ui.ScopeProvider;
 import org.netbeans.modules.refactoring.spi.ui.ScopeReference;
 import org.openide.filesystems.FileObject;
 import org.openide.loaders.DataObject;
 import org.openide.loaders.DataObjectNotFoundException;
+import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle.Messages;
 
@@ -42,7 +42,7 @@ import org.openide.util.NbBundle.Messages;
 public final class CurrentFileScopeProvider extends ScopeProvider {
 
     private Scope scope;
-    private ImageIcon icon;
+    private Icon icon;
     private String detail;
 
     @Override
@@ -57,7 +57,7 @@ public final class CurrentFileScopeProvider extends ScopeProvider {
             currentFileDo = DataObject.find(file);
         } catch (DataObjectNotFoundException ex) {
         } // Not important, only for Icon.
-        icon = currentFileDo != null ? new ImageIcon(currentFileDo.getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16)) : null;
+        icon = currentFileDo != null ? ImageUtilities.image2Icon(currentFileDo.getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16)) : null;
         detail = file.getNameExt();
         scope = Scope.create(null, null, Arrays.asList(file));
 

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CurrentJavaProjectDependenciesScopeProvider.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CurrentJavaProjectDependenciesScopeProvider.java
@@ -98,7 +98,7 @@ public final class CurrentJavaProjectDependenciesScopeProvider extends ScopeProv
         }
         scope = Scope.create(Arrays.asList(projectSources), null, null, true);
         detail = pi.getDisplayName();
-        icon = new ImageIcon(ImageUtilities.mergeImages(
+        icon = ImageUtilities.image2Icon(ImageUtilities.mergeImages(
                 ImageUtilities.icon2Image(pi.getIcon()),
                 ImageUtilities.loadImage("org/netbeans/modules/refactoring/java/resources/binary_badge.gif"),
                 10, 10));

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CurrentJavaProjectDependenciesScopeProvider.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/scope/CurrentJavaProjectDependenciesScopeProvider.java
@@ -98,10 +98,10 @@ public final class CurrentJavaProjectDependenciesScopeProvider extends ScopeProv
         }
         scope = Scope.create(Arrays.asList(projectSources), null, null, true);
         detail = pi.getDisplayName();
-        icon = ImageUtilities.image2Icon(ImageUtilities.mergeImages(
-                ImageUtilities.icon2Image(pi.getIcon()),
-                ImageUtilities.loadImage("org/netbeans/modules/refactoring/java/resources/binary_badge.gif"),
-                10, 10));
+        icon = ImageUtilities.mergeIcons(
+                pi.getIcon(),
+                ImageUtilities.loadIcon("org/netbeans/modules/refactoring/java/resources/binary_badge.gif"),
+                10, 10);
         return true;
     }
 

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/FileTreeElement.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/FileTreeElement.java
@@ -19,12 +19,10 @@
 
 package org.netbeans.modules.refactoring.java.ui.tree;
 
-import java.awt.Image;
 import java.beans.BeanInfo;
 import java.net.URISyntaxException;
 import java.net.URL;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import org.netbeans.api.actions.Openable;
 import org.netbeans.api.java.platform.JavaPlatform;
 import org.netbeans.api.java.platform.JavaPlatformManager;
@@ -112,14 +110,13 @@ public class FileTreeElement implements TreeElement, Openable {
     @Override
     public Icon getIcon() {
         try {
-            ImageIcon imageIcon = new ImageIcon(DataObject.find(fo).getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16));
+            Icon icon = ImageUtilities.image2Icon(DataObject.find(fo).getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16));
             Boolean inTestFile = ElementGripFactory.getDefault().inTestFile(fo);
             if(Boolean.TRUE == inTestFile) {
-                Image mergeImages = ImageUtilities.mergeImages(imageIcon.getImage(),
-                        ImageUtilities.loadImageIcon("org/netbeans/modules/refactoring/java/resources/found_item_test.png", false).getImage(), 4, 4);
-                imageIcon = new ImageIcon(mergeImages);
+                icon = ImageUtilities.mergeIcons(icon,
+                    ImageUtilities.loadIcon("org/netbeans/modules/refactoring/java/resources/found_item_test.png"), 4, 4);
             }
-            return imageIcon;
+            return icon;
         } catch (DataObjectNotFoundException ex) {
             return null;
         }

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/JavaPlatformTreeElement.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/JavaPlatformTreeElement.java
@@ -41,7 +41,7 @@ public class JavaPlatformTreeElement implements TreeElement {
     JavaPlatformTreeElement(JavaPlatform platform) {
         this.platform = platform;
 
-        icon = new ImageIcon(ImageUtilities.loadImage(PLATFORM_ICON));
+        icon = ImageUtilities.loadIcon(PLATFORM_ICON);
         displayName = platform.getDisplayName();
     }
 

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/SourceGroupTreeElement.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/tree/SourceGroupTreeElement.java
@@ -23,7 +23,6 @@ import java.awt.Image;
 import java.beans.BeanInfo;
 import java.lang.ref.WeakReference;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.SourceGroup;
 import org.netbeans.modules.refactoring.spi.ui.TreeElement;
@@ -55,7 +54,7 @@ public class SourceGroupTreeElement implements TreeElement {
             try {
                 Image image = DataObject.find(sg.getRootFolder()).getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16);
                 image = ImageUtilities.mergeImages( image, ImageUtilities.loadImage(PACKAGE_BADGE), 7, 7 );
-                icon = new ImageIcon(image);
+                icon = ImageUtilities.image2Icon(image);
             } catch (DataObjectNotFoundException d) {
             }
         }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/actions/ImportModulePanel.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/actions/ImportModulePanel.java
@@ -331,7 +331,7 @@ public class ImportModulePanel extends javax.swing.JPanel {
                 }
                 // TODO - depend on gsf directly and get icons from there!
                 //setIcon( ElementIcons.getElementIcon( td.kind, null ) );
-                setIcon(new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/php/editor/resources/interface.png"))); // NOI18N
+                setIcon(ImageUtilities.loadIcon("org/netbeans/modules/php/editor/resources/interface.png")); // NOI18N
             } else {
                 setText(value.toString());
             }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/codegen/ui/CheckBoxTreeRenderer.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/codegen/ui/CheckBoxTreeRenderer.java
@@ -20,13 +20,13 @@ package org.netbeans.modules.php.editor.codegen.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
-import javax.swing.ImageIcon;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.JTree;
 import javax.swing.tree.TreeCellRenderer;
+import org.openide.util.ImageUtilities;
 
 /**
  *
@@ -59,7 +59,7 @@ public class CheckBoxTreeRenderer extends JPanel implements TreeCellRenderer {
         if (value instanceof CheckNode) {
             CheckNode n = (CheckNode) value;
             check.setSelected(n.isSelected());
-            label.setIcon(new ImageIcon(n.getIcon())); // XXX Ask description directly
+            label.setIcon(ImageUtilities.image2Icon(n.getIcon())); // XXX Ask description directly
         }
         if (isSelected) {
             label.setForeground(LIST_FOR_COLORS.getSelectionForeground());

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPDOCCodeCompletion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPDOCCodeCompletion.java
@@ -227,7 +227,7 @@ public final class PHPDOCCodeCompletion {
 
     public static class PHPDOCCodeCompletionItem implements CompletionProposal {
         private static final String PHP_ANNOTATION_ICON = "org/netbeans/modules/php/editor/resources/annotation.png"; //NOI18N
-        private static final ImageIcon ANNOTATION_ICON = new ImageIcon(ImageUtilities.loadImage(PHP_ANNOTATION_ICON));
+        private static final ImageIcon ANNOTATION_ICON = ImageUtilities.loadImageIcon(PHP_ANNOTATION_ICON, false);
         private final AnnotationCompletionTag tag;
         private final int anchorOffset;
         private final PHPDOCTagElement elem;

--- a/php/php.editor/src/org/netbeans/modules/php/editor/nav/hierarchy/ClassHierarchyPanel.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/nav/hierarchy/ClassHierarchyPanel.java
@@ -31,7 +31,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JPanel;
@@ -580,7 +579,7 @@ public class ClassHierarchyPanel extends JPanel implements HelpCtx.Provider {
             if (value instanceof TypeNode) {
                 TypeNode n = (TypeNode) value;
                 stringValue = n.toStringAsHtml();
-                label.setIcon(new ImageIcon(n.getIcon()));
+                label.setIcon(ImageUtilities.image2Icon(n.getIcon()));
             }
             if (isSelected) {
                 label.setForeground(LIST_FOR_COLORS.getSelectionForeground());

--- a/php/php.editor/src/org/netbeans/modules/php/editor/sql/SelectConnectionItem.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/sql/SelectConnectionItem.java
@@ -41,7 +41,7 @@ import org.openide.util.NbBundle;
  */
 public class SelectConnectionItem implements CompletionItem {
 
-    private static final ImageIcon CONNECTION_ICON = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/php/editor/resources/connection.gif")); // NOI18N
+    private static final ImageIcon CONNECTION_ICON = ImageUtilities.loadImageIcon("org/netbeans/modules/php/editor/resources/connection.gif", false); // NOI18N
 
     private Document doc;
     private DatabaseConnection dbconn;

--- a/php/php.latte/src/org/netbeans/modules/php/latte/completion/LatteCompletionProposal.java
+++ b/php/php.latte/src/org/netbeans/modules/php/latte/completion/LatteCompletionProposal.java
@@ -102,7 +102,7 @@ public abstract class LatteCompletionProposal implements CompletionProposal {
     }
 
     abstract static class MacroCompletionProposal extends LatteCompletionProposal {
-        private static final ImageIcon MACRO_ICON = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/php/latte/resources/macro_cc_icon.png")); //NOI18N
+        private static final ImageIcon MACRO_ICON = ImageUtilities.loadImageIcon("org/netbeans/modules/php/latte/resources/macro_cc_icon.png", false); //NOI18N
 
         public MacroCompletionProposal(LatteElement element, CompletionRequest request) {
             super(element, request);
@@ -159,7 +159,7 @@ public abstract class LatteCompletionProposal implements CompletionProposal {
     }
 
     static class HelperCompletionProposal extends LatteCompletionProposal {
-        private static final ImageIcon HELPER_ICON = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/php/latte/resources/helper_cc_icon.png")); //NOI18N
+        private static final ImageIcon HELPER_ICON = ImageUtilities.loadImageIcon("org/netbeans/modules/php/latte/resources/helper_cc_icon.png", false); //NOI18N
 
         public HelperCompletionProposal(LatteElement element, CompletionRequest request) {
             super(element, request);
@@ -184,7 +184,7 @@ public abstract class LatteCompletionProposal implements CompletionProposal {
     }
 
     static class KeywordCompletionProposal extends LatteCompletionProposal {
-        private static final ImageIcon KEYWORD_ICON = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/php/latte/resources/latte_cc_icon.png")); //NOI18N
+        private static final ImageIcon KEYWORD_ICON = ImageUtilities.loadImageIcon("org/netbeans/modules/php/latte/resources/latte_cc_icon.png", false); //NOI18N
         public KeywordCompletionProposal(LatteElement element, CompletionRequest request) {
             super(element, request);
         }
@@ -301,7 +301,7 @@ public abstract class LatteCompletionProposal implements CompletionProposal {
     }
 
     static class ControlCompletionProposal extends LatteCompletionProposal {
-        private static final ImageIcon CONTROL_ICON = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/php/latte/resources/latte_cc_icon.png")); //NOI18N
+        private static final ImageIcon CONTROL_ICON = ImageUtilities.loadImageIcon("org/netbeans/modules/php/latte/resources/latte_cc_icon.png", false); //NOI18N
 
         public ControlCompletionProposal(LatteElement element, CompletionRequest request) {
             super(element, request);

--- a/php/php.project/src/org/netbeans/modules/php/project/connections/ui/transfer/TransferFilesChooserVisual.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/connections/ui/transfer/TransferFilesChooserVisual.java
@@ -100,7 +100,7 @@ public final class TransferFilesChooserVisual extends JPanel {
                 default:
                     throw new IllegalStateException("Unknown transfer type: " + transferType);
             }
-            warningLabel.setIcon(new ImageIcon(ImageUtilities.loadImage(INFO_ICON, false)));
+            warningLabel.setIcon(ImageUtilities.loadIcon(INFO_ICON));
             warningLabel.setText(NbBundle.getMessage(TransferFilesChooserVisual.class, msgKey));
         }
     }

--- a/php/php.project/src/org/netbeans/modules/php/project/ui/PathUiSupport.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/ui/PathUiSupport.java
@@ -190,8 +190,8 @@ public final class PathUiSupport {
                 = "org/netbeans/modules/php/project/ui/resources/brokenProjectBadge.gif"; //NOI18N
 
         private static final ImageIcon ICON_BROKEN_BADGE = ImageUtilities.loadImageIcon(RESOURCE_ICON_BROKEN_BADGE, false);
-        private static ImageIcon ICON_FOLDER = null;
-        private static ImageIcon ICON_BROKEN_FOLDER = null;
+        private static Icon ICON_FOLDER = null;
+        private static Icon ICON_BROKEN_FOLDER = null;
 
         private final DefaultListCellRenderer delegate = new DefaultListCellRenderer();
         private final PropertyEvaluator evaluator;
@@ -253,8 +253,7 @@ public final class PathUiSupport {
                 default:
                     if (item.isBroken()) {
                         if (ICON_BROKEN_FOLDER == null) {
-                            ICON_BROKEN_FOLDER = new ImageIcon(ImageUtilities.mergeImages(getFolderIcon().getImage(),
-                                    ICON_BROKEN_BADGE.getImage(), 7, 7));
+                            ICON_BROKEN_FOLDER = ImageUtilities.mergeIcons(getFolderIcon(), ICON_BROKEN_BADGE, 7, 7);
                         }
                         return ICON_BROKEN_FOLDER;
                     }
@@ -280,10 +279,10 @@ public final class PathUiSupport {
             return null;
         }
 
-        private static ImageIcon getFolderIcon() {
+        private static Icon getFolderIcon() {
             if (ICON_FOLDER == null) {
                 DataFolder dataFolder = DataFolder.findFolder(FileUtil.getConfigRoot());
-                ICON_FOLDER = new ImageIcon(dataFolder.getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16));
+                ICON_FOLDER = ImageUtilities.image2Icon(dataFolder.getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16));
             }
             return ICON_FOLDER;
         }

--- a/php/php.refactoring/src/org/netbeans/modules/refactoring/php/ui/tree/FileTreeElement.java
+++ b/php/php.refactoring/src/org/netbeans/modules/refactoring/php/ui/tree/FileTreeElement.java
@@ -20,7 +20,6 @@ package org.netbeans.modules.refactoring.php.ui.tree;
 
 import java.beans.BeanInfo;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.refactoring.spi.ui.TreeElement;
@@ -28,6 +27,7 @@ import org.netbeans.modules.refactoring.spi.ui.TreeElementFactory;
 import org.openide.filesystems.FileObject;
 import org.openide.loaders.DataObject;
 import org.openide.loaders.DataObjectNotFoundException;
+import org.openide.util.ImageUtilities;
 
 /**
  *
@@ -55,7 +55,7 @@ public class FileTreeElement implements TreeElement {
     public Icon getIcon() {
         Icon result = null;
         try {
-            result = new ImageIcon(DataObject.find(fileObject).getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16));
+            result = ImageUtilities.image2Icon(DataObject.find(fileObject).getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16));
         } catch (DataObjectNotFoundException ex) {
             //no-op
         }

--- a/php/php.refactoring/src/org/netbeans/modules/refactoring/php/ui/tree/FolderTreeElement.java
+++ b/php/php.refactoring/src/org/netbeans/modules/refactoring/php/ui/tree/FolderTreeElement.java
@@ -20,7 +20,6 @@ package org.netbeans.modules.refactoring.php.ui.tree;
 
 import java.beans.BeanInfo;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.refactoring.spi.ui.TreeElement;
@@ -28,6 +27,7 @@ import org.netbeans.modules.refactoring.spi.ui.TreeElementFactory;
 import org.openide.filesystems.FileObject;
 import org.openide.loaders.DataObject;
 import org.openide.loaders.DataObjectNotFoundException;
+import org.openide.util.ImageUtilities;
 
 /**
  *
@@ -55,7 +55,7 @@ public class FolderTreeElement implements TreeElement {
     public Icon getIcon() {
         Icon result = null;
         try {
-            result = new ImageIcon(DataObject.find(fileObject).getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16));
+            result = ImageUtilities.image2Icon(DataObject.find(fileObject).getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16));
         } catch (DataObjectNotFoundException ex) {
             //no-op
         }

--- a/php/php.twig/src/org/netbeans/modules/php/twig/editor/completion/TwigCompletionProposal.java
+++ b/php/php.twig/src/org/netbeans/modules/php/twig/editor/completion/TwigCompletionProposal.java
@@ -123,7 +123,7 @@ public abstract class TwigCompletionProposal implements CompletionProposal {
 
     static class FilterCompletionProposal extends TwigCompletionProposal {
 
-        private static final ImageIcon ICON = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/php/twig/resources/filter.png")); //NOI18N
+        private static final ImageIcon ICON = ImageUtilities.loadImageIcon("org/netbeans/modules/php/twig/resources/filter.png", false); //NOI18N
 
         public FilterCompletionProposal(TwigElement element, CompletionRequest request) {
             super(element, request);
@@ -197,7 +197,7 @@ public abstract class TwigCompletionProposal implements CompletionProposal {
 
     static class OperatorCompletionProposal extends TwigCompletionProposal {
 
-        private static final ImageIcon ICON = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/php/twig/resources/twig-logo.png")); //NOI18N
+        private static final ImageIcon ICON = ImageUtilities.loadImageIcon("org/netbeans/modules/php/twig/resources/twig-logo.png", false); //NOI18N
 
         public OperatorCompletionProposal(TwigElement element, CompletionRequest request) {
             super(element, request);

--- a/platform/core.ui/src/org/netbeans/core/ui/options/general/GeneralOptionsPanel.java
+++ b/platform/core.ui/src/org/netbeans/core/ui/options/general/GeneralOptionsPanel.java
@@ -23,7 +23,6 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.EventQueue;
-import java.awt.Image;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.net.MalformedURLException;
@@ -32,7 +31,6 @@ import java.util.prefs.Preferences;
 import javax.swing.AbstractButton;
 import javax.swing.ButtonGroup;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
@@ -82,8 +80,8 @@ public class GeneralOptionsPanel extends JPanel implements ActionListener {
             nbErrorForeground = new Color(255, 0, 0);
         }
         errorLabel.setForeground(nbErrorForeground);
-        Image img = ImageUtilities.loadImage("org/netbeans/core/ui/resources/error.gif"); //NOI18N
-        errorLabel.setIcon(new ImageIcon(img));
+        Icon icon = ImageUtilities.loadIcon("org/netbeans/core/ui/resources/error.gif"); //NOI18N
+        errorLabel.setIcon(icon);
         errorLabel.setVisible(false);
         
         loc (lWebBrowser, "Web_Browser");

--- a/platform/javahelp/src/org/netbeans/modules/javahelp/HelpCtxProcessor.java
+++ b/platform/javahelp/src/org/netbeans/modules/javahelp/HelpCtxProcessor.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.util.logging.Level;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
-import javax.swing.ImageIcon;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.openide.loaders.DataObject;
@@ -43,6 +42,7 @@ import org.openide.nodes.NodeEvent;
 import org.openide.nodes.NodeListener;
 import org.openide.nodes.NodeMemberEvent;
 import org.openide.nodes.NodeReorderEvent;
+import org.openide.util.ImageUtilities;
 import org.openide.util.RequestProcessor;
 import org.openide.util.WeakListeners;
 import org.openide.util.lookup.Lookups;
@@ -211,7 +211,7 @@ public final class HelpCtxProcessor implements Environment.Provider {
             if (obj.isValid()) {
                 Image icon = obj.getNodeDelegate().getIcon(BeanInfo.ICON_COLOR_16x16);
                 if (icon != null) {
-                    putValue(Action.SMALL_ICON, new ImageIcon(icon));
+                    putValue(Action.SMALL_ICON, ImageUtilities.image2Icon(icon));
                 }
             }
         }

--- a/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETableColumn.java
+++ b/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETableColumn.java
@@ -25,7 +25,6 @@ import java.awt.Point;
 import java.util.Comparator;
 import java.util.Properties;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JViewport;
@@ -528,39 +527,4 @@ public class ETableColumn extends TableColumn implements Comparable<ETableColumn
             return obj1.toString().compareTo(obj2.toString());
         }
     }
-    
-    /**
-     * Utility method merging 2 icons.
-     */
-    private static Icon mergeIcons(Icon icon1, Icon icon2, int x, int y, Component c) {
-        int w = 0, h = 0;
-        if (icon1 != null) {
-            w = icon1.getIconWidth();
-            h = icon1.getIconHeight();
-        }
-        if (icon2 != null) {
-            w = icon2.getIconWidth()  + x > w ? icon2.getIconWidth()   + x : w;
-            h = icon2.getIconHeight() + y > h ? icon2.getIconHeight()  + y : h;
-        }
-        if (w < 1) w = 16;
-        if (h < 1) h = 16;
-        
-        java.awt.image.ColorModel model = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment ().
-                                          getDefaultScreenDevice ().getDefaultConfiguration ().
-                                          getColorModel (java.awt.Transparency.BITMASK);
-        java.awt.image.BufferedImage buffImage = new java.awt.image.BufferedImage (model,
-             model.createCompatibleWritableRaster (w, h), model.isAlphaPremultiplied (), null);
-        
-        java.awt.Graphics g = buffImage.createGraphics ();
-        if (icon1 != null) {
-            icon1.paintIcon(c, g, 0, 0);
-        }
-        if (icon2 != null) {
-            icon2.paintIcon(c, g, x, y);
-        }
-        g.dispose();
-        
-        return new ImageIcon(buffImage);
-    }
-
 }

--- a/platform/openide.loaders/src/org/openide/awt/DynaMenuModel.java
+++ b/platform/openide.loaders/src/org/openide/awt/DynaMenuModel.java
@@ -46,7 +46,7 @@ import org.openide.util.actions.Presenter;
  * @author mkleint
  */
 class DynaMenuModel {
-    private static final Icon BLANK_ICON = new ImageIcon(ImageUtilities.loadImage("org/openide/loaders/empty.gif")); // NOI18N
+    private static final Icon BLANK_ICON = ImageUtilities.loadIcon("org/openide/loaders/empty.gif"); // NOI18N
     
     private List<JComponent> menuItems;
     private HashMap<DynamicMenuContent, JComponent[]> actionToMenuMap;

--- a/platform/options.api/test/unit/src/org/netbeans/api/options/RegisteredCategory.java
+++ b/platform/options.api/test/unit/src/org/netbeans/api/options/RegisteredCategory.java
@@ -56,8 +56,7 @@ public final class RegisteredCategory extends OptionsCategory {
     @Override
     public Icon getIcon() {
         if (icon == null) {
-            Image image = ImageUtilities.loadImage("org/netbeans/modules/options/resources/advanced.png");
-            icon = new ImageIcon(image);
+            icon = ImageUtilities.loadIcon("org/netbeans/modules/options/resources/advanced.png");
         }
         return icon;
     }

--- a/platform/progress.ui/src/org/netbeans/modules/progress/ui/ListComponent.java
+++ b/platform/progress.ui/src/org/netbeans/modules/progress/ui/ListComponent.java
@@ -196,7 +196,7 @@ public class ListComponent extends JPanel {
     static Icon iconOrImage2icon( Object iconOrImage ) {
         return (iconOrImage instanceof Icon)
                 ? (Icon) iconOrImage
-                : new ImageIcon( (Image) iconOrImage );
+                : ImageUtilities.image2Icon( (Image) iconOrImage );
     }
     
     

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/image/ImageDetailProvider.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/image/ImageDetailProvider.java
@@ -30,7 +30,6 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.util.logging.Level;
-import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
@@ -51,6 +50,7 @@ import org.openide.util.lookup.ServiceProvider;
 import org.openide.windows.TopComponent;
 import static org.netbeans.modules.profiler.heapwalk.details.jdk.image.ImageBuilder.LOGGER;
 import static org.netbeans.modules.profiler.heapwalk.details.jdk.image.ImageBuilder.BUILDERS;
+import org.openide.util.ImageUtilities;
 
 /**
  *
@@ -305,7 +305,7 @@ public class ImageDetailProvider extends DetailsProvider.Basic {
             drawChecker(g, 0, 0, width, height);
             g.drawImage(image, 0, 0, null);
 
-            JComponent c = new JScrollPane(new JLabel(new ImageIcon(displayedImage)));
+            JComponent c = new JScrollPane(new JLabel(ImageUtilities.image2Icon(displayedImage)));
             add(c, BorderLayout.CENTER);
 
 

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/BaseBuilders.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/BaseBuilders.java
@@ -33,6 +33,7 @@ import org.netbeans.modules.profiler.heapwalk.details.jdk.image.ImageBuilder;
 import org.netbeans.modules.profiler.heapwalk.details.jdk.ui.Utils.InstanceBuilder;
 import org.netbeans.modules.profiler.heapwalk.details.jdk.ui.Utils.PlaceholderIcon;
 import org.netbeans.modules.profiler.heapwalk.details.spi.DetailsUtils;
+import org.openide.util.ImageUtilities;
 
 /**
  *
@@ -219,7 +220,7 @@ final class BaseBuilders {
             if(image == null) {
                     return new PlaceholderIcon(width, height);
             }
-            return new ImageIcon(image);
+            return ImageUtilities.image2Icon(image);
         }
         
     }

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/WindowBuilders.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/details/jdk/ui/WindowBuilders.java
@@ -25,7 +25,6 @@ import java.awt.Frame;
 import java.awt.Image;
 import java.beans.PropertyVetoException;
 import java.util.List;
-import javax.swing.ImageIcon;
 import javax.swing.JDesktopPane;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
@@ -42,6 +41,7 @@ import org.netbeans.modules.profiler.heapwalk.details.jdk.ui.ComponentBuilders.C
 import org.netbeans.modules.profiler.heapwalk.details.jdk.ui.ComponentBuilders.ContainerBuilder;
 import org.netbeans.modules.profiler.heapwalk.details.jdk.ui.ComponentBuilders.JComponentBuilder;
 import org.netbeans.modules.profiler.heapwalk.details.spi.DetailsUtils;
+import org.openide.util.ImageUtilities;
 
 /**
  *
@@ -184,7 +184,7 @@ final class WindowBuilders {
             } else {
                 JInternalFrame presenter = new JInternalFrame(instance.getTitle());
                 Image img = instance.getIconImage();
-                if (img != null) presenter.setFrameIcon(new ImageIcon(img));
+                if (img != null) presenter.setFrameIcon(ImageUtilities.image2Icon(img));
                 for (Component c : instance.getComponents()) presenter.add(c);
                 presenter.pack();
                 return presenter;
@@ -265,7 +265,7 @@ final class WindowBuilders {
                 JInternalFrame presenter = new JInternalFrame(instance.getTitle());
                 List<Image> images = instance.getIconImages();
                 Image img = images.isEmpty() ? null : images.get(0);
-                if (img != null) presenter.setFrameIcon(new ImageIcon(img));
+                if (img != null) presenter.setFrameIcon(ImageUtilities.image2Icon(img));
                 for (Component c : instance.getComponents()) presenter.add(c);
                 presenter.pack();
                 return presenter;

--- a/profiler/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TimedTakeSnapshotProfilingPointFactory.java
+++ b/profiler/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TimedTakeSnapshotProfilingPointFactory.java
@@ -23,13 +23,11 @@ import org.netbeans.modules.profiler.ppoints.ui.TimedTakeSnapshotCustomizer;
 import org.openide.ErrorManager;
 import org.openide.util.NbBundle;
 import java.util.Properties;
-import javax.swing.GrayFilter;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
-import javax.swing.UIManager;
 import org.netbeans.modules.profiler.api.ProjectUtilities;
 import org.netbeans.modules.profiler.api.icons.Icons;
 import org.netbeans.modules.profiler.ppoints.ui.ProfilingPointsIcons;
+import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
 
 
@@ -61,12 +59,7 @@ public class TimedTakeSnapshotProfilingPointFactory extends CodeProfilingPointFa
     }
     
     public Icon getDisabledIcon() {
-        Icon icon = UIManager.getLookAndFeel().getDisabledIcon(null, 
-                Icons.getIcon(ProfilingPointsIcons.TAKE_SNAPSHOT_TIMED));
-        if (icon == null)
-            icon = new ImageIcon(GrayFilter.createDisabledImage(
-                    Icons.getImage(ProfilingPointsIcons.TAKE_SNAPSHOT_TIMED)));
-        return icon;
+        return ImageUtilities.createDisabledIcon(getIcon());
     }
 
     public int getScope() {

--- a/profiler/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TriggeredTakeSnapshotProfilingPointFactory.java
+++ b/profiler/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/TriggeredTakeSnapshotProfilingPointFactory.java
@@ -23,13 +23,11 @@ import org.netbeans.modules.profiler.ppoints.ui.TriggeredTakeSnapshotCustomizer;
 import org.openide.ErrorManager;
 import org.openide.util.NbBundle;
 import java.util.Properties;
-import javax.swing.GrayFilter;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
-import javax.swing.UIManager;
 import org.netbeans.modules.profiler.api.ProjectUtilities;
 import org.netbeans.modules.profiler.api.icons.Icons;
 import org.netbeans.modules.profiler.ppoints.ui.ProfilingPointsIcons;
+import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
 
 
@@ -60,12 +58,7 @@ public class TriggeredTakeSnapshotProfilingPointFactory extends CodeProfilingPoi
     }
     
     public Icon getDisabledIcon() {
-        Icon icon = UIManager.getLookAndFeel().getDisabledIcon(null, 
-                Icons.getIcon(ProfilingPointsIcons.TAKE_SNAPSHOT_TRIGGERED));
-        if (icon == null)
-            icon = new ImageIcon(GrayFilter.createDisabledImage(
-                    Icons.getImage(ProfilingPointsIcons.TAKE_SNAPSHOT_TRIGGERED)));
-        return icon;
+        return ImageUtilities.createDisabledIcon(getIcon());
     }
 
     public int getScope() {

--- a/profiler/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/Utils.java
+++ b/profiler/profiler.ppoints/src/org/netbeans/modules/profiler/ppoints/Utils.java
@@ -152,7 +152,7 @@ public class Utils {
             }
             
             setText(""); // NOI18N
-            setIcon(isEnabled() ? icon : disabledIcon(icon));
+            setIcon(isEnabled() ? icon : ImageUtilities.createDisabledIcon(icon));
         }
         
         public String toString() {
@@ -160,10 +160,6 @@ public class Utils {
         }
     }
     
-    private static Icon disabledIcon(Icon icon) {
-        return new ImageIcon(GrayFilter.createDisabledImage(((ImageIcon)icon).getImage()));
-    }
-
     private static class ProjectPresenterListRenderer extends DefaultListCellRenderer {
         //~ Inner Classes --------------------------------------------------------------------------------------------------------
 
@@ -241,7 +237,7 @@ public class Utils {
                 Lookup.Provider project = (Lookup.Provider)value;
                 setText(ProjectUtilities.getDisplayName(project));
                 Icon icon = ProjectUtilities.getIcon(project);
-                setIcon(isEnabled() ? icon : disabledIcon(icon));
+                setIcon(isEnabled() ? icon : ImageUtilities.createDisabledIcon(icon));
                 setFont(Objects.equals(ProjectUtilities.getMainProject(), value) ? font.deriveFont(Font.BOLD) : font); // bold for main project
             }
         }

--- a/profiler/profiler/src/org/netbeans/modules/profiler/v2/impl/ProjectsSelector.java
+++ b/profiler/profiler/src/org/netbeans/modules/profiler/v2/impl/ProjectsSelector.java
@@ -26,9 +26,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import javax.swing.BorderFactory;
-import javax.swing.GrayFilter;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JToolBar;
@@ -43,6 +41,7 @@ import org.netbeans.lib.profiler.ui.swing.ProfilerTableContainer;
 import org.netbeans.lib.profiler.ui.swing.renderer.CheckBoxRenderer;
 import org.netbeans.lib.profiler.ui.swing.renderer.LabelRenderer;
 import org.netbeans.modules.profiler.api.ProjectUtilities;
+import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
 
@@ -216,15 +215,10 @@ public abstract class ProjectsSelector {
                 Lookup.Provider project = (Lookup.Provider)value;
                 setText(ProjectUtilities.getDisplayName(project));
                 Icon icon = ProjectUtilities.getIcon(project);
-                setIcon(isEnabled() ? icon : disabledIcon(icon));
+                setIcon(isEnabled() ? icon : ImageUtilities.createDisabledIcon(icon));
                 setFont(Objects.equals(main, value) ? font.deriveFont(Font.BOLD) : font);
             }
         }
-        
-        private static Icon disabledIcon(Icon icon) {
-            return new ImageIcon(GrayFilter.createDisabledImage(((ImageIcon)icon).getImage()));
-        }
-        
     }
     
 }

--- a/rust/rust.grammar/src/org/netbeans/modules/rust/grammar/structure/RustStructureItem.java
+++ b/rust/rust.grammar/src/org/netbeans/modules/rust/grammar/structure/RustStructureItem.java
@@ -71,7 +71,7 @@ public final class RustStructureItem implements StructureItem {
 
     @Override
     public ImageIcon getCustomIcon() {
-        return new ImageIcon(ImageUtilities.loadImage(getIconBase(node)));
+        return ImageUtilities.loadImageIcon(getIconBase(node), false);
     }
 
     @Override

--- a/rust/rust.options/src/org/netbeans/modules/rust/options/impl/CargoOptionsImpl.java
+++ b/rust/rust.options/src/org/netbeans/modules/rust/options/impl/CargoOptionsImpl.java
@@ -22,7 +22,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.prefs.Preferences;
-import javax.swing.ImageIcon;
+import javax.swing.Icon;
 import javax.swing.SwingUtilities;
 import org.netbeans.api.options.OptionsDisplayer;
 import org.netbeans.modules.rust.project.api.RustProjectAPI;
@@ -139,7 +139,7 @@ public final class CargoOptionsImpl {
         NotificationDisplayer.Priority priority = NotificationDisplayer.Priority.HIGH;
         String title = NbBundle.getMessage(CargoOptionsImpl.class, "MISSING_CARGO_TITLE"); // NOI18N
         String details = NbBundle.getMessage(CargoOptionsImpl.class, "MISSING_CARGO_DETAILS"); // NOI18N
-        ImageIcon icon = new ImageIcon(ImageUtilities.loadImage(RustProjectAPI.ICON));
+        Icon icon = ImageUtilities.loadIcon(RustProjectAPI.ICON);
         NotificationDisplayer.getDefault().notify(title, icon, details, (actionEvent) -> {
             showRustCargoOptions();
         });

--- a/rust/rust.project/src/org/netbeans/modules/rust/project/RustProjectFactory.java
+++ b/rust/rust.project/src/org/netbeans/modules/rust/project/RustProjectFactory.java
@@ -70,7 +70,7 @@ public final class RustProjectFactory implements ProjectFactory2 {
         if (src == null || !src.isFolder()) {
             return null;
         }
-        return new ProjectManager.Result(new ImageIcon(ImageUtilities.loadImage(RustProjectAPI.ICON)));
+        return new ProjectManager.Result(ImageUtilities.loadIcon(RustProjectAPI.ICON));
     }
 
     @Override

--- a/rust/rust.project/src/org/netbeans/modules/rust/project/RustProjectInformation.java
+++ b/rust/rust.project/src/org/netbeans/modules/rust/project/RustProjectInformation.java
@@ -22,7 +22,6 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.event.SwingPropertyChangeSupport;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectInformation;
@@ -56,7 +55,7 @@ final class RustProjectInformation implements ProjectInformation, PropertyChange
 
     @Override
     public Icon getIcon() {
-        return new ImageIcon(ImageUtilities.loadImage(RustProjectAPI.ICON));
+        return ImageUtilities.loadIcon(RustProjectAPI.ICON);
     }
 
     @Override

--- a/rust/rust.project/src/org/netbeans/modules/rust/project/RustSourceGroup.java
+++ b/rust/rust.project/src/org/netbeans/modules/rust/project/RustSourceGroup.java
@@ -21,11 +21,11 @@ package org.netbeans.modules.rust.project;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import org.netbeans.api.project.SourceGroup;
 import org.netbeans.modules.rust.project.api.RustIconFactory;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
+import org.openide.util.ImageUtilities;
 
 /**
  * A RustSourceGroup represents a "folder" with sources, this is used for the
@@ -63,7 +63,7 @@ public final class RustSourceGroup implements SourceGroup {
 
     @Override
     public Icon getIcon(boolean opened) {
-        return new ImageIcon(RustIconFactory.getSourceFolderIcon(opened));
+        return ImageUtilities.image2Icon(RustIconFactory.getSourceFolderIcon(opened));
     }
 
     @Override

--- a/webcommon/html.angular/src/org/netbeans/modules/html/angular/editor/AngularJsCompletionItem.java
+++ b/webcommon/html.angular/src/org/netbeans/modules/html/angular/editor/AngularJsCompletionItem.java
@@ -78,7 +78,7 @@ public class AngularJsCompletionItem implements CompletionProposal {
     @Override
     public ImageIcon getIcon() {
         if (angularIcon == null) {
-            angularIcon = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/html/angular/resources/AngularJS_icon_16.png")); //NOI18N
+            angularIcon = ImageUtilities.loadImageIcon("org/netbeans/modules/html/angular/resources/AngularJS_icon_16.png", false); //NOI18N
         }
         return angularIcon;
     }

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsStructureScanner.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsStructureScanner.java
@@ -667,30 +667,30 @@ public class JsStructureScanner implements StructureScanner {
         public ImageIcon getCustomIcon() {
             if (getFunctionScope().getJSKind() == JsElement.Kind.CALLBACK) {
                 if (callbackIcon == null) {
-                    callbackIcon = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/javascript2/editor/resources/methodCallback.png")); //NOI18N
+                    callbackIcon = ImageUtilities.loadImageIcon("org/netbeans/modules/javascript2/editor/resources/methodCallback.png", false); //NOI18N
                 }
                 return callbackIcon;
             } else  if (getFunctionScope().getJSKind() == JsElement.Kind.GENERATOR) {
                 if (getModifiers().contains(Modifier.PUBLIC)) {
                     if (publicGenerator == null) {
-                        publicGenerator = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/javascript2/editor/resources/generatorPublic.png")); //NOI18N
+                        publicGenerator = ImageUtilities.loadImageIcon("org/netbeans/modules/javascript2/editor/resources/generatorPublic.png", false); //NOI18N
                     }
                     return publicGenerator;
                 } else if (getModifiers().contains(Modifier.PRIVATE)) {
                     if (privateGenerator == null) {
-                        privateGenerator = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/javascript2/editor/resources/generatorPrivate.png")); //NOI18N
+                        privateGenerator = ImageUtilities.loadImageIcon("org/netbeans/modules/javascript2/editor/resources/generatorPrivate.png", false); //NOI18N
                     }
                     return privateGenerator;
                 } else if (getModifiers().contains(Modifier.PROTECTED)) {
                     if (priviligedGenerator == null) {
-                        priviligedGenerator = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/javascript2/editor/resources/generatorPriviliged.png")); //NOI18N
+                        priviligedGenerator = ImageUtilities.loadImageIcon("org/netbeans/modules/javascript2/editor/resources/generatorPriviliged.png", false); //NOI18N
                     }
                     return priviligedGenerator;
                 }
             }
             if (getModifiers().contains(Modifier.PROTECTED)) {
                 if(priviligedIcon == null) {
-                    priviligedIcon = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/javascript2/editor/resources/methodPriviliged.png")); //NOI18N
+                    priviligedIcon = ImageUtilities.loadImageIcon("org/netbeans/modules/javascript2/editor/resources/methodPriviliged.png", false); //NOI18N
                 }
                 return priviligedIcon;
             }

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/doc/JsDocumentationCodeCompletion.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/doc/JsDocumentationCodeCompletion.java
@@ -74,7 +74,7 @@ public class JsDocumentationCodeCompletion {
     public static class JsDocumentationCodeCompletionItem implements CompletionProposal {
 
         private static final String ANNOTATION_ICON = "org/netbeans/modules/csl/source/resources/icons/annotation.png"; //NOI18N
-        private static final ImageIcon IMAGE_ICON = new ImageIcon(ImageUtilities.loadImage(ANNOTATION_ICON));
+        private static final ImageIcon IMAGE_ICON = ImageUtilities.loadImageIcon(ANNOTATION_ICON, false);
 
         private final AnnotationCompletionTag tag;
         private final int anchorOffset;

--- a/webcommon/javascript2.html/src/org/netbeans/modules/javascript2/html/CssIdCompletionItem.java
+++ b/webcommon/javascript2.html/src/org/netbeans/modules/javascript2/html/CssIdCompletionItem.java
@@ -82,7 +82,7 @@ class CssIdCompletionItem implements CompletionProposal {
     @Override
     public ImageIcon getIcon() {
         if (cssIcon == null) {
-            cssIcon = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/javascript2/jquery/resources/style_sheet_16.png")); //NOI18N
+            cssIcon = ImageUtilities.loadImageIcon("org/netbeans/modules/javascript2/jquery/resources/style_sheet_16.png", false); //NOI18N
         }
         return cssIcon;
     }

--- a/webcommon/javascript2.jade/src/org/netbeans/modules/javascript2/jade/editor/JadeCompletionItem.java
+++ b/webcommon/javascript2.jade/src/org/netbeans/modules/javascript2/jade/editor/JadeCompletionItem.java
@@ -193,7 +193,7 @@ public class JadeCompletionItem implements CompletionProposal {
         @Override
         public ImageIcon getIcon() {
             if (keywordIcon == null) {
-                keywordIcon = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/javascript2/jade/resources/jade16.png")); //NOI18N
+                keywordIcon = ImageUtilities.loadImageIcon("org/netbeans/modules/javascript2/jade/resources/jade16.png", false); //NOI18N
             }
             return keywordIcon;
         }

--- a/webcommon/javascript2.jquery/src/org/netbeans/modules/javascript2/jquery/editor/JQueryCompletionItem.java
+++ b/webcommon/javascript2.jquery/src/org/netbeans/modules/javascript2/jquery/editor/JQueryCompletionItem.java
@@ -176,7 +176,7 @@ public abstract class JQueryCompletionItem implements CompletionProposal {
         @Override
         public ImageIcon getIcon() {
             if (cssIcon == null) {
-                cssIcon = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/javascript2/jquery/resources/style_sheet_16.png")); //NOI18N
+                cssIcon = ImageUtilities.loadImageIcon("org/netbeans/modules/javascript2/jquery/resources/style_sheet_16.png", false); //NOI18N
             }
             return cssIcon;
         }
@@ -227,7 +227,7 @@ public abstract class JQueryCompletionItem implements CompletionProposal {
         @Override
         public ImageIcon getIcon() {
             if (jQIcon == null) {
-                jQIcon = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/javascript2/jquery/resources/jquery_16_2.png")); //NOI18N
+                jQIcon = ImageUtilities.loadImageIcon("org/netbeans/modules/javascript2/jquery/resources/jquery_16_2.png", false); //NOI18N
             }
             return jQIcon;
         }

--- a/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/NodeJsUtils.java
+++ b/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/NodeJsUtils.java
@@ -65,7 +65,7 @@ public class NodeJsUtils {
     
     public static ImageIcon getNodeJsIcon () {
         if (NODEJS_ICON == null) {
-            NODEJS_ICON = new ImageIcon(ImageUtilities.loadImage(NODEJS_ICON_PATH)); //NOI18N
+            NODEJS_ICON = ImageUtilities.loadImageIcon(NODEJS_ICON_PATH, false); //NOI18N
         }
         return NODEJS_ICON;
     }

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/EditorUtils.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/EditorUtils.java
@@ -50,7 +50,7 @@ public class EditorUtils {
     
     public static ImageIcon getRequireJsIcon () {
         if (REQUIREJS_ICON == null) {
-            REQUIREJS_ICON = new ImageIcon(ImageUtilities.loadImage(REQUIRE_JS_ICON_PATH)); //NOI18N
+            REQUIREJS_ICON = ImageUtilities.loadImageIcon(REQUIRE_JS_ICON_PATH, false); //NOI18N
         }
         return REQUIREJS_ICON;
     }

--- a/webcommon/web.clientproject.api/src/org/netbeans/modules/web/clientproject/browser/ActiveBrowserAction.java
+++ b/webcommon/web.clientproject.api/src/org/netbeans/modules/web/clientproject/browser/ActiveBrowserAction.java
@@ -380,9 +380,9 @@ public class ActiveBrowserAction extends CallableSystemAction implements LookupL
     private Icon badgeWithArrowIcon(Image im) {
         // #235642
         assert im != null : "Image must be provided";
-        return ImageUtilities.image2Icon(ImageUtilities.mergeImages(im,
-            ImageUtilities.icon2Image(DropDownButtonFactory.getArrowIcon(false)),
-            isSmallToolbarIcon() ? 20 : 28, isSmallToolbarIcon() ? 6 : 10)); // NOI18N
+        return ImageUtilities.mergeIcons(ImageUtilities.image2Icon(im),
+            DropDownButtonFactory.getArrowIcon(false),
+            isSmallToolbarIcon() ? 20 : 28, isSmallToolbarIcon() ? 6 : 10); // NOI18N
     }
 
     private void showBrowserPickerPopup( JButton invoker ) {

--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ClientSideProject.java
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ClientSideProject.java
@@ -597,7 +597,7 @@ public class ClientSideProject implements Project {
 
         @Override
         public Icon getIcon() {
-            return new ImageIcon(ImageUtilities.loadImage(ClientSideProject.HTML5_PROJECT_ICON));
+            return ImageUtilities.loadIcon(ClientSideProject.HTML5_PROJECT_ICON);
         }
 
         @Override

--- a/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/ui/DomPanel.java
+++ b/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/ui/DomPanel.java
@@ -306,7 +306,7 @@ public class DomPanel extends JPanel implements ExplorerManager.Provider {
             if (image == null) {
                 icon = lookup.lookup(Icon.class);
             } else {
-                icon = new ImageIcon(image);
+                icon = ImageUtilities.image2Icon(image);
             }
             if (icon == null) {
                 BrowserFamilyId id = lookup.lookup(BrowserFamilyId.class);
@@ -315,7 +315,7 @@ public class DomPanel extends JPanel implements ExplorerManager.Provider {
                         if (browser.hasNetBeansIntegration() && (id == browser.getBrowserFamily())) {
                             image = browser.getIconImage(true);
                             if (image != null) {
-                                icon = new ImageIcon(image);
+                                icon = ImageUtilities.image2Icon(image);
                                 break;
                             }
                         }


### PR DESCRIPTION
In previous PRs, e.g. https://github.com/apache/netbeans/pull/7463 and https://github.com/apache/netbeans/pull/8083, SVG versions of various NetBeans icons were added to look better on Retina/HiDPI monitors. ImageUtilities has supported automatic loading of SVG versions of icons since https://github.com/apache/netbeans/pull/1278 .

To render at full HiDPI resolution, Icon/Image instances must be created via the methods in ImageUtilities rather than, in particular, the constructors of ImageIcon. Uses of the latter must be replaced with e.g. ImageUtilities.image2Icon and ImageUtilities.loadImageIcon. Some such replacements were done in https://github.com/apache/netbeans/pull/7472 .

This PR replaces most of the remaining trivial uses of the ImageIcon(Image) constructor. This allows SVG icons, when/once present, to render in full resolution on HiDPI/Retina displays. Bitmap icons also benefit from the improved scaling hints applied by ImageUtilities.

While this PR touches many lines, the changes should be simple enough that they can be reviewed by simply reading over the diffs (rather than by opening every dialog, UI panel etc. in a running IDE). I will also run my working IDE with these changes for a while to see if I bump into any observable problems. It's not necessary to have a HiDPI screen to test this patch; merely seeing that there are no new exceptions etc. when running the IDE should be sufficient.

There are still many uses of the "new ImageIcon(String)" and "new ImageIcon(URL)" variations of the ImageIcon constructors. Removing these is left for future work.