### PR TITLE
Add `System.Logger` to logger hints and code generation; minor new features

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/LoggerNotStaticFinal.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/LoggerNotStaticFinal.java
@@ -22,11 +22,14 @@ package org.netbeans.modules.java.hints;
 import com.sun.source.tree.ModifiersTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
+
 import java.util.EnumSet;
 import java.util.Set;
+
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
+
 import org.netbeans.api.java.source.TreePathHandle;
 import org.netbeans.api.java.source.WorkingCopy;
 import org.netbeans.spi.editor.hints.ErrorDescription;
@@ -47,7 +50,9 @@ public class LoggerNotStaticFinal {
 
     @TriggerPatterns({
         @TriggerPattern(value="$mods$ java.util.logging.Logger $LOG;"), //NOI18N
-        @TriggerPattern(value="$mods$ java.util.logging.Logger $LOG = $init;") //NOI18N
+        @TriggerPattern(value="$mods$ java.util.logging.Logger $LOG = $init;"), //NOI18N
+        @TriggerPattern(value="$mods$ java.lang.System.Logger $LOG;"), //NOI18N
+        @TriggerPattern(value="$mods$ java.lang.System.Logger $LOG = $init;") //NOI18N
     })
     public static ErrorDescription checkLoggerDeclaration(HintContext ctx) {
         Element e = ctx.getInfo().getTrees().getElement(ctx.getPath());

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/Bundle.properties
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/Bundle.properties
@@ -203,3 +203,6 @@ FIX_EnablePreviewFeature=Enable Preview Feature
 FIX_EnablePreviewFeatureSetSourceLevel=Enable Preview Feature and Set Source Level To {0}
 # {0} - source level
 FIX_EnablePreviewFeatureSetSourceLevelManual=Enable Preview Feature (Set Source Level To {0} Manually)
+SurroundWithTryCatchLog.jLabel2.text=When possible:
+SurroundWithTryCatchLog.systemLogger.text=Use java.lang.System.Logger
+SurroundWithTryCatchLog.existing.text=Use existing declared logger of specified type

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/ErrorFixesFakeHint.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/ErrorFixesFakeHint.java
@@ -21,13 +21,16 @@ package org.netbeans.modules.java.hints.errors;
 
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.TreePath;
+
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.prefs.Preferences;
+
 import javax.swing.JComponent;
+
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.modules.java.hints.providers.spi.HintMetadata;
 import org.netbeans.modules.java.hints.spi.AbstractHint;
@@ -48,7 +51,7 @@ public class ErrorFixesFakeHint extends AbstractHint {
         super(true, false, null);
         this.kind = kind;
     }
-    
+
     @Override
     public String getDescription() {
         return NbBundle.getMessage(ErrorFixesFakeHint.class, "DESC_ErrorFixesFakeHint" + kind.name());
@@ -87,6 +90,8 @@ public class ErrorFixesFakeHint extends AbstractHint {
                 setPrintStackTrace(node, isPrintStackTrace(node));
                 setUseExceptions(node, isUseExceptions(node));
                 setUseLogger(node, isUseLogger(node));
+                setUseSystemLogger(node, isUseSystemLogger(node));
+                setUseExistingLogger(node, isUseExistingLogger(node));
                 break;
             case CREATE_FINAL_FIELD_CTOR:
                 customizer = new FinalFieldsFromCtorCustomiser(node);
@@ -195,12 +200,32 @@ public class ErrorFixesFakeHint extends AbstractHint {
         p.putBoolean(SURROUND_USE_JAVA_LOGGER, v);
     }
     
+    public static boolean isUseSystemLogger(Preferences p) {
+        return p.getBoolean(SURROUND_USE_SYSTEM_LOGGER, true);
+    }
+
+    public static void setUseSystemLogger(Preferences p, boolean v)
+    {
+        p.putBoolean(SURROUND_USE_SYSTEM_LOGGER, v);
+    }
+    
+    public static boolean isUseExistingLogger(Preferences p) {
+        return p.getBoolean(SURROUND_USE_EXISTING_LOGGER, true);
+    }
+
+    public static void setUseExistingLogger(Preferences p, boolean v)
+    {
+        p.putBoolean(SURROUND_USE_EXISTING_LOGGER, v);
+    }
+    
     public static final String LOCAL_VARIABLES_INPLACE = "create-local-variables-in-place"; // NOI18N
     public static final String SURROUND_USE_EXCEPTIONS = "surround-try-catch-org-openide-util-Exceptions"; // NOI18N
     public static final String SURROUND_PRINT_STACK_TRACE = "surround-try-catch-printStackTrace"; // NOI18N
     public static final String SURROUND_RETHROW_AS_RUNTIME = "surround-try-catch-rethrow-runtime"; // NOI18N
     public static final String SURROUND_RETHROW = "surround-try-catch-rethrow"; // NOI18N
     public static final String SURROUND_USE_JAVA_LOGGER = "surround-try-catch-java-util-logging-Logger"; // NOI18N
+    public static final String SURROUND_USE_SYSTEM_LOGGER = "surround-try-catch-java-lang-System-Logger"; // NOI18N
+    public static final String SURROUND_USE_EXISTING_LOGGER = "surround-try-catch-use-existing-Logger"; // NOI18N
     public static final String FINAL_FIELDS_FROM_CTOR = "create-final-fields-from-ctor"; // NOI18N
     
     public static final String ORGANIZE_AFTER_IMPORT_CLASS = "organize-import-class"; // NOI18N

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/SurroundWithTryCatchLog.form
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/SurroundWithTryCatchLog.form
@@ -37,18 +37,21 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="1" attributes="0">
+          <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="1" attributes="0">
+              <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="jLabel1" alignment="0" min="-2" max="-2" attributes="0"/>
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace min="12" pref="12" max="12" attributes="0"/>
+                  <Component id="jLabel2" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Group type="102" attributes="0">
+                      <EmptySpace min="12" pref="12" max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="existing" min="-2" max="-2" attributes="0"/>
                           <Component id="logger" alignment="0" min="-2" max="-2" attributes="0"/>
                           <Component id="exceptions" alignment="0" min="-2" max="-2" attributes="0"/>
                           <Component id="printStackTrace" alignment="0" min="-2" max="-2" attributes="0"/>
                           <Component id="rethrowRuntime" alignment="0" min="-2" max="-2" attributes="0"/>
                           <Component id="rethrow" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Component id="systemLogger" alignment="0" min="-2" max="-2" attributes="0"/>
                       </Group>
                   </Group>
               </Group>
@@ -63,14 +66,20 @@
               <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
               <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Component id="exceptions" min="-2" max="-2" attributes="0"/>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="systemLogger" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Component id="logger" min="-2" max="-2" attributes="0"/>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Component id="printStackTrace" min="-2" max="-2" attributes="0"/>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Component id="rethrowRuntime" min="-2" max="-2" attributes="0"/>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Component id="rethrow" min="-2" max="-2" attributes="0"/>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <Component id="jLabel2" min="-2" pref="20" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="existing" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
@@ -144,6 +153,35 @@
       </Properties>
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="rethrowActionPerformed"/>
+      </Events>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="systemLogger">
+      <Properties>
+        <Property name="selected" type="boolean" value="true"/>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/java/hints/errors/Bundle.properties" key="SurroundWithTryCatchLog.systemLogger.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="systemLoggerActionPerformed"/>
+      </Events>
+    </Component>
+    <Component class="javax.swing.JLabel" name="jLabel2">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/java/hints/errors/Bundle.properties" key="SurroundWithTryCatchLog.jLabel2.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="existing">
+      <Properties>
+        <Property name="selected" type="boolean" value="true"/>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/java/hints/errors/Bundle.properties" key="SurroundWithTryCatchLog.existing.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="existingActionPerformed"/>
       </Events>
     </Component>
   </SubComponents>

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/SurroundWithTryCatchLog.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/SurroundWithTryCatchLog.java
@@ -34,10 +34,12 @@ public class SurroundWithTryCatchLog extends javax.swing.JPanel {
         initComponents();
         this.p = p;
         exceptions.setSelected(ErrorFixesFakeHint.isUseExceptions(p));
+        systemLogger.setSelected(ErrorFixesFakeHint.isUseSystemLogger(p));
         logger.setSelected(ErrorFixesFakeHint.isUseLogger(p));
         printStackTrace.setSelected(ErrorFixesFakeHint.isPrintStackTrace(p));
         rethrowRuntime.setSelected(ErrorFixesFakeHint.isRethrowAsRuntimeException(p));
         rethrow.setSelected(ErrorFixesFakeHint.isRethrow(p));
+        existing.setSelected(ErrorFixesFakeHint.isUseExistingLogger(p));
     }
 
     /** This method is called from within the constructor to
@@ -47,7 +49,8 @@ public class SurroundWithTryCatchLog extends javax.swing.JPanel {
      */
     @SuppressWarnings("unchecked")
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
-    private void initComponents() {
+    private void initComponents()
+    {
 
         jLabel1 = new javax.swing.JLabel();
         exceptions = new javax.swing.JCheckBox();
@@ -55,44 +58,79 @@ public class SurroundWithTryCatchLog extends javax.swing.JPanel {
         printStackTrace = new javax.swing.JCheckBox();
         rethrowRuntime = new javax.swing.JCheckBox();
         rethrow = new javax.swing.JCheckBox();
+        systemLogger = new javax.swing.JCheckBox();
+        jLabel2 = new javax.swing.JLabel();
+        existing = new javax.swing.JCheckBox();
 
         jLabel1.setText(org.openide.util.NbBundle.getBundle(SurroundWithTryCatchLog.class).getString("SurroundWithTryCatchLog.jLabel1.text")); // NOI18N
 
         exceptions.setSelected(true);
         org.openide.awt.Mnemonics.setLocalizedText(exceptions, org.openide.util.NbBundle.getBundle(SurroundWithTryCatchLog.class).getString("SurroundWithTryCatchLog.exceptions.text")); // NOI18N
-        exceptions.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
+        exceptions.addActionListener(new java.awt.event.ActionListener()
+        {
+            public void actionPerformed(java.awt.event.ActionEvent evt)
+            {
                 exceptionsActionPerformed(evt);
             }
         });
 
         logger.setSelected(true);
         org.openide.awt.Mnemonics.setLocalizedText(logger, org.openide.util.NbBundle.getBundle(SurroundWithTryCatchLog.class).getString("SurroundWithTryCatchLog.logger.text")); // NOI18N
-        logger.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
+        logger.addActionListener(new java.awt.event.ActionListener()
+        {
+            public void actionPerformed(java.awt.event.ActionEvent evt)
+            {
                 loggerActionPerformed(evt);
             }
         });
 
         printStackTrace.setSelected(true);
         org.openide.awt.Mnemonics.setLocalizedText(printStackTrace, org.openide.util.NbBundle.getBundle(SurroundWithTryCatchLog.class).getString("SurroundWithTryCatchLog.printStackTrace.text")); // NOI18N
-        printStackTrace.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
+        printStackTrace.addActionListener(new java.awt.event.ActionListener()
+        {
+            public void actionPerformed(java.awt.event.ActionEvent evt)
+            {
                 printStackTraceActionPerformed(evt);
             }
         });
 
         rethrowRuntime.setText(org.openide.util.NbBundle.getMessage(SurroundWithTryCatchLog.class, "SurroundWithTryCatchLog.rethrowRuntime.text")); // NOI18N
-        rethrowRuntime.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
+        rethrowRuntime.addActionListener(new java.awt.event.ActionListener()
+        {
+            public void actionPerformed(java.awt.event.ActionEvent evt)
+            {
                 rethrowRuntimeActionPerformed(evt);
             }
         });
 
         rethrow.setText(org.openide.util.NbBundle.getMessage(SurroundWithTryCatchLog.class, "SurroundWithTryCatchLog.rethrow.text")); // NOI18N
-        rethrow.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
+        rethrow.addActionListener(new java.awt.event.ActionListener()
+        {
+            public void actionPerformed(java.awt.event.ActionEvent evt)
+            {
                 rethrowActionPerformed(evt);
+            }
+        });
+
+        systemLogger.setSelected(true);
+        systemLogger.setText(org.openide.util.NbBundle.getMessage(SurroundWithTryCatchLog.class, "SurroundWithTryCatchLog.systemLogger.text")); // NOI18N
+        systemLogger.addActionListener(new java.awt.event.ActionListener()
+        {
+            public void actionPerformed(java.awt.event.ActionEvent evt)
+            {
+                systemLoggerActionPerformed(evt);
+            }
+        });
+
+        jLabel2.setText(org.openide.util.NbBundle.getMessage(SurroundWithTryCatchLog.class, "SurroundWithTryCatchLog.jLabel2.text")); // NOI18N
+
+        existing.setSelected(true);
+        existing.setText(org.openide.util.NbBundle.getMessage(SurroundWithTryCatchLog.class, "SurroundWithTryCatchLog.existing.text")); // NOI18N
+        existing.addActionListener(new java.awt.event.ActionListener()
+        {
+            public void actionPerformed(java.awt.event.ActionEvent evt)
+            {
+                existingActionPerformed(evt);
             }
         });
 
@@ -100,18 +138,21 @@ public class SurroundWithTryCatchLog extends javax.swing.JPanel {
         this.setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+            .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                    .addComponent(jLabel1, javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(jLabel1)
+                    .addComponent(jLabel2)
+                    .addGroup(layout.createSequentialGroup()
                         .addGap(12, 12, 12)
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(existing)
                             .addComponent(logger)
                             .addComponent(exceptions)
                             .addComponent(printStackTrace)
                             .addComponent(rethrowRuntime)
-                            .addComponent(rethrow))))
+                            .addComponent(rethrow)
+                            .addComponent(systemLogger))))
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         layout.setVerticalGroup(
@@ -121,14 +162,20 @@ public class SurroundWithTryCatchLog extends javax.swing.JPanel {
                 .addComponent(jLabel1)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(exceptions)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(systemLogger)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(logger)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(printStackTrace)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(rethrowRuntime)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(rethrow)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(jLabel2, javax.swing.GroupLayout.PREFERRED_SIZE, 20, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(existing)
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
@@ -153,14 +200,27 @@ private void rethrowActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST
         ErrorFixesFakeHint.setPrintStackTrace(p, printStackTrace.isSelected());
     }//GEN-LAST:event_printStackTraceActionPerformed
 
+    private void systemLoggerActionPerformed(java.awt.event.ActionEvent evt)//GEN-FIRST:event_systemLoggerActionPerformed
+    {//GEN-HEADEREND:event_systemLoggerActionPerformed
+        ErrorFixesFakeHint.setUseSystemLogger(p, systemLogger.isSelected());
+    }//GEN-LAST:event_systemLoggerActionPerformed
+
+    private void existingActionPerformed(java.awt.event.ActionEvent evt)//GEN-FIRST:event_existingActionPerformed
+    {//GEN-HEADEREND:event_existingActionPerformed
+        ErrorFixesFakeHint.setUseExistingLogger(p, existing.isSelected());
+    }//GEN-LAST:event_existingActionPerformed
+
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JCheckBox exceptions;
+    private javax.swing.JCheckBox existing;
     private javax.swing.JLabel jLabel1;
+    private javax.swing.JLabel jLabel2;
     private javax.swing.JCheckBox logger;
     private javax.swing.JCheckBox printStackTrace;
     private javax.swing.JCheckBox rethrow;
     private javax.swing.JCheckBox rethrowRuntime;
+    private javax.swing.JCheckBox systemLogger;
     // End of variables declaration//GEN-END:variables
 
 }

--- a/java/java.hints/src/org/netbeans/modules/java/hints/jackpot/hintsimpl/Bundle.properties
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jackpot/hintsimpl/Bundle.properties
@@ -21,5 +21,3 @@ OpenIDE-Module-Name=Hints Impl
 DN_org.netbeans.modules.java.hints.jackpot.hintsimpl.LoggerStringConcat=String concatenation in logger
 DESC_org.netbeans.modules.java.hints.jackpot.hintsimpl.LoggerStringConcat=It is not performance efficient to concatenate strings in logger messages. \
 It is better to use a template message with placeholders that are replaced by concrete values only when the message is really going to be logged.
-MSG_LoggerStringConcat=Inefficient use of string concatenation in logger
-MSG_LoggerStringConcat_fix=Convert string concatenation to a message template

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LoggerGenerator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LoggerGenerator.java
@@ -21,9 +21,11 @@ package org.netbeans.modules.java.lsp.server.protocol;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
+
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -33,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
+
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
@@ -40,6 +43,7 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
+
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionParams;
@@ -129,7 +133,7 @@ public final class LoggerGenerator extends CodeActionsProvider {
         try {
             String uri = data.getAsJsonPrimitive(URI).getAsString();
             int offset = data.getAsJsonPrimitive(OFFSET).getAsInt();
-            client.showInputBox(new ShowInputBoxParams(Bundle.DN_GenerateLogger(), Bundle.DN_SelectLoggerName(), "LOG", false)).thenAccept(value -> {
+            client.showInputBox(new ShowInputBoxParams(Bundle.DN_GenerateLogger(), Bundle.DN_SelectLoggerName(), org.netbeans.modules.java.editor.codegen.LoggerGenerator.getBaseLoggerName(), false)).thenAccept(value -> {
                 try {
                     if (value != null && BaseUtilities.isJavaIdentifier(value)) {
                         FileObject file = Utils.fromUri(uri);
@@ -143,7 +147,7 @@ public final class LoggerGenerator extends CodeActionsProvider {
                             tp = wc.getTreeUtilities().getPathElementOfKind(TreeUtilities.CLASS_TREE_KINDS, tp);
                             if (tp != null) {
                                 ClassTree cls = (ClassTree) tp.getLeaf();
-                                VariableTree field = org.netbeans.modules.java.editor.codegen.LoggerGenerator.createLoggerField(wc.getTreeMaker(), cls, value, EnumSet.of(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL));
+                                VariableTree field = org.netbeans.modules.java.editor.codegen.LoggerGenerator.createLoggerField(wc.getTreeMaker(), cls, value, EnumSet.of(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL), wc);
                                 wc.rewrite(cls, GeneratorUtilities.get(wc).insertClassMember(cls, field));
                             }
                         });


### PR DESCRIPTION
This default is also used by `Generate > Logger...`. Addresses some issues in raised in #8240.
New feature `Use existing declared Logger`. Fix `Logging` hints to handle `System.Logger`.
Add "Put string concatenation in lambda" hint fix. Adjust tests; new tests.

![trycatch](https://github.com/user-attachments/assets/c553acbe-a942-4aa4-b291-1b7393cf5720)
