### PR TITLE
Fixing the build output appearance in vscode

### DIFF
--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -458,11 +458,18 @@ class LineBufferingPseudoterminal implements vscode.Pseudoterminal {
                 name: this.name,
                 pty: this,
             });
+
+            // Listen for terminal close events
+            vscode.window.onDidCloseTerminal((closedTerminal) => {
+                if (closedTerminal === this.terminal) {
+                    this.terminal = undefined; // Clear the terminal reference
+                }
+            });
         }
         // Prevent 'stealing' of the focus when running tests in parallel 
-        if (!testAdapter?.testInParallelProfileExist()) {
+//        if (!testAdapter?.testInParallelProfileExist()) {
             this.terminal.show(true);
-        }
+//        }
     }
 
     /**

--- a/java/java.lsp.server/vscode/src/panels/GuidePanel.ts
+++ b/java/java.lsp.server/vscode/src/panels/GuidePanel.ts
@@ -51,11 +51,6 @@ export abstract class GuidePanel {
                 localResourceRoots: [vscode.Uri.file(path.join(context.extensionPath, this.webviewsFolder))],
             }
         );
-        const iconPath: vscode.Uri = vscode.Uri.file(path.join(context.extensionPath, "images", "Apache_NetBeans_Logo.png"));
-        this.panel.iconPath = {
-            light: iconPath,
-            dark: iconPath,
-        };
 
         this.disposables.push(
             this.panel.onDidDispose(


### PR DESCRIPTION
The output from `AbstractLspInputOutputProvider` is now displayed in a new terminal in VSCode. However, if the terminal is closed after the build finishes, it does not reappear when the next build is started.
I am addressing this issue by ensuring the terminal is recreated as needed. Additionally, I am modifying the logic so that the outputs for **Run**, **Debug**, and **Test** actions are written to the VSCode Debug Console, as they were previously.