### PR TITLE
Cleanup the few remaining HashSet warnings.

### DIFF
--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/ServerInstance.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/ServerInstance.java
@@ -141,7 +141,7 @@ public class ServerInstance implements Node.Cookie, Comparable {
     private DatasourceManager ddsMgr;
     private MessageDestinationDeployment msgDestDeploymentConnected;
     private MessageDestinationDeployment msgDestDeploymentDisconnected;
-    private final Set targetsStartedByIde = new HashSet(); // valued by target name
+    private final Set<String> targetsStartedByIde = new HashSet<>(); // valued by target name
     private Map targets; // keyed by target name, valued by ServerTarget
     private boolean managerStartedByIde = false;
     private ServerTarget coTarget = null;

--- a/enterprise/web.jsf.navigation/src/org/netbeans/modules/web/jsf/navigation/graph/actions/MapActionUtility.java
+++ b/enterprise/web.jsf.navigation/src/org/netbeans/modules/web/jsf/navigation/graph/actions/MapActionUtility.java
@@ -270,7 +270,7 @@ public class MapActionUtility {
             scene.setSelectedObjects(set);
             scene.setFocusedObject(nextElement);
         } else {
-            scene.setSelectedObjects(new HashSet());
+            scene.setSelectedObjects(new HashSet<>());
             scene.setHoveredObject(null); //Not sure if I can do this yet.
         }
     }

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/Provider.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/Provider.java
@@ -112,7 +112,7 @@ public abstract class Provider {
     }
     
     private Set initPropertyNames(){
-        Set result = new HashSet();
+        Set<String> result = new HashSet<>();
         result.add(getJdbcDriver());
         result.add(getJdbcUsername());
         result.add(getJdbcUrl());

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableClosure.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/TableClosure.java
@@ -364,7 +364,7 @@ public class TableClosure {
             assert !initialContents.contains(null);
 
             queue = new ArrayList<>(initialContents);
-            contents = new HashSet(initialContents);
+            contents = new HashSet<>(initialContents);
         }
 
         /**

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/FSCompletionItem.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/FSCompletionItem.java
@@ -155,7 +155,7 @@ public class FSCompletionItem implements CompletionProposal {
 
         public FSElementHandle(FileObject fo) {
             this.fo = fo;
-            this.representedFiles = new HashSet(1);
+            this.representedFiles = new HashSet<>(1);
             representedFiles.add(fo);
         }
 

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsCompletionItem.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsCompletionItem.java
@@ -715,7 +715,7 @@ public class JsCompletionItem implements CompletionProposal {
                                     for (TypeUsage type : jsObject.getAssignmentForOffset(jsObject.getOffset() + 1)) {
                                         Set<String> resolvedType = resolvedTypes.get(type.getType());
                                         if (resolvedType == null) {
-                                            resolvedType = new HashSet(1);
+                                            resolvedType = new HashSet<>(1);
                                             String displayName = ModelUtils.getDisplayName(type);
                                             if (!displayName.isEmpty()) {
                                                 resolvedType.add(displayName);
@@ -743,7 +743,7 @@ public class JsCompletionItem implements CompletionProposal {
                                     for (String type : paramEntry.getValue()) {
                                         Set<String> resolvedType = resolvedTypes.get(type);
                                         if (resolvedType == null) {
-                                            resolvedType = new HashSet(1);
+                                            resolvedType = new HashSet<>(1);
                                             String displayName = ModelUtils.getDisplayName(type);
                                             if (!displayName.isEmpty()) {
                                                 resolvedType.add(displayName);
@@ -791,7 +791,7 @@ public class JsCompletionItem implements CompletionProposal {
                                         if (resolvedType == null) {
                                             toResolve.clear();
                                             toResolve.add(type);
-                                            resolvedType = new HashSet(1);
+                                            resolvedType = new HashSet<>(1);
                                             Collection<TypeUsage> resolved = ModelUtils.resolveTypes(toResolve,
                                                     Model.getModel(request.result, false),
                                                     jsIndex, false);


### PR DESCRIPTION
Cleanup the few remaining HashSet warnings.. Reduce warnings that look like this:

   [repeat] /home/bwalker/src/netbeans/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/ServerInstance.java:144: warning: [rawtypes] found raw type: HashSet
   [repeat]     private final Set<String> targetsStartedByIde = new HashSet(); // valued by target name
   [repeat]                                                         ^
   [repeat]   missing type arguments for generic class HashSet<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in class HashSet





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
