### PR TITLE
Bump maven indexer query limits

### DIFF
--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexManager.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexManager.java
@@ -164,7 +164,7 @@ public final class NexusRepositoryIndexManager implements RepositoryIndexerImple
 
     private final NexusRepositoryQueries queries;
     
-    static final int MAX_RESULT_COUNT = 1024;
+    static final int MAX_RESULT_COUNT = 4096;
     static final int NO_CAP_RESULT_COUNT = AbstractSearchRequest.UNDEFINED;
 
     @SuppressWarnings("this-escape")

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryQueries.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryQueries.java
@@ -248,7 +248,10 @@ final class NexusRepositoryQueries implements
                 .add(new BooleanClause(setBooleanRewrite(new PrefixQuery(new Term(ArtifactInfo.UINFO, id))), BooleanClause.Occur.MUST))
                 .build();
         iterate(repos, (RepositoryInfo repo, IndexingContext context) -> {
-            IteratorSearchResponse response = repeatedPagedSearch(bq, context, NexusRepositoryIndexManager.MAX_RESULT_COUNT);
+            // Some projects generated quite a lot of artifacts by now.
+            // Since this query is sometimes used by code which wants to find the top x most recent artifacts,
+            // we have to use a relatively high results limit - this doesn't seem to be a performance problem (other queries set no limit)
+            IteratorSearchResponse response = repeatedPagedSearch(bq, context, 10_000);
             if (response != null) {
                 try {
                     for (ArtifactInfo ai : response) {


### PR DESCRIPTION
Some projects generated quite a lot of artifacts by now. Some queries didn't produce good results since pagination gave up too early.

example: `getVersions()` is sometimes used to query the top x most recent artifacts. If cut off too early, some might be missing.

(this is only relevant if the year cutoff filter isn't used which removes many entries of the index)

symptoms:
 - the version auto completion in the pom doesn't have the latest version or has entries missing
 - the version updater hint doesn't update an artifact, even though the index contains newer artifact information already


targets delivery