### PR TITLE
Do not remove the just-added annotation from the list of annotations.

### DIFF
--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/annotation/RunDebugTestGutterAction.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/annotation/RunDebugTestGutterAction.java
@@ -36,6 +36,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
+import javax.swing.text.Position;
 import javax.swing.text.StyledDocument;
 import org.netbeans.editor.AnnotationDesc;
 import org.netbeans.editor.BaseDocument;
@@ -89,8 +90,8 @@ public class RunDebugTestGutterAction extends AbstractAction {
         "DN_debug.single.method=Debug {0} method",
         "CAP_SelectAction=Select Action",
     })
-    public void actionPerformed(ActionEvent e) {
-        Object source = e.getSource();
+    public void actionPerformed(ActionEvent evt) {
+        Object source = evt.getSource();
 
         if (!(source instanceof JTextComponent)) {
             StatusDisplayer.getDefault().setStatusText(Bundle.ERR_NoTestMethod());
@@ -104,8 +105,11 @@ public class RunDebugTestGutterAction extends AbstractAction {
         AnnotationDesc activeAnnotation = ((BaseDocument) doc).getAnnotations().getActiveAnnotation(line);
 
         if (activeAnnotation != null && fixableAnnotations.contains(activeAnnotation.getAnnotationType())) {
-            Map<Integer, TestMethod> annotationLines = (Map<Integer, TestMethod>) doc.getProperty(TestMethodAnnotation.DOCUMENT_ANNOTATION_LINES_KEY);
-            TestMethod testMethod = annotationLines.get(line);
+            Map<Position, TestMethod> annotationLines = (Map<Position, TestMethod>) doc.getProperty(TestMethodAnnotation.DOCUMENT_ANNOTATION_LINES_KEY);
+            int lineStartOffset = NbDocument.findLineOffset((StyledDocument) doc, line);
+            int nextLineStartOffset = NbDocument.findLineOffset((StyledDocument) doc, line + 1);
+            TestMethod testMethod = annotationLines.entrySet().stream().filter(e -> lineStartOffset <= e.getKey().getOffset() && e.getKey().getOffset() < nextLineStartOffset).map(e -> e.getValue()).findAny().orElse(null);
+
             if (testMethod != null) {
                 SingleMethod singleMethod = testMethod.method();
 
@@ -163,7 +167,7 @@ public class RunDebugTestGutterAction extends AbstractAction {
         if (actions.length > nextAction) {
             Action a = actions[nextAction];
             if (a != null && a.isEnabled()){
-                a.actionPerformed(e);
+                a.actionPerformed(evt);
             }
         }
     }

--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestMethodController.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/TestMethodController.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 import javax.swing.text.Document;
 import javax.swing.text.Position;
 import javax.swing.text.StyledDocument;
@@ -55,11 +56,11 @@ public class TestMethodController {
             doc.putProperty(TestMethodAnnotation.DOCUMENT_ANNOTATIONS_KEY, annotations);
         }
 
-        Map<Integer, TestMethod> annotationLines = (Map<Integer, TestMethod>) doc.getProperty(TestMethodAnnotation.DOCUMENT_ANNOTATION_LINES_KEY);
+        Map<Position, TestMethod> annotationPositions = (Map<Position, TestMethod>) doc.getProperty(TestMethodAnnotation.DOCUMENT_ANNOTATION_LINES_KEY);
 
-        if (annotationLines == null) {
-            annotationLines = new HashMap<>();
-            doc.putProperty(TestMethodAnnotation.DOCUMENT_ANNOTATION_LINES_KEY, annotationLines);
+        if (annotationPositions == null) {
+            annotationPositions = new TreeMap<>((p1, p2) -> p1.getOffset() - p2.getOffset());
+            doc.putProperty(TestMethodAnnotation.DOCUMENT_ANNOTATION_LINES_KEY, annotationPositions);
         }
 
         Set<TestMethod> added = new HashSet<>(methods);
@@ -68,18 +69,19 @@ public class TestMethodController {
         removed.keySet().removeAll(added);
         added.removeAll(annotations.keySet());
 
+        //remove dropped test methods:
+        for (Entry<TestMethod, TestMethodAnnotation> e : removed.entrySet()) {
+            NbDocument.removeAnnotation(doc, e.getValue());
+            annotations.remove(e.getKey());
+            annotationPositions.remove(e.getKey().preferred);
+        }
+
+        //add new test methods
         for (TestMethod method : added) {
             TestMethodAnnotation a = new TestMethodAnnotation(method);
             NbDocument.addAnnotation(doc, method.preferred, 0, a);
             annotations.put(method, a);
-            int line = NbDocument.findLineNumber(doc, method.preferred.getOffset());
-            annotationLines.put(line, method);
-        }
-        for (Entry<TestMethod, TestMethodAnnotation> e : removed.entrySet()) {
-            NbDocument.removeAnnotation(doc, e.getValue());
-            annotations.remove(e.getKey());
-            int line = NbDocument.findLineNumber(doc, e.getKey().preferred.getOffset());
-            annotationLines.remove(line);
+            annotationPositions.put(method.preferred, method);
         }
     }
 

--- a/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/ComputeTestMethodsImpl.java
+++ b/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/ComputeTestMethodsImpl.java
@@ -84,14 +84,14 @@ public class ComputeTestMethodsImpl extends EditorAwareJavaSourceTaskFactory {
             List<TestMethod> methods = new ArrayList<>();
 
             for (Factory factory : Lookup.getDefault().lookupAll(Factory.class)) {
+                if (cancel.get()) {
+                    return ;
+                }
+
                 try {
                     ComputeTestMethods ctm = factory.create();
 
                     currentProvider.set(ctm);
-
-                    if (cancel.get()) {
-                        return ;
-                    }
 
                     List<TestMethod> currentMethods = ctm.computeTestMethods(info);
 
@@ -102,10 +102,11 @@ public class ComputeTestMethodsImpl extends EditorAwareJavaSourceTaskFactory {
                     currentProvider.set(null);
                 }
 
-                if (!cancel.get()) {
-                    List<TestMethod> updateMethods = new ArrayList<>(methods);
-                    WORKER.post(() -> TestMethodController.setTestMethods(doc, updateMethods));
-                }
+            }
+
+            if (!cancel.get()) {
+                List<TestMethod> updateMethods = new ArrayList<>(methods);
+                WORKER.post(() -> TestMethodController.setTestMethods(doc, updateMethods));
             }
         }
     }

--- a/php/php.project/src/org/netbeans/modules/php/project/ComputeTestMethodAnnotations.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/ComputeTestMethodAnnotations.java
@@ -173,17 +173,7 @@ public class ComputeTestMethodAnnotations implements DocumentListener, PropertyC
     public void run() {
         List<TestMethod> testMethods = getTestMethods(handledDocument);
 
-        /*
-         * Apparently, this method should update the list of annotations at each call of this method,
-         * when the passed collection of methods changes.
-         * Вut I didn't manage to achieve correct work in this case.
-         * So I made the method call first with the empty collection, to clear the annotation list,
-         * then already with the method collection.
-         */
-        TestMethodController.setTestMethods(handledDocument, Collections.emptyList());
-        if (!testMethods.isEmpty()) {
-            TestMethodController.setTestMethods(handledDocument, testMethods);
-        }
+        TestMethodController.setTestMethods(handledDocument, testMethods);
     }
 
     /**


### PR DESCRIPTION
Here:
https://github.com/apache/netbeans/pull/8142#discussion_r1929484735
was a note that `TestMethodController.setTestMethods` must first be called with an empty list, and only then with the real values. Looking at the code, the issue is that first the new annotations are added, and then the old ones are removed. And when one annotation replaces another on the same line, the removal will remove registration of the newly-added annotation in the `annotationLines`/`TestMethodAnnotation.DOCUMENT_ANNOTATION_LINES_KEY` map.

This was not obvious for Java, as Java support runs several providers, and calls `setTestMethods` after running each provider (passing cumulative results into the method). As a consequence, in many cases, the `setTestMethods` was first called with an empty list, effectively replicating the PHP workaround.

The proposal here is to:
- first remove and then add annotations, which should avoid the above problem
- for Java, collect the test methods, and call `setTestMethods` only once
- remove the workaround from PHP.
