### PR TITLE
GroovyParsetTest: don't clear workdir while indexer is active

### DIFF
--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParserTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParserTest.java
@@ -67,7 +67,8 @@ public class GroovyParserTest extends GroovyTestBase {
         Logger.getLogger(org.netbeans.modules.groovy.editor.api.parser.GroovyParser.class.getName())
                 .setLevel(Level.FINEST);
     }
-    
+
+    @Override
     protected void tearDown() throws Exception {
         // remove the static stuff
         parserUnit = null;
@@ -76,7 +77,10 @@ public class GroovyParserTest extends GroovyTestBase {
         enabledForUnit = null;
         GroovyTestTransformer.parserCompUnit = null;
         
-        clearWorkDir();
+        // TODO cancel indexing?
+        // don't clear since indexer might be still active; setUp() clears on reruns
+//        clearWorkDir();
+
         URL u = URLMapper.findURL(FileUtil.getConfigRoot(), URLMapper.EXTERNAL);
         if (u != null) {
             Path p = Paths.get(u.toURI());

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/test/GroovyTestBase.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/test/GroovyTestBase.java
@@ -19,8 +19,6 @@
 
 package org.netbeans.modules.groovy.editor.test;
 
-import java.io.File;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.StringTokenizer;
 import java.util.logging.Level;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.editor.BaseDocument;
@@ -46,7 +43,6 @@ import org.netbeans.modules.java.source.BootClassPathUtil;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
-import org.openide.util.Utilities;
 
 /**
  * In order to be able to run tests using java.source on Mac, you need to apply patch
@@ -78,6 +74,14 @@ public class GroovyTestBase extends CslTestBase {
         
         FileObject workDir = FileUtil.toFileObject(getWorkDir());
         testFO = workDir.createData("Test.groovy");
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        if (testFO != null) {
+            testFO.delete();
+        }
+        super.tearDown();
     }
 
     @Override


### PR DESCRIPTION
fixes sporadic `DirectoryNotEmptyExcepton`

closer look showed that no other groovy tests clear the ws on `tearDown()`. Lets do the same; ws is cleared on `setUp()` anyway.

`NbTestCase`: print some more details when recursive clearing fails, might help with identifying other concurrent write issues

meta issue https://github.com/apache/netbeans/issues/8183