### PR TITLE
SYNCHRONIZE permission added to 'readWriteAcl' list

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/assets/TempFileGenerator.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/assets/TempFileGenerator.java
@@ -84,7 +84,8 @@ public class TempFileGenerator {
                 READ_ATTRIBUTES,
                 WRITE_ATTRIBUTES,
                 READ_ACL,
-                WRITE_ACL
+                WRITE_ACL,
+                SYNCHRONIZE
         );
     
     private final boolean readOnly;


### PR DESCRIPTION
On Windows, GDK Gradle project with object storage fails to start. 
There is an error message in the log:
```
[Error - 10:07:02 AM] Request workspace/executeCommand failed.
  Message: C:\Users\opc\AppData\Roaming\Code\User\workspaceStorage\5468365a2d917a0639ba28ba2ba65853\asf.apache-netbeans-java\userdir\var\cache\nbls.db.connection\db-12911251458086315716.properties (Access is denied)
  Code: -32603
```

The reason for `Access is denied` is missing `SYNCHRONIZE` permission in `readWriteAcl` list. 

This PR adds missing `SYNCHRONIZE` permission to `readWriteAcl` list.