### PR TITLE
ImageUtilities code cleanup

### DIFF
--- a/platform/openide.util.ui/nbproject/project.properties
+++ b/platform/openide.util.ui/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial -Xlint:-processing
-javac.release=11
+javac.release=17
 module.jar.dir=lib
 
 


### PR DESCRIPTION
 - simplify if/else image loading cascade
 - remove redundant logger with same name
 - java 17 language level upgrade, dead code removal etc

to shrink my stash a bit :)

Originally I only intended to simplify the loading method and remove the logger - but there will be more eyes on this class due to all the usage refactoring so why not do a more complete cleanup. This might be easier to review in the IDE side-by-side view.