### PR TITLE
NB config: disable TopSecurityManager and enable exit logging

### DIFF
--- a/nb/ide.launcher/netbeans.conf
+++ b/nb/ide.launcher/netbeans.conf
@@ -56,7 +56,7 @@ netbeans_default_cachedir="${DEFAULT_CACHEDIR_ROOT}/@@metabuild.RawVersion@@"
 # The automatically selected value can be overridden by specifying -J-Xmx
 # here or on the command line.
 #
-netbeans_default_options="-J-XX:+UseStringDeduplication -J-Xss2m @@metabuild.logcli@@ -J-Djava.security.manager=allow -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.application.appearance=system -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.extbrowser.manual_chrome_plugin_install=yes @@metabuild.jms-flags@@ -J-XX:+IgnoreUnrecognizedVMOptions"
+netbeans_default_options="-J-XX:+UseStringDeduplication -J-Xss2m @@metabuild.logcli@@ -J-DTopSecurityManager.disable=true -J-Djava.lang.Runtime.level=FINE -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.application.appearance=system -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.extbrowser.manual_chrome_plugin_install=yes @@metabuild.jms-flags@@ -J-XX:+IgnoreUnrecognizedVMOptions"
 
 # Default location of JDK:
 # (set by installer or commented out if launcher should decide)


### PR DESCRIPTION
Suggestion came up on apache slack to do another release without applying #3386 or #7928 but disabling `TopSecurityManager` instead.

this PR:
 - replaces `-Djava.security.manager=allow' with `-DTopSecurityManager.disable=true` and `-Djava.lang.Runtime.level=FINE`
 - allows launching NB builds on JDK 17-24

cons:
 - contrary to #7928, no tests ran on JDK 24 with this config
 - even though I run those flags since NB 23 on JDK 23, I didn't actually test it on JDK 24 (I tested the _removal_ PR instead)
 - -> current confidence level regarding JDK 24 + topsec disabled: "works on my machine"

pros:
 - can be switched on again if problems are encountered