### PR TITLE
Remove maven 2 output parsing, cleanup and some parsing fixes

### DIFF
--- a/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/optional/ErrorLineConvertor.java
+++ b/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/optional/ErrorLineConvertor.java
@@ -180,6 +180,7 @@ public class ErrorLineConvertor implements LineConvertor {
             path = filePath;
         }
 
+        @Override
         public void outputLineAction(OutputEvent ev) {
             FileObject sourceFile = GlobalPathRegistry.getDefault().findResource(
                     path);
@@ -211,12 +212,6 @@ public class ErrorLineConvertor implements LineConvertor {
                 }
                 errorLine.show(ShowOpenType.OPEN, ShowVisibilityType.NONE);
             }
-        }
-        
-        public void outputLineCleared(OutputEvent ev) {
-        }
-        
-        public void outputLineSelected(OutputEvent ev) {           
         }
         
     }

--- a/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/LogHyperLinkSupport.java
+++ b/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/LogHyperLinkSupport.java
@@ -257,9 +257,6 @@ public class LogHyperLinkSupport {
             }
         }
 
-        @Override
-        public void outputLineSelected(OutputEvent ev) {
-        }
     }
 
     /**

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/LogHyperLinkSupport.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/LogHyperLinkSupport.java
@@ -257,9 +257,6 @@ public class LogHyperLinkSupport {
             }
         }
 
-        @Override
-        public void outputLineSelected(OutputEvent ev) {
-        }
     }
 
     /**

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/LogSupport.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/LogSupport.java
@@ -254,9 +254,6 @@ public class LogSupport {
                 links.clear();
             }
         }
-        
-        @Override
-        public void outputLineSelected(OutputEvent ev) {           
-        }
+
     }    
 }

--- a/ide/db.core/src/org/netbeans/modules/db/sql/loader/SQLExecutionLoggerImpl.java
+++ b/ide/db.core/src/org/netbeans/modules/db/sql/loader/SQLExecutionLoggerImpl.java
@@ -261,10 +261,6 @@ public class SQLExecutionLoggerImpl implements SQLExecutionLogger {
         }
 
         @Override
-        public void outputLineCleared(OutputEvent ev) {
-        }
-
-        @Override
         public void outputLineAction(OutputEvent ev) {
             goToLine(true);
         }

--- a/ide/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/TerminalSupportImpl.java
+++ b/ide/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/TerminalSupportImpl.java
@@ -143,7 +143,7 @@ public final class TerminalSupportImpl {
                 @SuppressWarnings("PackageVisibleField")
                 RequestProcessor.Task task = RP.create(delegate);
 
-                private final HyperlinkAdapter retryLink = new HyperlinkAdapter() {
+                private final OutputListener retryLink = new OutputListener() {
                     @Override
                     public void outputLineAction(OutputEvent ev) {
                         task.schedule(0);
@@ -411,21 +411,6 @@ public final class TerminalSupportImpl {
                     }
                 }
             }
-        }
-    }
-    
-    private static class HyperlinkAdapter implements OutputListener{
-
-        @Override
-        public void outputLineSelected(OutputEvent ev) {
-        }
-
-        @Override
-        public void outputLineAction(OutputEvent ev) {
-        }
-
-        @Override
-        public void outputLineCleared(OutputEvent ev) {
         }
     }
 

--- a/ide/extexecution/src/org/netbeans/modules/extexecution/print/FileListener.java
+++ b/ide/extexecution/src/org/netbeans/modules/extexecution/print/FileListener.java
@@ -18,11 +18,7 @@
  */
 package org.netbeans.modules.extexecution.print;
 
-import java.awt.Desktop;
 import java.io.File;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.extexecution.print.LineConvertors.FileLocator;
 import org.netbeans.spi.extexecution.open.FileOpenHandler;
@@ -65,10 +61,7 @@ public class FileListener implements OutputListener {
         this.handler = handler;
     }
 
-    public void outputLineSelected(OutputEvent ev) {
-
-    }
-
+    @Override
     public void outputLineAction(OutputEvent ev) {
         // Find file such and such and warp to it
         FileObject fo = findFile(file);
@@ -76,9 +69,6 @@ public class FileListener implements OutputListener {
         if (fo != null) {
             handler.open(fo, lineno);
         }
-    }
-
-    public void outputLineCleared(OutputEvent ev) {
     }
 
     private FileObject findFile(final String path) {

--- a/ide/extexecution/src/org/netbeans/modules/extexecution/print/UrlListener.java
+++ b/ide/extexecution/src/org/netbeans/modules/extexecution/print/UrlListener.java
@@ -38,16 +38,9 @@ public class UrlListener implements OutputListener {
         this.handler = handler;
     }
 
+    @Override
     public void outputLineAction(OutputEvent ev) {
         handler.open(url);
-    }
-
-    public void outputLineCleared(OutputEvent ev) {
-        // noop
-    }
-
-    public void outputLineSelected(OutputEvent ev) {
-        // noop
     }
 
 }

--- a/ide/git/src/org/netbeans/modules/git/utils/LogUtils.java
+++ b/ide/git/src/org/netbeans/modules/git/utils/LogUtils.java
@@ -53,7 +53,7 @@ public class LogUtils {
             String line = Bundle.MSG_LogUtils_updateBranch_actions("{0}", "{1}");
             int historyPos = line.indexOf("{0}");
             int diffPos = line.indexOf("{1}");
-            List<String> segments = new ArrayList<String>();
+            List<String> segments = new ArrayList<>();
             OutputListener list1, list2;
             if (historyPos < diffPos) {
                 segments.add(line.substring(0, historyPos));
@@ -91,20 +91,12 @@ public class LogUtils {
             this.from = from.length() > 7 ? from.substring(0, 7) : from;
             this.to = to.length() > 7 ? to.substring(0, 7) : to;
         }
-        
-        @Override
-        public void outputLineSelected (OutputEvent ev) {
-        }
 
         @Override
         public void outputLineAction (OutputEvent ev) {
             SearchHistoryAction.openSearch(repository, repository, repository.getName(), from, to);
         }
 
-        @Override
-        public void outputLineCleared (OutputEvent ev) {
-        }
-        
     }
     
     @NbBundle.Messages({
@@ -125,20 +117,12 @@ public class LogUtils {
             this.from = from.length() > 7 ? from.substring(0, 7) : from;
             this.to = to.length() > 7 ? to.substring(0, 7) : to;
         }
-        
-        @Override
-        public void outputLineSelected (OutputEvent ev) {
-        }
 
         @Override
         public void outputLineAction (OutputEvent ev) {
             SystemAction.get(DiffAction.class).diff(GitUtils.getContextForFile(repository),
                     new Revision(from, Bundle.MSG_LogUtils_updateBranch_actions_diff_previous(branchName, from)),
                     new Revision(to, Bundle.MSG_LogUtils_updateBranch_actions_diff_previous(branchName, to)));
-        }
-
-        @Override
-        public void outputLineCleared (OutputEvent ev) {
         }
         
     }

--- a/ide/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/PlainLogger.java
+++ b/ide/hudson.ui/src/org/netbeans/modules/hudson/ui/impl/PlainLogger.java
@@ -201,12 +201,6 @@ public class PlainLogger implements HudsonLogger {
             URLDisplayer.getDefault().showURL(u);
         }
 
-        @Override
-        public void outputLineSelected(OutputEvent ev) {}
-
-        @Override
-        public void outputLineCleared(OutputEvent ev) {}
-
         public @Override String toString() {
             return u.toString();
         }

--- a/ide/subversion/src/org/netbeans/modules/subversion/OutputLogger.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/OutputLogger.java
@@ -300,16 +300,10 @@ public class OutputLogger implements ISVNNotifyListener {
         }
 
         @Override
-        public void outputLineSelected(OutputEvent ev) { }
-
-        @Override
         public void outputLineAction(OutputEvent ev) {
             Subversion.LOG.log(Level.FINE, "Opeining file [{0}]", f);           // NOI18N
             new OpenInEditorAction(new File[] {f}).actionPerformed(new ActionEvent(this, ActionEvent.ACTION_PERFORMED, f.getAbsolutePath()));
         }
-
-        @Override
-        public void outputLineCleared(OutputEvent ev) { }
 
     }
 

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/IOManager.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/IOManager.java
@@ -136,9 +136,7 @@ public class IOManager {
     // innerclasses ............................................................
     
     private class Listener implements OutputListener {
-        @Override
-        public void outputLineSelected (OutputEvent ev) {
-        }
+
         @Override
         public void outputLineAction (final OutputEvent ev) {
             SwingUtilities.invokeLater (new Runnable () {

--- a/java/maven/src/org/netbeans/modules/maven/execute/AbstractOutputHandler.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/AbstractOutputHandler.java
@@ -19,12 +19,10 @@
 
 package org.netbeans.modules.maven.execute;
 
-import java.awt.Color;
+import com.google.common.base.Predicates;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -36,10 +34,8 @@ import org.netbeans.modules.maven.api.output.OutputProcessor;
 import org.netbeans.modules.maven.api.output.OutputProcessorFactory;
 import org.netbeans.modules.maven.api.output.OutputVisitor;
 import org.netbeans.api.project.Project;
-import org.netbeans.modules.maven.ActionProviderImpl;
 import org.netbeans.modules.maven.api.execute.RunUtils;
 import org.netbeans.modules.project.indexingbridge.IndexingBridge;
-import org.netbeans.spi.project.ActionProvider;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.RequestProcessor;
@@ -48,6 +44,8 @@ import org.openide.windows.IOColorPrint;
 import org.openide.windows.IOColors;
 import org.openide.windows.InputOutput;
 import org.openide.windows.OutputWriter;
+
+import static org.netbeans.modules.maven.ActionProviderImpl.*;
 
 /**
  *
@@ -71,16 +69,14 @@ public abstract class AbstractOutputHandler {
     private static final int SLEEP_DELAY = Integer.getInteger(AbstractOutputHandler.class.getName() + ".SLEEP_DELAY", 15000); // #270005
 
     protected AbstractOutputHandler(Project proj, final ProgressHandle hand, RunConfig config, OutputVisitor visitor) {
-        processors = new HashMap<String, Set<OutputProcessor>>();
+        processors = new HashMap<>();
         id2count = new HashMap<>();
-        currentProcessors = new HashSet<OutputProcessor>();
+        currentProcessors = new HashSet<>();
         this.visitor = visitor;
-        toFinishProcessors = new HashSet<NotifyFinishOutputProcessor>();
-        sleepTask = new RequestProcessor(AbstractOutputHandler.class).create(new Runnable() {
-            public @Override void run() {
-                hand.suspend("");
-                exitProtectedMode();
-            }
+        toFinishProcessors = new HashSet<>();
+        sleepTask = new RequestProcessor(AbstractOutputHandler.class).create(() -> {
+            hand.suspend("");
+            exitProtectedMode();
         });
         enterProtectedMode(isProtectedWait(proj, config));
     }
@@ -106,17 +102,15 @@ public abstract class AbstractOutputHandler {
         if(action == null || proj == null || !RunUtils.isCompileOnSaveEnabled(proj)) {
             return false;
         }
-        switch(action) {
-            case ActionProvider.COMMAND_RUN: 
-            case ActionProvider.COMMAND_RUN_SINGLE:
-            case ActionProvider.COMMAND_DEBUG:
-            case ActionProvider.COMMAND_DEBUG_SINGLE:
-            case ActionProviderImpl.COMMAND_DEBUG_MAIN:
-            case ActionProviderImpl.COMMAND_RUN_MAIN:
-                return true;
-            default:
-                return false;
-        }
+        return switch (action) {
+            case COMMAND_RUN,
+                COMMAND_RUN_SINGLE,
+                COMMAND_DEBUG,
+                COMMAND_DEBUG_SINGLE,
+                COMMAND_DEBUG_MAIN,
+                COMMAND_RUN_MAIN -> true;
+            default -> false;
+        };
     }
     
     protected abstract InputOutput getIO();
@@ -152,28 +146,18 @@ public abstract class AbstractOutputHandler {
     protected final void initProcessorList(Project proj, RunConfig config) {
         // get the registered processors.
         Lookup.Result<OutputProcessorFactory> result  = Lookup.getDefault().lookupResult(OutputProcessorFactory.class);
-        Iterator<? extends OutputProcessorFactory> it = result.allInstances().iterator();
-        while (it.hasNext()) {
-            OutputProcessorFactory factory = it.next();
-            Set<? extends OutputProcessor> procs = factory.createProcessorsSet(proj);
-            if (factory instanceof ContextOutputProcessorFactory) {
-                Set<OutputProcessor> _procs = new HashSet<OutputProcessor>(procs);
-                _procs.addAll(((ContextOutputProcessorFactory)factory).createProcessorsSet(proj, config));
-                procs = _procs;
+        result.allInstances().forEach(factory -> {
+            Set<OutputProcessor> procs = new HashSet<>(factory.createProcessorsSet(proj));
+            if (factory instanceof ContextOutputProcessorFactory cof) {
+                procs.addAll(cof.createProcessorsSet(proj, config));
             }
             for (OutputProcessor proc : procs) {
-                String[] regs = proc.getRegisteredOutputSequences();
-                for (int i = 0; i < regs.length; i++) {
-                    String str = regs[i];
-                    Set<OutputProcessor> set = processors.get(str);
-                    if (set == null) {
-                        set = new HashSet<OutputProcessor>();
-                        processors.put(str, set);
-                    }
-                    set.add(proc);
+                for (String reg : proc.getRegisteredOutputSequences()) {
+                    processors.computeIfAbsent(reg, k -> new HashSet<>())
+                              .add(proc);
                 }
             }
-        }
+        });
     }
     
     protected final void processStart(String id, OutputWriter writer) {
@@ -213,12 +197,10 @@ public abstract class AbstractOutputHandler {
     protected final void processEnd(String id, OutputWriter writer) {
         checkSleepiness();
         visitor.resetVisitor();
-        Iterator<OutputProcessor> it = currentProcessors.iterator();
-        while (it.hasNext()) {
-            OutputProcessor proc = it.next();
+        for (OutputProcessor proc : currentProcessors) {
             proc.sequenceEnd(id, visitor);
-            if (proc instanceof NotifyFinishOutputProcessor) {
-                toFinishProcessors.add((NotifyFinishOutputProcessor)proc);
+            if (proc instanceof NotifyFinishOutputProcessor nfop) {
+                toFinishProcessors.add(nfop);
             }
         }
         if (visitor.getLine() != null) {
@@ -234,7 +216,7 @@ public abstract class AbstractOutputHandler {
         }
         AtomicInteger count = id2count.getOrDefault(id, new AtomicInteger(1));
         if (count.decrementAndGet() == 0) {
-            Set set = processors.get(id);
+            Set<OutputProcessor> set = processors.get(id);
             if (set != null) {
                 //TODO a bulletproof way would be to keep a list of currently started
                 // sections and compare to the list of getRegisteredOutputSequences fo each of the
@@ -249,8 +231,8 @@ public abstract class AbstractOutputHandler {
         checkSleepiness();
         visitor.resetVisitor();
         for (OutputProcessor proc : currentProcessors) {
-            if (proc instanceof NotifyFinishOutputProcessor) {
-                toFinishProcessors.add((NotifyFinishOutputProcessor)proc);
+            if (proc instanceof NotifyFinishOutputProcessor nfop) {
+                toFinishProcessors.add(nfop);
             }
             proc.sequenceFail(id, visitor);
         }
@@ -267,11 +249,9 @@ public abstract class AbstractOutputHandler {
         }
         Set<OutputProcessor> set = processors.get(id);
         if (set != null) {
-            Set<OutputProcessor> retain = new HashSet<OutputProcessor>();
-            retain.addAll(set);
+            Set<OutputProcessor> retain = new HashSet<>(set);
             retain.retainAll(currentProcessors);
-            Set<OutputProcessor> remove = new HashSet<OutputProcessor>();
-            remove.addAll(set);
+            Set<OutputProcessor> remove = new HashSet<>(set);
             remove.removeAll(retain);
             currentProcessors.removeAll(remove);
         }
@@ -306,16 +286,9 @@ public abstract class AbstractOutputHandler {
             String line = visitor.getLine() == null ? input : visitor.getLine();
             if (visitor.getColor(getIO()) == null && visitor.getOutputListener() == null) {
                 switch (level) {
-                case DEBUG:
-                    visitor.setOutputType(IOColors.OutputType.LOG_DEBUG);
-                    break;
-                case WARNING:
-                    visitor.setOutputType(IOColors.OutputType.LOG_WARNING);
-                    break;
-                case ERROR:
-                case FATAL:
-                    visitor.setOutputType(IOColors.OutputType.LOG_FAILURE);
-                    break;
+                    case DEBUG -> visitor.setOutputType(IOColors.OutputType.LOG_DEBUG);
+                    case WARNING -> visitor.setOutputType(IOColors.OutputType.LOG_WARNING);
+                    case ERROR, FATAL -> visitor.setOutputType(IOColors.OutputType.LOG_FAILURE);
                 }
             }
             try {
@@ -343,13 +316,8 @@ public abstract class AbstractOutputHandler {
     
     //MEVENIDE-637   
     public static List<String> splitMultiLine(String input) {
-        List<String> list = new ArrayList<String>();
-        String[] strs = input.split("\\r|\\n"); //NOI18N
-        for (int i = 0; i < strs.length; i++) {
-            if(strs[i].length()>0){
-              list.add(strs[i]);
-            }
-        }
-        return list;
+        return input.lines()
+                    .filter(Predicates.not(String::isEmpty))
+                    .toList();
     }   
 }

--- a/java/maven/src/org/netbeans/modules/maven/output/DefaultOutputProcessorFactory.java
+++ b/java/maven/src/org/netbeans/modules/maven/output/DefaultOutputProcessorFactory.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.maven.output;
 
-import java.util.HashSet;
 import java.util.Set;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.maven.NbMavenProjectImpl;
@@ -32,24 +31,28 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=OutputProcessorFactory.class)
 public class DefaultOutputProcessorFactory implements ContextOutputProcessorFactory {
     
-    @Override public Set<OutputProcessor> createProcessorsSet(Project project) {
-        Set<OutputProcessor> toReturn = new HashSet<>();
+    @Override
+    public Set<OutputProcessor> createProcessorsSet(Project project) {
         if (project != null) {
-            toReturn.add(new JavadocOutputProcessor());
-            toReturn.add(new TestOutputListenerProvider());
-            toReturn.add(new SiteOutputProcessor(project));
             NbMavenProjectImpl nbprj = project.getLookup().lookup(NbMavenProjectImpl.class);
-            toReturn.add(new JavaStacktraceOutputProcessor(nbprj));
-            toReturn.add(new DependencyAnalyzeOutputProcessor(nbprj));
+            return Set.of(
+//                new JavadocOutputProcessor(),  // TODO update processor
+                new TestOutputListenerProvider(),
+                new SiteOutputProcessor(project),
+                new JavaStacktraceOutputProcessor(nbprj),
+                new DependencyAnalyzeOutputProcessor(nbprj)
+            );
+        } else {
+            return Set.of();
         }
-        return toReturn;
     }
 
-    @Override public Set<? extends OutputProcessor> createProcessorsSet(Project project, RunConfig config) {
-        Set<OutputProcessor> toReturn = new HashSet<>(); 
-        toReturn.add(new JavaOutputListenerProvider(config));
-        toReturn.add(new GlobalOutputProcessor(config));
-        return toReturn;
+    @Override
+    public Set<? extends OutputProcessor> createProcessorsSet(Project project, RunConfig config) {
+        return Set.of(
+            new JavaOutputListenerProvider(config), 
+            new GlobalOutputProcessor(config)
+        );
     }
     
 }

--- a/java/maven/src/org/netbeans/modules/maven/output/DependencyAnalyzeOutputProcessor.java
+++ b/java/maven/src/org/netbeans/modules/maven/output/DependencyAnalyzeOutputProcessor.java
@@ -117,9 +117,6 @@ public class DependencyAnalyzeOutputProcessor implements OutputProcessor {
             scope = sc;
             project = prj;
         }
-        @Override
-        public void outputLineSelected(OutputEvent arg0) {
-        }
         
         @Messages({"# {0} - groupId:artifactId", "MSG_Dependency=Dependency {0} added to project''s POM."})
         @Override
@@ -128,10 +125,6 @@ public class DependencyAnalyzeOutputProcessor implements OutputProcessor {
                     group, artifact, version, type, scope, null,false);
             NotifyDescriptor nd = new NotifyDescriptor.Message(MSG_Dependency(group + ":" + artifact));
             DialogDisplayer.getDefault().notify(nd);
-        }
-        
-        @Override
-        public void outputLineCleared(OutputEvent arg0) {
         }
     }
 }

--- a/java/maven/src/org/netbeans/modules/maven/output/ExecPluginOutputListenerProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/output/ExecPluginOutputListenerProvider.java
@@ -27,7 +27,7 @@ import org.netbeans.modules.maven.NbMavenProjectImpl;
  * 
  * @deprecated use JavaStacktraceOutputListenerProvider instead
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class ExecPluginOutputListenerProvider extends JavaStacktraceOutputProcessor {
 
     private static final String[] EXECGOALS = new String[] {

--- a/java/maven/src/org/netbeans/modules/maven/output/JavaOutputListenerProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/output/JavaOutputListenerProvider.java
@@ -122,11 +122,10 @@ public class JavaOutputListenerProvider implements OutputProcessor {
                     }
                 }
                 line = line.replace(clazz, newclazz); //NOI18N
-                boolean isImportant = text.indexOf("[deprecation]") < 0; // NOI18N
+                boolean isImportant = !text.contains("[deprecation]"); // NOI18N
                 if(COMPILER_PROBLEM.matcher(line).matches() && !isJDK9CompilerVersion()) {
                     visitor.setLine(line + "\n" + TXT_ModulesNotSupported());
                     visitor.setOutputListener(new OutputListener() {
-                        @Override public void outputLineSelected(OutputEvent ev) {}
                         @Override public void outputLineAction(OutputEvent ev) {
                             FileObject pomFO = FileUtil.toFileObject(config.getMavenProject().getFile());                                                                
                             ModelSource modelSource = Utilities.createModelSource(pomFO);                                    
@@ -159,7 +158,6 @@ public class JavaOutputListenerProvider implements OutputProcessor {
                                 Logger.getLogger(JavaOutputListenerProvider.class.getName()).log(Level.INFO, null, x);
                             }
                         }
-                        @Override public void outputLineCleared(OutputEvent ev) {}
                     }
                     , false );
                 } else {

--- a/java/maven/src/org/netbeans/modules/maven/output/JavadocOutputProcessor.java
+++ b/java/maven/src/org/netbeans/modules/maven/output/JavadocOutputProcessor.java
@@ -80,17 +80,13 @@ public class JavadocOutputProcessor implements OutputProcessor {
     }
     
     private static class Listener implements OutputListener {
-        private String root;
+        private final String root;
         private Listener(String path) {
             root = path;
         }
-        @Override
-        public void outputLineSelected(OutputEvent arg0) {
-            
-        }
         
-       @Override
-       public void outputLineAction(OutputEvent arg0) {
+        @Override
+        public void outputLineAction(OutputEvent arg0) {
             File javadoc = FileUtil.normalizeFile(new File(root));
             FileUtil.refreshFor(javadoc);
             FileObject fo = FileUtil.toFileObject(javadoc);
@@ -101,10 +97,6 @@ public class JavadocOutputProcessor implements OutputProcessor {
                     HtmlBrowser.URLDisplayer.getDefault().showURL(link);
                 }
             }
-        }
-        
-        @Override
-        public void outputLineCleared(OutputEvent arg0) {
         }
     }
 }

--- a/java/maven/src/org/netbeans/modules/maven/output/SiteOutputProcessor.java
+++ b/java/maven/src/org/netbeans/modules/maven/output/SiteOutputProcessor.java
@@ -87,10 +87,6 @@ public class SiteOutputProcessor implements OutputProcessor {
         private Listener(Project prj) {
             this.prj = prj;
         }
-        @Override
-        public void outputLineSelected(OutputEvent arg0) {
-            
-        }
         
         @Messages({"# {0} - file name", "SiteOutputProcessor.not_found=No site index created at {0}"})
         @Override
@@ -106,9 +102,6 @@ public class SiteOutputProcessor implements OutputProcessor {
                 StatusDisplayer.getDefault().setStatusText(SiteOutputProcessor_not_found(html));
             }
         }
-        
-        @Override
-        public void outputLineCleared(OutputEvent arg0) {
-        }
+
     }
 }

--- a/java/maven/src/org/netbeans/modules/maven/output/TestOutputListenerProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/output/TestOutputListenerProvider.java
@@ -183,12 +183,6 @@ public class TestOutputListenerProvider implements OutputProcessor {
             testname = test;
             outputDir = outDir;
         }
-        /** Called when a line is selected.
-         * @param ev the event describing the line
-         */
-        @Override
-        public void outputLineSelected(OutputEvent ev) {
-        }
         
         /** Called when some sort of action is performed on a line.
          * @param ev the event describing the line
@@ -250,13 +244,6 @@ public class TestOutputListenerProvider implements OutputProcessor {
                     StatusDisplayer.getDefault().setStatusText(MSG_CannotFollowLink2());
                 }
             }
-        }
-        
-        /** Called when a line is cleared from the buffer of known lines.
-         * @param ev the event describing the line
-         */
-        @Override
-        public void outputLineCleared(OutputEvent ev) {
         }
         
         private void openLog(final FileObject fo, String title, final File testDir) {

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/execute/CommandLineOutputHandlerTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/execute/CommandLineOutputHandlerTest.java
@@ -20,8 +20,6 @@
 package org.netbeans.modules.maven.execute;
 
 import java.util.regex.Matcher;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -33,29 +31,20 @@ public class CommandLineOutputHandlerTest {
 
     public CommandLineOutputHandlerTest() {
     }
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-    }
     
     @Test
     public void testRegExp() throws Exception {
-        Matcher m = CommandLineOutputHandler.startPatternM2.matcher("[INFO] [surefire:test]");
-        assertTrue(m.matches());
-        assertEquals("surefire", m.group(1));
-        assertEquals("test", m.group(2));
-        m = CommandLineOutputHandler.startPatternM2.matcher("[INFO] [compiler:testCompile {execution: default-testCompile}]");
-        assertTrue(m.matches());
-        assertEquals("compiler", m.group(1));
-        assertEquals("testCompile", m.group(2));
+        Matcher m;
+        
         m = CommandLineOutputHandler.startPatternM3.matcher("[INFO] --- maven-compiler-plugin:2.3.2:compile (default-compile) @ mavenproject3 ---");
         assertTrue(m.matches());
         assertEquals("maven-compiler-plugin", m.group(1));
         assertEquals("compile", m.group(2));
+        
+        m = CommandLineOutputHandler.startPatternM3.matcher("[INFO] --- surefire:3.2.5:test (default-test) @ mavenproject1 ---");
+        assertTrue(m.matches());
+        assertEquals("surefire", m.group(1));
+        assertEquals("test", m.group(2));
     }
 
     @Test
@@ -69,6 +58,12 @@ public class CommandLineOutputHandlerTest {
         assertTrue(m.matches());
         
         m = CommandLineOutputHandler.reactorSummaryLine.matcher("Maven Aether Provider ............................. SUCCESS [1.014s]");
+        assertTrue(m.matches());
+        
+        m = CommandLineOutputHandler.reactorSummaryLine.matcher("Maven 4 API ........................................ SUCCESS [  1.655 s]");
+        assertTrue(m.matches());
+        
+        m = CommandLineOutputHandler.reactorSummaryLine.matcher("Maven 4 API :: Meta annotations .................... SUCCESS [  0.603 s]");
         assertTrue(m.matches());
 
     }

--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/RequestedUrlEvalResponse.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/RequestedUrlEvalResponse.java
@@ -63,20 +63,12 @@ public class RequestedUrlEvalResponse extends EvalResponse {
     private static class OutputListenerImpl implements OutputListener {
 
         @Override
-        public void outputLineSelected(OutputEvent ev) {
-        }
-
-        @Override
         public void outputLineAction(OutputEvent ev) {
             try {
                 HtmlBrowser.URLDisplayer.getDefault().showURL(new URL(ev.getLine()));
             } catch (MalformedURLException ex) {
                 LOGGER.log(Level.WARNING, null, ex);
             }
-        }
-
-        @Override
-        public void outputLineCleared(OutputEvent ev) {
         }
 
     }

--- a/php/php.phpdoc/src/org/netbeans/modules/php/phpdoc/PhpDocScript.java
+++ b/php/php.phpdoc/src/org/netbeans/modules/php/phpdoc/PhpDocScript.java
@@ -287,16 +287,8 @@ public final class PhpDocScript {
         }
 
         @Override
-        public void outputLineSelected(OutputEvent ev) {
-        }
-
-        @Override
         public void outputLineAction(OutputEvent ev) {
             HtmlBrowser.URLDisplayer.getDefault().showURL(url);
-        }
-
-        @Override
-        public void outputLineCleared(OutputEvent ev) {
         }
 
     }

--- a/platform/core.output2/src/org/netbeans/core/output2/options/OutputSettingsPanel.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/options/OutputSettingsPanel.java
@@ -43,7 +43,6 @@ import org.openide.util.NbBundle;
 import org.openide.windows.IOColorPrint;
 import org.openide.windows.IOContainer;
 import org.openide.windows.InputOutput;
-import org.openide.windows.OutputEvent;
 import org.openide.windows.OutputListener;
 
 @NbBundle.Messages({
@@ -565,7 +564,7 @@ public final class OutputSettingsPanel extends javax.swing.JPanel {
         previewInputOutput.setInputVisible(true); // Instead of reading from in.
         previewInputOutput.getOut().println("Standard Output");         //NOI18N
         previewInputOutput.getErr().println("Error Output");            //NOI18N
-        OutputListener ol = new OutputListenerImpl();
+        OutputListener ol = new OutputListener() {};
         try {
             IOColorPrint.print(previewInputOutput, "Standard Link", //NOI18N
                     ol, false, null);
@@ -627,21 +626,4 @@ public final class OutputSettingsPanel extends javax.swing.JPanel {
         cmbLinkStyle.repaint();
     }
 
-    private static class OutputListenerImpl implements OutputListener {
-
-        public OutputListenerImpl() {
-        }
-
-        @Override
-        public void outputLineSelected(OutputEvent ev) {
-        }
-
-        @Override
-        public void outputLineAction(OutputEvent ev) {
-        }
-
-        @Override
-        public void outputLineCleared(OutputEvent ev) {
-        }
-    }
 }

--- a/platform/openide.io/src/org/openide/io/BridgingInputOutputProvider.java
+++ b/platform/openide.io/src/org/openide/io/BridgingInputOutputProvider.java
@@ -71,7 +71,7 @@ public final class BridgingInputOutputProvider
     private static final Logger LOG
             = Logger.getLogger(BridgingInputOutputProvider.class.getName());
 
-    private final Deque<FoldHandle> foldStack = new ArrayDeque<FoldHandle>();
+    private final Deque<FoldHandle> foldStack = new ArrayDeque<>();
 
     @Override
     public String getId() {
@@ -284,7 +284,7 @@ public final class BridgingInputOutputProvider
         if (link == null) {
             return null;
         }
-        return new OutputListenerAdapter() {
+        return new OutputListener() {
             @Override
             public void outputLineAction(OutputEvent ev) {
                 Hyperlinks.invoke(link);
@@ -324,18 +324,4 @@ public final class BridgingInputOutputProvider
         }
     }
 
-    private static class OutputListenerAdapter implements OutputListener {
-
-        @Override
-        public void outputLineSelected(OutputEvent ev) {
-        }
-
-        @Override
-        public void outputLineAction(OutputEvent ev) {
-        }
-
-        @Override
-        public void outputLineCleared(OutputEvent ev) {
-        }
-    }
 }

--- a/platform/openide.io/src/org/openide/windows/OutputListener.java
+++ b/platform/openide.io/src/org/openide/windows/OutputListener.java
@@ -28,15 +28,15 @@ public interface OutputListener extends java.util.EventListener {
     /** Called when a line is selected.
     * @param ev the event describing the line
     */
-    public void outputLineSelected (OutputEvent ev);
+    public default void outputLineSelected(OutputEvent ev) {}
 
     /** Called when some sort of action is performed on a line.
     * @param ev the event describing the line
     */
-    public void outputLineAction (OutputEvent ev);
+    public default void outputLineAction(OutputEvent ev) {}
 
     /** Called when a line is cleared from the buffer of known lines.
     * @param ev the event describing the line
     */
-    public void outputLineCleared (OutputEvent ev);
+    public default void outputLineCleared(OutputEvent ev) {}
 }

--- a/rust/rust.cargo/src/org/netbeans/modules/rust/cargo/output/RustErrorHyperlinkConvertorFactory.java
+++ b/rust/rust.cargo/src/org/netbeans/modules/rust/cargo/output/RustErrorHyperlinkConvertorFactory.java
@@ -72,16 +72,6 @@ public class RustErrorHyperlinkConvertorFactory implements OutputListener, LineC
 
     // OutputListener
     @Override
-    public void outputLineSelected(OutputEvent ev) {
-    }
-
-    // OutputListener
-    @Override
-    public void outputLineCleared(OutputEvent ev) {
-    }
-
-    // OutputListener
-    @Override
     public void outputLineAction(OutputEvent ev) {
         // Invoked to show a given position in the source code
         Matcher m = matchesSourcePosition(ev.getLine());

--- a/webcommon/javascript.jstestdriver/src/org/netbeans/modules/javascript/jstestdriver/JSTestDriverSupport.java
+++ b/webcommon/javascript.jstestdriver/src/org/netbeans/modules/javascript/jstestdriver/JSTestDriverSupport.java
@@ -492,10 +492,6 @@ public class JSTestDriverSupport {
             this.line = line;
             this.column = column;
         }
-        
-        @Override
-        public void outputLineSelected(OutputEvent ev) {
-        }
 
         @Override
         public void outputLineAction(OutputEvent ev) {
@@ -520,10 +516,6 @@ public class JSTestDriverSupport {
                 return result.getLineSet().getCurrent(line-1);
             }
             return null;
-        }
-
-        @Override
-        public void outputLineCleared(OutputEvent ev) {
         }
         
         public boolean isValidHyperlink() {

--- a/webcommon/javascript.karma/src/org/netbeans/modules/javascript/karma/exec/KarmaExecutable.java
+++ b/webcommon/javascript.karma/src/org/netbeans/modules/javascript/karma/exec/KarmaExecutable.java
@@ -382,11 +382,6 @@ public class KarmaExecutable {
         }
 
         @Override
-        public void outputLineSelected(OutputEvent ev) {
-            // noop
-        }
-
-        @Override
         public void outputLineAction(OutputEvent ev) {
             RequestProcessor.getDefault().post(new Runnable() {
                 @Override
@@ -394,11 +389,6 @@ public class KarmaExecutable {
                     FileUtils.openFile(new File(file), line);
                 }
             });
-        }
-
-        @Override
-        public void outputLineCleared(OutputEvent ev) {
-            // noop
         }
 
     }

--- a/webcommon/javascript.nodejs/src/org/netbeans/modules/javascript/nodejs/exec/NodeExecutable.java
+++ b/webcommon/javascript.nodejs/src/org/netbeans/modules/javascript/nodejs/exec/NodeExecutable.java
@@ -653,11 +653,6 @@ public class NodeExecutable {
         }
 
         @Override
-        public void outputLineSelected(OutputEvent ev) {
-            // noop
-        }
-
-        @Override
         public void outputLineAction(OutputEvent ev) {
             RequestProcessor.getDefault().post(new Runnable() {
                 @Override
@@ -665,11 +660,6 @@ public class NodeExecutable {
                     FileUtils.openFile(file, line);
                 }
             });
-        }
-
-        @Override
-        public void outputLineCleared(OutputEvent ev) {
-            // noop
         }
 
     }

--- a/webcommon/selenium2.webclient.mocha/src/org/netbeans/modules/selenium2/webclient/mocha/MochaRunner.java
+++ b/webcommon/selenium2.webclient.mocha/src/org/netbeans/modules/selenium2/webclient/mocha/MochaRunner.java
@@ -360,11 +360,6 @@ public class MochaRunner {
         }
 
         @Override
-        public void outputLineSelected(OutputEvent ev) {
-            // noop
-        }
-
-        @Override
         public void outputLineAction(OutputEvent ev) {
             RequestProcessor.getDefault().post(new Runnable() {
                 @Override
@@ -374,10 +369,6 @@ public class MochaRunner {
             });
         }
 
-        @Override
-        public void outputLineCleared(OutputEvent ev) {
-            // noop
-        }
     }
     
 }

--- a/webcommon/selenium2.webclient.protractor/src/org/netbeans/modules/selenium2/webclient/protractor/ProtractorRunner.java
+++ b/webcommon/selenium2.webclient.protractor/src/org/netbeans/modules/selenium2/webclient/protractor/ProtractorRunner.java
@@ -378,11 +378,6 @@ class ProtractorRunner {
         }
 
         @Override
-        public void outputLineSelected(OutputEvent ev) {
-            // noop
-        }
-
-        @Override
         public void outputLineAction(OutputEvent ev) {
             RequestProcessor.getDefault().post(new Runnable() {
                 @Override
@@ -390,11 +385,6 @@ class ProtractorRunner {
                     Utils.openFile(file, line, column);
                 }
             });
-        }
-
-        @Override
-        public void outputLineCleared(OutputEvent ev) {
-            // noop
         }
     }
     

--- a/webcommon/web.webkit.tooling/src/org/netbeans/modules/web/webkit/tooling/console/BrowserConsoleLogger.java
+++ b/webcommon/web.webkit.tooling/src/org/netbeans/modules/web/webkit/tooling/console/BrowserConsoleLogger.java
@@ -504,10 +504,6 @@ public class BrowserConsoleLogger implements Console.Listener {
             this.column = column;
             this.project = project;
         }
-        
-        @Override
-        public void outputLineSelected(OutputEvent ev) {
-        }
 
         @Override
         public void outputLineAction(OutputEvent ev) {
@@ -519,10 +515,6 @@ public class BrowserConsoleLogger implements Console.Listener {
         }
         private Line getLine() {
             return BrowserConsoleLogger.getLine(project, url, line-1);
-        }
-
-        @Override
-        public void outputLineCleared(OutputEvent ev) {
         }
         
         public boolean isValidHyperlink() {


### PR DESCRIPTION
 - remove maven 2 specific output parsing
 - fix reactor summary parsing
 - disabled `JavadocOutputProcessor` since it doesn't do anything atm
 - code cleanup (dead code removal, Java 17 lang level simplifications, default methods for `OutputListener`)
 
 reactor summary link on failure is working again (useful with `--fail-at-end`):
 
![reactor-failure-link](https://github.com/user-attachments/assets/bec13500-1a6e-4ac8-96dc-d95eb6fbe6d5)
