### PR TITLE
Use mn:run for run/debug of Micronaut applications

### DIFF
--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/Bundle.properties
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/Bundle.properties
@@ -16,3 +16,5 @@
 # under the License.
 
 action.native-build=Build with Native Image
+action.run-simple=Run Without Micronaut Support
+action.debug-simple Debug Without Micronaut Support

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/micronaut-actions-maven.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/micronaut-actions-maven.xml
@@ -35,6 +35,124 @@
             <packaging>native-image</packaging>
         </properties>
     </action>
+    
+    <!-- Redefine the default action to use mn:run -->
+    <action>
+        <actionName>run</actionName>
+        <packagings>
+            <packaging>jar</packaging>
+        </packagings>
+        <goals>
+            <goal>process-classes</goal>
+            <goal>io.micronaut.maven:micronaut-maven-plugin:run</goal>
+        </goals>
+        <properties>
+            <!-- will not be used by MN plugin -->
+            <exec.args>-classpath %classpath</exec.args>
+            <mn.appArgs>${exec.appArgs}</mn.appArgs>
+            <mn.jvmArgs>${exec.vmArgs} -classpath %classpath</mn.jvmArgs>
+            <exec.mainClass>${packageClassName}</exec.mainClass>
+            <mn.watch>false</mn.watch>
+        </properties>
+    </action>
+    <action>
+        <actionName>run.single.main</actionName>
+        <packagings>
+            <packaging>*</packaging>
+        </packagings>
+        <goals>
+            <goal>process-classes</goal>
+            <goal>io.micronaut.maven:micronaut-maven-plugin:run</goal>
+        </goals>
+        <properties>
+            <!-- will not be used by MN plugin -->
+            <exec.args>-classpath %classpath</exec.args>
+            <mn.appArgs>${exec.appArgs}</mn.appArgs>
+            <mn.jvmArgs>${exec.vmArgs} -classpath %classpath</mn.jvmArgs>
+            <exec.mainClass>${packageClassName}</exec.mainClass>
+            <mn.watch>false</mn.watch>
+        </properties>
+    </action>
+    <!-- The original Run action, for the reference -->
+    <action>
+        <actionName>run-simple</actionName>
+        <packagings>
+            <packaging>jar</packaging>
+        </packagings>
+        <goals>
+            <goal>process-classes</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
+        </goals>
+        <properties>
+            <exec.vmArgs></exec.vmArgs>
+            <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+            <exec.appArgs></exec.appArgs>
+            <exec.mainClass>${packageClassName}</exec.mainClass>
+            <exec.executable>java</exec.executable>
+        </properties>
+    </action>
+
+    <action>
+        <actionName>debug</actionName>
+        <packagings>
+            <packaging>jar</packaging>
+        </packagings>
+        <goals>
+            <goal>process-classes</goal>
+            <goal>io.micronaut.maven:micronaut-maven-plugin:run</goal>
+        </goals>
+        <properties>
+            <!-- will not be used by MN plugin -->
+            <exec.args>-classpath %classpath</exec.args>
+            <mn.appArgs>${exec.appArgs}</mn.appArgs>
+            <mn.jvmArgs>${exec.vmArgs} -classpath %classpath</mn.jvmArgs>
+            <exec.mainClass>${packageClassName}</exec.mainClass>
+            <exec.vmArgs>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address}</exec.vmArgs>
+            <mn.watch>false</mn.watch>
+            <jpda.listen>true</jpda.listen>
+        </properties>
+    </action>
+    <action>
+        <actionName>debug.single.main</actionName>
+        <packagings>
+            <packaging>*</packaging>
+        </packagings>
+        <goals>
+            <goal>process-test-classes</goal>
+            <goal>io.micronaut.maven:micronaut-maven-plugin:run</goal>
+        </goals>
+        <properties>
+            <!-- will not be used by MN plugin -->
+            <exec.args>-classpath %classpath</exec.args>
+            <mn.appArgs>${exec.appArgs}</mn.appArgs>
+            <mn.jvmArgs>${exec.vmArgs} -classpath %classpath</mn.jvmArgs>
+            <exec.mainClass>${packageClassName}</exec.mainClass>
+            <mn.watch>false</mn.watch>
+            <exec.vmArgs>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address}</exec.vmArgs>
+            <jpda.listen>true</jpda.listen>
+        </properties>
+    </action>
+
+    <!-- The original debug action, for reference -->
+    <action>
+        <actionName>debug-simple</actionName>
+        <packagings>
+            <packaging>jar</packaging>
+        </packagings>
+        <goals>
+            <goal>process-classes</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.1.0:exec</goal>
+        </goals>
+        <properties>
+            <exec.vmArgs>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address}</exec.vmArgs>
+            <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+            <exec.appArgs></exec.appArgs>
+            <exec.mainClass>${packageClassName}</exec.mainClass>
+            <exec.executable>java</exec.executable>
+            <jpda.listen>true</jpda.listen>
+        </properties>
+    </action>
+
     <action>
         <actionName>test.single</actionName>
         <packagings>


### PR DESCRIPTION
Micronaut applications are best run using `mn:run` goal, as it conditionally sets up `testresources` such as MySQL database etc, if permitted by `pom.xml` settings.

This PR changes the default project run/debug actions just for micronaut applications (those that actually use `micronaut-maven-plugin`) to use `mn:run` for running.