### PR TITLE
Code scanner and search should tolerate CoderMalfunctionErrors

### DIFF
--- a/platform/api.search/src/org/netbeans/modules/search/matcher/AbstractMatcher.java
+++ b/platform/api.search/src/org/netbeans/modules/search/matcher/AbstractMatcher.java
@@ -18,11 +18,9 @@
  */
 package org.netbeans.modules.search.matcher;
 
-import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
-import java.nio.charset.UnmappableCharacterException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.search.provider.SearchListener;
@@ -111,7 +109,7 @@ public abstract class AbstractMatcher  {
      */
     protected final void handleDecodingError(SearchListener listener,
             FileObject file, CharsetDecoder decoder,
-            CharacterCodingException e) {
+            Throwable e) {
 
         String charsetName;
         try {

--- a/platform/api.search/src/org/netbeans/modules/search/matcher/SingleLineStreamMatcher.java
+++ b/platform/api.search/src/org/netbeans/modules/search/matcher/SingleLineStreamMatcher.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CoderMalfunctionError;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -49,13 +50,13 @@ public class SingleLineStreamMatcher extends AbstractMatcher {
 
     private static final int limit = Constants.DETAILS_COUNT_LIMIT;
     private volatile boolean terminated = false;
-    private SearchPattern searchPattern;
-    private Pattern pattern;
+    private final SearchPattern searchPattern;
+    private final Pattern pattern;
     private int count = 0;
 
     public SingleLineStreamMatcher(SearchPattern searchPattern) {
         this.searchPattern = searchPattern;
-        pattern = TextRegexpUtil.makeTextPattern(searchPattern);
+        this.pattern = TextRegexpUtil.makeTextPattern(searchPattern);
     }
 
     @Override
@@ -72,7 +73,7 @@ public class SingleLineStreamMatcher extends AbstractMatcher {
             } else {
                 return new Def(file, charset, textDetails);
             }
-        } catch (CharacterCodingException e) {
+        } catch (CharacterCodingException | CoderMalfunctionError e) {
             handleDecodingError(listener, file, decoder, e);
             return null;
         } catch (Exception e) {

--- a/platform/api.search/src/org/netbeans/modules/search/ui/AbstractSearchResultsPanel.form
+++ b/platform/api.search/src/org/netbeans/modules/search/ui/AbstractSearchResultsPanel.form
@@ -22,23 +22,6 @@
 -->
 
 <Form version="1.5" maxVersion="1.8" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
-  <NonVisualComponents>
-    <Container class="javax.swing.JPanel" name="jPanel1">
-
-      <Layout>
-        <DimensionLayout dim="0">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <EmptySpace min="0" pref="100" max="32767" attributes="0"/>
-          </Group>
-        </DimensionLayout>
-        <DimensionLayout dim="1">
-          <Group type="103" groupAlignment="0" attributes="0">
-              <EmptySpace min="0" pref="100" max="32767" attributes="0"/>
-          </Group>
-        </DimensionLayout>
-      </Layout>
-    </Container>
-  </NonVisualComponents>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="1"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
@@ -56,7 +39,6 @@
   <SubComponents>
     <Container class="javax.swing.JToolBar" name="toolBar">
       <Properties>
-        <Property name="floatable" type="boolean" value="false"/>
         <Property name="orientation" type="int" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
           <Connection code="JToolBar.VERTICAL" type="code"/>
         </Property>

--- a/platform/api.search/src/org/netbeans/modules/search/ui/AbstractSearchResultsPanel.java
+++ b/platform/api.search/src/org/netbeans/modules/search/ui/AbstractSearchResultsPanel.java
@@ -21,9 +21,7 @@ package org.netbeans.modules.search.ui;
 import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 import java.util.LinkedList;
 import java.util.List;
@@ -130,24 +128,11 @@ public abstract class AbstractSearchResultsPanel extends javax.swing.JPanel
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
-        jPanel1 = new javax.swing.JPanel();
         toolBar = new ToolbarWithOverflow();
         contentPanel = new javax.swing.JPanel();
 
-        javax.swing.GroupLayout jPanel1Layout = new javax.swing.GroupLayout(jPanel1);
-        jPanel1.setLayout(jPanel1Layout);
-        jPanel1Layout.setHorizontalGroup(
-            jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 100, Short.MAX_VALUE)
-        );
-        jPanel1Layout.setVerticalGroup(
-            jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 100, Short.MAX_VALUE)
-        );
-
         setLayout(new java.awt.BorderLayout());
 
-        toolBar.setFloatable(false);
         toolBar.setOrientation(JToolBar.VERTICAL);
         toolBar.setRollover(true);
         toolBar.setPreferredSize(null);
@@ -160,7 +145,6 @@ public abstract class AbstractSearchResultsPanel extends javax.swing.JPanel
     }// </editor-fold>//GEN-END:initComponents
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel contentPanel;
-    private javax.swing.JPanel jPanel1;
     private javax.swing.JToolBar toolBar;
     // End of variables declaration//GEN-END:variables
 


### PR DESCRIPTION
 - scanner will skip the file and log a warning
 - search will add it to the regular search result error list

cleanup:

 - removed unused UI component of search results window
 - simplified exception handling in `Source#createSnapshot`

![image](https://github.com/user-attachments/assets/7dd3a426-9b88-4684-bc7f-a70617cee1e6)

indexer log:
```
WARNING [org.netbeans.modules.parsing.api.Source]: Can't create snapshot of /tmp/mavenproject1/src/main/java/com/mycompany/mavenproject1/error_file2.xml@cbec52aa:59023f9d, mimeType=text/xml. CoderMalfunctionError: java.lang.IllegalArgumentException: newPosition > limit: (1 > 0)
```
fixes #3842
fixes #4354
fixes #4762
fixes #6671
fixes #7839