### PR TITLE
Fixing imports for static item completion.

### DIFF
--- a/java/java.editor/nbproject/project.xml
+++ b/java/java.editor/nbproject/project.xml
@@ -559,6 +559,10 @@
                         <test/>
                     </test-dependency>
                     <test-dependency>
+                        <code-name-base>org.netbeans.modules.lexer.nbbridge</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
                         <code-name-base>org.netbeans.modules.masterfs</code-name-base>
                         <recursive/>
                     </test-dependency>

--- a/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionCollector.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/javadoc/JavadocCompletionCollector.java
@@ -276,7 +276,7 @@ public class JavadocCompletionCollector implements CompletionCollector {
             }
             if (handle != null) {
                 builder.documentation(JavaCompletionCollector.getDocumentation(doc, offset, handle));
-                builder.additionalTextEdits(JavaCompletionCollector.addImport(doc, offset, handle));
+                builder.additionalTextEdits(JavaCompletionCollector.addImportAndInjectPackageIfNeeded(doc, offset, handle));
             }
             if (isDeprecated) {
                 builder.addTag(Completion.Tag.Deprecated);

--- a/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaCompletionCollectorTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaCompletionCollectorTest.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.editor.java;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import javax.swing.text.Document;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
+import org.netbeans.api.editor.mimelookup.MimePath;
+import org.netbeans.api.java.lexer.JavaTokenId;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.SourceUtilsTestUtil;
+import org.netbeans.api.java.source.TestUtilities;
+import org.netbeans.api.lsp.Completion;
+import org.netbeans.api.lsp.Completion.Context;
+import org.netbeans.api.lsp.Completion.TriggerKind;
+import org.netbeans.api.lsp.TextEdit;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.spi.editor.mimelookup.MimeDataProvider;
+import org.openide.cookies.EditorCookie;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.MIMEResolver;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+
+public class JavaCompletionCollectorTest extends NbTestCase {
+
+    public JavaCompletionCollectorTest(String name) {
+        super(name);
+    }
+
+    public void testStaticMembersAndImports() throws Exception {
+        AtomicBoolean found = new AtomicBoolean();
+        runJavaCollector(List.of(new FileDescription("test/Test.java",
+                                                     """
+                                                     package test;
+                                                     public class Test {
+                                                         public void test() {
+                                                             if (call(|)) {
+                                                             }
+                                                         }
+                                                         private boolean call(test.other.E e) {
+                                                             return false;
+                                                         }
+                                                     }
+                                                     """),
+                                 new FileDescription("test/other/E.java",
+                                                     """
+                                                     package test.other;
+                                                     public enum E {
+                                                         A, B, C;
+                                                     }
+                                                     """)),
+                         completions -> {
+                             for (Completion completion : completions) {
+                                 if (completion.getLabel().equals("E.A")) {
+                                     assertEquals("14-14:\\nimport test.other.E;\\n\\n",
+                                                  completion.getAdditionalTextEdits()
+                                                            .get()
+                                                            .stream()
+                                                            .map(JavaCompletionCollectorTest::textEdit2String)
+                                                            .collect(Collectors.joining(", ")));
+                                     assertEquals("E.A",
+                                                  completion.getInsertText());
+                                     found.set(true);
+                                 }
+                             }
+                         });
+        assertTrue(found.get());
+    }
+
+    public void testStaticMembersAndNoImports() throws Exception {
+        AtomicBoolean found = new AtomicBoolean();
+        runJavaCollector(List.of(new FileDescription("test/Test.java",
+                                                     """
+                                                     package test;
+                                                     public class Test {
+                                                         public void test() {
+                                                             if (call(|)) {
+                                                             }
+                                                         }
+                                                         private boolean call(Outter.E e) {
+                                                             return false;
+                                                         }
+                                                     }
+                                                     class Outter {
+                                                         public enum E {
+                                                             A, B, C;
+                                                         }
+                                                     }
+                                                     """)),
+                         completions -> {
+                             for (Completion completion : completions) {
+                                 if (completion.getLabel().equals("E.A")) {
+                                     assertNull(completion.getAdditionalTextEdits());
+                                     assertEquals("Outter.E.A",
+                                                  completion.getInsertText());
+                                     found.set(true);
+                                 }
+                             }
+                         });
+        assertTrue(found.get());
+    }
+
+    public void testTypeFromIndex1() throws Exception {
+        AtomicBoolean found = new AtomicBoolean();
+        runJavaCollector(List.of(new FileDescription("test/Test.java",
+                                                     """
+                                                     package test;
+                                                     public class Test {
+                                                         public void test() {
+                                                             EEE|
+                                                         }
+                                                     }
+                                                     """),
+                                 new FileDescription("test/other/EEE.java",
+                                                     """
+                                                     package test.other;
+                                                     public class EEE {
+                                                     }
+                                                     """)),
+                         completions -> {
+                             for (Completion completion : completions) {
+                                 if (completion.getLabel().equals("EEE")) {
+                                     assertEquals("14-14:\\nimport test.other.EEE;\\n\\n",
+                                                  completion.getAdditionalTextEdits()
+                                                            .get()
+                                                            .stream()
+                                                            .map(JavaCompletionCollectorTest::textEdit2String)
+                                                            .collect(Collectors.joining(", ")));
+                                     assertEquals("EEE",
+                                                  completion.getInsertText());
+                                     found.set(true);
+                                 }
+                             }
+                         });
+        assertTrue(found.get());
+    }
+
+    public void testTypeFromIndex2() throws Exception {
+        AtomicBoolean found = new AtomicBoolean();
+        runJavaCollector(List.of(new FileDescription("test/Test.java",
+                                                     """
+                                                     package test;
+                                                     public class Test {
+                                                         public void test() {
+                                                             EEE|
+                                                         }
+                                                         interface EEE {}
+                                                     }
+                                                     """),
+                                 new FileDescription("test/other/EEE.java",
+                                                     """
+                                                     package test.other;
+                                                     public class EEE {
+                                                     }
+                                                     """)),
+                         completions -> {
+                             for (Completion completion : completions) {
+                                 if (completion.getLabel().equals("EEE") &&
+                                     completion.getKind() == Completion.Kind.Class) {
+                                     assertEquals("67-67:test.other.",
+                                                  completion.getAdditionalTextEdits()
+                                                            .get()
+                                                            .stream()
+                                                            .map(JavaCompletionCollectorTest::textEdit2String)
+                                                            .collect(Collectors.joining(", ")));
+                                     assertEquals("EEE",
+                                                  completion.getInsertText());
+                                     found.set(true);
+                                 }
+                             }
+                         });
+        assertTrue(found.get());
+    }
+
+    private void runJavaCollector(List<FileDescription> files, Validator<List<Completion>> validator) throws Exception {
+        SourceUtilsTestUtil.prepareTest(new String[]{"org/netbeans/modules/java/editor/resources/layer.xml"}, new Object[]{new MIMEResolverImpl(), new MIMEDataProvider()});
+
+        FileObject scratch = SourceUtilsTestUtil.makeScratchDir(this);
+        FileObject cache = scratch.createFolder("cache");
+        FileObject src = scratch.createFolder("src");
+        FileObject mainFile = null;
+        int caretPosition = -1;
+
+        for (FileDescription testFile : files) {
+            FileObject testFO = FileUtil.createData(src, testFile.fileName);
+            String code = testFile.code;
+
+            if (mainFile == null) {
+                mainFile = testFO;
+                caretPosition = code.indexOf('|');
+
+                assertTrue(caretPosition >= 0);
+
+                code = code.substring(0, caretPosition) + code.substring(caretPosition + 1);
+            }
+
+            TestUtilities.copyStringToFile(testFO, code);
+        }
+
+        assertNotNull(mainFile);
+
+        if (sourceLevel != null) {
+            SourceUtilsTestUtil.setSourceLevel(mainFile, sourceLevel);
+        }
+
+        SourceUtilsTestUtil.prepareTest(src, FileUtil.createFolder(scratch, "test-build"), cache);
+        SourceUtilsTestUtil.compileRecursively(src);
+
+        EditorCookie ec = mainFile.getLookup().lookup(EditorCookie.class);
+        Document doc = ec.openDocument();
+        JavaCompletionCollector collector = new JavaCompletionCollector();
+        Context ctx = new Context(TriggerKind.Invoked, null);
+        List<Completion> completions = new ArrayList<>();
+
+        JavaSource.forDocument(doc).runUserActionTask(cc -> {
+            cc.toPhase(JavaSource.Phase.RESOLVED);
+        }, true);
+        collector.collectCompletions(doc, caretPosition, ctx, completions::add);
+        validator.validate(completions);
+    }
+
+    private static String textEdit2String(TextEdit te) {
+        return te.getStartOffset() + "-" + te.getEndOffset() + ":" + te.getNewText().replace("\n", "\\n");
+    }
+
+    private String sourceLevel;
+
+    private final void setSourceLevel(String sourceLevel) {
+        this.sourceLevel = sourceLevel;
+    }
+
+    interface Validator<T> {
+        public void validate(T t) throws Exception;
+    }
+
+    static class MIMEResolverImpl extends MIMEResolver {
+
+        public String findMIMEType(FileObject fo) {
+            if ("java".equals(fo.getExt())) {
+                return "text/x-java";
+            } else {
+                return null;
+            }
+        }
+    }
+
+    static class MIMEDataProvider implements MimeDataProvider {
+
+        @Override
+        public Lookup getLookup(MimePath mimePath) {
+            if ("text/x-java".equals(mimePath.getPath())) {
+                return Lookups.fixed(JavaTokenId.language());
+            }
+            return null;
+        }
+
+    }
+
+    private static final class FileDescription {
+
+        final String fileName;
+        final String code;
+
+        public FileDescription(String fileName, String code) {
+            this.fileName = fileName;
+            this.code = code;
+        }
+    }
+}


### PR DESCRIPTION
Consider case like:
https://github.com/openjdk/jdk/blob/55c3e78f4ec982908e9a4b5e64b8be89717c49f4/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java#L2382

calling the code completion after `.hasTag(`. Given `TypeTag` is an enum, the CC should show all the enum constants. But, inside the VS Code, it fails to show anything.

This is (sadly) a consequence of a series of mishaps (see later), but one of them is that `JavaCompletionCollector.createStaticMemberItem` is using `GeneratorUtilities.addImport`, which itself misbehaves. But, the collector should not use this method at all: `addImport` does not allow to inject FQNs if needed, etc. The main proposal in this patch is to use `SourceUtils.resolveImport` to resolve imports for `createStaticMemberItem`, which adds imports as needed, and provides the simple or qualified name that should be injected into the source. `resolveImport` was already used on another place in the class.

The other problems I've ran into, but are not fixed by this PR:
- `TextEdit.getNewText` is specified to never return null, but it might return null, as there's no check when the instance is created.
- The `TextEdit` with the `null` new text is created from a `ModificationResult.Difference` for text removal - where the method is also specified to not return null
- `GeneratorUtilities.addImports` is removing package imports, intending to replace them with single-class imports, but it does not do the replacement. I think `addImports` should not remove package imports, unless called from `OrganizeImports`. Or, possibly, there should be a different entrypoint for `OrganizeImports`. But it seems wrong to manipulate imports in such an intrusive manner in simple `addImports`.

I've also fixed for I think was flipped logic for sort text and smart typing for `createStaticMemberItem`.
