### PR TITLE
create new AclEntry if ownerEntry is not found

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/assets/TempFileGenerator.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/assets/TempFileGenerator.java
@@ -39,6 +39,7 @@ import static java.nio.file.attribute.AclEntryPermission.WRITE_ACL;
 import static java.nio.file.attribute.AclEntryPermission.WRITE_ATTRIBUTES;
 import static java.nio.file.attribute.AclEntryPermission.WRITE_DATA;
 import static java.nio.file.attribute.AclEntryPermission.WRITE_NAMED_ATTRS;
+import java.nio.file.attribute.AclEntryType;
 import java.nio.file.attribute.AclFileAttributeView;
 import java.nio.file.attribute.DosFileAttributeView;
 import java.nio.file.attribute.FileAttribute;
@@ -163,12 +164,16 @@ public class TempFileGenerator {
     private void setFileOwnerAcl(Path filePath, Set<AclEntryPermission> permissions) throws IOException {
         AclFileAttributeView acl = Files.getFileAttributeView(filePath, AclFileAttributeView.class);
         AclEntry ownerEntry = findFileOwner(acl);
+        AclEntry.Builder aclBuilder;
         
         if (ownerEntry == null) {
-            throw new IOException("Owner missing, file:" + filePath.toString()); // NOI18N
-        } 
+            LOG.info("Owner missing, file:" + filePath.toString()); // NOI18N
+            aclBuilder = AclEntry.newBuilder().setPrincipal(acl.getOwner()).setType(AclEntryType.ALLOW);
+        } else {
+            aclBuilder = AclEntry.newBuilder(ownerEntry);
+        }
 
-        AclEntry ownerAcl = AclEntry.newBuilder(ownerEntry).setPermissions(permissions).build();
+        AclEntry ownerAcl = aclBuilder.setPermissions(permissions).build();
         acl.setAcl(Collections.singletonList(ownerAcl));
     }
 


### PR DESCRIPTION
On Windows, GDK Gradle project with object storage fails to start.
There is an error message in the log:
```
[Error - 4:26:22 PM] Request workspace/executeCommand failed.
  Message: Owner missing, file:C:\Temp\Downloads \vscode-work-datadir \User \workspaceStorage\b372ec8d4119692fb0336080c81661a\ast apache-netbeans-java\userdir\var\cache\nbls.db.connection\db-10622290301022902981.properties
  Code: -32603
```

`Owner missing:` error is caused by special Windows setup, where new files do not have owner listed in file permissions. There are some aliases instead.
The situation looks like this:
```
Find owner JISEDLAC--CZ\jisedlac (User)
 Entry principal BUILTIN\Administrators (Alias)
 Entry principal NT AUTHORITY\SYSTEM (Well-known group)
 Entry principal BUILTIN\Users (Alias)
 Entry principal NT AUTHORITY\Authenticated Users (Well-known group)
```
none of the entries contains logged user.
This is fixed in this PR by removing all entries and adding new one, with user as principal.
