### PR TITLE
Improve support for Jakarta EE 11

### DIFF
--- a/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/config/J2EEVersion.java
+++ b/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/config/J2EEVersion.java
@@ -92,6 +92,12 @@ public final class J2EEVersion extends J2EEBaseVersion {
             "10.0.0", 100000,    // NOI18N
             "10.0.0", 100000);   // NOI18N
     
+    /** Represents Jakarta EE version 11.0.0
+     */
+    public static final J2EEVersion JAKARTAEE_11_0 = new J2EEVersion(
+            "11.0.0", 110000,    // NOI18N
+            "11.0.0", 110000);   // NOI18N
+    
     /** -----------------------------------------------------------------------
      *  Implementation
      */
@@ -135,8 +141,10 @@ public final class J2EEVersion extends J2EEBaseVersion {
             result = JAKARTAEE_9_0;
         } else if(JAKARTAEE_9_1.toString().equals(version)) {
             result = JAKARTAEE_9_1;
-        }else if(JAKARTAEE_10_0.toString().equals(version)) {
+        } else if(JAKARTAEE_10_0.toString().equals(version)) {
             result = JAKARTAEE_10_0;
+        } else if(JAKARTAEE_11_0.toString().equals(version)) {
+            result = JAKARTAEE_11_0;
         }
 
         return result;


### PR DESCRIPTION
NetBeans Notes:

- Add missing Jakarta EE 11 constant for GlassFish module

NetBeans Testing:

- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Verify Sigtests
- Verify successful execution of unit tests for modules `glassfish.common`, `glassfish.javaee`, `glassfish.tooling`,  and `glassfish.eecommon`
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Successfully register GlassFish 8.0.0-M9
  - Create a Jakarta EE 11 maven web app and verify that it works
  - Create a Jakarta EE 11 ant web app and verify that it works.