### PR TITLE
Prevent terminal stealing focus when test in parallel profile exist

### DIFF
--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -467,9 +467,9 @@ class LineBufferingPseudoterminal implements vscode.Pseudoterminal {
             });
         }
         // Prevent 'stealing' of the focus when running tests in parallel 
-//        if (!testAdapter?.testInParallelProfileExist()) {
+       if (!testAdapter?.testInParallelProfileExist()) {
             this.terminal.show(true);
-//        }
+       }
     }
 
     /**


### PR DESCRIPTION
This prevents `Terminal` panel stealing focus when test in parallel profile exist.