### PR TITLE
Fix sporadic CME in gradle JavaToolchainSupport

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/spi/support/JavaToolchainSupport.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/spi/support/JavaToolchainSupport.java
@@ -20,8 +20,8 @@ package org.netbeans.modules.gradle.java.spi.support;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.netbeans.api.java.platform.JavaPlatform;
@@ -48,7 +48,7 @@ public final class JavaToolchainSupport {
     private static JavaToolchainSupport instance;
     
     private JavaToolchainSupport() {
-        platformCache = new HashMap<>();
+        platformCache = new ConcurrentHashMap<>();
     }
     
     public static JavaToolchainSupport getDefault() {


### PR DESCRIPTION
 - switch to `ConcurrentHashMap` to avoid `computeIfAbsent()` throwing CMEs


Noticed it while testing an unrelated PR (https://github.com/apache/netbeans/pull/8223#issuecomment-2636551635). Happened only once, either during project creation or project opening (can't remember).

<details>

<summary>exception</summary>



```
java.util.ConcurrentModificationException
	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1230)
	at org.netbeans.modules.gradle.java.spi.support.JavaToolchainSupport.platformByHome(JavaToolchainSupport.java:70)
	at org.netbeans.modules.gradle.java.classpath.BootClassPathImpl.createPath(BootClassPathImpl.java:59)
	at org.netbeans.modules.gradle.java.classpath.AbstractGradleClassPathImpl.getResources(AbstractGradleClassPathImpl.java:108)
	at org.netbeans.api.java.classpath.ClassPath.entries(ClassPath.java:363)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater.findDependencies(RepositoryUpdater.java:1891)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater.access$2400(RepositoryUpdater.java:135)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$RootsWork.getDone(RepositoryUpdater.java:4965)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$InitialRootsWork.getDone(RepositoryUpdater.java:5842)
[catch] at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Work.doTheWork(RepositoryUpdater.java:3452)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Task._run(RepositoryUpdater.java:6197)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Task.access$3400(RepositoryUpdater.java:5855)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Task$2.lambda$call$0(RepositoryUpdater.java:6116)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:288)
	at org.netbeans.modules.parsing.impl.RunWhenScanFinishedSupport.performScan(RunWhenScanFinishedSupport.java:83)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Task$2.call(RepositoryUpdater.java:6116)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Task$2.call(RepositoryUpdater.java:6112)
	at org.netbeans.modules.masterfs.filebasedfs.utils.FileChangedManager.priorityIO(FileChangedManager.java:153)
	at org.netbeans.modules.masterfs.providers.ProvidedExtensions.priorityIO(ProvidedExtensions.java:335)
	at org.netbeans.modules.parsing.nb.DataObjectEnvFactory.runPriorityIO(DataObjectEnvFactory.java:118)
	at org.netbeans.modules.parsing.impl.Utilities.runPriorityIO(Utilities.java:67)
	at org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater$Task.run(RepositoryUpdater.java:6112)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1403)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2018)

```

</details>