### PR TITLE
Reapply "LSP: Speed up publish diagnostics on project scan."

### DIFF
--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/hints/MicronautConfigErrorProvider.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/hints/MicronautConfigErrorProvider.java
@@ -109,9 +109,11 @@ public class MicronautConfigErrorProvider extends CustomIndexer implements Error
                                     scan(text, scanner.scan((ParserResult) result), structure -> {
                                         int start = (int) structure.getPosition();
                                         int end = (int) structure.getEndPosition();
+                                        String[] startLines = text.substring(0, start).split("\n");
+                                        String[] endLines = text.substring(0, end).split("\n");
                                         diags.add(Diagnostic.Builder.create(() -> start, () -> end, Bundle.ERR_PropertyWithoutValue())
                                                 .setSeverity(Diagnostic.Severity.Warning)
-                                                .setCode(ERR_CODE_PREFIX + text.substring(0, start).split("\n").length)
+                                                .setCode(ERR_CODE_PREFIX + startLines.length + ',' + (startLines[startLines.length - 1].length() + 1) + '-' + endLines.length + ',' + (endLines[endLines.length - 1].length() + 1))
                                                 .build());
                                     });
                                 }
@@ -135,7 +137,7 @@ public class MicronautConfigErrorProvider extends CustomIndexer implements Error
                             int end = offset + line.length();
                             diags.add(Diagnostic.Builder.create(() -> start, () -> end, Bundle.ERR_PropertyWithoutValue())
                                     .setSeverity(Diagnostic.Severity.Warning)
-                                    .setCode(ERR_CODE_PREFIX + (i + 1))
+                                    .setCode(ERR_CODE_PREFIX + (i + 1) + ",1-" + (i + 1) + "," + line.length() + 1)
                                     .build());
                         }
                     }
@@ -205,7 +207,19 @@ public class MicronautConfigErrorProvider extends CustomIndexer implements Error
         }
         @Override
         public int getLineNumber(Diagnostic t) {
-            return Integer.parseInt(t.getCode().substring(ERR_CODE_PREFIX.length()));
+            String text = t.getCode().substring(ERR_CODE_PREFIX.length());
+            int idx = text.indexOf(',');
+            return Integer.parseInt(text.substring(0, idx));
+        }
+        @Override
+        public ErrorsCache.Range getRange(Diagnostic t) {
+            String text = t.getCode().substring(ERR_CODE_PREFIX.length());
+            int idx1 = text.indexOf(',');
+            int idx2 = text.indexOf('-');
+            int idx3 = text.indexOf(',', idx2);
+            ErrorsCache.Position start = new ErrorsCache.Position(Integer.parseInt(text.substring(0, idx1)), Integer.parseInt(text.substring(idx1 + 1, idx2)));
+            ErrorsCache.Position end = new ErrorsCache.Position(Integer.parseInt(text.substring(idx2 + 1, idx3)), Integer.parseInt(text.substring(idx3 + 1, text.length())));
+            return new ErrorsCache.Range(start, end);
         }
         @Override
         public String getMessage(Diagnostic t) {

--- a/ide/parsing.indexing/apichanges.xml
+++ b/ide/parsing.indexing/apichanges.xml
@@ -87,6 +87,20 @@ is the proper place.
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
   <changes>
+      <change id="ErrorsCache.getErrors">
+          <api name="IndexingAPI"/>
+          <summary>Added method to ErrorsCache to return all errors or warnings for the given file</summary>
+          <version major="9" minor="40"/>
+          <date day="6" month="9" year="2024"/>
+          <author login="dbalek"/>
+          <compatibility source="compatible" binary="compatible" semantic="compatible" addition="yes"/>
+          <description>
+              <p>
+                  Added the <a href="@TOP@/org/netbeans/modules/parsing/spi/indexing/ErrorsCache.html#getErrors-org.openide.filesystems.FileObject-org.netbeans.modules.parsing.spi.indexing.ErrorsCache.ReverseConvertor-">getErrors()</a> method to return errors or warnings for the given file.
+              </p>
+          </description>
+          <class package="org.netbeans.modules.parsing.spi.indexing" name="ErrorsCache"/>
+      </change>
       <change id="ErrorsCache.getAllFilesWithRecord">
           <api name="IndexingAPI"/>
           <summary>Added method to ErrorsCache to return all files with error or warning</summary>

--- a/ide/parsing.indexing/nbproject/project.properties
+++ b/ide/parsing.indexing/nbproject/project.properties
@@ -14,9 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
-spec.version.base=9.39.0
+spec.version.base=9.40.0
 is.autoload=true
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskCache.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskCache.java
@@ -45,6 +45,8 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.project.FileOwnerQuery;
@@ -53,8 +55,10 @@ import org.netbeans.modules.parsing.impl.indexing.CacheFolder;
 import org.netbeans.modules.parsing.impl.indexing.PathRegistry;
 import org.netbeans.modules.parsing.impl.indexing.URLCache;
 import org.netbeans.modules.parsing.impl.indexing.implspi.CacheFolderProvider;
+import org.netbeans.modules.parsing.spi.indexing.ErrorsCache;
 import org.netbeans.modules.parsing.spi.indexing.ErrorsCache.Convertor;
 import org.netbeans.modules.parsing.spi.indexing.ErrorsCache.ErrorKind;
+import org.netbeans.modules.parsing.spi.indexing.ErrorsCache.ReverseConvertor;
 import org.netbeans.modules.parsing.spi.indexing.Indexable;
 import org.netbeans.spi.tasklist.Task;
 import org.openide.filesystems.FileObject;
@@ -77,6 +81,10 @@ public class TaskCache {
     
     private static final Logger LOG = Logger.getLogger(TaskCache.class.getName());
     
+    // Matches the diagnostic range with both the start and the end positions specified (e.g. 1,2-1,7)
+    // or with only the start position specified (e.g. 1,2) where positions are written in a form line,column
+    private static final Pattern PATTERN = Pattern.compile("(\\d*),(\\d*)(?:-(\\d*),(\\d*))?");
+
     static {
 //        LOG.setLevel(Level.FINEST);
     }
@@ -103,17 +111,31 @@ public class TaskCache {
         }
         return null;
     }
-    
+
+    private ReverseConvertor<Task> getTaskConvertor(FileObject file) {
+        return (kind, range, message) -> {
+            String severity = getTaskType(kind);
+            if (null != severity) {
+                return Task.create(file, severity, message, range.start().line());
+            }
+            return null;
+        };
+    }
+
     public List<Task> getErrors(FileObject file) {
-        List<Task> result = new LinkedList<Task>();
+        return getErrors(file, getTaskConvertor(file));
+    }
+
+    public <T> List<T> getErrors(FileObject file, ReverseConvertor<T> convertor) {
+        List<T> result = new LinkedList<>();
         
-        result.addAll(getErrors(file, ERR_EXT));
-        result.addAll(getErrors(file, WARN_EXT));
+        result.addAll(getErrors(file, convertor, ERR_EXT));
+        result.addAll(getErrors(file, convertor, WARN_EXT));
 
         return result;
     }
     
-    private List<Task> getErrors(FileObject file, String ext) {
+    private <T> List<T> getErrors(FileObject file, ReverseConvertor<T> convertor, String ext) {
         LOG.log(Level.FINE, "getErrors, file={0}, ext={1}", new Object[] {FileUtil.getFileDisplayName(file), ext}); //NOI18N
         
         try {
@@ -122,16 +144,16 @@ public class TaskCache {
             LOG.log(Level.FINE, "getErrors, error file={0}", input == null ? "null" : input.getAbsolutePath()); //NOI18N
             
             if (input == null || !input.canRead())
-                return Collections.<Task>emptyList();
+                return Collections.emptyList();
             
             input.getParentFile().mkdirs();
             
-            return loadErrors(input, file);
+            return loadErrors(input, convertor);
         } catch (IOException e) {
             LOG.log(Level.FINE, null, e);
         }
         
-        return Collections.<Task>emptyList();
+        return Collections.emptyList();
     }
     
     private <T> boolean dumpErrors(File output, Iterable<? extends T> errors, Convertor<T> convertor, boolean interestedInReturnValue) throws IOException {
@@ -144,7 +166,15 @@ public class TaskCache {
                     for (T err : errors) {
                         pw.print(convertor.getKind(err).name());
                         pw.print(':'); //NOI18N
-                        pw.print(convertor.getLineNumber(err));
+                        ErrorsCache.Range range = convertor.getRange(err);
+                        if (range != null) {
+                            pw.print(String.format("%d,%d", range.start().line(), range.start().column()));
+                            if (range.end() != null) {
+                                pw.print(String.format("-%d,%d", range.end().line(), range.end().column()));
+                            }
+                        } else {
+                            pw.print(convertor.getLineNumber(err));
+                        }
                         pw.print(':'); //NOI18N
 
                         String description = convertor.getMessage(err);
@@ -200,6 +230,7 @@ public class TaskCache {
                 }
             });
         } catch (IOException ex) {
+            Exceptions.attachMessage(ex, "can't dump errors for: " + String.valueOf(i));
             Exceptions.printStackTrace(ex);
         }
     }
@@ -255,8 +286,8 @@ public class TaskCache {
         c.rootsToRefresh.add(root);
     }
 
-    private List<Task> loadErrors(File input, FileObject file) throws IOException {
-        List<Task> result = new LinkedList<Task>();
+    private <T> List<T> loadErrors(File input, ReverseConvertor<T> convertor) throws IOException {
+        List<T> result = new LinkedList<>();
         BufferedReader pw = new BufferedReader(new InputStreamReader(new FileInputStream(input), StandardCharsets.UTF_8));
         String line;
 
@@ -277,18 +308,26 @@ public class TaskCache {
                 continue;
             }
 
-            int lineNumber = Integer.parseInt(parts[1]);
+            ErrorsCache.Range range;
+            Matcher matcher = PATTERN.matcher(parts[1]);
+            if (matcher.matches()) {
+                ErrorsCache.Position start = new ErrorsCache.Position(Integer.parseInt(matcher.group(1)), Integer.parseInt(matcher.group(2)));
+                ErrorsCache.Position end = matcher.group(3) != null && matcher.group(4) != null ? new ErrorsCache.Position(Integer.parseInt(matcher.group(3)), Integer.parseInt(matcher.group(4))) : null;
+                range = new ErrorsCache.Range(start, end);
+            } else {
+                int lineNumber = Integer.parseInt(parts[1]);
+                range = new ErrorsCache.Range(new ErrorsCache.Position(lineNumber, 1), null);
+            }
+
             String message = parts[2];
 
-            message = message.replaceAll("\\\\d", ":"); //NOI18N
-            message = message.replaceAll("\\\\n", " "); //NOI18N
-            message = message.replaceAll("\\\\\\\\", "\\\\"); //NOI18N
+            message = message.replace("\\d", ":") //NOI18N
+                             .replace("\\n", "\n") //NOI18N
+                             .replace("\\\\", "\\"); //NOI18N
 
-            String severity = getTaskType(kind);
-
-            if (null != severity) {
-                Task err = Task.create(file, severity, message, lineNumber);
-                result.add(err);
+            T item = convertor.get(kind, range, message);
+            if (null != item) {
+                result.add(item);
             }
         }
 
@@ -351,12 +390,12 @@ public class TaskCache {
     public List<URL> getAllFilesInError(URL root) throws IOException {
         return getAllFilesWithRecord(root, true);
     }
-    
+
     public boolean isInError(FileObject file, boolean recursive) {
         LOG.log(Level.FINE, "file={0}, recursive={1}", new Object[] {file, Boolean.valueOf(recursive)}); //NOI18N
         
         if (file.isData()) {
-            return !getErrors(file, ERR_EXT).isEmpty();
+            return !getErrors(file, getTaskConvertor(file), ERR_EXT).isEmpty();
         } else {
             try {
                 ClassPath cp = Utilities.getSourceClassPathFor (file);

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/ErrorsCache.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/ErrorsCache.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import org.netbeans.modules.parsing.impl.indexing.errors.TaskCache;
 import org.openide.filesystems.FileObject;
 
@@ -74,12 +75,46 @@ public class ErrorsCache {
         return Collections.unmodifiableCollection(TaskCache.getDefault().getAllFilesWithRecord(root));
     }
 
-    /**Getter for properties of the given error description.
+    /**Return all errors or warnings for the given file
+     *
+     * @param file file for which the errors are being retrieved
+     * @param convertor constructor of {@code T} instances from error description properties
+     * @return errors or warnings
+     * @since 9.40
+     */
+    public static <T> List<T> getErrors(FileObject file, ReverseConvertor<T> convertor) throws IOException {
+        return Collections.unmodifiableList(TaskCache.getDefault().getErrors(file, convertor));
+    }
+
+    /**Position in a text expressed as 1-based line and character offset.
+     * @since 9.40
+     */
+    public record Position(int line, int column) {}
+
+    /**Range in a text expressed as (1-based) start and end positions.
+     * @since 9.40
+     */
+    public record Range(Position start, Position end) {}
+
+    /**Getter for properties of the given error description including the range.
      */
     public static interface Convertor<T> {
         public ErrorKind getKind(T t);
         public int       getLineNumber(T t);
         public String    getMessage(T t);
+        /**
+         * @since 9.40
+         */
+        public default Range getRange(T t) {
+            return null;
+        }
+    }
+
+    /**Constructor of error description from the properties.
+     * @since 9.40
+     */
+    public static interface ReverseConvertor<T> {
+        public T get(ErrorKind kind, Range range, String message);
     }
 
     public static enum ErrorKind {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ErrorsNotifier.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ErrorsNotifier.java
@@ -18,22 +18,29 @@
  */
 package org.netbeans.modules.java.lsp.server.protocol;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.Future;
-import java.util.stream.Collectors;
-import org.netbeans.api.lsp.Diagnostic;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.java.lsp.server.LspServerState;
+import org.netbeans.modules.java.lsp.server.URITranslator;
 import org.netbeans.modules.parsing.spi.indexing.ErrorsCache;
+import org.openide.filesystems.FileObject;
 import org.openide.filesystems.URLMapper;
 import org.openide.util.Exceptions;
-import org.openide.util.lookup.Lookups;
 
 /**
  *
@@ -42,6 +49,7 @@ import org.openide.util.lookup.Lookups;
 public final class ErrorsNotifier {
 
     private final Map<LspServerState, Future<Void>> servers = new WeakHashMap<>();
+    private final Map<URL, Collection<? extends URL>> lastFilesWithErrors = new HashMap<>();
 
     public void connect(LspServerState server, Future<Void> future) {
         synchronized (servers) {
@@ -63,19 +71,52 @@ public final class ErrorsNotifier {
             servers.keySet().removeAll(toRemove);
         }
         try {
+            Collection<? extends URL> last = lastFilesWithErrors.getOrDefault(root, Collections.emptyList());
             Collection<? extends URL> filesWithErrors = ErrorsCache.getAllFilesWithRecord(root);
-            if (!filesWithErrors.isEmpty()) {
+            if (filesWithErrors.isEmpty()) {
+                lastFilesWithErrors.remove(root);
+            } else {
+                lastFilesWithErrors.put(root, new ArrayList<>(filesWithErrors));
+                last.removeAll(filesWithErrors);
+            }
+            if (!filesWithErrors.isEmpty() || !last.isEmpty()) {
                 Project project = FileOwnerQuery.getOwner(root.toURI());
+                boolean inOpenedProject = false;
                 for (LspServerState server : toProcess) {
                     for (Project p : server.openedProjects().getNow(new Project[0])) {
                         if (p == project) {
-                            Diagnostic.ReporterControl control = Diagnostic.findReporterControl(Lookups.fixed(server), null);
-                            control.diagnosticChanged(filesWithErrors.stream().map(url -> URLMapper.findFileObject(url)).filter(fo -> fo != null).collect(Collectors.toList()), null);
+                            inOpenedProject = true;
+                            for (URL fileWithError : filesWithErrors) {
+                                FileObject fo = URLMapper.findFileObject(fileWithError);
+                                if (fo != null) {
+                                    List<Diagnostic> diags = ErrorsCache.getErrors(fo, (kind, range, message) -> {
+                                        Position start = new Position(range.start().line() - 1, range.start().column() - 1);
+                                        Position end = range.end() != null ? new Position(range.end().line() - 1, range.end().column() - 1) : start;
+                                        Diagnostic d = new Diagnostic(new Range(start, end), message);
+                                        d.setSeverity(kind == ErrorsCache.ErrorKind.WARNING ? DiagnosticSeverity.Warning : DiagnosticSeverity.Error);
+                                        return d;
+                                    });
+                                    if (!diags.isEmpty()) {
+                                        String lspUri = URITranslator.getDefault().uriToLSP(fileWithError.toURI().toString());
+                                        ((TextDocumentServiceImpl) server.getTextDocumentService()).publishDiagnostics(lspUri, diags);
+                                    }
+                                }
+                            }
+                            for (URL fileWithError : last) {
+                                FileObject fo = URLMapper.findFileObject(fileWithError);
+                                if (fo != null) {
+                                    String lspUri = URITranslator.getDefault().uriToLSP(fileWithError.toURI().toString());
+                                    ((TextDocumentServiceImpl) server.getTextDocumentService()).publishDiagnostics(lspUri, Collections.emptyList());
+                                }
+                            }
                         }
                     }
                 }
+                if (!inOpenedProject) {
+                    lastFilesWithErrors.remove(root);
+                }
             }
-        } catch (Exception ex) {
+        } catch (IOException | URISyntaxException ex) {
             Exceptions.printStackTrace(ex);
         }
     }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -2403,7 +2403,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
      * @param uri file URI
      * @param mergedDiags the diagnostics
      */
-    private void publishDiagnostics(String uri, List<Diagnostic> mergedDiags) {
+    public void publishDiagnostics(String uri, List<Diagnostic> mergedDiags) {
         knownFiles.put(uri, Instant.now());
         client.publishDiagnostics(new PublishDiagnosticsParams(uri, mergedDiags));
     }

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
@@ -1734,6 +1734,7 @@ public class ServerTest extends NbTestCase {
             w.write(code);
         }
         List<Diagnostic>[] diags = new List[1];
+        AtomicBoolean checkForDiags = new AtomicBoolean(false);
         CountDownLatch indexingComplete = new CountDownLatch(1);
         Launcher<LanguageServer> serverLauncher = createClientLauncherWithLogging(new TestCodeLanguageClient() {
             @Override
@@ -1745,9 +1746,11 @@ public class ServerTest extends NbTestCase {
         
             @Override
             public void publishDiagnostics(PublishDiagnosticsParams params) {
-                synchronized (diags) {
-                    diags[0] = params.getDiagnostics();
-                    diags.notifyAll();
+                if (checkForDiags.get()) {
+                    synchronized (diags) {
+                        diags[0] = params.getDiagnostics();
+                        diags.notifyAll();
+                    }
                 }
             }
         }, client.getInputStream(), client.getOutputStream());
@@ -1760,6 +1763,7 @@ public class ServerTest extends NbTestCase {
         InitializeResult result = server.initialize(initParams).get();
         indexingComplete.await();
         String uri = toURI(src);
+        checkForDiags.set(true);
         server.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(new TextDocumentItem(uri, "java", 0, code)));
 
         Diagnostic unresolvable = assertDiags(diags, "Error:2:8-2:12").get(0);

--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
@@ -340,7 +340,7 @@ final class VanillaCompileWorker extends CompileWorker {
                 }
                 ExecutableFilesIndex.DEFAULT.setMainClass(context.getRoot().toURL(), active.indexable.getURL(), main[0]);
                 dropMethodsAndErrors(jt.getContext(), unit.getKey(), dc);
-                JavaCustomIndexer.setErrors(context, active, dc);
+                JavaCustomIndexer.setErrors(context, active, unit.getKey(), dc);
             }
             if (context.isCancelled()) {
                 return null;

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -53,11 +54,16 @@ import org.netbeans.junit.NbTestSuite;
 import org.netbeans.modules.classfile.ClassFile;
 import org.netbeans.modules.java.source.indexing.CompileWorker.ParsingOutput;
 import org.netbeans.modules.java.source.indexing.JavaCustomIndexer.CompileTuple;
+import org.netbeans.modules.parsing.impl.indexing.errors.TaskCache;
 import org.netbeans.modules.parsing.spi.indexing.Context;
+import org.netbeans.modules.parsing.spi.indexing.ErrorsCache;
+import org.netbeans.modules.parsing.spi.indexing.ErrorsCache.ErrorKind;
+import org.netbeans.modules.parsing.spi.indexing.ErrorsCache.Range;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
+import org.openide.util.Pair;
 
 /**
  *
@@ -2456,6 +2462,54 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
                 "}");
         if (!"\n".equals(System.lineSeparator())) file2Fixed.replaceAll((k, v) -> v.replaceAll(System.lineSeparator(), "\n"));
         assertEquals(expected, file2Fixed);
+    }
+
+    public void testBrokenWarningEndPos() throws Exception { //NETBEANS-7981
+        setCompilerOptions(Arrays.asList("-Xlint:deprecation"));
+
+        String code = """
+                      package test;
+                      public class Test {
+                          void t() {
+                              new D() {};
+                          }
+                      }
+                      class D {
+                          @Deprecated
+                          D() {}
+                      }
+                      """;
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test.java",
+                                                                      code)),
+                                           Arrays.asList());
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig",
+                                                       "cache/s1/java/15/classes/test/Test$1.sig",
+                                                       "cache/s1/java/15/classes/test/D.sig")),
+                     createdFiles);
+        record Data(ErrorKind kind, Pair<Pair<Integer, Integer>, Pair<Integer, Integer>> range) {}
+        List<Data> errors = TaskCache.getDefault().getErrors(getRoot().getFileObject("test/Test.java"), new ErrorsCache.ReverseConvertor<Data>() {
+            @Override
+            public Data get(ErrorKind kind, Range range, String message) {
+                return new Data(kind, Pair.of(Pair.of(range.start().line(),
+                                                      range.start().column()),
+                                              range.end() != null ? Pair.of(range.end().line(),
+                                                                               range.end().column())
+                                                                     : null));
+            }
+        });
+        assertEquals(List.of(new Data(ErrorKind.WARNING, Pair.of(Pair.of(4, 9), Pair.of(4, 19))),
+                             new Data(ErrorKind.WARNING, Pair.of(Pair.of(4, 17), null))),
+                     errors);
     }
 
     public static void noop() {}


### PR DESCRIPTION
Attempt to reapply https://github.com/apache/netbeans/pull/7737 reverted by https://github.com/apache/netbeans/pull/7982 with additional fixes proposed in https://github.com/apache/netbeans/pull/7998.

The aim of this change is to speed up opening projects within the NetBeans Language Server and therefore improve its start up time.
So far, when opening the project, initial scan is performed (similar to regular NetBeans). During this scan all compilation errors (together with their source files and line numbers) are stored in the NB caches. After the scan completes, the Language Server iterates through all the source files with compilation errors (the list of them is obtained from caches) and compiles them again to produce diagnostic that are sent over Language Server Protocol to client - e.g. VSCode that displays them in the `Project Problems` view.
With the changes in this PR, the Language Server (after the initial scan completes) produces the diagnostic directly from the information stored in caches without the necessity of the second compilation of the source files with compilations errors. To that purpose, the precise positions are added to the information about compilation errors stored in NB chaches during the initial scan. The LSP's [Diagnostic](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic) requires the range at which the message applies to be specified (not only the line number stored in caches so far).
