### PR TITLE
Translate `Diagnostic.Kind.NOTE` to `Security.HINT` not `WARNING`

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProvider.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProvider.java
@@ -108,7 +108,7 @@ public final class ErrorHintsProvider extends JavaParserResultTask {
         errorKind2Severity.put(Diagnostic.Kind.ERROR, Severity.ERROR);
         errorKind2Severity.put(Diagnostic.Kind.MANDATORY_WARNING, Severity.WARNING);
         errorKind2Severity.put(Diagnostic.Kind.WARNING, Severity.WARNING);
-        errorKind2Severity.put(Diagnostic.Kind.NOTE, Severity.WARNING);
+        errorKind2Severity.put(Diagnostic.Kind.NOTE, Severity.HINT);
         errorKind2Severity.put(Diagnostic.Kind.OTHER, Severity.WARNING);
     }
 


### PR DESCRIPTION
Ever since https://github.com/jenkinsci/stapler/pull/575 I have bothered by the NetBeans editor showing gratuitous yellow warning lines for a variety of annotation processor notes that are not in fact warnings. For example https://github.com/jenkinsci/workflow-job-plugin/blob/5b18defc07f27c7bde3521e04b7bab66398a89d3/src/main/java/org/jenkinsci/plugins/workflow/job/properties/DisableConcurrentBuildsJobProperty.java#L49-L50 displays warning just because the processor noted that it was generating a file in response to an annotation. Downgrading the “severity” to a “hint” still shows an icon in the gutter, which is OK, and still shows a “warning” in the **Action Items** window, which is less OK, but at least the editor does not make it look like I did something wrong.
