### PR TITLE
Change parameter order for runDebug, compat with NBLS codelenses.

### DIFF
--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -953,16 +953,16 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
         testAdapter?.registerRunInParallelProfile(projects);
     }));
 
-    context.subscriptions.push(commands.registerCommand(COMMAND_PREFIX + '.run.test', async (uri, methodName?, nestedClass?, launchConfiguration?, testInParallel?, projects?) => {
+    context.subscriptions.push(commands.registerCommand(COMMAND_PREFIX + '.run.test', async (uri, methodName?, launchConfiguration?, nestedClass?, testInParallel?, projects?) => {
         await runDebug(true, true, uri, methodName, nestedClass, launchConfiguration, false, testInParallel, projects);
     }));
-    context.subscriptions.push(commands.registerCommand(COMMAND_PREFIX + '.debug.test', async (uri, methodName?, nestedClass?, launchConfiguration?) => {
+    context.subscriptions.push(commands.registerCommand(COMMAND_PREFIX + '.debug.test', async (uri, methodName?, launchConfiguration?, nestedClass?) => {
         await runDebug(false, true, uri, methodName, nestedClass, launchConfiguration);
     }));
-    context.subscriptions.push(commands.registerCommand(COMMAND_PREFIX + '.run.single', async (uri, methodName?, nestedClass?, launchConfiguration?) => {
+    context.subscriptions.push(commands.registerCommand(COMMAND_PREFIX + '.run.single', async (uri, methodName?, launchConfiguration?, nestedClass?) => {
         await runDebug(true, false, uri, methodName, nestedClass, launchConfiguration);
     }));
-    context.subscriptions.push(commands.registerCommand(COMMAND_PREFIX + '.debug.single', async (uri, methodName?, nestedClass?, launchConfiguration?) => {
+    context.subscriptions.push(commands.registerCommand(COMMAND_PREFIX + '.debug.single', async (uri, methodName?, launchConfiguration?, nestedClass?) => {
         await runDebug(false, false, uri, methodName, nestedClass, launchConfiguration);
     }));
     context.subscriptions.push(commands.registerCommand(COMMAND_PREFIX + '.project.run', async (node, launchConfiguration?) => {

--- a/java/java.lsp.server/vscode/src/testAdapter.ts
+++ b/java/java.lsp.server/vscode/src/testAdapter.ts
@@ -107,7 +107,8 @@ export class NbTestAdapter {
                         }
                         if (!cancellation.isCancellationRequested) {
                             try {
-                                await commands.executeCommand(request.profile?.kind === TestRunProfileKind.Debug ? COMMAND_PREFIX + '.debug.single' : COMMAND_PREFIX + '.run.single', item.uri.toString(), idx < 0 ? undefined : item.id.slice(idx + 1), nestedClass);
+                                await commands.executeCommand(request.profile?.kind === TestRunProfileKind.Debug ? COMMAND_PREFIX + '.debug.single' : COMMAND_PREFIX + '.run.single', item.uri.toString(), idx < 0 ? undefined : item.id.slice(idx + 1), 
+                                    undefined /* configuration */, nestedClass);
                             } catch(err) {
                                 // test state will be handled in the code below
                                 console.log(err);


### PR DESCRIPTION
NBLS action "run with Micronaut: dev mode" throws Internal error.

PR #7979 introduced additional parameters for `.run.test`, `.debug.test`, `.run.single` and `.debug.single` - the `nestedClass` parameter was however added before `launchConfiguration`. 
The relevant part in NBLS [which produce Code Lenses](https://github.com/apache/netbeans/blob/master/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java#L1338) was not adapted.

The issue surfaces only if there are multiple project configurations in the project that provide Run/Debug action overrides; for Micronaut, the Micronaut module supplies a Project Configuration that (re) define Run action. The action is available from the editor code lens on the main class main() method, for example.
It seems that a minimal change is to change the parameters added by PR #7979 and order them after the existing ones, which allows pre-existing code to function. 

I had to adapt the `testAdapter.ts` code that actually works with nested classes and uses the introduced parameter. There was one other usage in `testAdapters` but as it passed `udefined` to both configuration AND nestedclass, it can stay as it is.

When reviewing, please consult also the original PR code - there are 2 places that invoke the changed NBLS commands.