### PR TITLE
Fix: tabs without file objects had null title in tab switcher

### DIFF
--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/DocumentSwitcherTable.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/DocumentSwitcherTable.java
@@ -68,8 +68,6 @@ class DocumentSwitcherTable extends SwitcherTable {
     private final ItemBorder ITEM_BORDER = new ItemBorder();
     private final Border SEPARATOR_BORDER = BorderFactory.createEmptyBorder( 2, 2, 0, 5 );
 
-    private String itemText;
-
     public DocumentSwitcherTable( Controller controller, SwitcherTableItem[] items, int y ) {
         super( items, y );
         this.controller = controller;
@@ -113,9 +111,14 @@ class DocumentSwitcherTable extends SwitcherTable {
             } else {
                 if(null != folderNameDecorator && null != item) {
                     TabData tab = item.getTabData();
-                    if(null != tab) {
-                        itemText = folderNameDecorator.getText(tab) + (item.isActive() ? " ←" : ""); //NOI18N
-                        lbl.setText(itemText);
+                    if (null != tab) {
+                        String decorated = folderNameDecorator.getText(tab);
+                        if (decorated != null) {
+                            if (item.isActive()) {
+                                decorated +=  " ←"; //NOI18N
+                            }
+                            lbl.setText(decorated);
+                        }
                     }
                 }
                 lbl.setBorder( ITEM_BORDER );

--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/FolderNameTabDecorator.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/FolderNameTabDecorator.java
@@ -21,6 +21,7 @@ package org.netbeans.core.multitabs.impl;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Rectangle;
+import java.io.CharConversionException;
 import java.io.File;
 import javax.swing.Icon;
 import javax.swing.UIManager;
@@ -32,6 +33,7 @@ import org.openide.filesystems.FileObject;
 import org.openide.loaders.DataObject;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.windows.TopComponent;
+import org.openide.xml.XMLUtil;
 
 import static java.util.Objects.requireNonNullElse;
 
@@ -123,8 +125,18 @@ public class FolderNameTabDecorator extends TabDecorator {
             res.append( prefix );
             res.append( baseText.substring( 6 ) );
         } else {
-            res.append( prefix );
-            res.append( baseText );
+            if (prefix.startsWith("<font")) { //NOI18N
+                res.append("<html>"); //NOI18N
+                res.append(prefix);
+                try {
+                    res.append(XMLUtil.toElementContent(baseText));
+                } catch (CharConversionException ex) {
+                    res.append(baseText);
+                }
+            } else {
+                res.append(prefix);
+                res.append(baseText);
+            }
         }
 
         return res.toString();


### PR DESCRIPTION
 - example: repo history with parent folder decorator enabled
 - regression since ad776db73d4410ae5bb69ff137e2f973b10aab6f / https://github.com/apache/netbeans/pull/7930
 
 
![image](https://github.com/user-attachments/assets/5b4bd1cc-1e80-40b7-b3da-8b1ce9cfe227)

 
 
 targets delivery