### PR TITLE
Fix NPE during project group creation caused by ergonomics

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectList.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectList.java
@@ -234,12 +234,9 @@ public final class OpenProjectList {
     }
 
     final Project unwrapProject(Project wrap) {
-        Project[] now = getOpenProjects();
-
         if (wrap instanceof LazyProject) {
-            LazyProject lp = (LazyProject)wrap;
-            for (Project p : now) {
-                if (lp.getProjectDirectory().equals(p.getProjectDirectory())) {
+            for (Project p : getOpenProjects()) {
+                if (wrap.getProjectDirectory().equals(p.getProjectDirectory())) {
                     return p;
                 }
             }
@@ -1379,6 +1376,7 @@ public final class OpenProjectList {
             public @Override Boolean run() {
             log(Level.FINER, "already opened: {0} ", openProjects);
             for (Project existing : openProjects) {
+                // TODO An old hack due to broken equals() contract; see https://bz.apache.org/netbeans/show_bug.cgi?id=156536
                 if (p.equals(existing) || existing.equals(p)) {
                     alreadyOpen.set(true);
                     return false;

--- a/ide/projectui/src/org/netbeans/modules/project/ui/groups/Group.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/groups/Group.java
@@ -562,7 +562,19 @@ public abstract class Group {
             h.start(200);
             ProjectUtilities.WaitCursor.show();
             final OpenProjectList opl = OpenProjectList.getDefault();
-            Set<Project> oldOpen = new HashSet<Project>(Arrays.asList(opl.getOpenProjects()));
+            
+            Set<Project> oldOpen = new HashSet<>();
+            for (Project open : opl.getOpenProjects()) {
+                // TODO fix this properly, e.g investigate if:
+                //  - getOpenProjects() should only return unboxed projects 
+                //       risk: called by public API
+                //  - review/fix the broken hashcode/equals contracts
+                //       risk: code contains hacks which account for this already, e.g if (a.equals(b) || b.equals(a))
+                // for now: unbox potential fod.FeatureNonProject wrapper since it breaks Sets/Maps due to incompatible hashcode/equals impls
+                Project real = open.getLookup().lookup(Project.class);
+                oldOpen.add(real != null ? real : open);
+            }
+
             //TODO switching to no group always clears the opened project list.
             Set<Project> newOpen = g != null ? g.getProjects(h, 10, 100) : getProjectsByPreferences(noneGroupPref, h, 10, 100);
             final Set<Project> toClose = new HashSet<Project>(oldOpen);


### PR DESCRIPTION
Projects can change class type due to ergonomics. Hashcode/equals matching problems make storage in sets/maps problematic.

Unbox "FeatureNonProject" since https://github.com/apache/netbeans/blob/235b99afb8c555e26c460f31c9d65e0265eac892/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FeatureProjectFactory.java#L383-L393

isn't compatible with

https://github.com/apache/netbeans/blob/235b99afb8c555e26c460f31c9d65e0265eac892/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java#L1336-L1355


discovered while implementing https://github.com/apache/netbeans/pull/8164

fixes #6011, https://issues.apache.org/jira/browse/NETBEANS-2167 and https://bz.apache.org/netbeans/show_bug.cgi?id=235897

reproducer:
 1) clean NB config, don't import on start
 2) open existing maven project
 3) open any project file
 4) create new project group -> NPE