### PR TITLE
[NETBEANS-8233] When creating a doc comment tree from a full body, avoid the spliting and merging of the body, and simply use the full body, so that the code generator sees the correct, unsplit, full body.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/builder/TreeFactory.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/builder/TreeFactory.java
@@ -1811,15 +1811,17 @@ public class TreeFactory {
     }
     
     public DocCommentTree DocComment(List<? extends DocTree> fullBody, List<? extends DocTree> tags) {
-        DCDocComment temp = docMake.at(NOPOS).newDocCommentTree(fullBody, tags);
-        return DocComment(temp.getFirstSentence(), temp.getBody(), temp.getBlockTags());
+        return DocComment(HTML_JAVADOC_COMMENT, fullBody, tags);
     }
 
     public DocCommentTree MarkdownDocComment(List<? extends DocTree> fullBody, List<? extends DocTree> tags) {
-        DCDocComment temp = docMake.at(NOPOS).newDocCommentTree(fullBody, tags);
-        return MarkdownDocComment(temp.getFirstSentence(), temp.getBody(), temp.getBlockTags());
+        return DocComment(MARKDOWN_JAVADOC_COMMENT, fullBody, tags);
     }
     
+    private DocCommentTree DocComment(Comment comment, List<? extends DocTree> fullBody, List<? extends DocTree> tags) {
+        return docMake.at(NOPOS).newDocCommentTree(comment, fullBody, tags, Collections.emptyList(), Collections.emptyList());
+    }
+
     public DocTree Snippet(List<? extends DocTree> attributes, TextTree text){
         try {
             return (DocTree) docMake.getClass().getMethod("newSnippetTree", List.class, TextTree.class).invoke(docMake.at(NOPOS), attributes, text);

--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
@@ -45,6 +45,7 @@ import com.sun.tools.javac.tree.DCTree.DCInheritDoc;
 import com.sun.tools.javac.tree.DCTree.DCLink;
 import com.sun.tools.javac.tree.DCTree.DCLiteral;
 import com.sun.tools.javac.tree.DCTree.DCParam;
+import com.sun.tools.javac.tree.DCTree.DCRawText;
 import com.sun.tools.javac.tree.DCTree.DCReference;
 import com.sun.tools.javac.tree.DCTree.DCReturn;
 import com.sun.tools.javac.tree.DCTree.DCSee;
@@ -4722,6 +4723,9 @@ public class CasualDiff {
             case TEXT:
                 localpointer = diffText(doc, (DCText)oldT, (DCText)newT, elementBounds);
                 break;
+            case MARKDOWN:
+                localpointer = diffRawText(doc, (DCRawText)oldT, (DCRawText)newT, elementBounds);
+                break;
             case AUTHOR:
                 localpointer = diffAuthor(doc, (DCAuthor)oldT, (DCAuthor)newT, elementBounds);
                 break;
@@ -4944,6 +4948,15 @@ public class CasualDiff {
         return elementBounds[1];
     }
     
+    private int diffRawText(DCDocComment doc, DCTree.DCRawText oldT, DCTree.DCRawText newT, int[] elementBounds) {
+        if(oldT.code.equals(newT.code)) {
+            copyTo(elementBounds[0], elementBounds[1]);
+        } else {
+            printer.print(newT.code);
+        }
+        return elementBounds[1];
+    }
+
     private int diffAuthor(DCDocComment doc, DCAuthor oldT, DCAuthor newT, int[] elementBounds) {
         int localpointer = oldT.name.isEmpty()? elementBounds[1] : getOldPos(oldT.name.get(0), doc);
         copyTo(elementBounds[0], localpointer);


### PR DESCRIPTION
When doing the Markdown work, I (IIRC) tried to canonicalize the way doc comment trees are created. But that does not behave sanely - when full body is split into the first sentence and the rest, the text trees might change, and that may then lead to the code generator doing the wrong thing.

Trying to only create the doc comment tree from the full body, if available (it will split internally anyway, but the split trees won't be used by the code gen, I think: the code gen uses full body).

(Not sure if this should go to 26 or 25 - not sure if it can get enough testing, but then this is probably not too dangerous.)
