### PR TITLE
No wait cursor on CSL navigator expand

### DIFF
--- a/ide/csl.api/src/org/netbeans/modules/csl/navigation/ClassMemberPanelUI.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/navigation/ClassMemberPanelUI.java
@@ -140,7 +140,7 @@ public class ClassMemberPanelUI extends javax.swing.JPanel
         initComponents();
         
         // Tree view of the elements
-        elementView = createBeanTreeView();        
+        elementView = createBeanTreeView();
         add(elementView, BorderLayout.CENTER);
                
         filters = new ClassMemberFilters( this );
@@ -302,7 +302,6 @@ public class ClassMemberPanelUI extends javax.swing.JPanel
                 public void run() {
                     long startTime = System.currentTimeMillis();
                     elementView.setRootVisible(false);
-                    elementView.setAutoWaitCursor(false);
                     manager.setRootContext(new ElementNode( description, ClassMemberPanelUI.this, fileObject ) );
 
                     int expandDepth = -1;
@@ -328,7 +327,6 @@ public class ClassMemberPanelUI extends javax.swing.JPanel
                             elementView.setScrollOnExpand( scrollOnExpand );
                         }
                     });
-                    elementView.setAutoWaitCursor(true);
                     long endTime = System.currentTimeMillis();
                     Logger.getLogger("TIMER").log(Level.FINE, "Navigator Initialization",
                             new Object[] {fileObject, endTime - startTime});
@@ -476,17 +474,8 @@ public class ClassMemberPanelUI extends javax.swing.JPanel
     }
     
     private MyBeanTreeView createBeanTreeView() {
-//        ActionMap map = getActionMap();
-//        map.put(DefaultEditorKit.copyAction, ExplorerUtils.actionCopy(manager));
-//        map.put(DefaultEditorKit.cutAction, ExplorerUtils.actionCut(manager));
-//        map.put(DefaultEditorKit.pasteAction, ExplorerUtils.actionPaste(manager));
-//        map.put("delete", new DelegatingAction(ActionProvider.COMMAND_DELETE, ExplorerUtils.actionDelete(manager, true)));
-//        
-        
         MyBeanTreeView btv = new MyBeanTreeView();    // Add the BeanTreeView        
-//      btv.setDragSource (true);        
-//      btv.setRootVisible(false);        
-//      associateLookup( ExplorerUtils.createLookup(manager, map) );        
+        btv.setAutoWaitCursor(false);
         return btv;
         
     }

--- a/java/form/src/org/netbeans/modules/form/ComponentInspector.java
+++ b/java/form/src/org/netbeans/modules/form/ComponentInspector.java
@@ -112,6 +112,7 @@ public class ComponentInspector extends JPanel
 
     private void createComponents() {
         treeView = new BeanTreeView();
+        treeView.setAutoWaitCursor(false);
         treeView.setDragSource(true);
         treeView.setDropTarget(true);
         treeView.getAccessibleContext().setAccessibleName(

--- a/java/java.navigation/src/org/netbeans/modules/java/navigation/ClassMemberPanelUI.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/navigation/ClassMemberPanelUI.java
@@ -173,7 +173,7 @@ public class ClassMemberPanelUI extends javax.swing.JPanel
         manager.addPropertyChangeListener(this);
         
         // Tree view of the elements
-        elementView = createBeanTreeView();        
+        elementView = createBeanTreeView();
         add(elementView, BorderLayout.CENTER);
                
         // filters
@@ -424,9 +424,7 @@ public class ClassMemberPanelUI extends javax.swing.JPanel
                     done();
                     boolean scrollOnExpand = getScrollOnExpand();
                     setScrollOnExpand( false );
-                    elementView.setAutoWaitCursor(false);
                     elementView.expandAll();
-                    elementView.setAutoWaitCursor(true);
                     setScrollOnExpand( scrollOnExpand );
 
                     if (PERF_LOG.isLoggable(Level.FINE)) {
@@ -525,7 +523,9 @@ public class ClassMemberPanelUI extends javax.swing.JPanel
     }
     
     private MyBeanTreeView createBeanTreeView() {
-        return new MyBeanTreeView();
+        MyBeanTreeView ret = new MyBeanTreeView();
+        ret.setAutoWaitCursor(false);
+        return ret;
     }
 
     private void scheduleJavadocRefresh(final int time) {


### PR DESCRIPTION
Well, I find it a bit annoying, that almost every time I edit a Yaml, HCL file, there is a flickering on the mouse cursor changing to wait cursor and then back.

It turned out that is because the navigator is expanding it's tree to the current location, so when the structure changes it issues an expand and the `TreeView.autoWaitCursor` is `true` by default and put the cursor in wait mode for a brief moment.

That led me to try other parts of the IDE, and expanding nodes could result with a brief mouse cursor change. That made me think to change the `TreeView` behavior. It would be good to have the default for the wait cursor to be `false`, though since it is down in the core I think it's being used many places outside of NetBeans.

Probably the best would be delaying the wait cursor change by 500ms or so, and if the tree could expand it in that time we just do not do that. Might try to create a PR for that one, however for the default CSL provided navigator, I do not thing that we need the `autoWaitCursor` functionality at all.