### PR TITLE
#8174: Bump ide/libs.tomljava

### DIFF
--- a/ide/languages.toml/test/unit/src/org/netbeans/modules/languages/toml/TomlKeystrokeTest.java
+++ b/ide/languages.toml/test/unit/src/org/netbeans/modules/languages/toml/TomlKeystrokeTest.java
@@ -82,12 +82,20 @@ public class TomlKeystrokeTest extends TomlTestBase {
         insertChar("foo= ^bar", '\'', "foo= 'bar'^", "bar");
     }
 
-    public void  testStepSingleQuote() throws Exception {
+    public void testStepSingleQuote() throws Exception {
         insertChar("foo= '^'", '\'', "foo= ''^");
     }
 
     public void testDeleteSingle2() throws Exception {
         deleteChar("foo= ''^", "foo= '^");
+    }
+
+    public void testDeleteLastBrace() throws Exception {
+        deleteChar("[plugins]\n"
+                + "jooq-codegen = { id = \"org.jooq.jooq-codegen-gradle\", version.ref=\"jooq\" }^",
+                "[plugins]\n"
+                + "jooq-codegen = { id = \"org.jooq.jooq-codegen-gradle\", version.ref=\"jooq\" ^"
+        );
     }
 
 }

--- a/ide/libs.tomljava/external/binaries-list
+++ b/ide/libs.tomljava/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-FC26667B60FE746EEA788957157FA280D8F456DF net.vieiro:toml-java:13.4.1
+47006953C4961EDC2B14E55D01801FF95CF321DF net.vieiro:toml-java:13.4.2

--- a/ide/libs.tomljava/external/toml-java-13.4.2-license.txt
+++ b/ide/libs.tomljava/external/toml-java-13.4.2-license.txt
@@ -1,5 +1,5 @@
 Name: TOML parser in Java
-Version: 13.4.1
+Version: 13.4.2
 Description: A parser for Tom's Obvious, Minimal Language (TOML).
 License: Apache-2.0
 Origin: https://github.com/vieiro/toml-java

--- a/ide/libs.tomljava/nbproject/project.properties
+++ b/ide/libs.tomljava/nbproject/project.properties
@@ -18,4 +18,4 @@
 is.autoload=true
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-release.external/toml-java-13.4.1.jar=modules/ext/toml-java-13.4.1.jar
+release.external/toml-java-13.4.2.jar=modules/ext/toml-java-13.4.2.jar

--- a/ide/libs.tomljava/nbproject/project.xml
+++ b/ide/libs.tomljava/nbproject/project.xml
@@ -40,8 +40,8 @@
                 <package>net.vieiro.toml.antlr4</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/toml-java-13.4.1.jar</runtime-relative-path>
-                <binary-origin>external/toml-java-13.4.1.jar</binary-origin>
+                <runtime-relative-path>ext/toml-java-13.4.2.jar</runtime-relative-path>
+                <binary-origin>external/toml-java-13.4.2.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
A fix for #8174 . The library now emits an `INVALID` token for unclosed inline arrays and tables.

> If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

Maybe we can add a link to the message above that points to the meaning of each label? It seems we have many labels now...
