### PR TITLE
Release candidates should not steal the maven index from GA releases

### DIFF
--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexManager.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexManager.java
@@ -400,17 +400,18 @@ public final class NexusRepositoryIndexManager implements RepositoryIndexerImple
     private void tryMoveRemoteIndexFromOldCache(RepositoryInfo info) {
 
         String buildnumber = System.getProperty("netbeans.buildnumber");
-        if (buildnumber == null) {
+        if (buildnumber == null || buildnumber.isBlank() || !buildnumber.contains("-")) {
             return; // tests
         }
+        // see org.netbeans.modules.janitor.Janitor for '.lastUsedVersion' format
         int ourVersion;
         try {
             String debugRelease = System.getProperty("maven.indexing.diag.release");
             ourVersion = debugRelease != null
                     ? Integer.parseInt(debugRelease)
-                    : Integer.parseInt(buildnumber.split("-")[0]);
+                    : Integer.parseInt(buildnumber.substring(0, buildnumber.lastIndexOf("-")));
         } catch (NumberFormatException ignore) {
-            return;
+            return; // rc or other dev build
         }
 
         Path cacheParent = Places.getCacheDirectory().toPath().getParent();
@@ -443,7 +444,7 @@ public final class NexusRepositoryIndexManager implements RepositoryIndexerImple
                     }
                 }
             } catch (Exception ex) {
-                LOGGER.log(Level.WARNING, "index import failed: {0}", ex.getMessage());
+                LOGGER.log(Level.WARNING, "index import failed: {0}: {1}", new Object[] {ex.getClass().getName(), ex.getMessage()});
             }
         }
     }


### PR DESCRIPTION
lets not move the index from NB 24 -> 25-rcN when testing new releases. This would only cause NB 24 to download it again which is unnecessary.

(if this happened to you you can simply move it back to the 24 cache. Setting `-J-Dmaven.indexing.diag.release=0` will also prevent it)

targets delivery