### PR TITLE
csl.api: Fix wrong @NonNull annotation in methods of Language

### DIFF
--- a/ide/csl.api/src/org/netbeans/modules/csl/core/Language.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/core/Language.java
@@ -610,7 +610,7 @@ public final class Language {
     /**
      * Return the occurrences finder for this language
      */
-    @NonNull
+    @CheckForNull
     public OccurrencesFinder getOccurrencesFinder() {
         if (occurrences == null) {
             if (occurrencesFile != null) {
@@ -653,7 +653,7 @@ public final class Language {
     /**
      * Return the semantic analyzer for this language
      */
-    @NonNull
+    @CheckForNull
     public SemanticAnalyzer getSemanticAnalyzer() {
         if (semantic == null) {
             if (semanticFile != null) {
@@ -679,7 +679,7 @@ public final class Language {
     /**
      * Return the semantic analyzer for this language
      */
-    @NonNull
+    @CheckForNull
     public IndexSearcher getIndexSearcher() {
         if (indexSearcher == null) {
             if (indexSearcherFile != null) {
@@ -735,7 +735,7 @@ public final class Language {
     /**
      * Return the overriding methods computer for this language
      */
-    @NonNull
+    @CheckForNull
     public OverridingMethods getOverridingMethods() {
         if (overridingMethods == null) {
             if (overridingMethodsFile != null) {

--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/MarkOccurrencesHighlighter.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/MarkOccurrencesHighlighter.java
@@ -135,8 +135,10 @@ public final class MarkOccurrencesHighlighter extends ParserResultTask<ParserRes
     @NonNull
     List<OffsetRange> processImpl(ParserResult info, Document doc, int caretPosition) {
         OccurrencesFinder finder = language.getOccurrencesFinder();
-        assert finder != null;
-        
+        if(finder == null) {
+            return List.of();
+        }
+
         finder.setCaretPosition(caretPosition);
         try {
             finder.run(info, null);

--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/SemanticHighlighter.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/SemanticHighlighter.java
@@ -142,7 +142,11 @@ public final class SemanticHighlighter extends IndexingAwareParserResultTask<Par
 
         ColoringManager manager = language.getColoringManager();
         SemanticAnalyzer task = language.getSemanticAnalyzer();
-        
+
+        if (task == null) {
+            return;
+        }
+
         // Allow language plugins to do their own analysis too
         try {
             task.run(result, null);


### PR DESCRIPTION
The methods:

  - getOccurrencesFinder
  - getSemanticAnalyzer
  - getIndexSearcher
  - getOverridingMethods

can return null, if the implemention does not provide these services. The @NonNull annotation is thus wrong. As Language is not API the use-sites that relied on the non-null assertion were fixed and the annotations updated.