### PR TITLE
PHP: implemented the ability to run a test method when clicking the run icon in the gutter editor.

### DIFF
--- a/php/php.project/src/org/netbeans/modules/php/project/ComputeTestMethodAnnotations.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/ComputeTestMethodAnnotations.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.project;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.SwingUtilities;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.JTextComponent;
+import org.netbeans.api.editor.EditorRegistry;
+import org.netbeans.modules.editor.NbEditorUtilities;
+import org.netbeans.modules.gsf.testrunner.ui.api.TestMethodController;
+import org.netbeans.modules.gsf.testrunner.ui.api.TestMethodController.TestMethod;
+import org.netbeans.modules.php.api.editor.EditorSupport;
+import org.netbeans.modules.php.api.editor.PhpClass;
+import org.netbeans.modules.php.api.editor.PhpType;
+import org.netbeans.modules.php.api.phpmodule.PhpModule;
+import org.netbeans.modules.php.api.util.FileUtils;
+import org.netbeans.modules.php.project.ui.actions.support.CommandUtils;
+import org.netbeans.modules.php.project.util.PhpProjectUtils;
+import org.netbeans.modules.php.spi.testing.PhpTestingProvider;
+import org.netbeans.spi.project.SingleMethod;
+import org.openide.filesystems.FileObject;
+import org.openide.util.Lookup;
+import org.openide.util.RequestProcessor;
+
+
+public class ComputeTestMethodAnnotations implements DocumentListener, PropertyChangeListener, Runnable {
+
+    private static final Logger LOGGER = Logger.getLogger(ComputeTestMethodAnnotations.class.getName());
+
+    private static final RequestProcessor RP = new RequestProcessor(ComputeTestMethodAnnotations.class);
+    private static final ComputeTestMethodAnnotations INSTANCE = new ComputeTestMethodAnnotations();
+    private static final AtomicInteger USAGES_COUNT = new AtomicInteger(0);
+    private final RequestProcessor.Task task = RP.create(this);
+    private volatile Document handledDocument;
+
+    public static ComputeTestMethodAnnotations getInstance() {
+        return INSTANCE;
+    }
+
+    private ComputeTestMethodAnnotations() {
+    }
+
+    public void register() {
+        if (USAGES_COUNT.getAndIncrement() == 0) {
+            EditorRegistry.addPropertyChangeListener(this);
+        }
+    }
+
+    public void unregister() {
+        if (USAGES_COUNT.decrementAndGet() == 0) {
+            EditorRegistry.removePropertyChangeListener(this);
+        }
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent event) {
+        assert SwingUtilities.isEventDispatchThread() : "UI thread expected but is: " + Thread.currentThread().getName();
+
+        String propertyName = event.getPropertyName();
+
+        JTextComponent textComponent = EditorRegistry.lastFocusedComponent();
+        if (textComponent != null) {
+            Document document = textComponent.getDocument();
+            if (document != null) {
+                FileObject fileObject = NbEditorUtilities.getFileObject(document);
+                if (fileObject != null) {
+                    if (FileUtils.isPhpFile(fileObject)) {
+                        if (propertyName.equals(EditorRegistry.FOCUS_GAINED_PROPERTY)) {
+                            handleFileChange(document);
+                            document.addDocumentListener(ComputeTestMethodAnnotations.this);
+                        } else if (propertyName.equals(EditorRegistry.FOCUS_LOST_PROPERTY)) {
+                            document.removeDocumentListener(this);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void insertUpdate(DocumentEvent event) {
+        handleFileChange(event.getDocument());
+    }
+
+    @Override
+    public void removeUpdate(DocumentEvent event) {
+        handleFileChange(event.getDocument());
+    }
+
+    @Override
+    public void changedUpdate(DocumentEvent event) {
+        handleFileChange(event.getDocument());
+    }
+
+    private void handleFileChange(Document doc) {
+        handledDocument = doc;
+        task.schedule(500);
+    }
+
+    @Override
+    public void run() {
+        List<TestMethod> testMethods = getTestMethods(handledDocument);
+
+        /*
+         * Apparently, this method should update the list of annotations at each call of this method,
+         * when the passed collection of methods changes.
+         * Вut I didn't manage to achieve correct work in this case.
+         * So I made the method call first with the empty collection, to clear the annotation list,
+         * then already with the method collection.
+         */
+        TestMethodController.setTestMethods(handledDocument, Collections.emptyList());
+        if (!testMethods.isEmpty()) {
+            TestMethodController.setTestMethods(handledDocument, testMethods);
+        }
+    }
+
+    private List<TestMethod> getTestMethods(Document document) {
+        List<TestMethod> testMethods = new ArrayList<>();
+        FileObject fileObject = NbEditorUtilities.getFileObject(document);
+        if (fileObject != null) {
+            PhpProject project = PhpProjectUtils.getPhpProject(fileObject);
+            assert project != null;
+            PhpModule phpModule = project.getPhpModule();
+            for (PhpTestingProvider testingProvider : project.getTestingProviders()) {
+
+                if (!document.equals(handledDocument)) {
+                    return Collections.emptyList();
+                }
+
+                if (testingProvider.isTestFile(phpModule, fileObject)) {
+                    EditorSupport editorSupport = Lookup.getDefault().lookup(EditorSupport.class);
+                    assert editorSupport != null;
+                    Collection<PhpClass> phpClasses = editorSupport.getClasses(fileObject);
+                    for (PhpClass phpClass : phpClasses) {
+
+                        if (!document.equals(handledDocument)) {
+                            return Collections.emptyList();
+                        }
+
+                        for (PhpType.Method method : phpClass.getMethods()) {
+
+                            if (!document.equals(handledDocument)) {
+                                return Collections.emptyList();
+                            }
+
+                            if (!testingProvider.isTestCase(phpModule, method)) {
+                                continue;
+                            }
+                            try {
+                                testMethods.add(new TestMethod(
+                                        phpClass.getName(),
+                                        new SingleMethod(fileObject, CommandUtils.encodeMethod(method.getPhpType().getFullyQualifiedName(), method.getName())),
+                                        document.createPosition(method.getOffset()),
+                                        document.createPosition(method.getOffset() + method.getName().length())
+                                ));
+                            } catch (BadLocationException exception) {
+                                LOGGER.log(Level.WARNING, "Unable to create position: offset: {0}; method: {1}; class: {2}.", new Object[] {exception.offsetRequested(), method.getName(), phpClass.getName()}); // NOI18N
+                            }
+                        }
+
+                        if (!testMethods.isEmpty()) {
+                            return testMethods;
+                        }
+                    }
+
+                }
+            }
+        }
+
+        return testMethods;
+    }
+}

--- a/php/php.project/src/org/netbeans/modules/php/project/PhpProject.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/PhpProject.java
@@ -848,6 +848,8 @@ public final class PhpProject implements Project {
             // autoconfigured?
             checkAutoconfigured();
 
+            ComputeTestMethodAnnotations.getInstance().register();
+
             // #187060 - exception in projectOpened => project IS NOT opened (so move it at the end of the hook)
             getCopySupport().projectOpened();
 
@@ -886,6 +888,8 @@ public final class PhpProject implements Project {
                 }
 
             } finally {
+                ComputeTestMethodAnnotations.getInstance().unregister();
+
                 // #187060 - exception in projectClosed => project IS closed (so do it in finally block)
                 getCopySupport().projectClosed();
                 // #192386


### PR DESCRIPTION
#### Before:
![before](https://github.com/user-attachments/assets/6ac569b7-7726-4b3a-baf3-49bc4f6d7c8f)

#### After:
![after](https://github.com/user-attachments/assets/1813cb4e-690e-4ca0-a8e9-66b44c608671)

#### Algorithm Description:
Each time a file is opened or edited, it checks for test methods in the file and uses [`TestMethodController.setTestMethods`](https://github.com/apache/netbeans/blob/master/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestMethodController.java) to create annotations that use the [`RunDebugTestGutterAction.java`](https://github.com/apache/netbeans/blob/master/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/annotation/RunDebugTestGutterAction.java) action to execute the test method.

#### Peculiarities of implementation:
- The implementation was done by analogy with the implementation of annotations for java ([ComputeTestMethodsImpl.java](https://github.com/apache/netbeans/blob/master/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/ComputeTestMethodsImpl.java)).

- Due to the fact that I have not found an analog of `EditorAwareJavaSourceTaskFactory` for php, I decided to make a binding to the event of getting the focus of the editor tab and changes in the edited document.
The php project [opening hook](https://github.com/apache/netbeans/blob/b5560425963730402b5cfdc15cd2a92c862a8a60/php/php.project/src/org/netbeans/modules/php/project/PhpProject.java#L809) seemed to me to be a less appropriate place to register a listener. Since events are handled for each editor tab regardless of the project and file type, I made the `ComputeTestMethodAnnotations` class a singleton to avoid having to register the listener multiple times if multiple php projects are open.

-  [`TestMethodController.setTestMethods`](https://github.com/apache/netbeans/blob/master/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestMethodController.java) implements all the work of creating an annotation to run a test method. 
Apparently, this method should update the list of annotations at each call of this method, when the passed collection of methods changes. Вut I didn't manage to achieve correct work in this case. While debugging the [ComputeTestMethodsImpl.java](https://github.com/apache/netbeans/blob/master/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/ComputeTestMethodsImpl.java) class for java, I noticed that the method is called twice: first for an empty collection, 
then for a collection with new computed methods. 
So I made the method call first with the empty collection, to clear the annotation list, then already with the method collection.

- The algorithm of searching for test methods was made by analogy as in the implementation of [action](https://github.com/apache/netbeans/blob/b5560425963730402b5cfdc15cd2a92c862a8a60/php/php.project/src/org/netbeans/modules/php/project/ui/actions/support/TestSingleMethodSupport.java#L85) for launching a test method for execution from the context menu of the editor.




