### PR TITLE
Organize Members hint: don't rearrange record components

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/OrganizeMembers.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/OrganizeMembers.java
@@ -45,7 +45,7 @@ import org.netbeans.api.editor.EditorActionRegistration;
 import org.netbeans.api.java.source.*;
 import org.netbeans.api.java.source.JavaSource.Phase;
 import org.netbeans.api.java.source.ModificationResult.Difference;
-import org.netbeans.api.progress.ProgressUtils;
+import org.netbeans.api.progress.BaseProgressUtils;
 import org.netbeans.editor.BaseAction;
 import org.netbeans.editor.BaseDocument;
 import org.netbeans.editor.GuardedDocument;
@@ -123,48 +123,41 @@ public class OrganizeMembers {
         clazz = gu.importComments(clazz, copy.getCompilationUnit());
         TreeMaker maker = copy.getTreeMaker();
         ClassTree nue = maker.Class(clazz.getModifiers(), clazz.getSimpleName(), clazz.getTypeParameters(), clazz.getExtendsClause(), clazz.getImplementsClause(), Collections.<Tree>emptyList());
-        List<Tree> members = new ArrayList<>(clazz.getMembers().size());
-        Map<Tree, Tree> memberMap = new HashMap<>(clazz.getMembers().size());
+        List<Tree> members = new ArrayList<>();
+        Map<Tree, Tree> memberMap = new HashMap<>();
         
-        List<Tree> enumValues = new ArrayList<>();
+        List<Tree> fixedMembers = new ArrayList<>();
         for (Tree tree : clazz.getMembers()) {
-            if (copy.getTreeUtilities().isSynthetic(new TreePath(path, tree))) {
+            if (copy.getTreeUtilities().isSynthetic(new TreePath(path, tree))
+                    && !(tree.getKind() == Kind.VARIABLE && copy.getTreeUtilities().isRecordComponent((VariableTree)tree))) {
                 continue;
             }
-            Tree member;
-            switch (tree.getKind()) {
-                case CLASS:
-                case INTERFACE:
-                case ENUM:
-                case ANNOTATION_TYPE:
-                    member = maker.setLabel(tree, ((ClassTree)tree).getSimpleName());
-                    break;
-                case VARIABLE:
-                    member = maker.setLabel(tree, ((VariableTree)tree).getName());
-                    if (copy.getTreeUtilities().isEnumConstant((VariableTree)tree)) {
-                        enumValues.add(member);
+            Tree member = switch (tree.getKind()) {
+                case CLASS, INTERFACE, ENUM, RECORD, ANNOTATION_TYPE -> 
+                    maker.setLabel(tree, ((ClassTree)tree).getSimpleName());
+                case VARIABLE -> {
+                    VariableTree vt = (VariableTree)tree;
+                    Tree mem = maker.setLabel(tree, vt.getName());
+                    if (copy.getTreeUtilities().isEnumConstant(vt) || copy.getTreeUtilities().isRecordComponent(vt)) {
+                        fixedMembers.add(mem);
                     }
-                    break;
-                case METHOD:
-                    member = maker.setLabel(tree, ((MethodTree)tree).getName());
-                    break;
-                case BLOCK:
-                    member = maker.asReplacementOf(maker.Block(((BlockTree)tree).getStatements(), ((BlockTree)tree).isStatic()), tree, true);
-                    break;
-                default:
-                    member = tree;    
-            }
+                    yield mem;
+                }
+                case METHOD -> maker.setLabel(tree, ((MethodTree)tree).getName());
+                case BLOCK -> maker.asReplacementOf(maker.Block(((BlockTree)tree).getStatements(), ((BlockTree)tree).isStatic()), tree, true);
+                default -> tree;    
+            };
             members.add(member);
             memberMap.put(member, tree);
         }
         // fool the generator utilities with cloned members, so it does not take positions into account
-        if (enumValues.isEmpty()) {
+        if (fixedMembers.isEmpty()) {
             nue = GeneratorUtilities.get(copy).insertClassMembers(nue, members);
         } else {
-            members.removeAll(enumValues);
+            members.removeAll(fixedMembers);
             int max = nue.getMembers().size();
-            // insert the enum values in the original order
-            for (Tree t : enumValues) {
+            // insert the enum values or record components in the original order
+            for (Tree t : fixedMembers) {
                 nue = maker.insertClassMember(nue, max++, t);
             }
             nue = GeneratorUtilities.get(copy).insertClassMembers(nue, members);
@@ -181,8 +174,8 @@ public class OrganizeMembers {
     }
     
     private static boolean checkGuarded(Document doc, List<? extends Difference> diffs) {
-        if (doc instanceof GuardedDocument) {
-            MarkBlockChain chain = ((GuardedDocument) doc).getGuardedBlockChain();
+        if (doc instanceof GuardedDocument guardedDocument) {
+            MarkBlockChain chain = guardedDocument.getGuardedBlockChain();
             for (Difference diff : diffs) {
                 if ((chain.compareBlock(diff.getStartPosition().getOffset(), diff.getEndPosition().getOffset()) & MarkBlock.OVERLAP) != 0) {
                     return true;
@@ -226,7 +219,7 @@ public class OrganizeMembers {
             final Source source = Source.create(doc);
             if (source != null) {
                 final AtomicBoolean cancel = new AtomicBoolean();
-                ProgressUtils.runOffEventDispatchThread(new Runnable() {
+                BaseProgressUtils.runOffEventDispatchThread(new Runnable() {
                     @Override
                     public void run() {
                         try {

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -151,7 +151,14 @@ public final class TreeUtilities {
     public boolean isEnumConstant(VariableTree tree) {
         return (((JCTree.JCModifiers) tree.getModifiers()).flags & Flags.ENUM) != 0;
     }
-    
+
+    /**
+     * Checks whether given variable tree represents a record component.
+     */
+    public boolean isRecordComponent(VariableTree tree) {
+        return (((JCTree.JCModifiers) tree.getModifiers()).flags & Flags.RECORD) != 0;
+    }
+
     /**Checks whether the given tree represents an annotation.
      * @deprecated since 0.67, <code>Tree.getKind() == Kind.ANNOTATION_TYPE</code> should be used instead.
      */


### PR DESCRIPTION
if the formatter is configured to sort members alphabetically, the hint should not rearrange record components.

The fix reuses the existing special case for enums, which holds the enum "members" in place and does the same for synthetic record members.

```java
import java.awt.Color;

// enable formatter setting: ordering -> alphabetical member sort
// this should not influence record components
public record OrderMembersRecord(Color borderColor, double borderSize, int width, int height) {

    public static int c;
    public static int b;
    public static int d;
    public static int a;

}
```