### PR TITLE
Adjust FlatLafDark tab-switcher and selection foreground colors

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -18,6 +18,9 @@
 nb.dark.theme=true
 nb.preferred.color.profile=FlatLaf Dark
 
+@foreground=#cccccc
+# switch to white if the text contrast is not enough - works somewhat similar to NB's html renderer
+@selectionForeground=contrast(@selectionBackground, @background, #ffffff, 25%)
 
 nb.errorForeground=#DB5860
 nb.warningForeground=@foreground
@@ -90,6 +93,11 @@ nb.multitabs.project.8.background=rgb(107, 135, 38)
 nb.multitabs.project.9.background=rgb(118, 89, 135)
 nb.multitabs.project.foreground=#f0f0f0
 
+#---- Tab switcher ----
+
+nb.popupswitcher.background=$MenuItem.background
+nb.popupswitcher.selectionForeground=$MenuItem.selectionForeground
+nb.popupswitcher.selectionBackground=$MenuItem.selectionBackground
 
 #---- PropSheet ----
 


### PR DESCRIPTION
 - use context menu colors for tab switcher popup
 - set selection foreground to white if contrast is not sufficient
 - slightly brighten foreground color for more contrast

before:
![image](https://github.com/user-attachments/assets/3e3ea460-151a-43b0-bbe8-dd3fdb9458bd)

after:
![image](https://github.com/user-attachments/assets/a7dc72f2-018a-4053-b138-175ab90ab2e7)

before:
![darklaf_reference](https://github.com/user-attachments/assets/10f08423-f2de-45b6-a5c5-a0c4da4c4690)
after:
![darklaf_updated](https://github.com/user-attachments/assets/bd04477a-f3c4-4691-bcb4-d34bac559fc4)

slightly higher contrast gives more options to use faded text for less important information, e.g https://github.com/apache/netbeans/pull/7930#issuecomment-2594268630