### PR TITLE
Add support for Java SE 25 for Tomcat, TomEE, and GlassFish

### DIFF
--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/JavaSEPlatform.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/JavaSEPlatform.java
@@ -75,7 +75,9 @@ public enum JavaSEPlatform {
     /** JavaSE 23. */
     v23,
     /** JavaSE 24. */
-    v24;
+    v24,
+    /** JavaSE 25. */
+    v25;
 
     ////////////////////////////////////////////////////////////////////////////
     // Class attributes                                                       //

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
@@ -556,11 +556,13 @@ public class TomcatPlatformImpl extends J2eePlatformImpl2 {
         if (manager.isTomEE()) {
             switch (manager.getTomEEVersion()) {
                 case TOMEE_100:
+                    versions = versionRange(17, 25);
+                    break;
                 case TOMEE_90:
-                    versions = versionRange(11, 24);
+                    versions = versionRange(11, 25);
                     break;
                 case TOMEE_80:
-                    versions = versionRange(8, 24);
+                    versions = versionRange(8, 25);
                     break;
                 case TOMEE_71:
                 case TOMEE_70:
@@ -577,20 +579,20 @@ public class TomcatPlatformImpl extends J2eePlatformImpl2 {
         } else {
             switch (manager.getTomcatVersion()) {
                 case TOMCAT_110:
-                    versions = versionRange(21, 24);
+                    versions = versionRange(17, 25);
                     break;
                 case TOMCAT_101:
-                    versions = versionRange(11, 24);
+                    versions = versionRange(11, 25);
                     break;
                 case TOMCAT_100:
                 case TOMCAT_90:
-                    versions = versionRange(8, 24);
+                    versions = versionRange(8, 25);
                     break;
                 case TOMCAT_80:
-                    versions = versionRange(7, 24);
+                    versions = versionRange(7, 25);
                     break;
                 case TOMCAT_70:
-                    versions = versionRange(6, 24);
+                    versions = versionRange(6, 25);
                     break;
                 case TOMCAT_60:
                     versions = versionRange(5, 8);


### PR DESCRIPTION
NetBeans Notes:

- Tomcat 11 runs on Java SE 17 and later
- TomEE 10 runs on Java SE 17 and later
- Add enum for Java SE 25 on GlassFish tooling

Currently only Tomcat support Java SE 25, this commit lay the groundwork for later support from TomEE and GlassFish.

NetBeans Testing:

- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Verify Sigtests
- Verify successful execution of unit tests for modules `glassfish.common`, `glassfish.javaee`, `glassfish.tooling`, `glassfish.eecommon`, and `tomcat5`
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Successfully register Tomcat 11
  - Create a Jakarta EE 11 maven web app and verify that it works
  - Create a Jakarta EE 11 ant web app and verify that it works.