### PR TITLE
Fixes several bugs in the editor annotation options.

### DIFF
--- a/ide/defaults/src/org/netbeans/modules/defaults/CityLights-annotations.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/CityLights-annotations.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
+
+<fontscolors>
+    <fontcolor bgColor="ffdcdcd8" name="OtherThreads_DBP"/>
+    <fontcolor bgColor="fffc9d9f" name="Breakpoint"/>
+    <fontcolor name="FieldBreakpoint_stroke"/>
+    <fontcolor bgColor="ffdcdcd8" name="DisabledBreakpoint"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err_fixable"/>
+    <fontcolor bgColor="ffbde6aa" name="CurrentPCLinePart"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements-has-implementations-combined"/>
+    <fontcolor bgColor="ffe9ffe6" name="CurrentExpressionLine_DBP"/>
+    <fontcolor name="org-netbeans-modules-git-Annotation"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err"/>
+    <fontcolor bgColor="ffdcdcd8" name="debugger-multi_DBPCBP"/>
+    <fontcolor bgColor="ffdcdcd8" name="Breakpoint_broken"/>
+    <fontcolor name="DisabledMethodBreakpoint"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_mixedBP"/>
+    <fontcolor bgColor="ffbde6aa" name="OtherThreads_PC_BP"/>
+    <fontcolor bgColor="ffbde6aa" name="CurrentPC2"/>
+    <fontcolor bgColor="ffbde6aa" name="OtherThreads_BP_broken"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn"/>
+    <fontcolor name="ClassBreakpoint"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_BP_stroke"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo"/>
+    <fontcolor bgColor="ffdcdcd8" name="DisabledBreakpoint_stroke"/>
+    <fontcolor bgColor="ffb4e4fc" name="loadgenProfilingPoint"/>
+    <fontcolor bgColor="fffc9d9f" name="debugger-mixed_BP"/>
+    <fontcolor name="DisabledMethodBreakpoint_stroke"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_DCBP"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn_fixable"/>
+    <fontcolor bgColor="ffe7e1ef" name="CallSite"/>
+    <fontcolor bgColor="ffbde6aa" name="OtherThread_PC"/>
+    <fontcolor bgColor="ffbde6aa" name="CurrentPC"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_multi_BPCBP"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_CBP"/>
+    <fontcolor name="DisabledFieldBreakpoint_stroke"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_DBP_stroke"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_multi_DBPCBP"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-override-is-overridden-combined"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_multi_BPCBP_broken"/>
+    <fontcolor bgColor="ffdcdcd8" name="CondBreakpoint_broken"/>
+    <fontcolor bgColor="ffb4e4fc" name="resetResultsProfilingPoint"/>
+    <fontcolor bgColor="ffdcdcd8" name="Breakpoint_stroke"/>
+    <fontcolor bgColor="ffe9ffe6" name="CurrentExpressionLine_BP"/>
+    <fontcolor bgColor="ffdcdcd8" name="debugger-mixed_BP_broken"/>
+    <fontcolor bgColor="ffdcdcd8" name="CondBreakpoint_stroke"/>
+    <fontcolor name="DisabledClassBreakpoint_stroke"/>
+    <fontcolor bgColor="fffc9d9f" name="OtherThreads_BP"/>
+    <fontcolor name="org-netbeans-modules-subversion-Annotation"/>
+    <fontcolor name="OtherThread"/>
+    <fontcolor bgColor="ffe9ffe6" name="CurrentExpressionLine_DCBP"/>
+    <fontcolor name="editor-bookmark"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_BP_broken"/>
+    <fontcolor bgColor="ffdcdcd8" name="DisabledCondBreakpoint"/>
+    <fontcolor bgColor="ffb4e4fc" name="stopwatchProfilingPoint"/>
+    <fontcolor name="ClassBreakpoint_stroke"/>
+    <fontcolor bgColor="ffe9ffe6" name="CurrentExpressionLine_CBP"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_mixedBP_broken"/>
+    <fontcolor name="DisabledFieldBreakpoint"/>
+    <fontcolor bgColor="ffdcdcd8" name="loadgenProfilingPointD"/>
+    <fontcolor bgColor="ffdcdcd8" name="debugger-multi_BPCBP_broken"/>
+    <fontcolor bgColor="fffc9d9f" name="debugger-multi_BPCBP"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_BP"/>
+    <fontcolor bgColor="ffdcdcd8" name="DisabledCondBreakpoint_stroke"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint_fixable"/>
+    <fontcolor bgColor="ffdcdcd8" name="OtherThread_DBP"/>
+    <fontcolor name="FieldBreakpoint"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements-is-overridden-combined"/>
+    <fontcolor bgColor="ffb4e4fc" name="takeSnapshotProfilingPoint"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_DCBP_stroke"/>
+    <fontcolor name="DisabledClassBreakpoint"/>
+    <fontcolor bgColor="ffbde6aa" name="OtherThread_BP_broken"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-is_overridden"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-overrides"/>
+    <fontcolor bgColor="ffe9ffe6" name="CurrentExpressionLine"/>
+    <fontcolor bgColor="ffdcdcd8" name="CurrentPC2_DBP"/>
+    <fontcolor bgColor="ffdcdcd8" name="resetResultsProfilingPointD"/>
+    <fontcolor name="MethodBreakpoint_stroke"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier_fixable"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_CBP_stroke"/>
+    <fontcolor name="org-netbeans-modules-mercurial-Annotation"/>
+    <fontcolor bgColor="ffbde6aa" name="CurrentPC2LinePart"/>
+    <fontcolor bgColor="ffdcdcd8" name="takeSnapshotProfilingPointD"/>
+    <fontcolor bgColor="fffc9d9f" name="OtherThread_BP"/>
+    <fontcolor name="org-netbeans-modules-versioning-annotate-Annotation"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_CBP_broken"/>
+    <fontcolor bgColor="ffdcdcd8" name="stopwatchProfilingPointD"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint"/>
+    <fontcolor name="MethodBreakpoint"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_DBP"/>
+    <fontcolor bgColor="fffc9d9f" name="CondBreakpoint"/>
+    <fontcolor bgColor="fffc9d9f" name="CurrentPC2_BP"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-has_implementations"/>
+    <fontcolor bgColor="ffbde6aa" name="OtherThread_PC_BP"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo_fixable"/>
+    <fontcolor bgColor="ffffa0a0" name="org-netbeans-modules-xml-error"/>
+    <fontcolor name="OtherThreads"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements"/>
+    <fontcolor bgColor="ffd1ffbc" name="CurrentExpression"/>
+</fontscolors>

--- a/ide/defaults/src/org/netbeans/modules/defaults/NetBeans55-annotations.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/NetBeans55-annotations.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
+
+<fontscolors>
+    <fontcolor bgColor="ffdcdcd8" name="OtherThreads_DBP"/>
+    <fontcolor bgColor="fffc9d9f" name="Breakpoint"/>
+    <fontcolor name="FieldBreakpoint_stroke"/>
+    <fontcolor bgColor="ffdcdcd8" name="DisabledBreakpoint"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err_fixable"/>
+    <fontcolor bgColor="ffbde6aa" name="CurrentPCLinePart"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements-has-implementations-combined"/>
+    <fontcolor bgColor="ffe9ffe6" name="CurrentExpressionLine_DBP"/>
+    <fontcolor name="org-netbeans-modules-git-Annotation"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err"/>
+    <fontcolor bgColor="ffdcdcd8" name="debugger-multi_DBPCBP"/>
+    <fontcolor bgColor="ffdcdcd8" name="Breakpoint_broken"/>
+    <fontcolor name="DisabledMethodBreakpoint"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_mixedBP"/>
+    <fontcolor bgColor="ffbde6aa" name="OtherThreads_PC_BP"/>
+    <fontcolor bgColor="ffbde6aa" name="CurrentPC2"/>
+    <fontcolor bgColor="ffbde6aa" name="OtherThreads_BP_broken"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn"/>
+    <fontcolor name="ClassBreakpoint"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_BP_stroke"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo"/>
+    <fontcolor bgColor="ffdcdcd8" name="DisabledBreakpoint_stroke"/>
+    <fontcolor bgColor="ffb4e4fc" name="loadgenProfilingPoint"/>
+    <fontcolor bgColor="fffc9d9f" name="debugger-mixed_BP"/>
+    <fontcolor name="DisabledMethodBreakpoint_stroke"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_DCBP"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn_fixable"/>
+    <fontcolor bgColor="ffe7e1ef" name="CallSite"/>
+    <fontcolor bgColor="ffbde6aa" name="OtherThread_PC"/>
+    <fontcolor bgColor="ffbde6aa" name="CurrentPC"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_multi_BPCBP"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_CBP"/>
+    <fontcolor name="DisabledFieldBreakpoint_stroke"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_DBP_stroke"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_multi_DBPCBP"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-override-is-overridden-combined"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_multi_BPCBP_broken"/>
+    <fontcolor bgColor="ffdcdcd8" name="CondBreakpoint_broken"/>
+    <fontcolor bgColor="ffb4e4fc" name="resetResultsProfilingPoint"/>
+    <fontcolor bgColor="ffdcdcd8" name="Breakpoint_stroke"/>
+    <fontcolor bgColor="ffe9ffe6" name="CurrentExpressionLine_BP"/>
+    <fontcolor bgColor="ffdcdcd8" name="debugger-mixed_BP_broken"/>
+    <fontcolor bgColor="ffdcdcd8" name="CondBreakpoint_stroke"/>
+    <fontcolor name="DisabledClassBreakpoint_stroke"/>
+    <fontcolor bgColor="fffc9d9f" name="OtherThreads_BP"/>
+    <fontcolor name="org-netbeans-modules-subversion-Annotation"/>
+    <fontcolor name="OtherThread"/>
+    <fontcolor bgColor="ffe9ffe6" name="CurrentExpressionLine_DCBP"/>
+    <fontcolor name="editor-bookmark"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_BP_broken"/>
+    <fontcolor bgColor="ffdcdcd8" name="DisabledCondBreakpoint"/>
+    <fontcolor bgColor="ffb4e4fc" name="stopwatchProfilingPoint"/>
+    <fontcolor name="ClassBreakpoint_stroke"/>
+    <fontcolor bgColor="ffe9ffe6" name="CurrentExpressionLine_CBP"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_mixedBP_broken"/>
+    <fontcolor name="DisabledFieldBreakpoint"/>
+    <fontcolor bgColor="ffdcdcd8" name="loadgenProfilingPointD"/>
+    <fontcolor bgColor="ffdcdcd8" name="debugger-multi_BPCBP_broken"/>
+    <fontcolor bgColor="fffc9d9f" name="debugger-multi_BPCBP"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_BP"/>
+    <fontcolor bgColor="ffdcdcd8" name="DisabledCondBreakpoint_stroke"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint_fixable"/>
+    <fontcolor bgColor="ffdcdcd8" name="OtherThread_DBP"/>
+    <fontcolor name="FieldBreakpoint"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements-is-overridden-combined"/>
+    <fontcolor bgColor="ffb4e4fc" name="takeSnapshotProfilingPoint"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_DCBP_stroke"/>
+    <fontcolor name="DisabledClassBreakpoint"/>
+    <fontcolor bgColor="ffbde6aa" name="OtherThread_BP_broken"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-is_overridden"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-overrides"/>
+    <fontcolor bgColor="ffe9ffe6" name="CurrentExpressionLine"/>
+    <fontcolor bgColor="ffdcdcd8" name="CurrentPC2_DBP"/>
+    <fontcolor bgColor="ffdcdcd8" name="resetResultsProfilingPointD"/>
+    <fontcolor name="MethodBreakpoint_stroke"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier_fixable"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_CBP_stroke"/>
+    <fontcolor name="org-netbeans-modules-mercurial-Annotation"/>
+    <fontcolor bgColor="ffbde6aa" name="CurrentPC2LinePart"/>
+    <fontcolor bgColor="ffdcdcd8" name="takeSnapshotProfilingPointD"/>
+    <fontcolor bgColor="fffc9d9f" name="OtherThread_BP"/>
+    <fontcolor name="org-netbeans-modules-versioning-annotate-Annotation"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_CBP_broken"/>
+    <fontcolor bgColor="ffdcdcd8" name="stopwatchProfilingPointD"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint"/>
+    <fontcolor name="MethodBreakpoint"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_DBP"/>
+    <fontcolor bgColor="fffc9d9f" name="CondBreakpoint"/>
+    <fontcolor bgColor="fffc9d9f" name="CurrentPC2_BP"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-has_implementations"/>
+    <fontcolor bgColor="ffbde6aa" name="OtherThread_PC_BP"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo_fixable"/>
+    <fontcolor bgColor="ffffa0a0" name="org-netbeans-modules-xml-error"/>
+    <fontcolor name="OtherThreads"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements"/>
+    <fontcolor bgColor="ffd1ffbc" name="CurrentExpression"/>
+</fontscolors>

--- a/ide/defaults/src/org/netbeans/modules/defaults/NetBeansEarth-annotations.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/NetBeansEarth-annotations.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
+
+<fontscolors>
+    <fontcolor bgColor="ffdcdcd8" name="OtherThreads_DBP"/>
+    <fontcolor bgColor="fffc9d9f" name="Breakpoint"/>
+    <fontcolor name="FieldBreakpoint_stroke"/>
+    <fontcolor bgColor="ffdcdcd8" name="DisabledBreakpoint"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err_fixable"/>
+    <fontcolor bgColor="ffbde6aa" name="CurrentPCLinePart"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements-has-implementations-combined"/>
+    <fontcolor bgColor="ffe9ffe6" name="CurrentExpressionLine_DBP"/>
+    <fontcolor name="org-netbeans-modules-git-Annotation"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err"/>
+    <fontcolor bgColor="ffdcdcd8" name="debugger-multi_DBPCBP"/>
+    <fontcolor bgColor="ffdcdcd8" name="Breakpoint_broken"/>
+    <fontcolor name="DisabledMethodBreakpoint"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_mixedBP"/>
+    <fontcolor bgColor="ffbde6aa" name="OtherThreads_PC_BP"/>
+    <fontcolor bgColor="ffbde6aa" name="CurrentPC2"/>
+    <fontcolor bgColor="ffbde6aa" name="OtherThreads_BP_broken"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn"/>
+    <fontcolor name="ClassBreakpoint"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_BP_stroke"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo"/>
+    <fontcolor bgColor="ffdcdcd8" name="DisabledBreakpoint_stroke"/>
+    <fontcolor bgColor="ffb4e4fc" name="loadgenProfilingPoint"/>
+    <fontcolor bgColor="fffc9d9f" name="debugger-mixed_BP"/>
+    <fontcolor name="DisabledMethodBreakpoint_stroke"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_DCBP"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn_fixable"/>
+    <fontcolor bgColor="ffe7e1ef" name="CallSite"/>
+    <fontcolor bgColor="ffbde6aa" name="OtherThread_PC"/>
+    <fontcolor bgColor="ffbde6aa" name="CurrentPC"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_multi_BPCBP"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_CBP"/>
+    <fontcolor name="DisabledFieldBreakpoint_stroke"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_DBP_stroke"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_multi_DBPCBP"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-override-is-overridden-combined"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_multi_BPCBP_broken"/>
+    <fontcolor bgColor="ffdcdcd8" name="CondBreakpoint_broken"/>
+    <fontcolor bgColor="ffb4e4fc" name="resetResultsProfilingPoint"/>
+    <fontcolor bgColor="ffdcdcd8" name="Breakpoint_stroke"/>
+    <fontcolor bgColor="ffe9ffe6" name="CurrentExpressionLine_BP"/>
+    <fontcolor bgColor="ffdcdcd8" name="debugger-mixed_BP_broken"/>
+    <fontcolor bgColor="ffdcdcd8" name="CondBreakpoint_stroke"/>
+    <fontcolor name="DisabledClassBreakpoint_stroke"/>
+    <fontcolor bgColor="fffc9d9f" name="OtherThreads_BP"/>
+    <fontcolor name="org-netbeans-modules-subversion-Annotation"/>
+    <fontcolor name="OtherThread"/>
+    <fontcolor bgColor="ffe9ffe6" name="CurrentExpressionLine_DCBP"/>
+    <fontcolor name="editor-bookmark"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_BP_broken"/>
+    <fontcolor bgColor="ffdcdcd8" name="DisabledCondBreakpoint"/>
+    <fontcolor bgColor="ffb4e4fc" name="stopwatchProfilingPoint"/>
+    <fontcolor name="ClassBreakpoint_stroke"/>
+    <fontcolor bgColor="ffe9ffe6" name="CurrentExpressionLine_CBP"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_mixedBP_broken"/>
+    <fontcolor name="DisabledFieldBreakpoint"/>
+    <fontcolor bgColor="ffdcdcd8" name="loadgenProfilingPointD"/>
+    <fontcolor bgColor="ffdcdcd8" name="debugger-multi_BPCBP_broken"/>
+    <fontcolor bgColor="fffc9d9f" name="debugger-multi_BPCBP"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_BP"/>
+    <fontcolor bgColor="ffdcdcd8" name="DisabledCondBreakpoint_stroke"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint_fixable"/>
+    <fontcolor bgColor="ffdcdcd8" name="OtherThread_DBP"/>
+    <fontcolor name="FieldBreakpoint"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements-is-overridden-combined"/>
+    <fontcolor bgColor="ffb4e4fc" name="takeSnapshotProfilingPoint"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_DCBP_stroke"/>
+    <fontcolor name="DisabledClassBreakpoint"/>
+    <fontcolor bgColor="ffbde6aa" name="OtherThread_BP_broken"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-is_overridden"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-overrides"/>
+    <fontcolor bgColor="ffe9ffe6" name="CurrentExpressionLine"/>
+    <fontcolor bgColor="ffdcdcd8" name="CurrentPC2_DBP"/>
+    <fontcolor bgColor="ffdcdcd8" name="resetResultsProfilingPointD"/>
+    <fontcolor name="MethodBreakpoint_stroke"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier_fixable"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_CBP_stroke"/>
+    <fontcolor name="org-netbeans-modules-mercurial-Annotation"/>
+    <fontcolor bgColor="ffbde6aa" name="CurrentPC2LinePart"/>
+    <fontcolor bgColor="ffdcdcd8" name="takeSnapshotProfilingPointD"/>
+    <fontcolor bgColor="fffc9d9f" name="OtherThread_BP"/>
+    <fontcolor name="org-netbeans-modules-versioning-annotate-Annotation"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_CBP_broken"/>
+    <fontcolor bgColor="ffdcdcd8" name="stopwatchProfilingPointD"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint"/>
+    <fontcolor name="MethodBreakpoint"/>
+    <fontcolor bgColor="ffbde6aa" name="debugger-PC_DBP"/>
+    <fontcolor bgColor="fffc9d9f" name="CondBreakpoint"/>
+    <fontcolor bgColor="fffc9d9f" name="CurrentPC2_BP"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-has_implementations"/>
+    <fontcolor bgColor="ffbde6aa" name="OtherThread_PC_BP"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo_fixable"/>
+    <fontcolor bgColor="ffffa0a0" name="org-netbeans-modules-xml-error"/>
+    <fontcolor name="OtherThreads"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements"/>
+    <fontcolor bgColor="ffd1ffbc" name="CurrentExpression"/>
+</fontscolors>

--- a/ide/defaults/src/org/netbeans/modules/defaults/mf-layer.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/mf-layer.xml
@@ -1110,6 +1110,9 @@
                             <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
                             <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
                         </file>
+                        <file name="org-netbeans-modules-editor-annotations-colorings.xml" url="NetBeans55-annotations.xml">
+                            <attr name="nbeditor-settings-ColoringType" stringvalue="annotation"/>
+                        </file>
                     </folder>
                 </folder>
             
@@ -1123,9 +1126,11 @@
                             <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
                             <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
                         </file>
+                        <file name="org-netbeans-modules-editor-annotations-colorings.xml" url="NetBeansEarth-annotations.xml">
+                            <attr name="nbeditor-settings-ColoringType" stringvalue="annotation"/>
+                        </file>
                     </folder>
                 </folder>
-            
             
                 <folder name="CityLights">
                     <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
@@ -1136,6 +1141,9 @@
                         <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="CityLights-editor.xml">
                             <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
                             <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
+                        </file>
+                        <file name="org-netbeans-modules-editor-annotations-colorings.xml" url="CityLights-annotations.xml">
+                            <attr name="nbeditor-settings-ColoringType" stringvalue="annotation"/>
                         </file>
                     </folder>
                 </folder>

--- a/ide/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/EditorSettingsImpl.java
+++ b/ide/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/EditorSettingsImpl.java
@@ -428,10 +428,10 @@ public class EditorSettingsImpl extends EditorSettings {
             // imported from previous version some colorings can be missing.
             // See #119709
             Map<String, AttributeSet> m = new HashMap<>();
-            if (defaultProfileColorings != null) {
-                m.putAll(defaultProfileColorings);
-            }
             if (profileColorings != null) {
+                if (defaultProfileColorings != null) {
+                    m.putAll(defaultProfileColorings);
+                }
                 m.putAll(profileColorings);
             }
 
@@ -442,7 +442,7 @@ public class EditorSettingsImpl extends EditorSettings {
         }
 
         Map<String, AttributeSet> h = annotations.get(profile);
-        return h == null ? Collections.<String, AttributeSet>emptyMap() : h;
+        return h == null ? Collections.emptyMap() : h;
     }
 
     @Override
@@ -452,7 +452,7 @@ public class EditorSettingsImpl extends EditorSettings {
             return annotationsStorage.load(MimePath.EMPTY, profile, true);
         } catch (IOException ioe) {
             LOG.log(Level.WARNING, null, ioe);
-            return Collections.<String, AttributeSet>emptyMap();
+            return Collections.emptyMap();
         }
     }
 

--- a/ide/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/SettingsProvider.java
+++ b/ide/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/SettingsProvider.java
@@ -146,30 +146,24 @@ public final class SettingsProvider implements MimeDataProvider {
             synchronized (this) {
                 boolean fcsChanged = false;
                 boolean kbsChanged = false;
-
-//                if (mimePath.getPath().contains("xml")) {
-//                    System.out.println("@@@ propertyChange: mimePath = " + mimePath.getPath() + " profile = " + fcsProfile + " property = " + evt.getPropertyName() + " oldValue = " + (evt.getOldValue() instanceof MimePath ? ((MimePath) evt.getOldValue()).getPath() : evt.getOldValue()) + " newValue = " + evt.getNewValue());
-//                }
                 
                 // Determine what has changed
+                String prop = evt.getPropertyName();
                 if (this.kbsi == evt.getSource()) {
                     kbsChanged = true;
-                    
-                } else if (evt.getPropertyName() == null) {
+                } else if (prop == null) {
                     // reset all
                     if (!specialFcsProfile) {
                         String currentProfile = EditorSettings.getDefault().getCurrentFontColorProfile();
                         fcsProfile = FontColorSettingsImpl.get(mimePath).getInternalFontColorProfile(currentProfile);
                     }
                     fcsChanged = true;
-                    
-                } else if (evt.getPropertyName().equals(EditorSettingsImpl.PROP_HIGHLIGHT_COLORINGS)) {
+                } else if (prop.equals(EditorSettingsImpl.PROP_HIGHLIGHT_COLORINGS) || prop.equals(EditorSettingsImpl.PROP_ANNOTATION_COLORINGS)) {
                     String changedProfile = (String) evt.getNewValue();
                     if (changedProfile.equals(fcsProfile)) {
                         fcsChanged = true;
                     }
-                    
-                } else if (evt.getPropertyName().equals(EditorSettingsImpl.PROP_TOKEN_COLORINGS)) {
+                } else if (prop.equals(EditorSettingsImpl.PROP_TOKEN_COLORINGS)) {
                     String changedProfile = (String) evt.getNewValue();
                     if (changedProfile.equals(fcsProfile)) {
                         MimePath changedMimePath = (MimePath) evt.getOldValue();
@@ -177,8 +171,7 @@ public final class SettingsProvider implements MimeDataProvider {
                             fcsChanged = true;
                         }
                     }
-                    
-                } else if (evt.getPropertyName().equals(EditorSettingsImpl.PROP_CURRENT_FONT_COLOR_PROFILE)) {
+                } else if (prop.equals(EditorSettingsImpl.PROP_CURRENT_FONT_COLOR_PROFILE)) {
                     if (!specialFcsProfile) {
                         String newProfile = (String) evt.getNewValue();
                         fcsProfile = FontColorSettingsImpl.get(mimePath).getInternalFontColorProfile(newProfile);

--- a/ide/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/api/EditorSettings.java
+++ b/ide/editor.settings.storage/src/org/netbeans/modules/editor/settings/storage/api/EditorSettings.java
@@ -207,11 +207,11 @@ public abstract class EditorSettings {
     );
     
     /**
-     * Returns annotations properties for given profile or null, if the 
+     * Returns annotations properties for given profile or an empty Map, if the 
      * profile is not known.
      *
      * @param profile a profile name
-     * @return annotations properties for given profile or null
+     * @return annotations properties for given profile or an empty map
      */
     public abstract Map<String, AttributeSet> getAnnotations (
 	String profile
@@ -219,10 +219,10 @@ public abstract class EditorSettings {
     
     /**
      * Returns defaults for annotation properties for given profile,
-     * or null if the profile is not known.
+     * or an empty Map if the profile is not known.
      *
      * @param profile a profile name
-     * @return annotation properties for given profile or null
+     * @return annotation properties for given profile or an empty map
      */
     public abstract Map<String, AttributeSet> getAnnotationDefaults (
 	String profile

--- a/ide/options.editor/nbproject/project.properties
+++ b/ide/options.editor/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 test.unit.run.cp.extra=${java/javacore.dir}/modules/org-netbeans-modules-javacore.jar:${java/javamodel.dir}/modules/org-netbeans-jmi-javamodel.jar:${java/javamodel.dir}/modules/ext/jmi.jar

--- a/ide/options.editor/src/org/netbeans/modules/options/colors/AnnotationsPanel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/colors/AnnotationsPanel.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -38,8 +37,6 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.ListSelectionModel;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
@@ -59,12 +56,17 @@ import org.openide.util.NbBundle;
 public class AnnotationsPanel extends JPanel implements ActionListener, 
     ItemListener, FontsColorsController {
     
-    private ColorModel          colorModel;
-    private boolean		listen = false;
-    private String              currentScheme;
-    private Map<String, List<AttributeSet>> schemes = new HashMap<String, List<AttributeSet>>();
-    private Set<String> toBeSaved = new HashSet<String>();
-    private boolean             changed = false;
+    private ColorModel colorModel;
+    /// Currently displayed profile.
+    private String currentProfile;
+    /// History of all profiles and their attributes which were at some point displayed in this panel. May hold modified data.
+    /// null value indicates the profile is marked for deletion.
+    private Map<String, List<AttributeSet>> profiles;
+    /// Profile names to save.
+    private Set<String> toBeSaved;
+
+    private boolean changed;
+    private boolean listen;
     
     
     /** Creates new form AnnotationsPanel1 */
@@ -84,10 +86,9 @@ public class AnnotationsPanel extends JPanel implements ActionListener,
         lCategories.getAccessibleContext ().setAccessibleDescription (loc ("AD_Categories"));
         lCategories.setSelectionMode (ListSelectionModel.SINGLE_SELECTION);
         lCategories.setVisibleRowCount (3);
-        lCategories.addListSelectionListener (new ListSelectionListener () {
-            public void valueChanged (ListSelectionEvent e) {
-                if (!listen) return;
-                refreshUI ();
+        lCategories.addListSelectionListener(evt -> {
+            if (listen) {
+                refreshUI();
             }
         });
 	lCategories.setCellRenderer (new CategoryRenderer ());
@@ -106,6 +107,7 @@ public class AnnotationsPanel extends JPanel implements ActionListener,
         cbEffects.getAccessibleContext ().setAccessibleName (loc ("AN_Effects"));
         cbEffects.getAccessibleContext ().setAccessibleDescription (loc ("AD_Effects"));
         cbEffects.addActionListener (this);
+        clearState();
     }
     
     /** This method is called from within the constructor to
@@ -212,6 +214,7 @@ public class AnnotationsPanel extends JPanel implements ActionListener,
     // End of variables declaration//GEN-END:variables
     
  
+    @Override
     public void actionPerformed (ActionEvent evt) {
         if (!listen) return;
         if (evt.getSource () == cbEffects) {
@@ -235,75 +238,94 @@ public class AnnotationsPanel extends JPanel implements ActionListener,
         updateData ();
         fireChanged();
     }
+
+    private void clearState() {
+        toBeSaved = new HashSet<>();
+        profiles = new HashMap<>();
+        changed = false;
+        currentProfile = null;
+    }
     
-    public void update (ColorModel colorModel) {
+    @Override
+    public void update(ColorModel colorModel) {
+        clearState();
         this.colorModel = colorModel;
-        listen = false;
-        currentScheme = colorModel.getCurrentProfile ();
-        lCategories.setListData (getAnnotations (currentScheme).toArray(new AttributeSet[]{}));
-        if (lCategories.getModel ().getSize () > 0)
-            lCategories.setSelectedIndex (0);
-        refreshUI ();
-        listen = true;
+        setCurrentProfile(colorModel.getCurrentProfile());
+        toBeSaved.remove(currentProfile);
         changed = false;
     }
     
-    public void cancel () {
-        toBeSaved = new HashSet<String>();
-        schemes = new HashMap<String, List<AttributeSet>>();
-        changed = false;
+    @Override
+    public void cancel() {
+        clearState();
     }
     
+    @Override
     public void applyChanges() {
         if (colorModel == null) return;
-        for(String scheme : toBeSaved) {
+        boolean currentChanged = toBeSaved.remove(currentProfile);
+        for (String scheme : toBeSaved) {
             colorModel.setAnnotations(scheme, getAnnotations(scheme));
         }
-        toBeSaved = new HashSet<String>();
-        schemes = new HashMap<String, List<AttributeSet>>();
-        changed = false;
+        // TODO the editor sometimes refreshes to whatever is set last instead of the current profile
+        // Setting current profile last fixes it in most cases. Restart helps too.
+        if (currentChanged) {
+            colorModel.setAnnotations(currentProfile, getAnnotations(currentProfile));
+        }
+        clearState();
     }
     
+    @Override
     public boolean isChanged () {
         return changed;
     }
     
-    public void setCurrentProfile (String currentScheme) {
-        if (this.currentScheme.equals(currentScheme)) {
+    @Override
+    public void setCurrentProfile(String profile) {
+        if (profile.equals(currentProfile)) {
             return;
         }
-        String oldScheme = this.currentScheme;
-        this.currentScheme = currentScheme;
-        List<AttributeSet> v = getAnnotations(currentScheme);
-        if (v == null) {
-            // clone scheme
-            v = getAnnotations (oldScheme);
-            schemes.put (currentScheme, new ArrayList<AttributeSet>(v));
-            toBeSaved.add (currentScheme);
-            v = getAnnotations (currentScheme);
+        // copy current if profile is new
+        if (!profiles.containsKey(profile)) {
+            if (!colorModel.getProfiles().contains(profile)) {
+                profiles.put(profile, copy(getAnnotations(currentProfile)));
+            }
         }
-        toBeSaved.add(currentScheme);
-        lCategories.setListData (v.toArray(new AttributeSet[0]));
-        if (lCategories.getModel ().getSize () > 0)
-            lCategories.setSelectedIndex (0);
-        refreshUI ();
+        toBeSaved.add(profile);
+        currentProfile = profile;
+        invokeWithoutListeners(() -> {
+            int selected = Math.max(lCategories.getSelectedIndex(), 0);
+            lCategories.setListData(getAnnotations(profile).toArray(AttributeSet[]::new));
+            if (lCategories.getModel().getSize() > selected) {
+                lCategories.setSelectedIndex(selected);
+            }
+        });
+        refreshUI();
         fireChanged();
     }
     
-    public void deleteProfile (String scheme) {
-        if (colorModel.isCustomProfile (scheme)) {
-            schemes.put(scheme,null);
+    @Override
+    public void deleteProfile(String profile) {
+        if (colorModel.isCustomProfile(profile)) {
+            // mark for deletion
+            profiles.put(profile, null);
         } else {
-            schemes.put (scheme, getDefaults (scheme));
-            lCategories.setListData (getAnnotations(scheme).toArray(new AttributeSet[]{}));
-            lCategories.repaint();
-            lCategories.setSelectedIndex (0);   
-            refreshUI ();
+            // restore default profile
+            profiles.put(profile, copy(getDefaults(profile)));
+            invokeWithoutListeners(() -> {
+                int selected = Math.max(lCategories.getSelectedIndex(), 0);
+                lCategories.setListData(getAnnotations(profile).toArray(AttributeSet[]::new));
+                if (lCategories.getModel().getSize() > selected) {
+                    lCategories.setSelectedIndex(selected);
+                }
+            });
+            refreshUI();
         }
-        toBeSaved.add(scheme); // 'default' profile restored
+        toBeSaved.add(profile); // restore or delete
         fireChanged();
     }
 
+    @Override
     public JComponent getComponent() {
         return this;
     }
@@ -314,21 +336,25 @@ public class AnnotationsPanel extends JPanel implements ActionListener,
         return NbBundle.getMessage (SyntaxColoringPanel.class, key);
     }
     
-    private static void loc (Component c, String key) {
-        if (c instanceof AbstractButton)
-            Mnemonics.setLocalizedText (
-                (AbstractButton) c, 
-                loc (key)
-            );
-        else
-            Mnemonics.setLocalizedText (
-                (JLabel) c, 
-                loc (key)
-            );
+    private static void loc(Component c, String key) {
+        if (c instanceof AbstractButton button) {
+            Mnemonics.setLocalizedText(button, loc(key));
+        } else {
+            Mnemonics.setLocalizedText((JLabel) c,loc(key));
+        }
+    }
+    
+    private void invokeWithoutListeners(Runnable run) {
+        try {
+            listen = false;
+            run.run();
+        } finally {
+            listen = true;
+        }
     }
 
     private void updateData () {
-        List<AttributeSet> annotations = getAnnotations(currentScheme);
+        List<AttributeSet> annotations = getAnnotations(currentProfile);
         int index = lCategories.getSelectedIndex();
         SimpleAttributeSet c = new SimpleAttributeSet(annotations.get(index));
         
@@ -356,8 +382,7 @@ public class AnnotationsPanel extends JPanel implements ActionListener,
         }
         
         annotations.set(index, c);
-        
-        toBeSaved.add(currentScheme);
+        toBeSaved.add(currentProfile);
     }
     
     private void fireChanged() {
@@ -408,7 +433,7 @@ public class AnnotationsPanel extends JPanel implements ActionListener,
     
     private Map<String, AttributeSet> toMap(Collection<AttributeSet> categories) {
         if (categories == null) return null;
-        Map<String, AttributeSet> result = new HashMap<String, AttributeSet>();
+        Map<String, AttributeSet> result = new HashMap<>();
         for(AttributeSet as : categories) {
             result.put((String) as.getAttribute(StyleConstants.NameAttribute), as);
         }
@@ -428,76 +453,70 @@ public class AnnotationsPanel extends JPanel implements ActionListener,
         cbBackground.setEnabled (true);
         cbEffectColor.setEnabled (true);
         
-        listen = false;
-        
-        // set defaults
-        AttributeSet defAs = getDefaultColoring();
-        if (defAs != null) {
-            Color inheritedForeground = (Color) defAs.getAttribute(StyleConstants.Foreground);
-            if (inheritedForeground == null) {
-                inheritedForeground = Color.black;
-            }
-            ColorComboBoxSupport.setInheritedColor((ColorComboBox)cbForeground, inheritedForeground);
-            
-            Color inheritedBackground = (Color) defAs.getAttribute(StyleConstants.Background);
-            if (inheritedBackground == null) {
-                inheritedBackground = Color.white;
-            }
-            ColorComboBoxSupport.setInheritedColor((ColorComboBox)cbBackground, inheritedBackground);
-        }
+        invokeWithoutListeners(() -> {
+            // set defaults
+            AttributeSet defAs = getDefaultColoring(currentProfile);
+            if (defAs != null) {
+                Color inheritedForeground = (Color) defAs.getAttribute(StyleConstants.Foreground);
+                if (inheritedForeground == null) {
+                    inheritedForeground = Color.black;
+                }
+                ColorComboBoxSupport.setInheritedColor((ColorComboBox)cbForeground, inheritedForeground);
 
-        // set values
-        List<AttributeSet> annotations = getAnnotations (currentScheme);
-        AttributeSet c = annotations.get (index);
-        ColorComboBoxSupport.setSelectedColor( (ColorComboBox)cbForeground, (Color) c.getAttribute (StyleConstants.Foreground));
-        ColorComboBoxSupport.setSelectedColor( (ColorComboBox)cbBackground, (Color) c.getAttribute (StyleConstants.Background));
-        if (c.getAttribute(EditorStyleConstants.WaveUnderlineColor) != null) {
-            cbEffects.setSelectedIndex(1);
-            cbEffectColor.setEnabled(true);
-            ((ColorComboBox)cbEffectColor).setSelectedColor((Color) c.getAttribute (EditorStyleConstants.WaveUnderlineColor));
-        } else {
-            cbEffects.setSelectedIndex(0);
-            cbEffectColor.setEnabled(false);
-            cbEffectColor.setSelectedIndex(-1);
-        } 
-        listen = true;
+                Color inheritedBackground = (Color) defAs.getAttribute(StyleConstants.Background);
+                if (inheritedBackground == null) {
+                    inheritedBackground = Color.white;
+                }
+                ColorComboBoxSupport.setInheritedColor((ColorComboBox)cbBackground, inheritedBackground);
+            }
+
+            // set values
+            AttributeSet c = getAnnotations(currentProfile).get(index);
+            ColorComboBoxSupport.setSelectedColor((ColorComboBox)cbForeground, (Color)c.getAttribute(StyleConstants.Foreground));
+            ColorComboBoxSupport.setSelectedColor((ColorComboBox)cbBackground, (Color)c.getAttribute(StyleConstants.Background));
+
+            if (c.getAttribute(EditorStyleConstants.WaveUnderlineColor) != null) {
+                cbEffects.setSelectedIndex(1);
+                cbEffectColor.setEnabled(true);
+                ((ColorComboBox)cbEffectColor).setSelectedColor((Color) c.getAttribute (EditorStyleConstants.WaveUnderlineColor));
+            } else {
+                cbEffects.setSelectedIndex(0);
+                cbEffectColor.setEnabled(false);
+                cbEffectColor.setSelectedIndex(-1);
+            }
+        });
     }
     
-    private AttributeSet getDefaultColoring() {
-        Collection<AttributeSet> defaults = colorModel.getCategories(currentScheme, ColorModel.ALL_LANGUAGES);
-        
-        for(Iterator i = defaults.iterator(); i.hasNext(); ) {
-            AttributeSet as = (AttributeSet) i.next();
-            String name = (String) as.getAttribute(StyleConstants.NameAttribute);
-            if (name != null && "default".equals(name)) { //NOI18N
-                return as;
+    private AttributeSet getDefaultColoring(String profile) {
+        for (AttributeSet set : colorModel.getCategories(profile, ColorModel.ALL_LANGUAGES)) {
+            if ("default".equals(set.getAttribute(StyleConstants.NameAttribute))) { //NOI18N
+                return set.copyAttributes();
             }
         }
-        
         return null;
     }
     
-    private List<AttributeSet> getAnnotations(String scheme) {
-        if (!schemes.containsKey(scheme)) {
-            Collection<AttributeSet> c = colorModel.getAnnotations(currentScheme);
-            if (c == null) return null;
-            List<AttributeSet> l = new ArrayList<AttributeSet>(c);
-            l.sort(new CategoryComparator());
-            schemes.put(scheme, new ArrayList<AttributeSet>(l));
+    private List<AttributeSet> getAnnotations(String profile) {
+        if (!profiles.containsKey(profile)) {
+            List<AttributeSet> copy = copy(colorModel.getAnnotations(profile));
+            copy.sort(new CategoryComparator());
+            profiles.put(profile, copy);
         }
-        return schemes.get(scheme);
+        return profiles.get(profile);
     }
-    /** cache Map (String (profile name) > List (AttributeSet)). */
-    private Map<String, List<AttributeSet>> profileToDefaults = new HashMap<String, List<AttributeSet>>();
     
     private List<AttributeSet> getDefaults(String profile) {
-        if (!profileToDefaults.containsKey(profile)) {
-            Collection<AttributeSet> c = colorModel.getAnnotationsDefaults(profile);
-            List<AttributeSet> l = new ArrayList<AttributeSet>(c);
-            l.sort(new CategoryComparator());
-            profileToDefaults.put(profile, l);
-        }
-        List<AttributeSet> defaultprofile = profileToDefaults.get(profile);
-        return new ArrayList<AttributeSet>(defaultprofile);
+        List<AttributeSet> defaults = new ArrayList<>(colorModel.getAnnotationsDefaults(profile));
+        defaults.sort(new CategoryComparator());
+        return defaults;
     }
+
+    private static List<AttributeSet> copy(Collection<AttributeSet> annotations) {
+        List<AttributeSet> copy = new ArrayList<>(annotations.size());
+        for (AttributeSet set : annotations) {
+            copy.add(set.copyAttributes());
+        }
+        return copy;
+    }
+
 }

--- a/ide/options.editor/src/org/netbeans/modules/options/colors/ColorModel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/colors/ColorModel.java
@@ -114,7 +114,7 @@ public final class ColorModel {
     }
 
     private List<AttributeSet> processAnnotations(Map<String, AttributeSet> annos, boolean isdefault) {
-        List<AttributeSet> annotations = new ArrayList<AttributeSet>();
+        List<AttributeSet> annotations = new ArrayList<>();
         for(Iterator it = AnnotationTypes.getTypes().getAnnotationTypeNames(); it.hasNext(); ) {
             String name = (String) it.next ();
             
@@ -142,18 +142,23 @@ public final class ColorModel {
                 LOG.log(Level.WARNING, "AnnotationType.getGlyph() returned invalid URI", e);
             }
             
+            AttributeSet as = annos.get(name);
+            // don't set if profile value is null so that inherited values don't show up as fixed colors
             Color bgColor = annotationType.getHighlight();
-            if (annotationType.isUseHighlightColor() && bgColor != null) {
+            if (annotationType.isUseHighlightColor() && bgColor != null
+                    && (as == null || as.getAttribute(StyleConstants.Background) != null)) {
                 category.addAttribute(StyleConstants.Background, bgColor);
             }
             
             Color fgColor = annotationType.getForegroundColor();
-            if (!annotationType.isInheritForegroundColor() && fgColor != null) {
+            if (!annotationType.isInheritForegroundColor() && fgColor != null
+                    && (as == null || as.getAttribute(StyleConstants.Foreground) != null)) {
                 category.addAttribute(StyleConstants.Foreground, fgColor);
             }
 
             Color underColor = annotationType.getWaveUnderlineColor();
-            if (annotationType.isUseWaveUnderlineColor() && underColor != null) {
+            if (annotationType.isUseWaveUnderlineColor() && underColor != null
+                    && (as == null || as.getAttribute(EditorStyleConstants.WaveUnderlineColor) != null)) {
                 category.addAttribute(EditorStyleConstants.WaveUnderlineColor, underColor);
             }
             
@@ -164,9 +169,7 @@ public final class ColorModel {
                     category.removeAttribute(StyleConstants.Foreground);
                     category.removeAttribute(EditorStyleConstants.WaveUnderlineColor);
                 }
-                AttributeSet as = annos.get(name);
                 category.addAttributes(as);
-                
             }
 
             annotations.add(category);

--- a/ide/options.editor/src/org/netbeans/modules/options/colors/FontAndColorsPanel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/colors/FontAndColorsPanel.java
@@ -270,11 +270,11 @@ public class FontAndColorsPanel extends JPanel implements ActionListener {
                 loc ("CTL_Create_New_Profile_Message"),                // NOI18N
                 loc ("CTL_Create_New_Profile_Title")                   // NOI18N
             );
-            il.setInputText (currentProfile);
+            il.setInputText(currentProfile + "_copy");  // NOI18N
             DialogDisplayer.getDefault ().notify (il);
             if (il.getValue () == NotifyDescriptor.OK_OPTION) {
-                String newScheme = il.getInputText ();                
-                for (int i = 0; i < cbProfile.getItemCount(); i++)                 
+                String newScheme = il.getInputText();
+                for (int i = 0; i < cbProfile.getItemCount(); i++) {
                     if (newScheme.equals (cbProfile.getItemAt(i))) {
                         Message md = new Message (
                             loc ("CTL_Duplicate_Profile_Name"),        // NOI18N
@@ -283,15 +283,14 @@ public class FontAndColorsPanel extends JPanel implements ActionListener {
                         DialogDisplayer.getDefault ().notify (md);
                         return;
                     }
-                setCurrentProfile (newScheme);
+                }     
+                setCurrentProfile(newScheme);
                 listen = false;
-                cbProfile.addItem (il.getInputText ());
-                cbProfile.setSelectedItem (il.getInputText ());
+                cbProfile.addItem(newScheme);
+                cbProfile.setSelectedItem(newScheme);
                 listen = true;
             }
-            return;
-        }
-        if (e.getSource () == bDelete) {
+        } else if (e.getSource () == bDelete) {
             deleteCurrentProfile ();
         }
     }

--- a/ide/options.editor/src/org/netbeans/modules/options/colors/spi/FontsColorsController.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/colors/spi/FontsColorsController.java
@@ -28,7 +28,16 @@ import javax.swing.JComponent;
 public interface FontsColorsController {
 
     public void update(ColorModel model);
+
+    /**
+     * Changes the profile to the provided profile for configuration. If the
+     * profile name does not exist, the currently set profile will be copied
+     * into a new profile with the provided name.
+     *
+     * @param profile The next profile which should be configured.
+     */
     public void setCurrentProfile(String profile);
+
     public void deleteProfile(String profile);
     public void applyChanges();
     public void cancel();


### PR DESCRIPTION
Fixes several issues with the editor annotation options.

 - Make sure the current editor annotation profile is correctly copied on profile duplication.
 - Make sure annotation profile settings are correctly persisted and applied on change
 - All profiles must have annotation color configs to have inherited values work correctly (added missing)
 - EditorSettings: fix javadoc since the impl never returned null in the last 20 years.

manual test:
 - open `options -> fonts & colors -> annotations`
 - change settings, try duplicate, delete, restore etc
   - changes to copied profiles shouldn't apply to other profiles
   - UI should display the right values when profile is switched
   - persistence should work
   - editor should update to the changed settings

fixes #8143 and https://issues.apache.org/jira/browse/NETBEANS-1493