### PR TITLE
If a ClassIndex ignores a root due to missing index, make sure the ClassIndex is rebuilt when the index is created.

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/ClassIndex.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ClassIndex.java
@@ -830,6 +830,8 @@ public final class ClassIndex {
                 if (ci != null) {
                     ci.addClassIndexImplListener(spiListener);
                     queries.add (ci);
+                } else {
+                    spiListener.attachClassIndexManagerListener();
                 }
             }
 	}

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/ClassIndexTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/ClassIndexTest.java
@@ -31,6 +31,8 @@ import java.util.concurrent.TimeUnit;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import javax.swing.event.ChangeListener;
+import javax.tools.JavaFileObject;
+import javax.tools.ToolProvider;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.classpath.GlobalPathRegistry;
 import org.netbeans.api.java.platform.JavaPlatformManager;
@@ -92,6 +94,7 @@ public class ClassIndexTest extends NbTestCase {
         suite.addTest(new ClassIndexTest("testPackageUsages"));    //NOI18N
         suite.addTest(new ClassIndexTest("testNullRootPassedToClassIndexEvent"));    //NOI18N
         suite.addTest(new ClassIndexTest("testFindSymbols"));    //NOI18N
+        suite.addTest(new ClassIndexTest("testQueryIndexRefreshQueryAgain"));    //NOI18N
         return suite;
     }
 
@@ -576,6 +579,55 @@ public class ClassIndexTest extends NbTestCase {
         assertEquals(new HashSet<String>(Arrays.asList("test.foo:[foo]", "test.Test:[foo]")), actualResult);
     }
     
+    public void testQueryIndexRefreshQueryAgain() throws Exception {
+        final FileObject wd = FileUtil.toFileObject(getWorkDir());
+        final FileObject root = FileUtil.createFolder(wd,"src");    //NOI18N
+        final FileObject classes = FileUtil.createFolder(wd,"classes");    //NOI18N
+        sourcePath = ClassPathSupport.createClassPath(root);
+        final FileObject t1 = createJavaFile(
+                root,
+                "org.me.test",                                          //NOI18N
+                "T1",                                                   //NOI18N
+                "package org.me.test;\n"+                               //NOI18N
+                "public class T1 extends java.util.ArrayList {}");      //NOI18N
+        //compile binary dependency:
+        JavaFileObject libraryJFO =
+                FileObjects.memoryFileObject("lib",
+                                             "TestLib.java",
+                                             """
+                                             package lib;
+                                             public class TestLib {}
+                                             """);
+        ToolProvider.getSystemJavaCompiler()
+                    .getTask(null,
+                             null,
+                             null,
+                             List.of("-d",
+                                     FileUtil.toFile(classes).getAbsolutePath()),
+                             null,
+                             List.of(libraryJFO))
+                    .call();
+
+        compilePath = ClassPathSupport.createClassPath(classes);
+        bootPath = JavaPlatformManager.getDefault().getDefaultPlatform().getBootstrapLibraries();
+
+        final ClassIndex ci = ClasspathInfo.create(bootPath, compilePath, sourcePath).getClassIndex();
+        Set<ElementHandle<TypeElement>> result;
+        result = ci.getDeclaredTypes("TestLib", NameKind.PREFIX, Set.of(ClassIndex.SearchScope.DEPENDENCIES));
+        assertElementHandles(new String[] {}, result);
+
+        GlobalPathRegistry.getDefault().register(ClassPath.BOOT, new ClassPath[] {bootPath});
+        GlobalPathRegistry.getDefault().register(ClassPath.COMPILE, new ClassPath[] {compilePath});
+        GlobalPathRegistry.getDefault().register(ClassPath.SOURCE, new ClassPath[] {sourcePath});
+
+        IndexingManager.getDefault().refreshAllIndices(true, true, root);
+        SourceUtils.waitScanFinished();
+
+        result = ci.getDeclaredTypes("TestLib", NameKind.PREFIX, Set.of(ClassIndex.SearchScope.DEPENDENCIES));
+        assertNotNull(result);
+        assertElementHandles(new String[] {"lib.TestLib"}, result);
+    }
+
     private FileObject createJavaFile (
             final FileObject root,
             final String pkg,


### PR DESCRIPTION
While looking into:
https://github.com/oracle/javavscode/issues/375

it turned out there's this problem with `ClassIndex`: when the `ClassIndex` is created for a `ClasspathInfo`, it sets up delegate queries, one per (translated) root included in the `ClasspathInfo`. If a delegate query does not exist for a given root, it is ignored. The delegate may not exist if the root has not been indexed yet. The problem is, this given instance of `ClassIndex` is not refreshed when the root is indexed, and the delegate exists. Which may mean the index won't reply with answers for the root, basically forever.

I think this does not manifest much in the NetBeans IDE, as:
a) the `ClassIndex` is usually not queried before indexing is finished
b) the `ClasspathInfo`s are thrown away relatively commonly.

Inside the VS Code extension(s), the index query may happen much sooner, and the `ClasspathInfo` is apparently not throw away so easily. We could workaround by refreshing the `ClasspathInfo`s at the end of an indexing, or something like that, but it feels like a hack to me.

The proposal here is to add a listener to `ClassIndexManager` when a delegate does not exist for a root, and the existing code should then ensure the `ClassIndex` is refreshed when indexing finishes.

The listener is weak, and I did some experiments, and it seems it is being freed reasonably.
