### PR TITLE
solves #7044, refactor inner to outer for record

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/ElementHandle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ElementHandle.java
@@ -107,7 +107,7 @@ public final class ElementHandle<T extends Element> {
      * Resolves an {@link Element} from the {@link ElementHandle}.
      * @param compilationInfo representing the {@link javax.tools.JavaCompiler.CompilationTask}
      * in which the {@link Element} should be resolved.
-     * @return resolved subclass of {@link Element} or null if the elment does not exist on
+     * @return resolved subclass of {@link Element} or null if the element does not exist on
      * the classpath/sourcepath of {@link javax.tools.JavaCompiler.CompilationTask}.
      */
     @SuppressWarnings ("unchecked")     // NOI18N
@@ -143,12 +143,12 @@ public final class ElementHandle<T extends Element> {
         if (log.isLoggable(Level.FINE))
             log.log(Level.FINE, "Resolving element kind: {0}", this.kind); // NOI18N       
         ElementKind simplifiedKind = this.kind;
-        if (simplifiedKind.name().equals("RECORD")) {
-            simplifiedKind = ElementKind.CLASS; //TODO: test
-        }
-        if (simplifiedKind.name().equals("RECORD_COMPONENT")) {
-            simplifiedKind = ElementKind.FIELD; //TODO: test
-        }
+//        if (simplifiedKind.name().equals("RECORD")) {
+//            simplifiedKind = ElementKind.CLASS; //TODO: test
+//        }
+//        if (simplifiedKind.name().equals("RECORD_COMPONENT")) {
+//            simplifiedKind = ElementKind.FIELD; //TODO: test
+//        }
         switch (simplifiedKind) {
             case PACKAGE:
                 assert signatures.length == 1;
@@ -156,6 +156,7 @@ public final class ElementHandle<T extends Element> {
             case CLASS:
             case INTERFACE:
             case ENUM:
+            case RECORD:
             case ANNOTATION_TYPE: {
                 assert signatures.length == 1;
                 final Element type = getTypeElementByBinaryName (module, signatures[0], jt);
@@ -213,6 +214,8 @@ public final class ElementHandle<T extends Element> {
             }
             case FIELD:
             case ENUM_CONSTANT:
+            case RECORD_COMPONENT:
+
             {
                 assert signatures.length == 3;
                 final Element type = getTypeElementByBinaryName (module, signatures[0], jt);

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreePathHandle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreePathHandle.java
@@ -322,6 +322,7 @@ public final class TreePathHandle {
             case ENUM_CONSTANT:
             case RECORD:
                 //TODO: record component
+            case RECORD_COMPONENT:
                 return true;
             case PARAMETER:
                 //only method and constructor parameters supported (not lambda):

--- a/java/java.source.base/src/org/netbeans/api/java/source/WorkingCopy.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/WorkingCopy.java
@@ -1221,6 +1221,7 @@ public class WorkingCopy extends CompilationController {
             case INTERFACE: return "Templates/Classes/Interface.java"; // NOI18N
             case ANNOTATION_TYPE: return "Templates/Classes/AnnotationType.java"; // NOI18N
             case ENUM: return "Templates/Classes/Enum.java"; // NOI18N
+            case RECORD: return "Templates/Classes/Record.java"; // NOI18N
             case PACKAGE: return "Templates/Classes/package-info.java"; // NOI18N
             default:
                 Logger.getLogger(WorkingCopy.class.getName()).log(Level.SEVERE, "Cannot resolve template for {0}", kind);
@@ -1247,6 +1248,9 @@ public class WorkingCopy extends CompilationController {
                     break;
                 case ENUM:
                     kind = ElementKind.ENUM;
+                    break;
+                case RECORD:
+                    kind = ElementKind.RECORD;
                     break;
                 default:
                     Logger.getLogger(WorkingCopy.class.getName()).log(Level.SEVERE, "Cannot resolve template for {0}", cut.getTypeDecls().get(0).getKind());

--- a/java/java.source.base/src/org/netbeans/modules/java/source/base/SourceLevelUtils.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/base/SourceLevelUtils.java
@@ -34,6 +34,13 @@ public class SourceLevelUtils {
     public static final Source JDK1_9 = Source.lookup("9");
     public static final Source JDK14 = Source.lookup("14");
     public static final Source JDK15 = Source.lookup("15");
+    public static final Source JDK16 = Source.lookup("16");
+    public static final Source JDK17 = Source.lookup("17");
+    // for next release:
+//    public static final Source JDK18 = Source.lookup("18");
+//    public static final Source JDK19 = Source.lookup("19");
+//    public static final Source JDK20 = Source.lookup("20");
+//    public static final Source JDK21 = Source.lookup("21");
 
     public static boolean allowDefaultMethods(Source in) {
         return in.compareTo(JDK1_8) >= 0;

--- a/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
@@ -104,6 +104,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.lang.model.element.Modifier;
 
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.lexer.JavaTokenId;
@@ -231,7 +232,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
     public int getIndent() {
         return out.leftMargin;
     }
-    
+
     public void setIndent(int indent) {
         out.leftMargin = indent;
     }
@@ -270,14 +271,14 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
 	if (s == null)
 	    return;
         out.append(s);
-    }           
+    }
 
     public final void print(Name n) {
         if (n == null)
             return;
 	out.append(n.toString());
     }
-    
+
     private void print(javax.lang.model.element.Name n) {
         if (n == null)
             return;
@@ -291,11 +292,11 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
         doAccept(t, true);
         blankLines(t, false);
     }
-    
+
     public void print(DCTree t) {
         print(t, false);
     }
-    
+
     public void print(DCTree t, boolean noMarginAfter) {
         if (t == null) return;
         blankLines(t, true, false);
@@ -303,7 +304,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
         doAccept(t);
         blankLines(t, false, noMarginAfter);
     }
-    
+
     private Map<JCTree, Integer> overrideStartPositions;
 
     private int getOldPos(JCTree oldT) {
@@ -318,7 +319,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
     public int endPos(JCTree t) {
         return TreeInfo.getEndPos(t, diffContext.origUnit.endPositions);
     }
-    
+
     private java.util.List<? extends StatementTree> getStatements(Tree tree) {
         switch (tree.getKind()) {
             case BLOCK: return ((BlockTree) tree).getStatements();
@@ -326,31 +327,31 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
             default: return null;
         }
     }
-    
+
     private java.util.List<JCVariableDecl> printOriginalPartOfFieldGroup(FieldGroupTree fgt) {
         java.util.List<JCVariableDecl> variables = fgt.getVariables();
         TreePath tp = TreePath.getPath(diffContext.origUnit, variables.get(0));
         TreePath parent = tp != null ? tp.getParentPath() : null;
-            
+
         if (parent == null) return variables;
-            
+
         java.util.List<? extends StatementTree> statements = getStatements(parent.getLeaf());
-        
+
         if (statements == null) return variables;
         JCVariableDecl firstDecl = fgt.getVariables().get(0);
         int startIndex = statements.indexOf(firstDecl);
-            
+
         if (startIndex < 0) return variables; //XXX: should not happen
-        
+
         int origCount = 0;
         int s = statements.size();
         for (JCTree t : variables) {
             if (startIndex >= s || statements.get(startIndex++) != t) break;
             origCount++;
         }
-        
+
         if (origCount < 2) return variables;
-        
+
         int firstPos = getOldPos(firstDecl);
         int groupStart = startIndex;
         // find the start of the field group among the original statement. The fieldgroup is detected using
@@ -381,7 +382,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
         overrideStartPositions = null;
         return variables.subList(origCount, variables.size());
     }
-    
+
     public Set<Tree> oldTrees = Collections.emptySet();
     public SortedSet<int[]> reindentRegions = new TreeSet<>(new Comparator<int[]>() {
         @Override public int compare(int[] o1, int[] o2) {
@@ -394,7 +395,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
     private void doAccept(JCTree t, boolean printComments/*XXX: should ideally always print comments?*/) {
         if (!handlePossibleOldTrees(Collections.singletonList(t), printComments)) {
             if (printComments) printPrecedingComments(t, true);
-            
+
             int start = out.length();
 
             if (t instanceof FieldGroupTree) {
@@ -404,7 +405,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
                     printEnumConstants(List.from(fgt.getVariables().toArray(new JCTree[0])), !fgt.isEnum() || fgt.moreElementsFollowEnum(), printComments);
                 } else {
                     java.util.List<JCVariableDecl> remainder = printOriginalPartOfFieldGroup(fgt);
-                    
+
                     //XXX: this will unroll the field group (see FieldGroupTest.testMove187766)
                     //XXX: copied from visitClassDef
                     boolean firstMember = remainder.size() == fgt.getVariables().size();
@@ -430,14 +431,14 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
             if (tag != null) {
                 tag2Span.put(tag, new int[]{start + initialOffset, end + initialOffset});
             }
-        
+
             if (printComments) {
                 printInnerCommentsAsTrailing(t, true);
                 printTrailingComments(t, true);
             }
         }
     }
-    
+
     private void doAccept(DCTree t) {
 //        int start = toString().length();
 
@@ -465,36 +466,36 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
             CommentSet cs = commentHandler.getComments(t);
             if (cs.hasChanges()) return false;
         }
-        
+
         if (toPrint.size() > 1) {
             //verify that all the toPrint trees belong to the same parent, and appear
             //in the same uninterrupted order under that parent:
             TreePath tp = TreePath.getPath(diffContext.mainUnit, toPrint.get(0));
             TreePath parent = tp.getParentPath();
-            
+
             if (parent == null) return false; //XXX: should not happen, right?
-            
+
             java.util.List<? extends StatementTree> statements = getStatements(parent.getLeaf());
-            
+
             if (statements == null) return false;
-            
+
             int startIndex = statements.indexOf(toPrint.get(0));
-            
+
             if (startIndex < 0) return false; //XXX: should not happen
-            
+
             for (JCTree t : toPrint) {
                 if (statements.get(startIndex++) != t) return false;
             }
         }
-        
+
         doPrintOriginalTree(toPrint, includeComments);
-        
+
         return true;
     }
-    
+
     private void doPrintOriginalTree(java.util.List<? extends JCTree> toPrint, final boolean includeComments) {
         if (out.isWhitespaceLine()) toLeftMargin();
-        
+
         JCTree firstTree = toPrint.get(0);
         JCTree lastTree = toPrint.get(toPrint.size() - 1);
 
@@ -507,7 +508,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
         } else {
             realStart = getOldPos(firstTree);
         }
-        
+
         final int newStart = out.length() + initialOffset;
 
         final int[] realEnd = {endPos(lastTree)};
@@ -520,7 +521,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
                         realEnd[0] = Math.max(realEnd[0], Math.max(CasualDiff.commentEnd(old, CommentSet.RelativePosition.INLINE), CasualDiff.commentEnd(old, CommentSet.RelativePosition.TRAILING)));
                         trailingCommentsHandled.add(node);
                     }
-                    
+
                     Object tag = tree2Tag != null ? tree2Tag.get(node) : null;
 
                     if (tag != null) {
@@ -528,7 +529,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
                         int e = endPos((JCTree) node);
                         tag2Span.put(tag, new int[]{s - realStart + newStart, e - realStart + newStart});
                     }
-                    
+
                 }
                 return super.scan(node, p);
             }
@@ -557,10 +558,10 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
         }
 
         String text = origText.substring(from, to);
-        
+
         int newLine = text.indexOf("\n") + 1;
         boolean wasWhitespaceLine = out.isWhitespaceLine();
-        
+
         if (newLine == 0 && !wasWhitespaceLine) {
             print(text);
         } else {
@@ -575,8 +576,8 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
     /**
      * Adjusts {@link #reindentRegions} if the char buffer conntents is
      * trimmed.
-     * 
-     * @param limit 
+     *
+     * @param limit
      */
     @Override
     public void trimmed(int limit) {
@@ -595,7 +596,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
             }
         }
     }
-    
+
 
     /** Print a package declaration.
      */
@@ -640,9 +641,17 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
             print(tree.name);
             s = replace(s, NAME);
         }
-        print('(');
-        wrapTrees(tree.params, WrapStyle.WRAP_NEVER, out.col);
-        print(')');
+        boolean isRecord = enclClass.getKind()== Kind.RECORD;
+        // return type null makes this method a constructor
+        boolean isCandidateCompactCtor = isRecord && null == t.getReturnType();
+        if (isCandidateCompactCtor) {
+            System.err.println("spotted compact "+ t.toString());
+        }
+        if (!isCandidateCompactCtor) {
+            print('(');
+            wrapTrees(tree.params, WrapStyle.WRAP_NEVER, out.col);
+            print(')');
+        }
         s = replace(s, PARAMETERS);
         if (tree.thrown.nonEmpty()) {
             print(" throws ");
@@ -844,7 +853,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
             printPackage(tree.pid);
         }
     }
-    
+
     @Override
     public void visitImport(JCImport tree) {
         print("import ");
@@ -977,6 +986,9 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
 
     @Override
     public void visitMethodDef(JCMethodDecl tree) {
+        boolean methodIsConstructor = null==tree.getReturnType();
+        boolean enclosingIsRecord= enclClass.getKind() == Kind.RECORD;
+        boolean paramsIsComponents= paramsIsComponents(tree.getParameters());
 	if ((tree.mods.flags & Flags.SYNTHETIC)==0 &&
 		tree.name != names.init ||
 		enclClass != null) {
@@ -995,18 +1007,9 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
                 needSpace();
                 print(tree.name);
             }
-            print(cs.spaceBeforeMethodDeclParen() ? " (" : "(");
-            if (cs.spaceWithinMethodDeclParens() && tree.params.nonEmpty())
-                print(' ');
-            boolean oldPrintingMethodParams = printingMethodParams;
-            printingMethodParams = true;
-            wrapTrees(tree.params, cs.wrapMethodParams(), cs.alignMultilineMethodParams()
-                    ? out.col : out.leftMargin + cs.getContinuationIndentSize(),
-                      true);
-            printingMethodParams = oldPrintingMethodParams;
-            if (cs.spaceWithinMethodDeclParens() && tree.params.nonEmpty())
-                needSpace();
-            print(')');
+            if (!(methodIsConstructor && enclosingIsRecord && paramsIsComponents)){
+                printMethodParams(tree);
+            }
             if (tree.thrown.nonEmpty()) {
                 wrap("throws ", cs.wrapThrowsKeyword());
                 wrapTrees(tree.thrown, cs.wrapThrowsList(), cs.alignMultilineThrows()
@@ -1024,6 +1027,21 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
             }
             enclClass = enclClassPrev;
 	}
+    }
+
+    void printMethodParams(JCMethodDecl tree) {
+        print(cs.spaceBeforeMethodDeclParen() ? " (" : "(");
+        if (cs.spaceWithinMethodDeclParens() && tree.params.nonEmpty())
+            print(' ');
+        boolean oldPrintingMethodParams = printingMethodParams;
+        printingMethodParams = true;
+        wrapTrees(tree.params, cs.wrapMethodParams(), cs.alignMultilineMethodParams()
+                ? out.col : out.leftMargin + cs.getContinuationIndentSize(),
+                true);
+        printingMethodParams = oldPrintingMethodParams;
+        if (cs.spaceWithinMethodDeclParens() && tree.params.nonEmpty())
+            needSpace();
+        print(')');
     }
 
     @Override
@@ -1656,7 +1674,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
             printNewClassBody(tree);
 	}
     }
-    
+
     public void printNewClassBody(JCNewClass tree) {
         JCClassDecl enclClassPrev = enclClass;
         enclClass = tree.def;
@@ -1828,8 +1846,8 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
     @Override
     public void visitTypeUnion(JCTypeUnion that) {
         boolean sep = cs.spaceAroundBinaryOps();
-        wrapTrees(that.getTypeAlternatives(), 
-                cs.wrapDisjunctiveCatchTypes(), 
+        wrapTrees(that.getTypeAlternatives(),
+                cs.wrapDisjunctiveCatchTypes(),
                 cs.alignMultilineDisjunctiveCatchTypes() ? out.col : out.leftMargin + cs.getContinuationIndentSize(),
                 false, sep, sep, "|"); // NOI18N
     }
@@ -1959,15 +1977,15 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
         }
         return sb.toString();
     }
-    
+
     private static final String[] typeTagNames = new String[TypeTag.values().length];
-    
+
     static {
         for (TypeTag tt : TypeTag.values()) {
             typeTagNames[tt.ordinal()] = tt.name().toLowerCase(Locale.ENGLISH);
         }
     }
-    
+
     /**
      * Workaround for defect #239258. Converts typetag names into lowercase using ENGLISH locale.
      */
@@ -2000,7 +2018,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
         print(' ');
 	printExpr(tree.underlyingType);
     }
-    
+
     @Override
     public void visitTypeParameter(JCTypeParameter tree) {
 	print(tree.name);
@@ -2195,7 +2213,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
                 return;
         }
     }
-    
+
     private boolean isFirst(JCTree tree, List<? extends JCTree> list) {
         for (JCTree t : list) {
             if (!isSynthetic(t)) {
@@ -2204,7 +2222,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
         }
         return false;
     }
-    
+
     private boolean isLast(JCTree tree, List<? extends JCTree> list) {
         boolean b = false;
         for (JCTree t : list) {
@@ -2214,7 +2232,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
         }
         return b;
     }
-    
+
     /**
      * The following tags are block-tags
      * <ul>
@@ -2729,6 +2747,42 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
         this.docCommentKind = docCommentKind;
     }
 
+    /**
+     * Check that the given parameters are equal to the classes (record) component.
+     *
+     * return true iff parameters and components are of same length, in same name and type order
+     * @param parameters of the method
+     * @return if the parameters equal the record components.
+     */
+    private boolean paramsIsComponents(List<JCVariableDecl> parameters) {
+        record TypeInfo(String name, String type){}
+        TypeInfo[] params = parameters.stream()
+                .map(p -> new TypeInfo(p.getName().toString(), p.getType().toString()))
+                .toArray(TypeInfo[]::new);
+        TypeInfo[] components = enclClass.getMembers().stream()
+                .filter(VeryPretty::isRecordComponent)
+                .map(x ->(VariableTree) x)
+                .map(p -> new TypeInfo(p.getName().toString(), p.getType().toString()))
+                .toArray(TypeInfo[]::new);
+        // short circuit on different length.
+        if (params.length != components.length) return false;
+        return Arrays.deepEquals(params, components);
+    }
+
+    /**
+     * A member is a normal field when not a class, (or enum ...) not a method
+     * and not static. For record that should be a record component then.
+     * @param t
+     * @return true if fields of the class/record are of same amount, order and types 
+     */
+    static boolean isRecordComponent(JCTree t){
+        if (t.getKind()==Kind.CLASS) return false;
+        if (t.getKind()==Kind.METHOD) return false;
+        if (t.getKind()==Kind.VARIABLE && t instanceof VariableTree vt){
+            return !vt.getModifiers().getFlags().contains(Modifier.STATIC);
+        }
+        return false;
+    }
     private final class Linearize extends ErrorAwareTreeScanner<Boolean, java.util.List<Tree>> {
         @Override
         public Boolean scan(Tree node, java.util.List<Tree> p) {
@@ -2766,12 +2820,12 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
         if (tree2Tag == null) {
             return; //nothing to  copy
         }
-        
+
         java.util.List<Tree> linearized = new LinkedList<Tree>();
         if (!new Linearize().scan(original, linearized) != Boolean.TRUE) {
             return; //nothing to  copy
         }
-        
+
             ClassPath empty = ClassPathSupport.createClassPath(new URL[0]);
             ClasspathInfo cpInfo = ClasspathInfo.create(JavaPlatformManager.getDefault().getDefaultPlatform().getBootstrapLibraries(), empty, empty);
             JavacTaskImpl javacTask = JavacParser.createJavacTask(cpInfo, null, null, null, null, null, null, null, Arrays.asList(FileObjects.memoryFileObject("", "Scratch.java", code)));
@@ -2798,7 +2852,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
 
     private boolean printAnnotationsFormatted(List<JCAnnotation> annotations) {
         if (reallyPrintAnnotations) return false;
-        
+
         VeryPretty del = new VeryPretty(diffContext, cs, new HashMap<Tree, Object>(), tree2Doc, new HashMap<Object, int[]>(), origText, 0);
         del.reallyPrintAnnotations = true;
         del.printingMethodParams = printingMethodParams;
@@ -2807,7 +2861,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
 
         String str = del.out.toString();
         int col = printingMethodParams ? out.leftMargin + cs.getContinuationIndentSize() : out.col;
-        
+
         str = Reformatter.reformat(str + " class A{}", cs, cs.getRightMargin() - col);
 
         str = str.trim().replace("\n", "\n" + whitespace(col));
@@ -2823,7 +2877,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
 
         return true;
     }
-    
+
     private void printAnnotations(List<JCAnnotation> annotations) {
         if (annotations.isEmpty()) return ;
 
@@ -2831,7 +2885,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
             toColExactly(out.leftMargin);
             return ;
         }
-        
+
         while (annotations.nonEmpty()) {
 	    printNoParenExpr(annotations.head);
             if (annotations.tail != null && annotations.tail.nonEmpty()) {
@@ -2889,19 +2943,19 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
 	        needSpace();
         }
     }
-    
+
     private static final String[] flagLowerCaseNames = new String[Flag.values().length];
-    
+
     static {
         for (Flag flag : Flag.values()) {
             flagLowerCaseNames[flag.ordinal()] = flag.name().toLowerCase(Locale.ENGLISH);
         }
     }
-    
+
     /**
-     * Workaround for defect #239258. Prints flag names converted to lowercase in ENGLISH locale to 
+     * Workaround for defect #239258. Prints flag names converted to lowercase in ENGLISH locale to
      * avoid weird Turkish I > i-without-dot-above conversion.
-     * 
+     *
      * @param flags flags
      * @return flag names, space-separated.
      */
@@ -3009,7 +3063,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
     private void printStat(JCTree tree) {
         printStat(tree, false, false);
     }
-    
+
     private void printStat(JCTree tree, boolean member, boolean first) {
         printStat(tree, member, first, false, false, false);
     }
@@ -3017,12 +3071,12 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
     /**
      * Prints blank lines before, positions to the exact column (optional), prints tree and
      * blank lines after. And optional additional newline.
-     * 
+     *
      * @param tree
      * @param member
      * @param first
      * @param col
-     * @param nl 
+     * @param nl
      */
     private void printStat(JCTree tree, boolean member, boolean first, boolean col, boolean nl, boolean printComments) {
 	if(tree==null) {
@@ -3040,13 +3094,13 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
             if (col) {
                 toColExactly(out.leftMargin);
             }
-            // because of comment duplication 
+            // because of comment duplication
 	    if(printComments) printPrecedingComments(tree, !member);
             printInnerCommentsAsTrailing(tree, !member);
             printExpr(tree, TreeInfo.notExpression);
 	    int tag = tree.getTag().ordinal();//XXX: comparing ordinals!!!
 	    if(JCTree.Tag.APPLY.ordinal()<=tag && tag<=JCTree.Tag.MOD_ASG.ordinal()) print(';');
-            
+
             printTrailingComments(tree, !member);
             blankLines(tree, false);
             if (nl) {
@@ -3122,7 +3176,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
     }
 
     public int conditionStartHack = (-1);
-    
+
     private void printBlock(JCTree tree, List<? extends JCTree> stats, BracePlacement bracePlacement, boolean spaceBeforeLeftBrace, boolean members, boolean printComments) {
         if (printComments) printPrecedingComments(tree, true);
 	int old = indent();
@@ -3446,14 +3500,14 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
     private <T extends JCTree> void wrapTrees(List<T> trees, WrapStyle wrapStyle, int wrapIndent) {
         wrapTrees(trees, wrapStyle, wrapIndent, false); //TODO: false for "compatibility", with the previous release, but maybe should be true for everyone?
     }
-    
+
     private <T extends JCTree> void wrapTrees(List<T> trees, WrapStyle wrapStyle, int wrapIndent, boolean wrapFirst) {
         wrapTrees(trees, wrapStyle, wrapIndent, wrapFirst, cs.spaceBeforeComma(), cs.spaceAfterComma(), ","); // NOI18N
     }
 
     private <T extends JCTree> void wrapTrees(List<T> trees, WrapStyle wrapStyle, int wrapIndent, boolean wrapFirst,
             boolean spaceBeforeSeparator, boolean spaceAfterSeparator, String separator) {
-        
+
         boolean first = true;
         for (List < T > l = trees; l.nonEmpty(); l = l.tail) {
             if (!first) {
@@ -3462,7 +3516,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
                 }
                 print(separator);
             }
-            
+
             if (!first || wrapFirst) {
                 switch(first && wrapStyle != WrapStyle.WRAP_NEVER ? WrapStyle.WRAP_IF_LONG : wrapStyle) {
                 case WRAP_IF_LONG:
@@ -3487,7 +3541,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
             first = false;
         }
     }
-    
+
     private void wrapAssignOpTree(final String operator, int col, final Runnable print) {
         final boolean spaceAroundAssignOps = cs.spaceAroundAssignOps();
         if (cs.wrapAfterAssignOps()) {
@@ -3506,7 +3560,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
             }
         });
     }
-    
+
     private void wrapTree(WrapStyle wrapStyle, boolean needsSpaceBefore, int colAfterWrap, Runnable print) {
         switch(wrapStyle) {
         case WRAP_NEVER:

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/RecordFormattingTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/RecordFormattingTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.source.save;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.prefs.Preferences;
+import javax.lang.model.SourceVersion;
+import javax.swing.JEditorPane;
+import javax.swing.text.Document;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.fail;
+import org.netbeans.api.editor.mimelookup.MimeLookup;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.api.java.lexer.JavaTokenId;
+import org.netbeans.api.java.source.SourceUtilsTestUtil;
+import org.netbeans.api.java.source.TestUtilities;
+import org.netbeans.api.lexer.Language;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.junit.NbTestSuite;
+import org.netbeans.modules.editor.indent.api.Reformat;
+import org.netbeans.modules.java.source.BootClassPathUtil;
+import org.netbeans.modules.java.source.usages.IndexUtil;
+import org.netbeans.spi.java.classpath.ClassPathProvider;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.netbeans.spi.java.queries.SourceLevelQueryImplementation;
+import org.openide.cookies.EditorCookie;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.loaders.DataObject;
+import org.openide.util.SharedClassObject;
+
+/**
+ * Test to show the problem mentioned in #7043.
+ *
+ * For some strange reason, the setting spaceWithinMethodDeclParens affects the
+ * formatting (indentation) of the trailing brace (}) of a record definition,
+ * both as inner record and as top level record.
+ *
+ * @author homberghp
+ */
+public class RecordFormattingTest extends NbTestCase {
+
+    File testFile = null;
+    private String sourceLevel = "1.8";
+    private static final List<String> EXTRA_OPTIONS = new ArrayList<>();
+
+    /**
+     * Creates a new instance of FormatingTest
+     */
+    public RecordFormattingTest(String name) {
+        super(name);
+    }
+
+    public static NbTestSuite suite() {
+        NbTestSuite suite = new NbTestSuite();
+        suite.addTestSuite(RecordFormattingTest.class);
+        return suite;
+    }
+
+    String content
+            = """
+              record Student(int id,String lastname,String firstname) implements Serializable {
+              int m(int x){ 
+              return id+x;
+              }
+              } // should stay flush to left margin
+              """;
+
+    public void test7043NoSpaces() throws Exception {
+        run7043("""
+                  record Student(int id, String lastname, String firstname) implements Serializable {
+                      int m(int x) {
+                          return id + x;
+                      }
+                  } // should stay flush to left margin
+                  """, false);
+    }
+
+    public void test7043WithSpaces() throws Exception {
+        run7043("""
+                  record Student( int id, String lastname, String firstname ) implements Serializable {
+                      int m( int x ) {
+                          return id + x;
+                      }
+                  } // should stay flush to left margin
+                  """, true);
+    }
+
+    /**
+     * The java formatter indents the final brace '}' of a record to far to the
+     * right, when the setting spaceWithinMethodDeclParens is True AND the
+     * record header defines parameters. This
+     *
+     * @throws Exception for some reason
+     */
+    // copied from testSealed
+    public void run7043(String golden, boolean spacesInMethodDecl) throws Exception {
+        try {
+            SourceVersion.valueOf("RELEASE_17"); //NOI18N
+        } catch (IllegalArgumentException ex) {
+            //OK, no RELEASE_15, skip test
+            return;
+        }
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile, "");
+        FileObject testSourceFO = FileUtil.toFileObject(testFile);
+        DataObject testSourceDO = DataObject.find(testSourceFO);
+        EditorCookie ec = (EditorCookie)testSourceDO.getCookie(EditorCookie.class);
+        Preferences preferences = MimeLookup.getLookup(JavaTokenId.language().mimeType()).lookup(Preferences.class);
+        preferences.putBoolean("spaceWithinMethodDeclParens", spacesInMethodDecl);
+        preferences.putInt("blankLinesAfterClassHeader", 0);
+
+        final Document doc = ec.openDocument();
+        doc.putProperty(Language.class, JavaTokenId.language());
+        reformat(doc, content, golden);
+    }
+
+    private void reformat(Document doc, String content, String golden) throws Exception {
+        reformat(doc, content, golden, 0, content.length());
+    }
+
+    private void reformat(Document doc, String content, String golden, int startOffset, int endOffset) throws Exception {
+        doc.remove(0, doc.getLength());
+        doc.insertString(0, content, null);
+
+        Reformat reformat = Reformat.get(doc);
+        reformat.lock();
+        try {
+            reformat.reformat(startOffset, endOffset);
+        } finally {
+            reformat.unlock();
+        }
+        String res = doc.getText(0, doc.getLength());
+        assertNoDiff(golden, res);
+    }
+
+    static void assertNoDiff(String expected, String actual) {
+        var expectedLines = expected.trim().split("\n");
+        var actualLines = actual.trim().split("\n");
+        // fail if not of equal length
+        String assertResult = "";
+        if (expectedLines.length != actualLines.length) {
+            assertResult
+                    = "number of lines differ :\n expected nr of lines = " + expectedLines.length
+                    + " actual nr of lines= " + actualLines.length;
+        }
+
+        for (int i = 0; i < expectedLines.length && i < actualLines.length; i++) {
+            String actualLine = actualLines[i];
+            String expLine = expectedLines[i];
+            if (expLine.equals(actualLine)) {
+                continue;
+            }
+            assertResult += "\n expected at line " + (i + 1) + ": \n'" + expLine + "'\n not equal to actual  \n'" + actualLine + "'";
+        }
+        if (assertResult.equals("")) {
+            return;
+        }
+        // output generated only when test fails, to help finding the difference.
+        for (int i = 1; i <= expectedLines.length; i++) {
+            String line = expectedLines[i-1];
+            System.err.format("%3d:  %s\n", i,line);
+            
+        }
+        System.err.println("actual");
+        for (int i = 1; i <= actualLines.length; i++) {
+            String line = actualLines[i-1];
+            System.err.format("%3d:  %s\n", i,line);
+        }
+        fail("not golden, see stderr for more info");
+
+    }
+
+}

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/api/InnerToOuterRefactoring.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/api/InnerToOuterRefactoring.java
@@ -22,10 +22,10 @@ import org.netbeans.api.java.source.TreePathHandle;
 import org.netbeans.modules.refactoring.api.AbstractRefactoring;
 import org.openide.util.lookup.Lookups;
 
-/** 
+/**
  * Convert Inner to Top-Level refactoring implementation class. This refactoring
  * is capable of converting an inner class into a top-level class.
- * 
+ *
  * @see org.netbeans.modules.refactoring.spi.RefactoringPlugin
  * @see org.netbeans.modules.refactoring.spi.RefactoringPluginFactory
  * @see org.netbeans.modules.refactoring.api.AbstractRefactoring
@@ -39,18 +39,23 @@ public final class InnerToOuterRefactoring extends AbstractRefactoring {
     // parameters of the refactoring
     private String className;
     private String referenceName;
-    
+
+    private boolean innerIsRecord;
+
     /**
      * Creates a new instance of InnerToOuterRefactoring.
-     * 
-     * @param sourceType An inner class that should be converted to a top-level class.
+     *
+     * @param sourceType An inner class that should be converted to a top-level
+     * class.
      */
     public InnerToOuterRefactoring(TreePathHandle sourceType) {
         super(Lookups.singleton(sourceType));
     }
-    
-    /** Returns the type the members of which should be pulled up
-     * by this refactoring.
+
+    /**
+     * Returns the type the members of which should be pulled up by this
+     * refactoring.
+     *
      * @return Source of the members to be pulled up.
      */
     public TreePathHandle getSourceType() {
@@ -58,34 +63,80 @@ public final class InnerToOuterRefactoring extends AbstractRefactoring {
     }
 
     // --- PARAMETERS ----------------------------------------------------------
-    
-    /** Returns the name for the top-level class to be created.
+    /**
+     * Returns the name for the top-level class to be created.
+     *
      * @return Class name.
      */
     public String getClassName() {
         return className;
     }
 
-    /** Sets name for the top-level class to be created.
+    /**
+     * Sets name for the top-level class to be created.
+     *
      * @param className Class name.
      */
     public void setClassName(String className) {
         this.className = className;
     }
 
-    /** Returns name of the field that should be generated as a reference to the original
-     * outer class. If null, no field will be generated.
-     * @return Name of the field to be generated or null if no field will be generated.
+    /**
+     * Returns name of the field that should be generated as a reference to the
+     * original outer class. If null, no field will be generated.
+     *
+     * @return Name of the field to be generated or null if no field will be
+     * generated.
      */
     public String getReferenceName() {
         return referenceName;
     }
-    
-    /** Sets name of the field that should be generated as a reference to the original
-     * outer class. Can be set to null which indicates that no field should be generated.
-     * @param referenceName Name of the field or null if no field should be generated.
-     */ 
+
+    /**
+     * Sets name of the field that should be generated as a reference to the
+     * original outer class. Can be set to null which indicates that no field
+     * should be generated.
+     *
+     * @param referenceName Name of the field or null if no field should be
+     * generated.
+     */
     public void setReferenceName(String referenceName) {
         this.referenceName = referenceName;
     }
+
+    /**
+     * Inner records need special handling because of the RecordComponents which
+     * are declared before the first curly brace, which differs from class,
+     * interface and enum.
+     *
+     * Also, the compact constructor should be considered.
+     *
+     * A compact constructor consists of the name of the Record, no parameters
+     * (not even the parens) and a block that does NOT assign the fields.
+     *
+     * @return the current value for this refactoring
+     */
+    public boolean isInnerIsRecord() {
+
+        return innerIsRecord;
+    }
+
+    /**
+     * Inner records need special handling because of the RecordComponents which
+     * are declared before the first curly brace, which differs from class,
+     * interface and enum.
+     *
+     * Also, the compact constructor should be considered.
+     *
+     * A compact constructor consists of the name of the Record, no parameters
+     * (not even the parens) and a block that does NOT assign the fields.
+     *
+     * @param innerIsRecord use when inner class needs the special handling of 
+     * an inner record.
+     */
+
+    public void setInnerIsRecord(boolean innerIsRecord) {
+        this.innerIsRecord = innerIsRecord;
+    }
+
 }

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/DeleteFile.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/DeleteFile.java
@@ -75,11 +75,10 @@ public class DeleteFile extends SimpleRefactoringElementImplementation {
     public void performChange() {
         try {
             FileObject fo = URLMapper.findFileObject(res);
-            if (fo == null) {
-                throw new IOException(res.toString());
+            if (fo != null) {
+                id = BackupFacility.getDefault().backup(fo);
+                DataObject.find(fo).delete();
             }
-            id = BackupFacility.getDefault().backup(fo);
-            DataObject.find(fo).delete();
         } catch (DataObjectNotFoundException ex) {
             Exceptions.printStackTrace(ex);
         } catch (IOException ex) {

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InnerToOuterTransformer.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InnerToOuterTransformer.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.netbeans.modules.refactoring.java.plugins;
 
 import com.sun.source.tree.*;
@@ -52,7 +51,7 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
     private InnerToOuterRefactoring refactoring;
     private boolean isInInnerClass = false;
     private Set<Element> referencedPrivateElement;
-    
+
     private Element getCurrentElement() {
         return workingCopy.getTrees().getElement(getCurrentPath());
     }
@@ -78,7 +77,7 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
             return null;
         }
         if (inner.equals(current)) {
-            Tree newTree = make.setLabel(node, refactoring.getClassName());        
+            Tree newTree = make.setLabel(node, refactoring.getClassName());
             rewrite(node, newTree);
         } else if (isThisReferenceToOuter() && isThisInInner()) {
             if (current.getModifiers().contains(Modifier.PRIVATE)) {
@@ -105,7 +104,7 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
                 TreePath elementPath = workingCopy.getTrees().getPath(current);
                 JavaFileObject sourceFile = elementPath != null ? elementPath.getCompilationUnit().getSourceFile() : null;
                 if (   (parent != null && parent.getKind() == Tree.Kind.CASE && ((CaseTree) parent).getExpression() == node && current.getKind() == ElementKind.ENUM_CONSTANT)
-                    || path.getCompilationUnit().getSourceFile() == sourceFile) {
+                        || path.getCompilationUnit().getSourceFile() == sourceFile) {
                     rewrite(node, make.Identifier(current.getSimpleName()));
                 } else {
                     rewrite(node, make.QualIdent(current));
@@ -141,7 +140,7 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
                 else {
                     thisString = "this"; // NOI18N
                 }
-            
+
             }
             if (thisString != null && currentElement instanceof ExecutableElement) {
                 ExecutableElement constr = (ExecutableElement) currentElement;
@@ -154,7 +153,7 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
                         removeEnclosingExpression = true;
                     }
                 }
-                
+
                 int index = constr.getParameters().size();
                 if (constr.isVarArgs()) {
                     index--;
@@ -209,7 +208,7 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
         }
         return super.visitNewClass(arg0, arg1);
     }
-    
+
     private TypeElement getOuter(TypeElement element) {
         while (element != null && !workingCopy.getTypes().isSubtype(element.asType(),outer.asType())) {
             element = workingCopy.getElementUtilities().enclosingTypeElement(element);
@@ -231,7 +230,7 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
                     rewrite(superCall, newSuperCall);
                 }
             }
-            
+
         }
         return super.visitMethod(constructor, element);
     }
@@ -242,26 +241,26 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
         if (currentElement == null) {
             return super.visitClass(classTree, element);
         }
-        GeneratorUtilities genUtils = GeneratorUtilities.get(workingCopy); // helper        
+        GeneratorUtilities genUtils = GeneratorUtilities.get(workingCopy); // helper
         if (currentElement!=null && currentElement == outer) {
             Element outerouter = outer.getEnclosingElement();
             Tree superVisit = super.visitClass(classTree, element);
-            TreePath tp = workingCopy.getTrees().getPath(inner);
-            if (tp==null) {
+            TreePath innerTp = workingCopy.getTrees().getPath(inner);
+            if (innerTp==null) {
                 //#194346
                 return superVisit;
             }
-            ClassTree innerClass = (ClassTree) tp.getLeaf();
+            ClassTree innerClass = (ClassTree) innerTp.getLeaf();
 
             ClassTree newInnerClass = innerClass;
             newInnerClass = genUtils.importComments(newInnerClass, workingCopy.getCompilationUnit());
 
             newInnerClass = make.setLabel(newInnerClass, refactoring.getClassName());
-            
+
             newInnerClass = refactorInnerClass(newInnerClass);
-            
+
             TreePath outerPath = workingCopy.getTrees().getPath(outer);
-            
+
             if (outerouter.getKind() == ElementKind.PACKAGE) {
                 FileObject sourceRoot=ClassPath.getClassPath(workingCopy.getFileObject(), ClassPath.SOURCE).findOwnerRoot(workingCopy.getFileObject());
                 ClassTree outerTree = (ClassTree) workingCopy.getTrees().getTree(outer);
@@ -270,7 +269,7 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
                 if(outerPath != null) {
                     JavaRefactoringUtils.cacheTreePathInfo(outerPath, workingCopy);
                 }
-                CompilationUnitTree compilationUnit = tp.getCompilationUnit();
+                CompilationUnitTree compilationUnit = innerTp.getCompilationUnit();
                 String relativePath = RefactoringUtils.getPackageName(compilationUnit).replace('.', '/') + '/' + refactoring.getClassName() + ".java"; // NOI18N
                 CompilationUnitTree newCompilation = JavaPluginUtils.createCompilationUnit(sourceRoot, relativePath, newInnerClass, workingCopy, make);
                 rewrite(null, newCompilation);
@@ -290,53 +289,53 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
                 rewrite(outerouterTree, newOuterOuter);
                 return newOuterOuter;
             }
-            
+
         } else if (refactoring.getReferenceName() != null && currentElement!=null && workingCopy.getTypes().isSubtype(currentElement.asType(), inner.asType()) && currentElement!=inner) {
-                VariableTree variable = make.Variable(make.Modifiers(Collections.<Modifier>emptySet()), refactoring.getReferenceName(), make.Type(outer.asType()), null);
+            VariableTree variable = make.Variable(make.Modifiers(Collections.<Modifier>emptySet()), refactoring.getReferenceName(), make.Type(outer.asType()), null);
                 for (Tree member:classTree.getMembers()) {
-                    if (member.getKind() == Tree.Kind.METHOD) {
-                        MethodTree m = (MethodTree) member;
+                if (member.getKind() == Tree.Kind.METHOD) {
+                    MethodTree m = (MethodTree) member;
                         if (m.getReturnType()==null) {
-                    
+
                             for( VariableTree var: m.getParameters() ) {
                                 if( var.getName().contentEquals(refactoring.getReferenceName()) ) {
-                                    problem = MoveTransformer.createProblem(problem, true, NbBundle.getMessage(InnerToOuterTransformer.class, "ERR_InnerToOuter_OuterNameClashSubtype", refactoring.getReferenceName(), refactoring.getClassName(), currentElement.getSimpleName()));
-                                }
+                                problem = MoveTransformer.createProblem(problem, true, NbBundle.getMessage(InnerToOuterTransformer.class, "ERR_InnerToOuter_OuterNameClashSubtype", refactoring.getReferenceName(), refactoring.getClassName(), currentElement.getSimpleName()));
                             }
-
-                            MethodInvocationTree superCall = (MethodInvocationTree) ((ExpressionStatementTree) m.getBody().getStatements().get(0)).getExpression();
-                            List<ExpressionTree> newArgs = new ArrayList<ExpressionTree>(superCall.getArguments());
-                            
-                            MethodTree newConstructor = null;
-                            ExpressionTree exprTree = (ExpressionTree)make.Identifier(variable.getName().toString());
-                            if (hasVarArgs(m)) {
-                                int index = m.getParameters().size() - 1;
-                                newArgs.add(index, exprTree);
-                                newConstructor = make.insertMethodParameter(m, index, variable);
-                            } else {
-                                newArgs.add(exprTree);
-                                newConstructor = make.addMethodParameter(m, variable);
-                            }
-                            MethodInvocationTree method = make.MethodInvocation(
-                                    Collections.<ExpressionTree>emptyList(), 
-                                    make.Identifier("super"), // NOI18N
-                                    newArgs);
-
-                            BlockTree block = make.insertBlockStatement(m.getBody(), 0, make.ExpressionStatement(method));
-                            block = make.removeBlockStatement(block, 1);
-                            
-                            newConstructor = make.Constructor(
-                                    make.Modifiers(newConstructor.getModifiers().getFlags(), newConstructor.getModifiers().getAnnotations()),
-                                    newConstructor.getTypeParameters(), 
-                                    newConstructor.getParameters(),
-                                    newConstructor.getThrows(),
-                                    block);
-
-                            rewrite(m, newConstructor);
                         }
+
+                        MethodInvocationTree superCall = (MethodInvocationTree) ((ExpressionStatementTree) m.getBody().getStatements().get(0)).getExpression();
+                        List<ExpressionTree> newArgs = new ArrayList<ExpressionTree>(superCall.getArguments());
+
+                        MethodTree newConstructor = null;
+                        ExpressionTree exprTree = (ExpressionTree) make.Identifier(variable.getName().toString());
+                        if (hasVarArgs(m)) {
+                            int index = m.getParameters().size() - 1;
+                            newArgs.add(index, exprTree);
+                            newConstructor = make.insertMethodParameter(m, index, variable);
+                        } else {
+                            newArgs.add(exprTree);
+                            newConstructor = make.addMethodParameter(m, variable);
+                        }
+                        MethodInvocationTree method = make.MethodInvocation(
+                                Collections.<ExpressionTree>emptyList(),
+                                make.Identifier("super"), // NOI18N
+                                newArgs);
+
+                        BlockTree block = make.insertBlockStatement(m.getBody(), 0, make.ExpressionStatement(method));
+                        block = make.removeBlockStatement(block, 1);
+
+                        newConstructor = make.Constructor(
+                                make.Modifiers(newConstructor.getModifiers().getFlags(), newConstructor.getModifiers().getAnnotations()),
+                                newConstructor.getTypeParameters(),
+                                newConstructor.getParameters(),
+                                newConstructor.getThrows(),
+                                block);
+
+                        rewrite(m, newConstructor);
                     }
-                }                
+                }
             }
+        }
 
         if (currentElement == inner) {
             try {
@@ -346,7 +345,7 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
                 isInInnerClass = false;
             }
         }
-        
+
         return super.visitClass(classTree, element);
     }
 
@@ -359,7 +358,7 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
         for (Element privEl : this.referencedPrivateElement) {
             problem = MoveTransformer.createProblem(problem, false, NbBundle.getMessage(InnerToOuterRefactoringPlugin.class, "WRN_InnerToOuterRefToPrivate", privEl));
         }
-        
+
         Trees trees = workingCopy.getTrees();
         CompilationUnitTree newNode = node;
         for (ImportTree imp : node.getImports()) {
@@ -376,7 +375,7 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
         }
         return result;
     }
-    
+
     private Problem problem;
 
     public Problem getProblem() {
@@ -391,7 +390,7 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
         }
         return false;
     }
-    
+
 
     @Override
     public Tree visitMemberSelect(MemberSelectTree memberSelect, Element element) {
@@ -456,9 +455,9 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
                     rewrite(variable.getModifiers(), make.removeModifiersModifier(variable.getModifiers(), Modifier.PRIVATE));
                 }
             }
-            
+
         }
-        
+
         return super.visitMemberSelect(memberSelect, element);
     }
 
@@ -495,7 +494,7 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
         TypeElement encl = workingCopy.getElementUtilities().enclosingTypeElement(cur);
         return encl!=null && workingCopy.getTypes().isSubtype(encl.asType(), inner.asType()) ;
     }
-    
+
     private boolean isThisReferenceToOuter() {
         Element cur = getCurrentElement();
         if (cur==null || cur.getKind() == ElementKind.PACKAGE) {
@@ -542,7 +541,7 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
         }
         return false;
     }
-    
+
     private boolean hasVarArgs(MethodTree mt) {
         List list = mt.getParameters();
         if (list.isEmpty()) {
@@ -551,8 +550,11 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
         VariableTree vt = (VariableTree)list.get(list.size() - 1);
         return vt.toString().indexOf("...") != -1; // [NOI18N] [TODO] temporal hack, will be rewritten
     }
-    
+
     private ClassTree refactorInnerClass(ClassTree innerClass) {
+        if (innerClass.getKind() == Tree.Kind.RECORD) {
+            return refactorInnerRecord(innerClass);
+        }
         ClassTree newInnerClass = innerClass;
         String referenceName = refactoring.getReferenceName();
         GeneratorUtilities genUtils = GeneratorUtilities.get(workingCopy);
@@ -568,11 +570,13 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
         } else {
             outerType = outer.asType();
         }
+        // for none static inner classes, add a member to point to the 'old' outer.
+        // because there has to be an explicit member after refactoring.
         if (referenceName != null) {
             VariableTree variable = make.Variable(make.Modifiers(EnumSet.of(Modifier.PRIVATE, Modifier.FINAL)), refactoring.getReferenceName(), make.Type(outerType), null);
             newInnerClass = genUtils.insertClassMember(newInnerClass, variable);
         }
-        
+
         ModifiersTree modifiersTree = newInnerClass.getModifiers();
         ModifiersTree newModifiersTree = make.removeModifiersModifier(modifiersTree, Modifier.PRIVATE);
         newModifiersTree = make.removeModifiersModifier(newModifiersTree, Modifier.STATIC);
@@ -582,16 +586,17 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
         }
         rewrite(modifiersTree, newModifiersTree);
 
+        // create constructor which refers with member to old outer.
         if (referenceName != null) {
             for (Tree member:newInnerClass.getMembers()) {
                 if (member.getKind() == Tree.Kind.METHOD) {
-                    MethodTree m = (MethodTree) member;
-                    if (m.getName().contentEquals("<init>") || m.getReturnType() == null) {
-                        VariableTree parameter = make.Variable(make.Modifiers(EnumSet.of(Modifier.FINAL)), refactoring.getReferenceName(), make.Type(outerType), null);
-                        MethodTree newConstructor = hasVarArgs(m) ?
-                            make.insertMethodParameter(m, m.getParameters().size() - 1, parameter) : 
-                            make.addMethodParameter(m, parameter);
-                        
+                    MethodTree ctor = (MethodTree) member;
+                    if (ctor.getName().contentEquals("<init>") || ctor.getReturnType() == null) {
+                        VariableTree parameter = make.Variable(make.Modifiers(EnumSet.of(Modifier.FINAL)), referenceName, make.Type(outerType), null);
+                        MethodTree newConstructor = hasVarArgs(ctor) ?
+                            make.insertMethodParameter(ctor, ctor.getParameters().size() - 1, parameter) :
+                            make.addMethodParameter(ctor, parameter);
+
                         AssignmentTree assign = make.Assignment(make.Identifier("this."+referenceName), make.Identifier(referenceName)); // NOI18N
                         BlockTree block = make.insertBlockStatement(newConstructor.getBody(), 1, make.ExpressionStatement(assign));
                         Set<Modifier> modifiers = EnumSet.noneOf(Modifier.class);
@@ -599,25 +604,60 @@ public class InnerToOuterTransformer extends RefactoringVisitor {
                         modifiers.remove(Modifier.PRIVATE);
                         newConstructor = make.Constructor(
                                 make.Modifiers(modifiers,newConstructor.getModifiers().getAnnotations()),
-                                newConstructor.getTypeParameters(), 
+                                newConstructor.getTypeParameters(),
                                 newConstructor.getParameters(),
                                 newConstructor.getThrows(),
                                 block);
 
-                        newInnerClass = make.removeClassMember(newInnerClass, m);
-                        genUtils.copyComments(m, newConstructor, true);
-                        genUtils.copyComments(m, newConstructor, false);
+                        newInnerClass = make.removeClassMember(newInnerClass, ctor);
+                        genUtils.copyComments(ctor, newConstructor, true);
+                        genUtils.copyComments(ctor, newConstructor, false);
                         newInnerClass = genUtils.insertClassMember(newInnerClass, newConstructor);
                     }
                 }
             }
         }
-        
+
         if(innerClass != newInnerClass) {
             genUtils.copyComments(innerClass, newInnerClass, true);
             genUtils.copyComments(innerClass, newInnerClass, false);
         }
         return newInnerClass;
+    }
+
+    private ClassTree refactorInnerRecord(ClassTree innerRecord) {
+        refactoring.setInnerIsRecord(true);
+        ClassTree newInnerRecord = innerRecord;
+        List<? extends Tree> members = newInnerRecord.getMembers();
+        int insertAt=0;
+        for (Tree member : members) {
+            Tree.Kind kind = member.getKind();
+//            System.out.println("member = " + kind + "" + member);
+            
+            switch (kind) {
+               // The fields, except the static, should loose private final modifiers
+               // so that they appear without these modifiers in the record header
+                case VARIABLE:
+                    VariableTree vt = (VariableTree) member;
+                    ModifiersTree mt = vt.getModifiers();
+                    if (mt.getFlags().contains(Modifier.STATIC)) {
+                        continue;
+                    }
+                    var mtype = vt.getType();
+                    var mName = vt.getName();
+                    var mods = make.Modifiers(EnumSet.noneOf(Modifier.class));
+                    var newMember = make.RecordComponent(mods, mName, mtype);
+                    newInnerRecord = make.removeClassMember(newInnerRecord, member);
+                    newInnerRecord = make.insertClassMember(newInnerRecord, insertAt, newMember);
+                    insertAt++;
+                    
+                    break;
+                default:
+            }
+
+//            if (member.getKind())
+        }
+        return newInnerRecord;
     }
 
     private boolean isThisInInner() {

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/JavaPluginUtils.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/JavaPluginUtils.java
@@ -523,8 +523,11 @@ public final class JavaPluginUtils {
     public static CompilationUnitTree createCompilationUnit(FileObject sourceRoot, String relativePath, Tree typeDecl, WorkingCopy workingCopy, TreeMaker make) {
         GeneratorUtilities genUtils = GeneratorUtilities.get(workingCopy);
         CompilationUnitTree newCompilation;
+        ElementKind clzOrRecord = ElementKind.CLASS;
+        if (typeDecl.getKind()== Kind.RECORD)
+            clzOrRecord=ElementKind.RECORD;
         try {
-            newCompilation = genUtils.createFromTemplate(sourceRoot, relativePath, ElementKind.CLASS);
+            newCompilation = genUtils.createFromTemplate(sourceRoot, relativePath, clzOrRecord);//ElementKind.CLASS);
             List<? extends Tree> typeDecls = newCompilation.getTypeDecls();
             if (typeDecls.isEmpty()) {
                 newCompilation = make.addCompUnitTypeDecl(newCompilation, typeDecl);

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/RefactoringVisitor.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/RefactoringVisitor.java
@@ -183,6 +183,7 @@ public class RefactoringVisitor extends ErrorAwareTreePathScanner<Tree, Element>
                 case CLASS:
                 case ENUM:
                 case INTERFACE:
+                case RECORD:
                 case VARIABLE:
                     TreePath path = new TreePath(currentPath, tree);
                     scanJavadoc(path, p);
@@ -456,6 +457,7 @@ public class RefactoringVisitor extends ErrorAwareTreePathScanner<Tree, Element>
         return docScanner.visitVersion(node, p, null);
     }
 
+    
     /**
      * @since 1.47
      */

--- a/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InnerOuterRecordTest.java
+++ b/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InnerOuterRecordTest.java
@@ -1,0 +1,713 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.refactoring.java.test;
+
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreePath;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Name;
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+import org.netbeans.api.java.source.CompilationController;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.Task;
+import org.netbeans.api.java.source.TreePathHandle;
+import org.netbeans.modules.refactoring.api.Problem;
+import org.netbeans.modules.refactoring.api.RefactoringSession;
+import org.netbeans.modules.refactoring.java.api.InnerToOuterRefactoring;
+import static org.netbeans.modules.refactoring.java.test.RefactoringTestBase.addAllProblems;
+import org.openide.util.Exceptions;
+
+/**
+ * Test inner to outer refactoring for test.
+ *
+ * In the input files, and the expected outcomes, the indentation does not
+ * really matter as far as the tests are concerned because the indentation is
+ * stripped away before the remaining source lines are compared to the expected
+ * lines.
+ *
+ * @author homberghp {@code <pieter.van.den.hombergh@gmail.com)>}
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class InnerOuterRecordTest extends RefactoringTestBase {
+
+    public InnerOuterRecordTest(String name) {
+        super(name);
+        //ensure we are running on at least 16.
+        try {
+            SourceVersion.valueOf("RELEASE_16"); //NOI18N
+        } catch (IllegalArgumentException ex) {
+            //OK, no RELEASE_16, skip test
+            throw new RuntimeException("need at least Java 16 for record");
+        }
+    }
+
+    // for reference
+    public void test0_259004() throws Exception {
+        String source
+                = """
+            package t;
+
+            import java.util.function.Consumer;
+
+            public class A {
+
+                public static void main(String[] args) {
+                    Consumer<F> c = f -> {};
+                }
+
+                public static final class F {}
+            }""";
+        String newOuter
+                = """
+            package t;
+
+            import java.util.function.Consumer;
+
+            public class A {
+
+            public static void main(String[] args) {
+                Consumer<F> c = f -> {};
+            }
+
+            }""";
+        String newInner
+                = """
+            /*
+            * Refactoring License
+            */
+
+            package t;
+
+            /**
+             *
+             * @author junit
+             */
+            public final class F {
+
+            }
+            """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+
+    }
+
+    public void test9ApacheNetbeans7044() throws Exception {
+        // initial outer has record with meaningful canonical constructor.
+        // note that Inner class should be in last member for assumptions in the test.
+        String source
+                = """
+                package t;
+
+                import java.time.LocalDate;
+                import java.util.Objects;
+
+                public class A {
+
+                    void useStudent() {
+                        F s = new F(42,"Jan Klaassen", LocalDate.now().minusDays(1));
+                        System.out.println("student = " + s);
+                    }
+
+                    record F(int id, String name, LocalDate dob) {
+
+                        /**
+                          * Validate stuff.
+                          */
+                        public F {
+                            Objects.requireNonNull(id);
+                            Objects.requireNonNull(name);
+                            Objects.requireNonNull(dob);
+                            assert !name.isEmpty() && !name.isBlank();
+                            assert dob.isAfter(LocalDate.EPOCH);
+                        }
+                    }
+
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+
+                import java.time.LocalDate;
+                import java.util.Objects;
+
+                public class A {
+
+                    void useStudent() {
+                        F s = new F(42,"Jan Klaassen", LocalDate.now().minusDays(1));
+                        System.out.println("student = " + s);
+                    }
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+                package t;
+
+                import java.time.LocalDate;
+                import java.util.Objects;
+                /**
+                  *
+                  * @author junit
+                  */
+                record F(int id, String name, LocalDate dob) {
+
+                    /**
+                     * Validate stuff.
+                     */
+                    public F {
+                        Objects.requireNonNull(id);
+                        Objects.requireNonNull(name);
+                        Objects.requireNonNull(dob);
+                        assert !name.isEmpty() && !name.isBlank();
+                        assert dob.isAfter(LocalDate.EPOCH);
+                    }
+                }
+                """;
+
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    public void test1BasicClassInClass() throws Exception {
+        // initial outer has record with meaningful canonical constructor.
+        String source
+                = """
+            package t;
+
+            import java.time.LocalDate;
+            import java.util.Objects;
+
+            public class A {
+
+                void useStudent() {
+                    F s = new F(42, "Jan Klaassen", LocalDate.now().minusDays(1));
+                    System.out.println("student = " + s);
+                }
+
+                public static class F {
+                    int id;
+                    String name;
+                    LocalDate dob
+                    public Student(int id, String name, LocalDate dob) {
+                        Objects.requireNonNull(id);
+                        Objects.requireNonNull(name);
+                        Objects.requireNonNull(dob);
+                        assert !name.isEmpty() && !name.isBlank();
+                        assert dob.isAfter(LocalDate.EPOCH);
+                        this.id=id;
+                        this.name=name;
+                        this.dob=dob;
+                    }
+                }
+
+            }
+            """;
+        String newOuter
+                = """
+                package t;
+
+                import java.time.LocalDate;
+                import java.util.Objects;
+
+                public class A {
+
+                    void useStudent() {
+                        F s = new F(42, "Jan Klaassen", LocalDate.now().minusDays(1));
+                        System.out.println("student = " + s);
+                    }
+
+
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.time.LocalDate;
+                import java.util.Objects;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                public class F {
+
+                    int id;
+                    String name;
+                    LocalDate dob;
+
+                    public F(int id, String name, LocalDate dob) {
+                        Objects.requireNonNull(id);
+                        Objects.requireNonNull(name);
+                        Objects.requireNonNull(dob);
+                        assert !name.isEmpty() && !name.isBlank();
+                        assert dob.isAfter(LocalDate.EPOCH);
+                        this.id = id;
+                        this.name = name;
+                        this.dob = dob;
+                    }
+
+                }
+                """;
+
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    public void test2BasicRecordInRecord() throws Exception {
+        String source
+                = """
+                package t;
+
+                import java.time.LocalDate;
+
+                record A(int id, String name, LocalDate dob) {
+                   static F f;
+                   record F(int x, int y){
+                      /** I should be back. */
+                      static String code = "nix";
+                   }
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+
+                import java.time.LocalDate;
+
+                record A(int id, String name, LocalDate dob) {
+
+                    static F f;
+
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+                package t;
+
+                /**
+                 *
+                 * @author hom
+                 */
+                record F(int x, int y) {
+                    /** I should be back. */
+                    static String code = "nix";
+                }
+                """;
+
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    /**
+     * Test to verify what happens to the compact constructor in the outer
+     * record. It appears to survive the refactoring.
+     *
+     * @throws Exception
+     */
+    public void test3OuterWithCompact() throws Exception {
+        String source
+                = """
+                package t;
+                import java.time.LocalDate;
+                /** Record with compact ctor. */
+                record A(F f){
+
+                     public A{
+                         assert f!=null;
+                     }
+                     record F(int id, String name, LocalDate dob){}
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+                import java.time.LocalDate;
+                /** Record with compact ctor. */
+                record A(F f){
+                    public A{
+                         assert f!=null;
+                    }
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+                package t;
+                import java.time.LocalDate;
+                /**
+                 *
+                 * @author junit
+                 */
+                record F(int id, String name, LocalDate dob) {
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    public void test4InnerWithCompact() throws Exception {
+        String source
+                = """
+                package t;
+                
+                import java.time.LocalDate;
+                
+                record A(F f) {
+                
+                    public A {
+                        assert f != null;
+                    }
+                
+                    record F(int id, String name, LocalDate dob) {
+                
+                        public F {
+                            if (dob.isBefore(LocalDate.EPOCH)) {
+                                throw new IllegalArgumentException("to old " + dob);
+                            }
+                        }
+                    }
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+                import java.time.LocalDate;
+                record A(F f) {
+                public A {
+                        assert f != null;
+                    }
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+                package t;
+                import java.time.LocalDate;
+                /**
+                 *
+                 * @author junit
+                 */
+                record F(int id, String name, LocalDate dob) {
+
+                    public F {
+                        if (dob.isBefore(LocalDate.EPOCH)) {
+                            throw new IllegalArgumentException("to old " + dob);
+                        }
+                    }
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    // outer may have effect
+    public void test5ClassWithInnerRecord() throws Exception {
+        String source
+                = """
+                package t;
+                
+                import java.time.LocalDate;
+                
+                class A {
+                    final F f;
+                    public A(F f) {
+                        assert f != null;
+                        this.f=f;
+                    }
+                
+                    record F(int id, String name, LocalDate dob) {
+                
+                        public F   {
+                            if (dob.isBefore(LocalDate.EPOCH)) {
+                                throw new IllegalArgumentException("to old " + dob);
+                            }
+                        }
+                    }
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+                import java.time.LocalDate;
+                class A {
+                    final F f;
+                    public A(F f) {
+                        assert f != null;
+                        this.f=f;
+                    }
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+                package t;
+                import java.time.LocalDate;
+                /**
+                 *
+                 * @author junit
+                 */
+                record F(int id, String name, LocalDate dob) {
+
+                    public F {
+                        if (dob.isBefore(LocalDate.EPOCH)) {
+                            throw new IllegalArgumentException("to old " + dob);
+                        }
+                    }
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+    
+    public void test6InnerWithCompactAndMethodAndExtraCtor() throws Exception {
+        String source
+                = """
+                package t;
+                
+                import java.time.LocalDate;
+                record A(F f) {
+
+                enum Suite {
+                    SPADE, CLUB, DIAMOND, HEART;
+                }
+                
+                    public A {
+                        assert f != null;
+                    }
+                
+                    record F(int id, String name, LocalDate dob) {
+                
+                        public F {
+                            if (dob.isBefore(LocalDate.EPOCH)) {
+                                throw new IllegalArgumentException("to old " + dob);
+                            }
+                        }
+                        public F(int id, String name){
+                            this(id,name,LocalDate.now());
+                        }
+                        boolean bornBefore(LocalDate someDate) {
+                            return dob.isBefore(someDate);
+                        } 
+                    }
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+                import java.time.LocalDate;
+                record A(F f) {
+                    enum Suite { 
+                      SPADE, CLUB, DIAMOND, HEART;
+                    }
+                    public A {
+                        assert f != null;
+                    }
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+                package t;
+                import java.time.LocalDate;
+                /**
+                 *
+                 * @author junit
+                 */
+                record F(int id, String name, LocalDate dob) {
+
+                    public F {
+                        if (dob.isBefore(LocalDate.EPOCH)) {
+                            throw new IllegalArgumentException("to old " + dob);
+                        }
+                    }
+                    public F(int id, String name) {
+                        this(id, name, LocalDate.now());
+                    }
+                    boolean bornBefore(LocalDate someDate) {
+                        return dob.isBefore(someDate);
+                    } 
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    
+    public void test7Generic() throws Exception{
+    String source
+                = """
+                package t;
+                
+                record A(F f) {
+                    public A {
+                        assert f != null;
+                    }
+                    record F<P, Q>(P first, Q second) {
+                
+                        public F {
+                            assert null != first;
+                            assert null != second;
+                        }
+                    }
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+                record A(F f) {
+                    public A {
+                        assert f != null;
+                    }
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+                package t;
+                /**
+                 *
+                 * @author junit
+                 */
+                record F<P, Q>(P first, Q second) {
+                    public F {
+                        assert null != first;
+                        assert null != second;
+                    }
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+
+    }
+    
+    void innerOuterSetupAndTest(String source, String newOuterName, String newInnerName) throws Exception {
+        writeFilesNoIndexing(src, new File("t/A.java", source));
+        performInnerToOuterTest2(null);
+        verifyContent(src, new File("t/A.java", newOuterName), new File("t/F.java", newInnerName));
+    }
+
+    boolean debug = false;
+
+    // variant for record inner to outer test
+    private void performInnerToOuterTest2(String newOuterName, Problem... expectedProblems) throws Exception {
+        final InnerToOuterRefactoring[] r = new InnerToOuterRefactoring[1];
+        JavaSource.forFileObject(src.getFileObject("t/A.java")).runUserActionTask(new Task<CompilationController>() {
+
+            @Override
+            public void run(CompilationController parameter) {
+                try {
+                    parameter.toPhase(JavaSource.Phase.RESOLVED);
+                } catch (IOException ex) {
+                    Exceptions.printStackTrace(ex);
+                }
+                CompilationUnitTree cut = parameter.getCompilationUnit();
+                if (debug) {
+                    System.err.println("cut is of type " + cut.getClass().getCanonicalName());
+                }
+                ClassTree outer = (ClassTree) cut.getTypeDecls().get(0);
+                if (debug) {
+                    printNumbered(System.err, "start source " + outer.getKind().toString(), outer.toString());
+                }
+                List<? extends Tree> members = outer.getMembers();
+                int m = 0;
+                if (debug) {
+                    printMembers(members, m);
+                }
+                // selecting the last element assumes that the inner class is the last member in the outer class.
+                Tree lastInnerClass = outer.getMembers().get(outer.getMembers().size() - 1);
+                if (debug && lastInnerClass instanceof ClassTree lct) {
+//                    String n = "lastInnerClass " + lastInnerClass.getKind().toString();
+//                    printNumbered(System.err, n, lastInnerClass.toString());
+                    printClassTree(lct);
+                }
+                TreePath tp = TreePath.getPath(cut, lastInnerClass);
+
+                try {
+                    r[0] = new InnerToOuterRefactoring(TreePathHandle.create(tp, parameter));
+                } catch (Throwable t) {
+                    System.err.println("InnerOuter refatoring failed with exception " + t);
+                    t.printStackTrace(System.out);
+                    throw t;
+                }
+            }
+
+        }, true);
+
+        r[0].setClassName("F");
+        if (debug) {
+            printNumbered(System.err, "result ", r[0].toString());
+        }
+        r[0].setReferenceName(newOuterName);
+
+        RefactoringSession rs = RefactoringSession.create("Session");
+        List<Problem> problems = new LinkedList<Problem>();
+
+        addAllProblems(problems, r[0].preCheck());
+        addAllProblems(problems, r[0].prepare(rs));
+        addAllProblems(problems, rs.doRefactoring(true));
+
+        assertProblems(Arrays.asList(expectedProblems), problems);
+    }
+
+    // test helper
+    static void printMembers(List<? extends Tree> members, int m) {
+        printMembers(members, m, "");
+    }
+
+    // test helper
+    static void printMembers(List<? extends Tree> members, int m, String indent) {
+        for (Tree member : members) {
+            printNumbered(System.err, indent + "member %d %15s".formatted(m, member.getKind()), member.toString());
+            String toString = member.toString();
+            if (member instanceof ClassTree ct) {
+                int n = 0;
+                Name simpleName = ct.getSimpleName();
+                List<? extends Tree> members1 = ct.getMembers();
+                printMembers(members1, n, indent + "  " + m + " ");
+            }
+            m++;
+        }
+    }
+
+    // test helper
+    static void printClassTree(ClassTree ct) {
+        printMembers(ct.getMembers(), 0, "class " + ct.getSimpleName() + " type " + ct.getKind() + " ");
+    }
+
+}

--- a/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RenameRecordTest.java
+++ b/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RenameRecordTest.java
@@ -344,7 +344,7 @@ public class RenameRecordTest extends RefactoringTestBase {
                           package test;
                           public record Te|st(int component) {
                               public Test {
-                                  component = "";
+                                  component = 42;
                               }
                           }
                           """;
@@ -367,7 +367,7 @@ public class RenameRecordTest extends RefactoringTestBase {
                                     package test;
                                     public record NewName(int component) {
                                         public NewName {
-                                            component = "";
+                                            component = 42;
                                         }
                                     }
                                     """),
@@ -377,6 +377,38 @@ public class RenameRecordTest extends RefactoringTestBase {
                                     public class Use {
                                         private NewName test() {
                                             return new NewName(0);
+                                        }
+                                    }
+                                    """));
+
+    }
+
+    public void testRenameInnerRecord() throws Exception {
+        String testCode = """
+                          package test;
+                          public record Test(Component component) {
+                              public Test {
+                                  assert component !=null;
+                              }
+                              record Comp|onent(int c){
+                                assert c >= 0;
+                              }
+                          }
+                          """;
+        TestInput splitCode = TestUtilities.splitCodeAndPos(testCode);
+        writeFilesAndWaitForScan(src,
+                                 new File("Test.java", splitCode.code()));
+        JavaRenameProperties props = new JavaRenameProperties();
+        performRename(src.getFileObject("Test.java"), splitCode.pos(), "Part", props, true);
+        verifyContent(src, new File("Test.java",
+                                    """
+                                    package test;
+                                    public record Test(Part component) {
+                                        public Test {
+                                            assert component !=null;
+                                        }
+                                        record Part(int c){
+                                          assert c >= 0;
                                         }
                                     }
                                     """));


### PR DESCRIPTION
see issue #7044 for exact problem.

Start with adding tests.

Introduced RECORD and RECORD_COMPONENT case labels in multiple places.

Deal with method params for the record header in InnerOuterTransformer. The given way of printing the 'method parameters' for the record header include 'private final', producing illegal java code. The solution found might not be the moset elegant, but since the tree modifications will not persist into any real source code, it is acceptable. The solution strips `private` and `final` from the VARIABLE trees.

Delete file threw and unnecessary exception where a simple null test
 suffices.





---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.
