### PR TITLE
Ant: fix GeneratedFilesHelper CRC cache

### DIFF
--- a/ide/project.ant/nbproject/project.properties
+++ b/ide/project.ant/nbproject/project.properties
@@ -24,7 +24,7 @@ antsrc.cp=\
     ${openide.filesystems.dir}/core/org-openide-filesystems.jar
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 


### PR DESCRIPTION
Cache used the xor function of timestamp and size as modification indicator for a CRC cache. This produced frequent collisions esp when timestamp and size were close together between two modifications.

example: write to a file 3 ms apart which added 5 bytes: 
```
1737766006001L ^ 208
1737766006004L ^ 213
```
produces the same value -> thinks there was no modification -> returns old/wrong CRC value

fix: store both values without combiner function

fixes the first item on https://github.com/apache/netbeans/issues/8183

edit: https://github.com/emilianbold/netbeans-releases/commit/fe56d24c7c2dc6ec4243b6b50b65689edc6fb203 close to 21 years old - might be new personal record after https://github.com/apache/netbeans/pull/7951#issuecomment-2473151141 :).