### PR TITLE
Add support for PHPStan error identifiers

### DIFF
--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/parsers/CheckStyleReportParser.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/parsers/CheckStyleReportParser.java
@@ -165,6 +165,10 @@ public class CheckStyleReportParser extends DefaultHandler {
         currentResult.setLine(lineNumber);
         currentResult.setColumn(getInt(attributes, "column")); // NOI18N
         String message = attributes.getValue("message"); // NOI18N
+        String errorIdentifier = attributes.getValue("source"); // NOI18N
+        if (errorIdentifier != null) {
+            message = String.format("%s: %s", errorIdentifier, message); // NOI18N
+        }
         currentResult.setCategory(String.format("%s: %s", attributes.getValue("severity"), message)); // NOI18N
         // Message can contain types like "array<string>" and description is renderd as HTML so it has to be properly escaped.
         currentResult.setDescription(StringEscapeUtils.escapeHtml(message));

--- a/php/php.code.analysis/test/unit/data/phpstan/phpstan-log-with-error-identifiers.xml
+++ b/php/php.code.analysis/test/unit/data/phpstan/phpstan-log-with-error-identifiers.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<checkstyle>
+<file name="HelloWorld.php">
+  <error line="8" column="1" severity="error" message="Expression on left side of ?? is not nullable." source="nullCoalesce.expr" />
+  <error line="13" column="1" severity="error" message="Method HelloWorld::readLength() should return float but return statement is missing." source="return.missing" />
+</file>
+</checkstyle>

--- a/php/php.code.analysis/test/unit/src/org/netbeans/modules/php/analysis/parsers/CheckStyleReportParserTest.java
+++ b/php/php.code.analysis/test/unit/src/org/netbeans/modules/php/analysis/parsers/CheckStyleReportParserTest.java
@@ -112,6 +112,27 @@ public class CheckStyleReportParserTest extends NbTestCase {
         assertEquals("Function count() should return int but returns array&lt;string&gt;.", result.getDescription());
     }
 
+    public void testParseWithHtmlErrorIdentifiers() throws Exception {
+        FileObject root = getDataDir("phpstan/PHPStanSupport");
+        FileObject workDir = root;
+        List<Result> results = CheckStyleReportParser.parse(getLogFile("phpstan-log-with-error-identifiers.xml"), root, workDir);
+        assertNotNull(results);
+
+        assertEquals(2, results.size());
+
+        Result result = results.get(0);
+        assertEquals(FileUtil.toFile(root.getFileObject("HelloWorld.php")).getAbsolutePath(), result.getFilePath());
+        assertEquals(8, result.getLine());
+        assertEquals("error: nullCoalesce.expr: Expression on left side of ?? is not nullable.", result.getCategory());
+        assertEquals("nullCoalesce.expr: Expression on left side of ?? is not nullable.", result.getDescription());
+
+        result = results.get(1);
+        assertEquals(FileUtil.toFile(root.getFileObject("HelloWorld.php")).getAbsolutePath(), result.getFilePath());
+        assertEquals(13, result.getLine());
+        assertEquals("error: return.missing: Method HelloWorld::readLength() should return float but return statement is missing.", result.getCategory());
+        assertEquals("return.missing: Method HelloWorld::readLength() should return float but return statement is missing.", result.getDescription());
+    }
+
     public void testPsalmParse() throws Exception {
         FileObject root = getDataDir("psalm/PsalmSupport");
         FileObject workDir = root;


### PR DESCRIPTION
PHPStan since version 1.11 uses identifiers for errors.
Error identifiers are read and displayed with this change.

Reference: https://phpstan.org/blog/phpstan-1-11-errors-identifiers-phpstan-pro-reboot#error-identifiers

Here is Inspector screen from sample project:
![image](https://github.com/user-attachments/assets/70aad398-0ef6-4f41-aabd-6fc5195bf50b)


