### PR TITLE
Versioning: don't wait for indexer before refresh

### DIFF
--- a/ide/git/src/org/netbeans/modules/git/FileStatusCache.java
+++ b/ide/git/src/org/netbeans/modules/git/FileStatusCache.java
@@ -207,7 +207,7 @@ public class FileStatusCache {
                 try {
                     // find all files with not up-to-date or ignored status
                     client = git.getClient(repository);
-                    interestingFiles = client.getStatus(refreshEntry.getValue().toArray(new File[refreshEntry.getValue().size()]), pm);
+                    interestingFiles = client.getStatus(refreshEntry.getValue().toArray(File[]::new), pm);
                     if (pm.isCanceled()) {
                         return;
                     }
@@ -295,10 +295,7 @@ public class FileStatusCache {
         }
 
         // check to roots if they apply to the given status
-        if (containsFilesIntern(roots, includeStatus, false, addExcluded, 0, repositories)) {
-            return true;
-        }
-        return false;
+        return containsFilesIntern(roots, includeStatus, false, addExcluded, 0, repositories);
     }
         
     /**
@@ -343,7 +340,7 @@ public class FileStatusCache {
         }
         // check also the root files for status and add them eventually
         set.addAll(listFilesIntern(roots, includeStatus, false, repositories));
-        return set.toArray(new File[0]);
+        return set.toArray(File[]::new);
     }
     
     /**
@@ -487,16 +484,13 @@ public class FileStatusCache {
         }
         if (addAsExcluded) {
             // add ignored file to cache
-            rp.post(new Runnable() {
-                @Override
-                public void run() {
-                    synchronized (FileStatusCache.this) {
-                        FileInformation info = getInfo(file);
-                        if (info == null || info.containsStatus(Status.UPTODATE)) {
-                            refreshFileStatus(file, file.isDirectory() 
-                                    ? new FileInformation(EnumSet.of(Status.NOTVERSIONED_EXCLUDED), true)
-                                    : FILE_INFORMATION_EXCLUDED);
-                        }
+            rp.post(() -> {
+                synchronized (FileStatusCache.this) {
+                    FileInformation info1 = getInfo(file);
+                    if (info1 == null || info1.containsStatus(Status.UPTODATE)) {
+                        refreshFileStatus(file, file.isDirectory()
+                                ? new FileInformation(EnumSet.of(Status.NOTVERSIONED_EXCLUDED), true)
+                                : FILE_INFORMATION_EXCLUDED);
                     }
                 }
             });
@@ -751,7 +745,7 @@ public class FileStatusCache {
         Map<File, Set<File>> conflicts = new HashMap<>();
         Map<File, Set<File>> ignores = new HashMap<>();
         for (IndexUpdateItem item : updates) {
-            File file = item.getFile();
+            File file = item.file();
             File parent = file.getParentFile();
             if (parent != null) {
                 Set<File> modified = get(modifications, parent, modifiedFiles);
@@ -764,7 +758,7 @@ public class FileStatusCache {
                     ignored.remove(file);
                 }
                 if (item.isAdd()) {
-                    FileInformation fi = item.getInfo();
+                    FileInformation fi = item.info();
                     if (fi.containsStatus(Status.NOTVERSIONED_EXCLUDED)) {
                         if (USE_IGNORE_INDEX) {
                             ignored.add(file);
@@ -789,13 +783,8 @@ public class FileStatusCache {
         }
     }
 
-    private Set<File> get (Map<File, Set<File>> cached, File parent, CacheIndex index) {
-        Set<File> modified = cached.get(parent);
-        if (modified == null) {
-            modified = new HashSet<>(Arrays.asList(index.get(parent)));
-            cached.put(parent, modified);
-        }
-        return modified;
+    private Set<File> get(Map<File, Set<File>> cached, File parent, CacheIndex index) {
+        return cached.computeIfAbsent(parent, k -> new HashSet<>(Arrays.asList(index.get(parent))));
     }
 
     /**
@@ -895,61 +884,21 @@ public class FileStatusCache {
 
     private void addUnderRoot (HashMap<File, Collection<File>> rootFiles, File repository, File file) {
         // file is a gitlink inside another repository, we need to refresh also the file's status explicitely
-        Collection<File> filesUnderRoot = rootFiles.get(repository);
-        if (filesUnderRoot == null) {
-            filesUnderRoot = new HashSet<>();
-            rootFiles.put(repository, filesUnderRoot);
-        }
+        Collection<File> filesUnderRoot = rootFiles.computeIfAbsent(repository, k -> new HashSet<>());
         GitUtils.prepareRootFiles(repository, filesUnderRoot, file);
     }
 
-    public static class ChangedEvent {
-
-        private final File file;
-        private final FileInformation oldInfo;
-        private final FileInformation newInfo;
-
-        public ChangedEvent(File file, FileInformation oldInfo, FileInformation newInfo) {
-            this.file = file;
-            this.oldInfo = oldInfo;
-            this.newInfo = newInfo;
-        }
-
-        public File getFile() {
-            return file;
-        }
-
+    public record ChangedEvent(File file, FileInformation oldInfo, FileInformation newInfo) {
         public FileInformation getOldInfo() {
             return oldInfo;
         }
-
         public FileInformation getNewInfo() {
             return newInfo;
         }
-    }
-
-    private static class IndexUpdateItem {
-
-        private final File file;
-        private final FileInformation fi;
-        private final boolean add;
-
-        public IndexUpdateItem (File file, FileInformation fi, boolean toBeAdded) {
-            this.file = file;
-            this.fi = fi;
-            this.add = toBeAdded;
-        }
-
-        public File getFile () {
+        public File getFile() {
             return file;
         }
-
-        public FileInformation getInfo () {
-            return fi;
-        }
-
-        public boolean isAdd () {
-            return add;
-        }
     }
+
+    private record IndexUpdateItem(File file, FileInformation info, boolean isAdd) {}
 }

--- a/ide/versioning.core/nbproject/project.properties
+++ b/ide/versioning.core/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.release=17
 
 javadoc.name=Versioning
 spec.version.base=1.59.0

--- a/ide/versioning.core/src/org/netbeans/modules/versioning/core/VersioningAnnotationProvider.java
+++ b/ide/versioning.core/src/org/netbeans/modules/versioning/core/VersioningAnnotationProvider.java
@@ -92,7 +92,7 @@ public class VersioningAnnotationProvider {
         return annotatedName == null ? htmlEncode(name) : annotatedName;
     }
 
-    public Action[] actions(Set files) {
+    public Action[] actions(Set<? extends FileObject> files) {
         if (files.isEmpty()) return new Action[0];
 
         if(!VersioningManager.isInitialized()) {
@@ -102,12 +102,12 @@ public class VersioningAnnotationProvider {
             };
         }
         
-        List<Action> actions = new ArrayList<Action>();
+        List<Action> actions = new ArrayList<>();
         LocalHistoryActions localHistoryAction = null;
 
         // group all given files by owner
-        Map<VersioningSystem, List<VCSFileProxy>> owners = new HashMap<VersioningSystem, java.util.List<VCSFileProxy>>(3);
-        for (FileObject fo : (Set<FileObject>) files) {
+        Map<VersioningSystem, List<VCSFileProxy>> owners = new HashMap<>(3);
+        for (FileObject fo : files) {
             VCSFileProxy file = VCSFileProxy.createFileProxy(fo);
             if (file != null) {
 
@@ -123,7 +123,7 @@ public class VersioningAnnotationProvider {
                 if(owner != null) {
                     List<VCSFileProxy> fileList = owners.get(owner);
                     if(fileList == null) {
-                        fileList = new ArrayList<VCSFileProxy>();
+                        fileList = new ArrayList<>();
                     }
                     fileList.add(file);
                     owners.put(owner, fileList);
@@ -131,11 +131,11 @@ public class VersioningAnnotationProvider {
             }
         }
 
-        VersioningSystem vs = null;
-        if(owners.keySet().size() == 1) {
+        VersioningSystem vs;
+        if(owners.size() == 1) {
             vs = owners.keySet().iterator().next();
         } else {
-            return actions.toArray(new Action [0]);
+            return actions.toArray(Action[]::new);
         } 
         
         VCSAnnotator an = null;
@@ -148,10 +148,10 @@ public class VersioningAnnotationProvider {
             actions.add(action);
         }
 
-        return actions.toArray(new Action [0]);
+        return actions.toArray(Action[]::new);
     }
     
-    public static class VersioningSystemActions extends AbstractVersioningSystemActions {               
+    public static class VersioningSystemActions extends AbstractVersioningSystemActions {
     }
 
     public static class LocalHistoryActions extends AbstractVersioningSystemActions {
@@ -173,7 +173,7 @@ public class VersioningAnnotationProvider {
         public void actionPerformed(ActionEvent ae) { }
         @Override
         public JMenuItem getPopupPresenter() {
-            return NoVCSMenuItem.createInitializingMenu(getName());            
+            return NoVCSMenuItem.createInitializingMenu(getName());
         }
         @Override
         public String getName() {
@@ -251,33 +251,27 @@ public class VersioningAnnotationProvider {
                     JMenuItem item = new JMenuItem(Bundle.LBL_PopupMenu_Initializing());
                     item.setEnabled(false);
                     add(item);
-                    Utils.postParallel(new Runnable() {
-                        @Override
-                        public void run () {
-                            VCSContext context = Utils.contextForLookup(lkp);
-                            final Action [] actions = system.getVCSAnnotator().getActions(context, VCSAnnotator.ActionDestination.PopupMenu);
-                            EventQueue.invokeLater(new Runnable() {
-                                @Override
-                                public void run () {
-                                    JPopupMenu popup = getPopupMenu();
-                                    boolean display = popup.isVisible();
-                                    popup.setVisible(false);
-                                    removeAll();
-                                    if (isShowing()) {
-                                        for (int i = 0; i < actions.length; i++) {
-                                            Action action = actions[i];
-                                            if (action == null) {
-                                                addSeparator();
-                                            } else {
-                                                JMenuItem item = Utils.toMenuItem(action);
-                                                add(item);
-                                            }
-                                        }
-                                        popup.setVisible(display);
+                    Utils.postParallel(() -> {
+                        VCSContext context = Utils.contextForLookup(lkp);
+                        Action [] actions = system.getVCSAnnotator().getActions(context, VCSAnnotator.ActionDestination.PopupMenu);
+                        EventQueue.invokeLater(() -> {
+                            JPopupMenu popup = getPopupMenu();
+                            boolean display = popup.isVisible();
+                            popup.setVisible(false);
+                            removeAll();
+                            if (isShowing()) {
+                                for (int i = 0; i < actions.length; i++) {
+                                    Action action1 = actions[i];
+                                    if (action1 == null) {
+                                        addSeparator();
+                                    } else {
+                                        JMenuItem item1 = Utils.toMenuItem(action1);
+                                        add(item1);
                                     }
                                 }
-                            });
-                        }
+                                popup.setVisible(display);
+                            }
+                        });
                     });
                 }
                 super.setSelected(selected);
@@ -341,12 +335,12 @@ public class VersioningAnnotationProvider {
     /**
      * Stores all files which have to be refreshed 
      */
-    private final Map<FileSystem, Set<FileObject>> filesToRefresh = new HashMap<FileSystem, Set<FileObject>>();
+    private final Map<FileSystem, Set<FileObject>> filesToRefresh = new HashMap<>();
     
     /**
      * Stores all parents from files which have to be refreshed 
      */
-    private final Map<FileSystem, Set<FileObject>> parentsToRefresh = new HashMap<FileSystem, Set<FileObject>>();        
+    private final Map<FileSystem, Set<FileObject>> parentsToRefresh = new HashMap<>();
     
     private RequestProcessor rp = new RequestProcessor("Versioning fire FileStatusChanged", 1, true);
     
@@ -368,21 +362,21 @@ public class VersioningAnnotationProvider {
     /**
      * Refreshes all files stored in filesToRefresh and parentsToRefresh
      */ 
-    private RequestProcessor.Task fireFileStatusChangedTask = rp.create(new Runnable() {        
+    private RequestProcessor.Task fireFileStatusChangedTask = rp.create(new Runnable() {
         @Override
         public void run() {
             
             // createInitializingMenu and fire for all files which have to be refreshed
-            List<VCSAnnotationEvent> fileEvents = new ArrayList<VCSAnnotationEvent>(); 
-            List<VCSAnnotationEvent> folderEvents = new ArrayList<VCSAnnotationEvent>(); 
+            List<VCSAnnotationEvent> fileEvents = new ArrayList<>();
+            List<VCSAnnotationEvent> folderEvents = new ArrayList<>();
 
             synchronized(filesToRefresh) {
                 if (filesToRefresh.isEmpty()) {
                     return;
                 }
                 for (Map.Entry<FileSystem, Set<FileObject>> e : filesToRefresh.entrySet()) {
-                    Set<FileObject> files = new HashSet<FileObject>();
-                    Set<FileObject> folders = new HashSet<FileObject>();
+                    Set<FileObject> files = new HashSet<>();
+                    Set<FileObject> folders = new HashSet<>();
                     Set<FileObject> set = e.getValue();
                     for(FileObject fo : set) {
                         if(fo.isFolder()) {
@@ -392,11 +386,11 @@ public class VersioningAnnotationProvider {
                         }
                     }        
                     set.clear();
-                    e.setValue(new HashSet<FileObject>());
-                    if(files.size() > 0) {
+                    e.setValue(new HashSet<>());
+                    if(!files.isEmpty()) {
                         fileEvents.add(new VCSAnnotationEvent(files, true, true));
                     }
-                    if(folders.size() > 0) {
+                    if(!folders.isEmpty()) {
                         folderEvents.add(new VCSAnnotationEvent(folders, true,  true));
                     }
                 }        
@@ -406,18 +400,18 @@ public class VersioningAnnotationProvider {
             fireFileStatusEvents(folderEvents);
 
             // createInitializingMenu and fire events for all parent from each file which has to be refreshed
-            List<VCSAnnotationEvent> parentEvents = new ArrayList<VCSAnnotationEvent>(); 
+            List<VCSAnnotationEvent> parentEvents = new ArrayList<>(); 
             synchronized(parentsToRefresh) {
                 for (Map.Entry<FileSystem, Set<FileObject>> e : parentsToRefresh.entrySet()) {
                     Set<FileObject> set = e.getValue();
-                    Set<FileObject> files = new HashSet<FileObject>(set);
-                    parentEvents.add(new VCSAnnotationEvent(files, true, false));                                        
-                    e.setValue(new HashSet<FileObject>()); 
-                    set.clear();                    
-                }                                
-            }       
-            fireFileStatusEvents(parentEvents);            
-        }    
+                    Set<FileObject> files = new HashSet<>(set);
+                    parentEvents.add(new VCSAnnotationEvent(files, true, false));
+                    e.setValue(new HashSet<>()); 
+                    set.clear();
+                }
+            }
+            fireFileStatusEvents(parentEvents);
+        }
         
         private void fireFileStatusEvents(Collection<VCSAnnotationEvent> events) {
             for(VCSAnnotationEvent event : events) {
@@ -428,10 +422,10 @@ public class VersioningAnnotationProvider {
     
     private void clearMap(Map<FileSystem, Set<FileObject>> map)  {
         synchronized(map) {
-            if(map.size() > 0) {                
+            if(!map.isEmpty()) {
                 map.clear();
             }
-        }                    
+        }
     }
     
     private void addToMap(Map<FileSystem, Set<FileObject>> map, FileObject fo, boolean removeFromCache) {
@@ -446,12 +440,8 @@ public class VersioningAnnotationProvider {
             return;
         }        
         synchronized (map) {                        
-            Set<FileObject> set = map.get(fs);
-            if(set == null) {
-                set = new HashSet<FileObject>();
-                map.put(fs, set);
-            }
-            set.add(fo);
+            map.computeIfAbsent(fs, k -> new HashSet<>())
+               .add(fo);
             if (removeFromCache) {
                 if (LOG.isLoggable(Level.FINER)) {
                     // TODO: remove after fix
@@ -477,8 +467,8 @@ public class VersioningAnnotationProvider {
         return fo;
     }
 
-    private final Cache<Image, String> iconCache = new Cache<Image, String>(Cache.ANNOTATION_TYPE_ICON);
-    private final Cache<String, String> labelCache = new Cache<String, String>(Cache.ANNOTATION_TYPE_LABEL);
+    private final Cache<Image, String> iconCache = new Cache<>(Cache.ANNOTATION_TYPE_ICON);
+    private final Cache<String, String> labelCache = new Cache<>(Cache.ANNOTATION_TYPE_LABEL);
 
     /**
      * Keeps cached annotations
@@ -490,17 +480,17 @@ public class VersioningAnnotationProvider {
         private final Object writeLock = new Object();
         private final Object LOCK_VALUES = new Object();
         private int peekCount;
-        private LinkedHashMap<ItemKey<T, KEY>, Item<T>> cachedValues = new LinkedHashMap<ItemKey<T, KEY>, Item<T>>(CACHE_INITIAL_SIZE);
-        private WeakHashMap<FileObject, Set<ItemKey<T, KEY>>> index = new WeakHashMap<FileObject, Set<ItemKey <T, KEY>>>(CACHE_INITIAL_SIZE);
+        private LinkedHashMap<ItemKey<T, KEY>, Item<T>> cachedValues = new LinkedHashMap<>(CACHE_INITIAL_SIZE);
+        private WeakHashMap<FileObject, Set<ItemKey<T, KEY>>> index = new WeakHashMap<>(CACHE_INITIAL_SIZE);
         private final LinkedHashSet<ItemKey<T, KEY>> filesToAnnotate;
         private final RequestProcessor.Task annotationRefreshTask;
         private final String type;
-        private HashSet<FileObject> refreshedFiles = new HashSet<FileObject>();
+        private HashSet<FileObject> refreshedFiles = new HashSet<>();
         private boolean allCleared;
 
         Cache(String type) {
             this.annotationRefreshTask = new RequestProcessor("VersioningAnnotator.annotationRefresh", 1, false, false).create(new AnnotationRefreshTask()); //NOI18N
-            this.filesToAnnotate = new LinkedHashSet<ItemKey<T, KEY>>();
+            this.filesToAnnotate = new LinkedHashSet<>();
             assert ANNOTATION_TYPE_ICON.equals(type) || ANNOTATION_TYPE_LABEL.equals(type);
             this.type = type;
         }
@@ -557,18 +547,14 @@ public class VersioningAnnotationProvider {
                     LOG.log(Level.FINEST, "{0}.setValue(): inserting for {1}:{2}", new Object[]{type, key.getFiles(), value}); //NOI18N
                 }
                 synchronized (LOCK_VALUES) {
-                    cachedValues.put(key, new Item(value));
+                    cachedValues.put(key, new Item<>(value));
                     peekCount = Math.max(peekCount, cachedValues.size() + 1);
                 }
                 // reference to the key must be added to index for every file in the set
                 // so the key can be quickly found when refresh annotations event comes
                 for (FileObject fo : files) {
-                    Set<ItemKey<T, KEY>> sets = index.get(fo);
-                    if (sets == null) {
-                        sets = new HashSet<ItemKey<T, KEY>>();
-                        index.put(fo, sets);
-                    }
-                    sets.add(key);
+                    index.computeIfAbsent(fo, k -> new HashSet<>())
+                         .add(key);
                 }
                 removeOldValues();
             }
@@ -626,6 +612,7 @@ public class VersioningAnnotationProvider {
             return retval;
         }
 
+        @SuppressWarnings("unchecked")
         private T annotate(VCSAnnotator annotator, T initialValue, VCSContext context) {
             if (ANNOTATION_TYPE_LABEL.equals(type)) {
                 return (T) annotator.annotateName((String) initialValue, context);
@@ -690,7 +677,8 @@ public class VersioningAnnotationProvider {
                             cachedValues.remove(key);
                         }
                     }
-                    ItemKey<T, KEY>[] keysArray = keys.toArray(new ItemKey[0]);
+                    @SuppressWarnings("unchecked")
+                    ItemKey<T, KEY>[] keysArray = keys.toArray(ItemKey[]::new);
                     for (ItemKey<T, KEY> key : keysArray) {
                         if (LOG.isLoggable(Level.FINEST)) {
                             // TODO: remove after fix
@@ -735,8 +723,8 @@ public class VersioningAnnotationProvider {
             if (peekCount > CACHE_INITIAL_SIZE && peekCount > cachedValues.size() * 4) {
                 LOG.log(Level.FINER, "{0}.shrinkMaps(): last peek was {1}", new Object[] { type, peekCount }); //NOI18N
                 synchronized (LOCK_VALUES) {
-                    cachedValues = new LinkedHashMap<ItemKey<T, KEY>, Item<T>>(cachedValues);
-                    index = new WeakHashMap<FileObject, Set<ItemKey<T, KEY>>>(index);
+                    cachedValues = new LinkedHashMap<>(cachedValues);
+                    index = new WeakHashMap<>(index);
                     peekCount = cachedValues.size();
                 }
             }
@@ -769,9 +757,9 @@ public class VersioningAnnotationProvider {
                     T newValue = annotate(initialValue, files);
                     boolean isNonRecursive = files instanceof NonRecursiveFolder;
                     files = new HashSet<FileObject>(files);
-                    boolean fireEvent = setValue(new ItemKey<T, KEY>(files, refreshCandidate.keyPart, isNonRecursive, initialValue), newValue);
+                    boolean fireEvent = setValue(new ItemKey<>(files, refreshCandidate.keyPart, isNonRecursive, initialValue), newValue);
                     if (fireEvent) {
-                        Set<VCSFileProxy> filesToRefresh = new HashSet<VCSFileProxy>(files.size());
+                        Set<VCSFileProxy> filesToRefresh = new HashSet<>(files.size());
                         for (FileObject fo : files) {
                             VCSFileProxy proxy = VCSFileProxy.createFileProxy(fo);
                             if(proxy != null) {
@@ -790,7 +778,7 @@ public class VersioningAnnotationProvider {
 
         private void clearEvents() {
             synchronized (writeLock) {
-                refreshedFiles = new HashSet<FileObject>();
+                refreshedFiles = new HashSet<>();
                 allCleared = false;
             }
         }
@@ -886,9 +874,7 @@ public class VersioningAnnotationProvider {
         return cacheItemAge;
     }
 
-    private static final java.util.regex.Pattern lessThan = java.util.regex.Pattern.compile("<"); //NOI18N
-    private String htmlEncode (String name) {
-        if (name.indexOf('<') == -1) return name;
-        return lessThan.matcher(name).replaceAll("&lt;");               //NOI18N
+    private String htmlEncode(String name) {
+        return name.replace("<", "&lt;");
     }
 }

--- a/ide/versioning.core/src/org/netbeans/modules/versioning/core/VersioningManager.java
+++ b/ide/versioning.core/src/org/netbeans/modules/versioning/core/VersioningManager.java
@@ -38,6 +38,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.modules.versioning.core.spi.VCSContext;
 import org.netbeans.modules.versioning.core.api.VCSFileProxy;
@@ -198,6 +199,16 @@ public class VersioningManager implements PropertyChangeListener, ChangeListener
                 }
                 // do not fire events under lock but asynchronously
                 refreshVersioningSystems(true);
+                // versioning annotations need refreshing on project re-open
+                OpenProjects.getDefault().addPropertyChangeListener(evt -> {
+                    if ("openProjects".equals(evt.getPropertyName())) {
+                        if (    evt.getOldValue() instanceof Project[] oldV
+                             && evt.getNewValue() instanceof Project[] newV
+                             && oldV.length < newV.length) {
+                            refreshAllAnnotations(); // impl handles debouncing
+                        }
+                    }
+                });
             }
             VersioningSupport.getPreferences().addPreferenceChangeListener(this);
         } finally {

--- a/ide/versioning.util/src/org/netbeans/modules/turbo/CacheIndex.java
+++ b/ide/versioning.util/src/org/netbeans/modules/turbo/CacheIndex.java
@@ -55,20 +55,18 @@ public abstract class CacheIndex {
             return new File[0];
         }
 
-        synchronized(this) {
-            Set<File> ret = index.get(key);
-            if(ret == null) {
-                LOG.log(Level.FINE, " get({0}) returns no files", new Object[]{key});
-                return new File[0];
-            }
-
-            LOG.log(Level.FINE, " get({0}) returns {1}", new Object[]{key, ret.size()});
-            if(LOG.isLoggable(Level.FINER)) {
-                LOG.finer("   " + ret);
-            }
-
-            return ret.toArray(File[]::new);
+        Set<File> ret = index.get(key);
+        if(ret == null) {
+            LOG.log(Level.FINE, " get({0}) returns no files", new Object[]{key});
+            return new File[0];
         }
+
+        LOG.log(Level.FINE, " get({0}) returns {1}", new Object[]{key, ret.size()});
+        if(LOG.isLoggable(Level.FINER)) {
+            LOG.finer("   " + ret);
+        }
+
+        return ret.toArray(File[]::new);
     }
 
     public File[] getAllValues() {

--- a/ide/versioning.util/src/org/netbeans/modules/versioning/util/DelayScanRegistry.java
+++ b/ide/versioning.util/src/org/netbeans/modules/versioning/util/DelayScanRegistry.java
@@ -29,15 +29,16 @@ import org.openide.util.RequestProcessor;
 import org.openide.util.RequestProcessor.Task;
 
 /**
- * Holds registered scans which can be delayed and thus not interfere with openning projects or indexing
+ * Holds registered scans which can be delayed and thus not interfere with opening projects or indexing
  * @author ondra
  */
 public final class DelayScanRegistry {
     private final WeakHashMap<RequestProcessor.Task, DelayedScan> registry;
     private static DelayScanRegistry instance;
-    private static int MAX_WAITING_TIME = 180000; // wait max 3 mins
-    private static int WAITING_PERIOD = 10000;
-    private static final boolean BLOCK_INDEFINITELY = "true".equals(System.getProperty("versioning.delayscan.nolimit", "false")); //NOI18N
+    private static final int MAX_WAITING_TIME = 180000; // wait max 3 mins
+    private static final int WAITING_PERIOD = 10000;
+    private static final boolean BLOCK_INDEFINITELY = Boolean.getBoolean("versioning.delayscan.nolimit"); //NOI18N
+    private static final boolean DELAY_SCAN = Boolean.getBoolean("versioning.delayscan"); //NOI18N
 
     public static synchronized DelayScanRegistry getInstance() {
         if (instance == null) {
@@ -46,20 +47,19 @@ public final class DelayScanRegistry {
         return instance;
     }
 
-    private DelayScanRegistry () {
-        registry = new WeakHashMap<Task, DelayedScan>(5);
+    private DelayScanRegistry() {
+        registry = new WeakHashMap<>(5);
     }
 
     /**
-     * Delays given task if neccessary - e.g. projects are currently openning - and reschedules the task if indexing is running
+     * Delays given task if necessary - e.g. projects are currently opening - and reschedules the task if indexing is running
      * This method waits for projects to open and thus blocks the current thread.
      * @param task task to be delayed
      * @param logger 
      * @param logMessagePrefix
      * @return true if the task was rescheduled
      */
-    public boolean isDelayed (RequestProcessor.Task task, Logger logger, String logMessagePrefix) {
-        boolean rescheduled = false;
+    public boolean isDelayed(RequestProcessor.Task task, Logger logger, String logMessagePrefix) {
         DelayedScan scan = getRegisteredScan(task);
         Future<Project[]> projectOpenTask = OpenProjects.getDefault().openProjects();
         if (!projectOpenTask.isDone()) {
@@ -69,26 +69,22 @@ public final class DelayScanRegistry {
                 // not interested
             }
         }
-        if (IndexingBridge.getInstance().isIndexingInProgress()
+        if (DELAY_SCAN && IndexingBridge.getInstance().isIndexingInProgress()
                 && (BLOCK_INDEFINITELY || scan.waitingLoops * WAITING_PERIOD < MAX_WAITING_TIME)) {
             // do not steal disk from openning projects and indexing tasks
             Level level = ++scan.waitingLoops < 10 ? Level.FINE : Level.INFO;
             logger.log(level, "{0}: Scanning in progress, trying again in {1}ms", new Object[]{logMessagePrefix, WAITING_PERIOD}); //NOI18N
             task.schedule(WAITING_PERIOD); // try again later
-            rescheduled = true;
+            return true;
         } else {
             scan.waitingLoops = 0;
         }
-        return rescheduled;
+        return false;
     }
 
     private DelayedScan getRegisteredScan(Task task) {
         synchronized (registry) {
-            DelayedScan scan = registry.get(task);
-            if (scan == null) {
-                registry.put(task, scan = new DelayedScan());
-            }
-            return scan;
+            return registry.computeIfAbsent(task, k -> new DelayedScan());
         }
     }
 


### PR DESCRIPTION
indexing and versioning status updates can run concurrently since they don't interact with each other.

git status refresh typically takes < 1s even in large projects, while indexing can take much longer.

bonus changes:

 - bugfix: re-opening projects would sometimes not show status badges until the project tree is expanded
 - `CacheIndex#get` can run lock free given that the index is a CHM and the values are synchronized Sets

expected results:

 - you should see the git file status update long before indexing finishes. for example while switching between branches on larger projects or right after NB startup
 - no noteworthy regressions for indexing totals or other tasks

old behavior can be restored with `-J-Dversioning.delayscan=true`

cleanup commit is split from the change