### PR TITLE
typescript: Fix location of binaries

### DIFF
--- a/webcommon/typescript.editor/external/binaries-list
+++ b/webcommon/typescript.editor/external/binaries-list
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-48304CC9611D4F3B4ACD5A6ABB88689913BFA7A0 https://doppel-helix.eu/test-typescript-update/48304CC9611D4F3B4ACD5A6ABB88689913BFA7A0-typescript-5.6.2.zip typescript-5.6.2.zip
-6895F0456E4B0FE3D857AA7D3F399932A026D060 https://doppel-helix.eu/test-typescript-update/typescript-language-server-4.3.3.zip typescript-language-server-4.3.3.zip
+48304CC9611D4F3B4ACD5A6ABB88689913BFA7A0 typescript-5.6.2.zip
+6895F0456E4B0FE3D857AA7D3F399932A026D060 typescript-language-server-4.3.3.zip


### PR DESCRIPTION
Fix for 9fe66a38858b55d1658c6a7b21ee159a7e4eca23
