### PR TITLE
Added Support for VScode keymap in Netbeans IDE for windows and mac #6458

### DIFF
--- a/ide/defaults/src/org/netbeans/modules/defaults/Bundle.properties
+++ b/ide/defaults/src/org/netbeans/modules/defaults/Bundle.properties
@@ -26,6 +26,7 @@ Keymaps/NetBeans55=NetBeans 5.5
 Keymaps/NetBeans=NetBeans
 Keymaps/Eclipse=Eclipse
 Keymaps/Idea=Idea
+Keymaps/VSCode=VSCode
 
 # Coloring profile names
 Editors/FontsColors/NetBeans55=NetBeans 5.5

--- a/ide/defaults/src/org/netbeans/modules/defaults/VSCode-keybindings-mac.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/VSCode-keybindings-mac.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+
+
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE bindings PUBLIC "-//NetBeans//DTD Editor KeyBindings settings 1.1//EN" "http://www.netbeans.org/dtds/EditorKeyBindings-1_1.dtd">
+
+<!--
+    IMPORTANT:  This file modifies keybindings from VSCode-keybindings.xml to make them work on Mac OS.
+-->
+
+<bindings>
+    <!-- Things we add that replace standard keybindings -->
+    
+    <!-- Basic Navigation -->
+    <bind key="C-HOME" remove="true"/>
+    <bind actionName="caret-begin" key="M-UP"/>
+    
+    <bind key="C-END" remove="true"/>
+    <bind actionName="caret-end" key="M-DOWN"/>
+    
+    <!-- Word Navigation -->
+    <bind key="C-LEFT" remove="true"/>
+    <bind key="A-LEFT" actionName="caret-previous-word"/>
+    
+    <bind key="C-RIGHT" remove="true"/>
+    <bind key="A-RIGHT" actionName="caret-next-word"/>
+    
+    <!-- Word Deletion -->
+    <bind key="C-DELETE" remove="true"/>
+    <bind actionName="remove-word-next" key="A-DELETE"/>
+    
+    <bind key="C-BACK_SPACE" remove="true"/>
+    <bind actionName="remove-word-previous" key="A-BACK_SPACE"/>
+    
+    <!-- Selection -->
+    <bind key="CS-LEFT" remove="true"/>
+    <bind key="AS-LEFT" actionName="selection-previous-word"/>
+    
+    <bind key="CS-RIGHT" remove="true"/>
+    <bind key="AS-RIGHT" actionName="selection-next-word"/>
+    
+    <!-- Mac-specific bindings -->
+    <bind actionName="copy-to-clipboard" key="D-C"/>
+    <bind actionName="cut-to-clipboard" key="D-X"/>
+    <bind actionName="paste-from-clipboard" key="D-V"/>
+    <bind actionName="select-all" key="D-A"/>
+    
+    <!-- Find and Replace -->
+    <bind key="C-F" remove="true"/>
+    <bind actionName="find" key="D-F"/>
+    
+    <bind key="C-H" remove="true"/>
+    <bind actionName="replace" key="D-H"/>
+    
+    <bind key="F3" remove="true"/>
+    <bind key="D-G" actionName="find-next"/>
+    
+    <bind key="S-F3" remove="true"/>
+    <bind key="DS-G" actionName="find-previous"/>
+    
+    <!-- Line Operations -->
+    <bind actionName="move-selection-else-line-down" key="A-DOWN"/>
+    <bind actionName="move-selection-else-line-up" key="A-UP"/>
+    <bind actionName="copy-selection-else-line-down" key="SA-DOWN"/>
+    <bind actionName="copy-selection-else-line-up" key="SA-UP"/>
+    
+    <!-- Code Folding -->
+    <bind actionName="collapse-fold" key="MA-LEFT"/>
+    <bind actionName="expand-fold" key="MA-RIGHT"/>
+    <bind actionName="collapse-all-folds" key="D-K D-0"/>
+    <bind actionName="expand-all-folds" key="D-K D-J"/>
+    
+    <!-- Comments -->
+    <bind actionName="toggle-comment" key="D-SLASH"/>
+    <bind actionName="toggle-block-comment" key="SA-A"/>
+    
+    <!-- Multi-cursor -->
+    <bind actionName="select-next-parameter" key="D-D"/>
+    <bind actionName="selection-grow" key="CS-RIGHT"/>
+    <bind actionName="selection-shrink" key="CS-LEFT"/>
+    
+    <!-- Editor Management -->
+    <bind actionName="close" key="D-W"/>
+    <bind actionName="split-editor" key="D-BACK_SLASH"/>
+    
+    <!-- Rich Language Features -->
+    <bind actionName="completion-show" key="C-SPACE"/>
+    <bind actionName="completion-show" key="D-I"/>
+    <bind actionName="format" key="SA-F"/>
+    
+    <!-- Debug -->
+    <bind actionName="toggle-breakpoint" key="F9"/>
+    <bind actionName="debug" key="F5"/>
+    <bind actionName="debug-step-over" key="F10"/>
+    <bind actionName="debug-step-into" key="F11"/>
+    <bind actionName="debug-step-out" key="S-F11"/>
+    
+    <!-- Terminal -->
+    <bind actionName="terminal-show" key="C-BACK_QUOTE"/>
+    <bind actionName="terminal-new" key="CS-BACK_QUOTE"/>
+    
+    <!-- Settings and Command Palette -->
+    <bind actionName="show-command-palette" key="DS-P"/>
+    <bind actionName="preferences-show" key="D-COMMA"/>
+</bindings>
+

--- a/ide/defaults/src/org/netbeans/modules/defaults/VSCode-keybindings.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/VSCode-keybindings.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+
+
+<!DOCTYPE bindings PUBLIC "-//NetBeans//DTD Editor KeyBindings settings 1.1//EN" "http://www.netbeans.org/dtds/EditorKeyBindings-1_1.dtd">
+<bindings>
+    <!-- Basic editing -->
+    <bind actionName="cut-to-clipboard" key="C-X"/>
+    <bind actionName="copy-to-clipboard" key="C-C"/>
+    <bind actionName="paste-from-clipboard" key="C-V"/>
+    <bind actionName="move-selection-else-line-down" key="A-DOWN"/>
+    <bind actionName="move-selection-else-line-up" key="A-UP"/>
+    <bind actionName="copy-selection-else-line-down" key="SA-DOWN"/>
+    <bind actionName="copy-selection-else-line-up" key="SA-UP"/>
+    <bind actionName="remove-line" key="CS-K"/>
+    <bind actionName="start-new-line" key="C-ENTER"/>
+    <bind actionName="insert-break-above" key="CS-ENTER"/>
+    <bind actionName="match-brace" key="CS-BACK_SLASH"/>
+    <bind actionName="indent" key="C-CLOSE_BRACKET"/>
+    <bind actionName="unindent" key="C-OPEN_BRACKET"/>
+    <bind actionName="caret-begin-line" key="HOME"/>
+    <bind actionName="caret-end-line" key="END"/>
+    <bind actionName="caret-begin" key="C-HOME"/>
+    <bind actionName="caret-end" key="C-END"/>
+    <bind actionName="scroll-up" key="C-UP"/>
+    <bind actionName="scroll-down" key="C-DOWN"/>
+    <bind actionName="page-up" key="A-PAGE_UP"/>
+    <bind actionName="page-down" key="A-PAGE_DOWN"/>
+    
+    <!-- Code folding -->
+    <bind actionName="collapse-fold" key="CS-OPEN_BRACKET"/>
+    <bind actionName="expand-fold" key="CS-CLOSE_BRACKET"/>
+    <bind actionName="collapse-all-folds" key="C-K C-OPEN_BRACKET"/>
+    <bind actionName="expand-all-folds" key="C-K C-CLOSE_BRACKET"/>
+    
+    <!-- Comments -->
+    <bind actionName="toggle-comment" key="C-SLASH"/>
+    <bind actionName="toggle-comment" key="C-K C-C"/>
+    <bind actionName="remove-comment" key="C-K C-U"/>
+    <bind actionName="toggle-block-comment" key="SA-A"/>
+    
+    <!-- Search and navigation -->
+    <bind actionName="find" key="C-F"/>
+    <bind actionName="replace" key="C-H"/>
+    <bind actionName="find-next" key="F3"/>
+    <bind actionName="find-previous" key="S-F3"/>
+    <bind actionName="find-selection" key="C-F3"/>
+    <bind actionName="goto" key="C-G"/>
+    <bind actionName="goto-declaration" key="F12"/>
+    <bind actionName="goto-source" key="A-F12"/>
+    <bind actionName="goto-implementation" key="C-F12"/>
+    
+    <!-- Multi-cursor and selection -->
+    <bind actionName="select-word" key="C-D"/>
+    <bind actionName="select-next-parameter" key="C-L"/>
+    <bind actionName="select-all" key="C-A"/>
+    <bind actionName="selection-grow" key="SA-RIGHT"/>
+    <bind actionName="selection-shrink" key="SA-LEFT"/>
+    
+    <!-- Editor management -->
+    <bind actionName="close" key="C-F4"/>
+    <bind actionName="close" key="C-W"/>
+    <bind actionName="split-editor" key="C-BACK_SLASH"/>
+    
+    <!-- Rich language features -->
+    <bind actionName="completion-show" key="C-SPACE"/>
+    <bind actionName="completion-show" key="C-I"/>
+    <bind actionName="parameter-hints-show" key="CS-SPACE"/>
+    <bind actionName="format" key="SA-F"/>
+    <bind actionName="fix-imports" key="C-DOT"/>
+    
+    <!-- Refactoring -->
+    <bind actionName="rename" key="F2"/>
+    <bind actionName="refactor-quickmenu" key="C-DOT"/>
+    
+    <!-- Debug -->
+    <bind actionName="toggle-breakpoint" key="F9"/>
+    <bind actionName="debug" key="F5"/>
+    <bind actionName="debug-step-over" key="F10"/>
+    <bind actionName="debug-step-into" key="F11"/>
+    <bind actionName="debug-step-out" key="S-F11"/>
+    
+    <!-- IDE features -->
+    <bind actionName="show-command-palette" key="CS-P"/>
+    <bind actionName="show-command-palette" key="F1"/>
+    <bind actionName="quick-open" key="C-P"/>
+    <bind actionName="preferences-show" key="C-COMMA"/>
+    
+    <!-- Terminal -->
+    <bind actionName="terminal-show" key="C-BACK_QUOTE"/>
+    <bind actionName="terminal-new" key="CS-BACK_QUOTE"/>
+</bindings>

--- a/ide/defaults/src/org/netbeans/modules/defaults/mf-layer.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/mf-layer.xml
@@ -160,8 +160,8 @@
                 <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-RunSingle.instance"/>
             </file>
             <file name="D-F4.shadow">
-        	    <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
-        	</file>
+                <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
+            </file>
             <file name="F8.shadow">
                 <attr name="originalFile" stringvalue="Actions/Debug/org-netbeans-modules-debugger-ui-actions-StepOverAction.instance"/>
             </file>
@@ -199,8 +199,8 @@
                 <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-PopupAction.instance"/>
             </file>
             <file name="S-F10.shadow">
-        	    <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-PopupAction.instance"/>
-        	</file>
+                <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-PopupAction.instance"/>
+            </file>
             <file name="SO-8.shadow">
                 <attr name="originalFile" stringvalue="Actions/Window/Debug/org-netbeans-modules-debugger-ui-actions-SourcesViewAction.instance"/>
             </file>
@@ -487,8 +487,8 @@
                 <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
             </file>
             <file name="D-F4.shadow">
-        	    <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
-        	</file>
+                <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
+            </file>
             <file name="F8.shadow">
                 <attr name="originalFile" stringvalue="Actions/Debug/org-netbeans-modules-debugger-ui-actions-StepOverAction.instance"/>
             </file>
@@ -739,11 +739,11 @@
                 <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-RunSingle.instance"/>
             </file>
             <file name="D-F4.shadow">
-        	    <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
-        	</file>
+                <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
+            </file>
             <file name="D-W.shadow">
-        	    <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
-        	</file>
+                <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseWindowAction.instance"/>
+            </file>
             <file name="F8.shadow">
                 <attr name="originalFile" stringvalue="Actions/Debug/org-netbeans-modules-debugger-ui-actions-StepOverAction.instance"/>
             </file>
@@ -1096,93 +1096,181 @@
                 <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-UndoAction.instance"/>
             </file>
         </folder>
+        <folder name="VSCode">
+            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.vscode.defaults.Bundle"/>
+    
+            <!-- General -->
+            <file name="CS-P.shadow">
+                <attr name="originalFile" stringvalue="Actions/Command/org-vscode-core-actions-ShowCommandPalette.instance"/>
+            </file>
+            <file name="C-P.shadow">
+                <attr name="originalFile" stringvalue="Actions/QuickOpen/org-vscode-core-actions-QuickOpen.instance"/>
+            </file>
+            <file name="CS-N.shadow">
+                <attr name="originalFile" stringvalue="Actions/Window/org-vscode-core-actions-NewWindow.instance"/>
+            </file>
+    
+            <!-- Basic Editing -->
+            <file name="C-X.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-vscode-core-actions-CutLine.instance"/>
+            </file>
+            <file name="C-C.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-vscode-core-actions-CopyLine.instance"/>
+            </file>
+            <file name="A-DOWN.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-vscode-core-actions-MoveLine-Down.instance"/>
+            </file>
+            <file name="A-UP.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-vscode-core-actions-MoveLine-Up.instance"/>
+            </file>
+    
+            <!-- Search and Navigation -->
+            <file name="C-F.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-vscode-core-actions-Find.instance"/>
+            </file>
+            <file name="C-H.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-vscode-core-actions-Replace.instance"/>
+            </file>
+            <file name="C-G.shadow">
+                <attr name="originalFile" stringvalue="Actions/Navigation/org-vscode-core-actions-GoToLine.instance"/>
+            </file>
+    
+            <!-- Multi-cursor -->
+            <file name="A-CLICK.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-vscode-core-actions-InsertCursor.instance"/>
+            </file>
+            <file name="CA-UP.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-vscode-core-actions-InsertCursorAbove.instance"/>
+            </file>
+            <file name="CA-DOWN.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-vscode-core-actions-InsertCursorBelow.instance"/>
+            </file>
+    
+            <!-- Rich Languages Editing -->
+            <file name="C-SPACE.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-vscode-core-actions-TriggerSuggestion.instance"/>
+            </file>
+            <file name="CS-SPACE.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-vscode-core-actions-TriggerParameterHints.instance"/>
+            </file>
+            <file name="F12.shadow">
+                <attr name="originalFile" stringvalue="Actions/Navigation/org-vscode-core-actions-GoToDefinition.instance"/>
+            </file>
+    
+            <!-- Debug -->
+            <file name="F5.shadow">
+                <attr name="originalFile" stringvalue="Actions/Debug/org-vscode-core-actions-StartDebug.instance"/>
+            </file>
+            <file name="F9.shadow">
+                <attr name="originalFile" stringvalue="Actions/Debug/org-vscode-core-actions-ToggleBreakpoint.instance"/>
+            </file>
+            <file name="F10.shadow">
+                <attr name="originalFile" stringvalue="Actions/Debug/org-vscode-core-actions-StepOver.instance"/>
+            </file>
+    
+            <!-- Integrated Terminal -->
+            <file name="C-BACKQUOTE.shadow">
+                <attr name="originalFile" stringvalue="Actions/Terminal/org-vscode-core-actions-ToggleTerminal.instance"/>
+            </file>
+            <file name="CS-BACKQUOTE.shadow">
+                <attr name="originalFile" stringvalue="Actions/Terminal/org-vscode-core-actions-NewTerminal.instance"/>
+            </file>
         </folder>
-        <folder name="Editors">
+    </folder>
+    <folder name="Editors">
 
-            <folder name="FontsColors">
-                <folder name="NetBeans55">
-                    <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                    <folder name="Defaults">
-                        <file name="org-netbeans-modules-defaults-token-colorings.xml" url="NetBeans55-fontsColorsDefaults.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                        </file>
-                        <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="NetBeans55-editor.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                            <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
-                        </file>
-                    </folder>
+        <folder name="FontsColors">
+            <folder name="NetBeans55">
+                <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-token-colorings.xml" url="NetBeans55-fontsColorsDefaults.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                    </file>
+                    <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="NetBeans55-editor.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                        <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
+                    </file>
                 </folder>
-            
-                <folder name="NetBeansEarth">
-                    <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                    <folder name="Defaults">
-                        <file name="org-netbeans-modules-defaults-token-colorings.xml" url="NetBeansEarth-fontsColorsDefaults.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                        </file>
-                        <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="NetBeansEarth-editor.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                            <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
-                        </file>
-                    </folder>
-                </folder>
-            
-            
-                <folder name="CityLights">
-                    <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                    <folder name="Defaults">
-                        <file name="org-netbeans-modules-defaults-token-colorings.xml" url="CityLights-fontsColorsDefaults.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                        </file>
-                        <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="CityLights-editor.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                            <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
-                        </file>
-                    </folder>
-                </folder>
-            
-                <folder name="BlueTheme">
-                    <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                    <folder name="Defaults">
-                        <file name="org-netbeans-modules-defaults-token-colorings.xml" url="BlueTheme-fontsColorsDefaults.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                        </file>
-                        <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="BlueTheme-editor.xml">
-                            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
-                            <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
-                        </file>
-                        <file name="org-netbeans-modules-editor-annotations-colorings.xml" url="BlueTheme-annotations.xml">
-                            <attr name="nbeditor-settings-ColoringType" stringvalue="annotation"/>
-                        </file>
-                    </folder>
-                </folder>
-            
             </folder>
+            
+            <folder name="NetBeansEarth">
+                <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-token-colorings.xml" url="NetBeansEarth-fontsColorsDefaults.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                    </file>
+                    <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="NetBeansEarth-editor.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                        <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
+                    </file>
+                </folder>
+            </folder>
+            
+            
+            <folder name="CityLights">
+                <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-token-colorings.xml" url="CityLights-fontsColorsDefaults.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                    </file>
+                    <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="CityLights-editor.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                        <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
+                    </file>
+                </folder>
+            </folder>
+            
+            <folder name="BlueTheme">
+                <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-token-colorings.xml" url="BlueTheme-fontsColorsDefaults.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                    </file>
+                    <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="BlueTheme-editor.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+                        <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
+                    </file>
+                    <file name="org-netbeans-modules-editor-annotations-colorings.xml" url="BlueTheme-annotations.xml">
+                        <attr name="nbeditor-settings-ColoringType" stringvalue="annotation"/>
+                    </file>
+                </folder>
+            </folder>
+            
+        </folder>
         
-            <folder name="Keybindings">
-                <folder name="Eclipse">
-                    <folder name="Defaults">
-                        <file name="org-netbeans-modules-defaults-keybindings.xml" url="Eclipse-keybindings.xml"/>
-                        <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="Eclipse-keybindings-mac.xml">
-                            <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
-                        </file>
-                    </folder>
+        <folder name="Keybindings">
+            <folder name="Eclipse">
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-keybindings.xml" url="Eclipse-keybindings.xml"/>
+                    <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="Eclipse-keybindings-mac.xml">
+                        <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
+                    </file>
                 </folder>
-                <folder name="Emacs">
-                    <folder name="Defaults">
-                        <file name="org-netbeans-modules-defaults-keybindings.xml" url="Emacs-keybindings.xml"/>
-                        <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="Emacs-keybindings-mac.xml">
-                            <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
-                        </file>
-                    </folder>
+            </folder>
+            <folder name="Emacs">
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-keybindings.xml" url="Emacs-keybindings.xml"/>
+                    <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="Emacs-keybindings-mac.xml">
+                        <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
+                    </file>
                 </folder>
-                <folder name="Idea">
-                    <folder name="Defaults">
-                        <file name="org-netbeans-modules-defaults-keybindings.xml" url="Idea-keybindings.xml"/>
-                        <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="Idea-keybindings-mac.xml">
-                            <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
-                        </file>
-                    </folder>
+            </folder>
+            <folder name="Idea">
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-keybindings.xml" url="Idea-keybindings.xml"/>
+                    <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="Idea-keybindings-mac.xml">
+                        <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
+                    </file>
                 </folder>
+            </folder>
+            <folder name="VSCode">
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-defaults-keybindings.xml" url="VSCode-keybindings.xml"/>
+                    <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="VSCode-keybindings-mac.xml">
+                        <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
+                    </file>
+                </folder>
+            </folder>
             <folder name="NetBeans55">
                 <folder name="Defaults">
                     <file name="org-netbeans-modules-defaults-keybindings.xml" url="NetBeans55-keybindings.xml"/>


### PR DESCRIPTION
### Description:

This is a pull request to facilitate the migration of keybindings from VSCode to NetBeans, aiming to ensure a smooth transition for users without altering their familiar keybinding setup.

### Fixes the Issue
Add a keymap for VS Code #6458

### Key changes:

Added new VSCode keymap profile for NetBeans
Mapped common VS Code keyboard shortcuts to equivalent NetBeans actions
Implemented platform-specific keybindings for Windows and macOS
Preserved NetBeans' core functionality while matching VS Code's keyboard interaction patterns

### Objective:
Enable users migrating from VSCode to NetBeans to retain their existing keybindings and workflows effectively.

### Attachments:
- Screenshot of the updated NetBeans keymap reflecting the VSCode keybindings.
![image](https://github.com/user-attachments/assets/122cd703-b46a-4ac8-b5fe-5927cdd4c330)


---

**By opening this pull request you confirm that, unless explicitly stated otherwise:**

- The changes are all your own work, and you have the right to contribute them.  
  **Yes**
- The contributions are made solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).  
  **Yes**
