### PR TITLE
Account for possible Element instance changed when lazily computing d…

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionCollector.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionCollector.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -824,6 +825,7 @@ public class JavaCompletionCollector implements CompletionCollector {
             }
             labelDetail.append(") - generate");
             sortParams.append(')');
+            ElementHandle<?> parentPath = ElementHandle.create(parent);
             return CompletionCollector.newBuilder(simpleName)
                     .kind(Completion.Kind.Constructor)
                     .labelDetail(labelDetail.toString())
@@ -834,7 +836,11 @@ public class JavaCompletionCollector implements CompletionCollector {
                         wc.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
                         TreePath tp = wc.getTreeUtilities().pathFor(substitutionOffset);
                         if (TreeUtilities.CLASS_TREE_KINDS.contains(tp.getLeaf().getKind())) {
-                            if (parent == wc.getTrees().getElement(tp)) {
+                            Element currentType = wc.getTrees().getElement(tp);
+                            ElementHandle<?> currentTypePath =
+                                    currentType != null ? ElementHandle.create(currentType)
+                                                        : null;
+                            if (Objects.equals(parentPath, currentTypePath)) {
                                 ArrayList<VariableElement> fieldElements = new ArrayList<>();
                                 for (VariableElement fieldElement : fields) {
                                     if (fieldElement != null && fieldElement.getKind().isField()) {


### PR DESCRIPTION
Consider code like:
```
public class Test {
|
}
```

And try to slowly type `Tes` inside VS Code. This will open code completion, and offer to create an initialize-all constructor. But, when the completion item is confirmed, it sometimes happens the action does not do anything (except removing the typed part of the identifier).

The reason is, I think, that the completion is computed for `T`, and when typing `es`, the completion is filtered, but not recomputed. But, reparsing the source code (due to the typed characters) may change `Element` instances, and the lazy computation for `TextEdit` for inserting the constructor will try to compare original and current `Element` for equality, and that will fail.

I am not quite clear why there is the `Element` check, but it would be better to compare e.g. `ElementHandle`s, not `Element`s.