### PR TITLE
New default template for initial comment

### DIFF
--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
@@ -94,6 +94,9 @@
             <attr name="new.sourceGroup" stringvalue="java"/>
             <attr name="new.sourceHint" stringvalue="main"/>
         </folder>
+        <folder name="Licenses">
+            <file name="license-default.txt" url="license-default.txt"/>
+        </folder>
         <folder name="Project">
             <file name="AntJava_hidden"/>
             <file name="ClientSide_hidden"/>

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/license-default.txt
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/license-default.txt
@@ -1,0 +1,24 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+${licenseFirst!""}
+${licensePrefix}TODO: provide your own project copyright and license here.
+${licenseLast!""}
+


### PR DESCRIPTION
NBLS 24.9.9 used.
Create new Controller class using Micronaut>Controller menu from packege level in File Explorer panel
File is generated and has this comment at the top:
```
/*
 * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
 * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
 */

package com.example;

import io.micronaut.http.annotation.Controller;
import io.micronaut.http.annotation.Get;
```

Click on `nbfs://` is misleading and ugly and does not work in VSCode.

The solution is to customize template for initial comment for NBLS to the following text:
```
/*
 * TODO: provide your own project copyright and license here.
*/
```
