### PR TITLE
Improve support for Jakarta EE 11

### DIFF
--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarProvider.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarProvider.java
@@ -304,7 +304,7 @@ public final class EjbJarProvider extends J2eeModuleProvider
         // return a version based on the Java EE version
         Profile platformVersion = getJ2eeProfile();
         if (platformVersion == null) {
-            platformVersion = Profile.JAVA_EE_7_FULL;
+            platformVersion = Profile.JAKARTA_EE_8_FULL;
         }
 
         if (platformVersion.isAtLeast(Profile.JAKARTA_EE_9_WEB)) {

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/Bundle.properties
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/Bundle.properties
@@ -141,9 +141,9 @@ MSG_RecommendationSetJdk11=<html>Note: JDK 11 will be used for Jakarta EE 9.1 an
 MSG_RecommendationSetSourceLevel11=<html>Note: Source Level 11 will be set for Jakarta EE 9.1 and Jakarta EE 10 project.
 MSG_RecommendationJDK11=<html>Recommendation: JDK 11 should be used for Jakarta EE 9.1 and Jakarta EE 10 projects.
 
-MSG_RecommendationSetJdk21=<html>Note: JDK 21 will be used for Jakarta EE 11 projects.
-MSG_RecommendationSetSourceLevel21=<html>Note: Source Level 21 will be set for Jakarta EE 11 project.
-MSG_RecommendationJDK21=<html>Recommendation: JDK 21 should be used for Jakarta EE 11 projects.
+MSG_RecommendationSetJdk17=<html>Note: JDK 17 will be used for Jakarta EE 11 projects.
+MSG_RecommendationSetSourceLevel17=<html>Note: Source Level 17 will be set for Jakarta EE 11 project.
+MSG_RecommendationJDK17=<html>Recommendation: JDK 17 should be used for Jakarta EE 11 projects.
 
 #Import wizard - existing sources
 LBL_IW_ImportTitle=Add Existing Sources

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/J2eeVersionWarningPanel.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/J2eeVersionWarningPanel.java
@@ -42,20 +42,20 @@ final class J2eeVersionWarningPanel extends javax.swing.JPanel {
     public static final String WARN_SET_JDK_7 = "warnSetJdk7"; // NOI18N
     public static final String WARN_SET_JDK_8 = "warnSetJdk8"; // NOI18N
     public static final String WARN_SET_JDK_11 = "warnSetJdk11"; // NOI18N
-    public static final String WARN_SET_JDK_21 = "warnSetJdk21"; // NOI18N
+    public static final String WARN_SET_JDK_17 = "warnSetJdk17"; // NOI18N
 
     public static final String WARN_SET_SOURCE_LEVEL_15 = "warnSetSourceLevel15"; // NOI18N
     public static final String WARN_SET_SOURCE_LEVEL_6 = "warnSetSourceLevel6"; // NOI18N
     public static final String WARN_SET_SOURCE_LEVEL_7 = "warnSetSourceLevel7"; // NOI18N
     public static final String WARN_SET_SOURCE_LEVEL_8 = "warnSetSourceLevel8"; // NOI18N
     public static final String WARN_SET_SOURCE_LEVEL_11 = "warnSetSourceLevel11"; // NOI18N
-    public static final String WARN_SET_SOURCE_LEVEL_21 = "warnSetSourceLevel21"; // NOI18N
+    public static final String WARN_SET_SOURCE_LEVEL_17 = "warnSetSourceLevel17"; // NOI18N
 
     public static final String WARN_JDK_6_REQUIRED = "warnJdk6Required"; // NOI18N
     public static final String WARN_JDK_7_REQUIRED = "warnJdk7Required"; // NOI18N
     public static final String WARN_JDK_8_REQUIRED = "warnJdk8Required"; // NOI18N
     public static final String WARN_JDK_11_REQUIRED = "warnJdk11Required"; // NOI18N
-    public static final String WARN_JDK_21_REQUIRED = "warnJdk21Required"; // NOI18N
+    public static final String WARN_JDK_17_REQUIRED = "warnJdk17Required"; // NOI18N
 
     private String warningType;
 
@@ -88,8 +88,8 @@ final class J2eeVersionWarningPanel extends javax.swing.JPanel {
                 case WARN_SET_JDK_11:
                     labelText = NbBundle.getMessage(J2eeVersionWarningPanel.class, "MSG_RecommendationSetJdk11");
                     break;
-                case WARN_SET_JDK_21:
-                    labelText = NbBundle.getMessage(J2eeVersionWarningPanel.class, "MSG_RecommendationSetJdk21");
+                case WARN_SET_JDK_17:
+                    labelText = NbBundle.getMessage(J2eeVersionWarningPanel.class, "MSG_RecommendationSetJdk17");
                     break;
                 case WARN_SET_SOURCE_LEVEL_15:
                     labelText = NbBundle.getMessage(J2eeVersionWarningPanel.class, "MSG_RecommendationSetSourceLevel15");
@@ -106,8 +106,8 @@ final class J2eeVersionWarningPanel extends javax.swing.JPanel {
                 case WARN_SET_SOURCE_LEVEL_11:
                     labelText = NbBundle.getMessage(J2eeVersionWarningPanel.class, "MSG_RecommendationSetSourceLevel11");
                     break;
-                case WARN_SET_SOURCE_LEVEL_21:
-                    labelText = NbBundle.getMessage(J2eeVersionWarningPanel.class, "MSG_RecommendationSetSourceLevel21");
+                case WARN_SET_SOURCE_LEVEL_17:
+                    labelText = NbBundle.getMessage(J2eeVersionWarningPanel.class, "MSG_RecommendationSetSourceLevel17");
                     break;
                 case WARN_JDK_6_REQUIRED:
                     labelText = NbBundle.getMessage(J2eeVersionWarningPanel.class, "MSG_RecommendationJDK6");
@@ -121,8 +121,8 @@ final class J2eeVersionWarningPanel extends javax.swing.JPanel {
                 case WARN_JDK_11_REQUIRED:
                     labelText = NbBundle.getMessage(J2eeVersionWarningPanel.class, "MSG_RecommendationJDK11");
                     break;
-                case WARN_JDK_21_REQUIRED:
-                    labelText = NbBundle.getMessage(J2eeVersionWarningPanel.class, "MSG_RecommendationJDK21");
+                case WARN_JDK_17_REQUIRED:
+                    labelText = NbBundle.getMessage(J2eeVersionWarningPanel.class, "MSG_RecommendationJDK17");
                     break;
                 default:
                     break;
@@ -157,8 +157,8 @@ final class J2eeVersionWarningPanel extends javax.swing.JPanel {
                     JavaPlatform[] javaPlatforms = getJavaPlatforms("11");
                     return getPreferredPlatform(javaPlatforms).getDisplayName();
                 }
-                case WARN_SET_JDK_21: {
-                    JavaPlatform[] javaPlatforms = getJavaPlatforms("21");
+                case WARN_SET_JDK_17: {
+                    JavaPlatform[] javaPlatforms = getJavaPlatforms("17");
                     return getPreferredPlatform(javaPlatforms).getDisplayName();
                 }
                 default:
@@ -193,8 +193,8 @@ final class J2eeVersionWarningPanel extends javax.swing.JPanel {
                     JavaPlatform[] javaPlatforms = getJavaPlatforms("11");
                     return getPreferredPlatform(javaPlatforms).getSpecification();
                 }
-                case WARN_SET_JDK_21: {
-                    JavaPlatform[] javaPlatforms = getJavaPlatforms("21");
+                case WARN_SET_JDK_17: {
+                    JavaPlatform[] javaPlatforms = getJavaPlatforms("17");
                     return getPreferredPlatform(javaPlatforms).getSpecification();
                 }
                 default:
@@ -261,9 +261,9 @@ final class J2eeVersionWarningPanel extends javax.swing.JPanel {
             return null;
         }
         
-        // no warning if 21 is the default for jakartaee11
+        // no warning if 17 is the default for jakartaee11
         if ((j2eeProfile == Profile.JAKARTA_EE_11_FULL || j2eeProfile == Profile.JAKARTA_EE_11_WEB) &&
-                isAcceptableSourceLevel("21", sourceLevel, acceptableSourceLevels)) { // NOI18N
+                isAcceptableSourceLevel("17", sourceLevel, acceptableSourceLevels)) { // NOI18N
             return null;
         }
         
@@ -322,14 +322,14 @@ final class J2eeVersionWarningPanel extends javax.swing.JPanel {
                 }
             }
         } else if (j2eeProfile == Profile.JAKARTA_EE_11_FULL || j2eeProfile == Profile.JAKARTA_EE_11_WEB) {
-            JavaPlatform[] java21Platforms = getJavaPlatforms("21"); //NOI18N
-            if (java21Platforms.length > 0) {
-                return WARN_SET_JDK_21;
+            JavaPlatform[] java17Platforms = getJavaPlatforms("17"); //NOI18N
+            if (java17Platforms.length > 0) {
+                return WARN_SET_JDK_17;
             } else {
-                if (canSetSourceLevel("21")) {
-                    return WARN_SET_SOURCE_LEVEL_21;
+                if (canSetSourceLevel("17")) {
+                    return WARN_SET_SOURCE_LEVEL_17;
                 } else {
-                    return WARN_JDK_21_REQUIRED;
+                    return WARN_JDK_17_REQUIRED;
                 }
             }
         } else {

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectServerPanel.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectServerPanel.java
@@ -611,7 +611,7 @@ private void serverLibraryCheckboxActionPerformed(java.awt.event.ActionEvent evt
                 Set<String> jdks = j2eePlatform.getSupportedJavaPlatformVersions();
                 // make sure that chosen source level is suported by server:
                 if (jdks != null && !jdks.contains(sourceLevel)) { // workaround for #212146 when jdks == null
-                    if ("21".equals(sourceLevel) && jdks.contains("11")) {
+                    if ("17".equals(sourceLevel) && jdks.contains("11")) {
                         sourceLevel = "11";
                     } else if ("11".equals(sourceLevel) && jdks.contains("1.8")) {
                         sourceLevel = "1.8";
@@ -634,8 +634,8 @@ private void serverLibraryCheckboxActionPerformed(java.awt.event.ActionEvent evt
                 String warningType = warningPanel.getWarningType();
                 if (warningType != null) {
                     switch (warningType) {
-                        case J2eeVersionWarningPanel.WARN_SET_SOURCE_LEVEL_21:
-                            sourceLevel = "21"; //NOI18N
+                        case J2eeVersionWarningPanel.WARN_SET_SOURCE_LEVEL_17:
+                            sourceLevel = "17"; //NOI18N
                             break;
                         case J2eeVersionWarningPanel.WARN_SET_SOURCE_LEVEL_11:
                             sourceLevel = "11"; //NOI18N

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
@@ -466,6 +466,7 @@ public class TomcatPlatformImpl extends J2eePlatformImpl2 {
                 switch (manager.getTomEEVersion()) {
                     case TOMEE_100:
                         profiles.add(Profile.JAKARTA_EE_10_FULL);
+                        break;
                     case TOMEE_90:
                         profiles.add(Profile.JAKARTA_EE_9_1_FULL);
                         break;
@@ -482,6 +483,7 @@ public class TomcatPlatformImpl extends J2eePlatformImpl2 {
             switch (manager.getTomEEVersion()) {
                 case TOMEE_100:
                     profiles.add(Profile.JAKARTA_EE_10_WEB);
+                    break;
                 case TOMEE_90:
                     profiles.add(Profile.JAKARTA_EE_9_1_WEB);
                     break;
@@ -525,6 +527,7 @@ public class TomcatPlatformImpl extends J2eePlatformImpl2 {
                     profiles.add(Profile.JAVA_EE_7_WEB);
                     profiles.add(Profile.JAVA_EE_6_WEB);
                     profiles.add(Profile.JAVA_EE_5);
+                    break;
                 case TOMCAT_80:
                     profiles.add(Profile.JAVA_EE_7_WEB);
                     profiles.add(Profile.JAVA_EE_6_WEB);


### PR DESCRIPTION
NetBeans Notes:
- Jakarta EE 11 runs on Java SE 17 and later
- Add missing `break` to switch statement
- Assume Jakarta EE 8 is supported instead of Java EE 7 when `platformVersion` is null when dealing with EJBs

NetBeans Testing:

- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Verify Sigtests
- Verify successful execution of unit tests for modules `j2ee.ejbjarproject`, `javaee.project`,  and `tomcat5`
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Successfully register TomEE 10 and GlassFish 8.0.0-M9
  - Create a Jakarta EE 11 web app and verify that it works
  - Create a Jakarta EE 10 web app and verify that it works.