### PR TITLE
Add ImageUtilities methods to help migrating away from "new ImageIcon" (SVG icon related)

### DIFF
--- a/apisupport/apisupport.project/nbproject/project.xml
+++ b/apisupport/apisupport.project/nbproject/project.xml
@@ -260,7 +260,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.3</specification-version>
+                        <specification-version>9.36</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/BadgingSupport.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/BadgingSupport.java
@@ -20,7 +20,6 @@
 package org.netbeans.modules.apisupport.project.layers;
 
 import java.awt.Image;
-import java.awt.Toolkit;
 import java.beans.BeanInfo;
 import java.io.IOException;
 import java.io.InputStream;
@@ -64,6 +63,7 @@ import org.openide.filesystems.URLMapper;
 import org.openide.loaders.DataObject;
 import org.openide.loaders.InstanceDataObject;
 import org.openide.util.Exceptions;
+import org.openide.util.ImageUtilities;
 import org.openide.util.Mutex;
 import org.openide.util.NbBundle;
 import org.openide.util.NbCollections;
@@ -373,7 +373,7 @@ final class BadgingSupport implements SynchronousStatus, FileChangeListener {
                         ufo.removeFileChangeListener(fileChangeListener);
                         ufo.addFileChangeListener(fileChangeListener);
                     }
-                    return Toolkit.getDefaultToolkit().getImage(u[0]);
+                    return ImageUtilities.loadImage(u[0].toURI());
                 } catch (Exception e) {
                     LOG.log(Level.INFO, "For " + value + " on " + fo.getPath(), e);
                 }

--- a/ide/editor.lib/nbproject/project.xml
+++ b/ide/editor.lib/nbproject/project.xml
@@ -184,7 +184,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.3</specification-version>
+                        <specification-version>9.36</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/ide/editor.lib/src/org/netbeans/editor/AnnotationType.java
+++ b/ide/editor.lib/src/org/netbeans/editor/AnnotationType.java
@@ -26,10 +26,12 @@ import java.beans.PropertyChangeSupport;
 import java.awt.Image;
 import java.awt.Toolkit;
 import java.awt.image.ImageObserver;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.openide.util.ImageUtilities;
 
 /** Definition of the annotation type. Annotation type is defined by attributes like
  * highlight color, foreground color, glyph icon, etc. Each annotation added to document
@@ -156,7 +158,12 @@ public class AnnotationType {
      */
     public Image getGlyphImage() {
         if (img == null) {
-            img = Toolkit.getDefaultToolkit().createImage(getGlyph());
+            try {
+                img = ImageUtilities.loadImage(getGlyph().toURI());
+            } catch (URISyntaxException e) {
+                LOG.log(Level.WARNING, "getGlyph() returned invalid URI", e);
+                return null;
+            }
             final boolean waiting[] = new boolean [1];
             waiting[0] = true;
             if (!Toolkit.getDefaultToolkit().prepareImage(img, -1, -1, new ImageObserver() {

--- a/ide/editor/nbproject/project.xml
+++ b/ide/editor/nbproject/project.xml
@@ -239,7 +239,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.31</specification-version>
+                        <specification-version>9.36</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/editor/src/org/netbeans/modules/editor/options/AnnotationTypesNode.java
+++ b/ide/editor/src/org/netbeans/modules/editor/options/AnnotationTypesNode.java
@@ -20,14 +20,12 @@
 package org.netbeans.modules.editor.options;
 
 import java.awt.Image;
-import java.awt.Toolkit;
 import org.openide.util.Exceptions;
 import org.openide.util.HelpCtx;
 import org.openide.util.ImageUtilities;
 import org.openide.util.actions.SystemAction;
 import org.openide.actions.PropertiesAction;
 import org.openide.nodes.Children;
-import org.netbeans.modules.editor.options.AnnotationTypesFolder;
 import org.netbeans.editor.AnnotationType;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.BeanNode;
@@ -40,7 +38,10 @@ import org.netbeans.editor.AnnotationTypes;
 import java.lang.Boolean;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeEvent;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** Node representing the Annotation Types in Options window.
  *
@@ -48,7 +49,7 @@ import java.net.URL;
  * @since 07/2001
  */
 public class AnnotationTypesNode extends AbstractNode {
-
+    private static final Logger LOGGER = Logger.getLogger(AnnotationTypesNode.class.getName());
     private static final String HELP_ID = "editing.configuring.annotations"; // !!! NOI18N
     private static final String ICON_BASE = "org/netbeans/modules/editor/resources/annotationtypes"; // NOI18N
     
@@ -196,12 +197,11 @@ public class AnnotationTypesNode extends AbstractNode {
             }
             
             public Image getIcon(int type) {
-                // Utilities.loadImage does not handle URLs.
-                // Toolkit.getImage would work, but U.lI does nicer caching.
-                if (iconURL.getProtocol().equals("nbresloc")) { // NOI18N
-                    return ImageUtilities.loadImage(iconURL.getPath().substring(1));
-                } else {
-                    return Toolkit.getDefaultToolkit().getImage(iconURL);
+                try {
+                    return ImageUtilities.loadImage(iconURL.toURI());
+                } catch (URISyntaxException e) {
+                    LOGGER.log(Level.WARNING, "AnnotationType.getGlyph() returned invalid URI", e);
+                    return super.getIcon(type);
                 }
             }
             

--- a/ide/options.editor/nbproject/project.xml
+++ b/ide/options.editor/nbproject/project.xml
@@ -215,7 +215,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.3</specification-version>
+                        <specification-version>9.36</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/options.editor/src/org/netbeans/modules/options/colors/ColorModel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/colors/ColorModel.java
@@ -25,9 +25,9 @@ import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Image;
 import java.awt.Rectangle;
-import java.awt.Toolkit;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.swing.ImageIcon;
 import javax.swing.JEditorPane;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
@@ -134,14 +133,13 @@ public final class ColorModel {
             category.addAttribute(StyleConstants.NameAttribute, annotationType.getName());
             
             URL iconURL = annotationType.getGlyph ();
-            Image image = null;
-            if (iconURL.getProtocol ().equals ("nbresloc")) { // NOI18N
-                image = ImageUtilities.loadImage(iconURL.getPath().substring(1));
-            } else {
-                image = Toolkit.getDefaultToolkit ().getImage (iconURL);
-            }
-            if (image != null) {
-                category.addAttribute("icon", new ImageIcon(image)); //NOI18N
+            try {
+                Image image = ImageUtilities.loadImage(iconURL.toURI());
+                if (image != null) {
+                    category.addAttribute("icon", ImageUtilities.image2Icon(image)); //NOI18N
+                }
+            } catch (URISyntaxException e) {
+                LOG.log(Level.WARNING, "AnnotationType.getGlyph() returned invalid URI", e);
             }
             
             Color bgColor = annotationType.getHighlight();

--- a/java/form/nbproject/project.xml
+++ b/java/form/nbproject/project.xml
@@ -189,7 +189,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.3</specification-version>
+                        <specification-version>9.36</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/form/src/org/netbeans/modules/form/palette/PaletteItemDataObject.java
+++ b/java/form/src/org/netbeans/modules/form/palette/PaletteItemDataObject.java
@@ -22,6 +22,8 @@ package org.netbeans.modules.form.palette;
 import java.util.*;
 import java.io.*;
 import java.beans.*;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 
 import org.openide.util.ImageUtilities;
@@ -423,10 +425,9 @@ public class PaletteItemDataObject extends MultiDataObject implements CookieSet.
             {
                 if (icon32URL != null) { // explicit icon specified in file
                     try {
-                        return java.awt.Toolkit.getDefaultToolkit().getImage(
-                                                 new java.net.URL(icon32URL));
+                        return ImageUtilities.loadImage(new URI(icon32URL));
                     }
-                    catch (java.net.MalformedURLException ex) {} // ignore
+                    catch (URISyntaxException ex) {} // ignore
                 }
                 else if (getPrimaryFile().getAttribute("SystemFileSystem.icon32") != null) // NOI18N
                     return super.getIcon(type);
@@ -434,10 +435,9 @@ public class PaletteItemDataObject extends MultiDataObject implements CookieSet.
             else { // get small icon in other cases
                 if (icon16URL != null) { // explicit icon specified in file
                     try {
-                        return java.awt.Toolkit.getDefaultToolkit().getImage(
-                                                 new java.net.URL(icon16URL));
+                        return ImageUtilities.loadImage(new URI(icon16URL));
                     }
-                    catch (java.net.MalformedURLException ex) {} // ignore
+                    catch (URISyntaxException ex) {} // ignore
                 }
                 else if (getPrimaryFile().getAttribute("SystemFileSystem.icon") != null) // NOI18N
                     return super.getIcon(type);

--- a/java/performance/actionsframework/src/org/netbeans/actions/simple/Interpreter.java
+++ b/java/performance/actionsframework/src/org/netbeans/actions/simple/Interpreter.java
@@ -19,9 +19,12 @@
 
 package org.netbeans.actions.simple;
 
+import jakarta.websocket.ContainerProvider;
+import java.awt.Image;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
-import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,13 +34,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 import java.util.StringTokenizer;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.KeyStroke;
-import org.netbeans.actions.spi.ActionProvider;
-import org.netbeans.actions.spi.ContainerProvider;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.util.ImageUtilities;
 import org.openide.xml.XMLUtil;
 import org.xml.sax.*;
 import org.xml.sax.helpers.XMLReaderAdapter;
@@ -253,9 +255,9 @@ public class Interpreter implements org.xml.sax.DocumentHandler {
             int idx = s.lastIndexOf("/");
             String urlString = s.substring(0, idx) + "/" + partialPath;
             try {
-                URL url = new URL (urlString);
-                return new ImageIcon(Toolkit.getDefaultToolkit().getImage(url));
-            } catch (Exception e) {
+                Image image = ImageUtilities.loadImage(new URI(urlString));
+                return image == null ? new ImageIcon() : ImageUtilities.image2Icon(image);
+            } catch (URISyntaxException e) {
                 e.printStackTrace();
             }
         }

--- a/java/performance/nbproject/project.xml
+++ b/java/performance/nbproject/project.xml
@@ -99,7 +99,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.3</specification-version>
+                        <specification-version>9.36</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/core.kit/test/perf/src/org/openide/filesystems/data/JavaSrc.java
+++ b/platform/core.kit/test/perf/src/org/openide/filesystems/data/JavaSrc.java
@@ -136,27 +136,6 @@ public final class JavaSrc {
             super(filter, Children.LEAF);
         }
 
-        /*
-        public Image getIcon (int type) {
-            if ((type == java.beans.BeanInfo.ICON_COLOR_16x16) ||
-                    (type == java.beans.BeanInfo.ICON_MONO_16x16)) {
-                if (itemIcon == null)
-                    itemIcon = Toolkit.getDefaultToolkit ().getImage (
-                                   getClass ().getResource ("/org/netbeans/core/resources/action.gif")); // NOI18N
-                return itemIcon;
-            } else {
-                if (itemIcon32 == null)
-                    itemIcon32 = Toolkit.getDefaultToolkit ().getImage (
-                                     getClass ().getResource ("/org/netbeans/core/resources/action32.gif")); // NOI18N
-                return itemIcon32;
-            }
-        }
-
-        public Image getOpenedIcon (int type) {
-            return getIcon (type);
-        }
-        */
-
         /** Actions.
         * @return array of actions for this node
         */

--- a/platform/o.n.core/test/unit/data/projects/sfs-attr-test/sfs_attr_test/Util.java
+++ b/platform/o.n.core/test/unit/data/projects/sfs-attr-test/sfs_attr_test/Util.java
@@ -29,6 +29,7 @@ import org.openide.util.Utilities;
 public abstract class Util {
     private Util() {}
 
+    // Called by reflection via registration in platform/o.n.core/test/unit/data/projects/sfs-attr-test/sfs_attr_test/layer.xml
     private static Image mergeIcons(FileObject fo) throws IOException {
         int count = ((Integer)fo.getAttribute("iconCount")).intValue();
         if (count < 2) throw new IOException();

--- a/platform/openide.awt/nbproject/project.xml
+++ b/platform/openide.awt/nbproject/project.xml
@@ -47,7 +47,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.12</specification-version>
+                        <specification-version>9.36</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/openide.awt/src/org/openide/awt/AlwaysEnabledAction.java
+++ b/platform/openide.awt/src/org/openide/awt/AlwaysEnabledAction.java
@@ -26,6 +26,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Map;
@@ -227,7 +228,11 @@ implements PropertyChangeListener, ContextAwareAction {
                 return (Icon) icon;
             }
             if (icon instanceof URL) {
-                icon = Toolkit.getDefaultToolkit().getImage((URL)icon);
+                try {
+                    icon = ImageUtilities.loadImage(((URL)icon).toURI());
+                } catch (URISyntaxException e) {
+                    LOG.log(Level.WARNING, "SMALL_ICON attribute had invalid URI", e);
+                }
             }
             if (icon instanceof Image) {
                 return ImageUtilities.image2Icon((Image)icon);

--- a/platform/openide.filesystems.compat8/nbproject/project.xml
+++ b/platform/openide.filesystems.compat8/nbproject/project.xml
@@ -62,7 +62,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.3</specification-version>
+                        <specification-version>9.36</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/platform/openide.filesystems.compat8/src/org/openide/filesystems/FileSystemCompat.java
+++ b/platform/openide.filesystems.compat8/src/org/openide/filesystems/FileSystemCompat.java
@@ -20,15 +20,16 @@
 package org.openide.filesystems;
 
 import java.awt.Image;
-import java.awt.Toolkit;
 import java.beans.BeanInfo;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Set;
+import java.util.logging.Level;
 import static org.openide.filesystems.FileSystem.LOG;
 import org.openide.modules.PatchFor;
 import org.openide.util.Exceptions;
@@ -284,7 +285,11 @@ public abstract class FileSystemCompat {
                 Object value = fo.getAttribute(attr);
                 if (value != null) {
                     if (value instanceof URL) {
-                        return Toolkit.getDefaultToolkit().getImage((URL) value);
+                        try {
+                            return ImageUtilities.loadImage(((URL) value).toURI());
+                        } catch (URISyntaxException e) {
+                            LOG.log(Level.WARNING, "Annotation has invalid icon URI", e);
+                        }
                     } else if (value instanceof Image) {
                         // #18832
                         return (Image) value;

--- a/platform/openide.filesystems.nb/nbproject/project.xml
+++ b/platform/openide.filesystems.nb/nbproject/project.xml
@@ -54,7 +54,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.3</specification-version>
+                        <specification-version>9.36</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/platform/openide.filesystems.nb/src/org/netbeans/modules/openide/filesystems/FileSystemStatus.java
+++ b/platform/openide.filesystems.nb/src/org/netbeans/modules/openide/filesystems/FileSystemStatus.java
@@ -20,8 +20,8 @@
 package org.netbeans.modules.openide.filesystems;
 
 import java.awt.Image;
-import java.awt.Toolkit;
 import java.beans.BeanInfo;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.MissingResourceException;
@@ -117,7 +117,11 @@ public final class FileSystemStatus implements StatusDecorator, ImageDecorator {
             Object value = fo.getAttribute(attr);
             if (value != null) {
                 if (value instanceof URL) {
-                    return Toolkit.getDefaultToolkit().getImage((URL) value);
+                    try {
+                        return ImageUtilities.loadImage(((URL) value).toURI());
+                    } catch (URISyntaxException e) {
+                        LOG.log(Level.WARNING, "Annotation has invalid icon URI", e);
+                    }
                 } else if (value instanceof Image) {
                     // #18832
                     return (Image) value;

--- a/platform/openide.filesystems/nbproject/project.xml
+++ b/platform/openide.filesystems/nbproject/project.xml
@@ -41,6 +41,14 @@
                         <specification-version>8.17</specification-version>
                     </run-dependency>
                 </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util.ui</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.36</specification-version>
+                    </run-dependency>
+                </dependency>
             </module-dependencies>
             <test-dependencies>
                 <test-type>

--- a/platform/openide.filesystems/src/org/openide/filesystems/FileSystem.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/FileSystem.java
@@ -854,49 +854,5 @@ public abstract class FileSystem implements Serializable {
             }
             return "Cannot load " + name + " for " + fo + " defined by " + by; // NOI18N
         }
-
-        /*
-        public Image annotateIcon(Image im, int type, Set<? extends FileObject> files) {
-            for (FileObject fo : files) {
-                Image img = annotateIcon(fo, type);
-                if (img != null) {
-                    return img;
-                }
-            }
-            return im;
-        }
-
-        private Image annotateIcon(FileObject fo, int type) {
-            String attr = null;
-            if (type == BeanInfo.ICON_COLOR_16x16) {
-                attr = "SystemFileSystem.icon"; // NOI18N
-            } else if (type == BeanInfo.ICON_COLOR_32x32) {
-                attr = "SystemFileSystem.icon32"; // NOI18N
-            }
-            if (attr != null) {
-                Object value = fo.getAttribute(attr);
-                if (value != null) {
-                    if (value instanceof URL) {
-                        return Toolkit.getDefaultToolkit().getImage((URL) value);
-                    } else if (value instanceof Image) {
-                        // #18832
-                        return (Image) value;
-                    } else {
-                        LOG.warning("Attribute " + attr + " on " + fo + " expected to be a URL or Image; was: " + value);
-                    }
-                }
-            }
-            String base = (String) fo.getAttribute("iconBase"); // NOI18N
-            if (base != null) {
-                if (type == BeanInfo.ICON_COLOR_16x16) {
-                    return ImageUtilities.loadImage(base, true);
-                } else if (type == BeanInfo.ICON_COLOR_32x32) {
-                    return ImageUtilities.loadImage(insertBeforeSuffix(base, "_32"), true); // NOI18N
-                }
-            }
-            return null;
-        }
-            */
-
     };
 }

--- a/platform/openide.util.ui/apichanges.xml
+++ b/platform/openide.util.ui/apichanges.xml
@@ -27,6 +27,20 @@
     <apidef name="actions">Actions API</apidef>
 </apidefs>
 <changes>
+    <change id="moreImageUtilsForHiDPI">
+      <api name="util"/>
+      <summary>Added methods to ImageUtilities, to aid migration from other icon loading methods.</summary>
+      <version major="9" minor="36"/>
+      <date day="5" month="1" year="2025"/>
+      <author login="ebakke"/>
+      <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible" deprecation="no" deletion="no" modification="yes"/>
+      <description>
+            <p>Added new utility methods to ImageUtilities to ease migration from other image loading methods used throughout the NetBeans codebase.
+            Loading icons via ImageUtilities is preferred as it permits alternative SVG versions to be loaded automatically when available.</p>
+       </description>
+       <class package="org.openide.util" name="ImageUtilities"/>
+    </change>
+
     <change id="mouseKeyCodes">
       <api name="util"/>
       <summary>Added methods to query mouse event pseudo-keycodes</summary>


### PR DESCRIPTION
Background: To ensure that SVG icons are loaded and drawn at full resolution, direct use of ImageIcon constructors should be avoided in the NetBeans codebase. The ImageIcon instances returned from methods in ImageUtilities, by contrast, are instances of a special subclass of ImageIcon that support vector graphics painting.

During work to remove uses of "new ImageIcon" constructors in the codebase (including https://github.com/apache/netbeans/pull/8109), I see that a few new utility methods would be useful in ImageUtilities. This PR proposes adding the following methods to ImageUtilities:
* loadIcon(String,boolean) works like loadIconImage(String,boolean) but returns only a plain Icon (not IconImage). This would help discourage use of IconImage in the future.
* loadIcon(String) is equivalent to loadIcon(String,false)
* toImageIcon(Icon) helps cases where an existing API requires an ImageIcon to be returned, but where we only have an Icon.
* loadImage(URL) helps migrate away from uses of Toolkit.getDefaultToolkit().createImage(), which has similar problems as "new ImageIcon".

This PR also contains, in a separate commit, migration away from the Toolkit.getDefaultToolkit().createImage() method, using the new loadImage(URL) method. This makes, for instance, the "lightbulb" icons in the editor gutter show up properly with their new SVG icons:

![image](https://github.com/user-attachments/assets/6c974393-837d-44e1-a940-d8851c574612)
