### PR TITLE
Error handling for TestAdapter and DBConfigurationProvider

### DIFF
--- a/java/java.lsp.server/vscode/src/dbConfigurationProvider.ts
+++ b/java/java.lsp.server/vscode/src/dbConfigurationProvider.ts
@@ -43,8 +43,15 @@ class DBConfigurationProvider implements vscode.DebugConfigurationProvider {
 	}
 
 	resolveDebugConfigurationWithSubstitutedVariables?(_folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, _token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
-        return new Promise<vscode.DebugConfiguration>(async resolve => {
-			let o: Object = await vscode.commands.executeCommand('nbls.db.connection');
+        return new Promise<vscode.DebugConfiguration>(async (resolve, reject) => {
+			let o: Object;
+			try {
+				o = await vscode.commands.executeCommand('nbls.db.connection');
+			} catch(err) {
+				console.log(err);
+				reject(err);
+				return;
+			}
 			if (config === undefined) {
 				config = {} as vscode.DebugConfiguration;
 			}

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -939,7 +939,7 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
     };
 
     context.subscriptions.push(commands.registerCommand(COMMAND_PREFIX + '.run.test.parallel', async (projects?) => {        
-        testAdapter?.runTestsWithParallelParallel(projects);
+        testAdapter?.runTestsWithParallelProfile(projects);
     }));
 
     context.subscriptions.push(commands.registerCommand(COMMAND_PREFIX + '.run.test.parallel.createProfile', async (projects?) => {        


### PR DESCRIPTION
Added error handling in TestAdapter and DBConfigurationProvider when invoking commands
 - it will prevent errors, similar to the one fixed in [PR](https://github.com/apache/netbeans/pull/8132), from affecting test infrastructure
 
Allow canceling test runs triggered by a command