### PR TITLE
For SVG icons, prefer Icon.paintIcon over Graphics.drawImage

### DIFF
--- a/enterprise/web.jsf.navigation/src/org/netbeans/modules/web/jsf/navigation/graph/PageFlowScene.java
+++ b/enterprise/web.jsf.navigation/src/org/netbeans/modules/web/jsf/navigation/graph/PageFlowScene.java
@@ -48,6 +48,7 @@ import java.util.List;
 import javax.swing.Action;
 import javax.swing.ActionMap;
 import javax.swing.BorderFactory;
+import javax.swing.Icon;
 import javax.swing.InputMap;
 import javax.swing.KeyStroke;
 import javax.swing.border.Border;
@@ -76,7 +77,6 @@ import org.netbeans.modules.web.jsf.navigation.graph.actions.PageFlowPopupProvid
 import org.netbeans.modules.web.jsf.navigation.graph.layout.ConnectionWrapperLayout;
 import org.openide.actions.DeleteAction;
 import org.openide.util.ImageUtilities;
-import org.openide.util.Utilities;
 import org.openide.util.actions.CallbackSystemAction;
 import org.openide.util.actions.SystemAction;
 
@@ -125,12 +125,12 @@ public class PageFlowScene extends GraphPinScene<Page, NavigationCaseEdge, Pin> 
     private PFObjectSceneListener pfObjectSceneListener;
     private static Paint PAINT_BACKGROUND;
     static {
-        Image sourceImage = ImageUtilities.loadImage("org/netbeans/modules/web/jsf/navigation/graph/resources/paper_grid.png"); // NOI18N
-        int width = sourceImage.getWidth(null);
-        int height = sourceImage.getHeight(null);
+        Icon sourceIcon = ImageUtilities.loadIcon("org/netbeans/modules/web/jsf/navigation/graph/resources/paper_grid.png"); // NOI18N
+        int width = sourceIcon.getIconWidth();
+        int height = sourceIcon.getIconHeight();
         BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
         Graphics2D graphics = image.createGraphics();
-        graphics.drawImage(sourceImage, 0, 0, null);
+        sourceIcon.paintIcon(null, graphics, 0, 0);
         graphics.dispose();
         PAINT_BACKGROUND = new TexturePaint(image, new Rectangle(0, 0, width, height));
     }

--- a/ide/db.dataview/src/org/netbeans/modules/db/dataview/output/DataViewUI.java
+++ b/ide/db.dataview/src/org/netbeans/modules/db/dataview/output/DataViewUI.java
@@ -43,7 +43,7 @@ import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.DefaultRowSorter;
-import javax.swing.ImageIcon;
+import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
@@ -237,7 +237,7 @@ class DataViewUI extends JPanel {
         dataPanelScrollPane.setRowHeaderView(rowHeader);
         dataPanelScrollPane.setCorner(JScrollPane.UPPER_LEFT_CORNER, rowHeader.getTableHeader());
         
-        ImageIcon icon = ImageUtilities.loadImageIcon(IMG_PREFIX + "preferences-desktop.png", false);  // NOI18N
+        Icon icon = ImageUtilities.loadIcon(IMG_PREFIX + "preferences-desktop.png", false);  // NOI18N
         JButton cornerButton = new JButton() {
             @Override
             protected void paintComponent(Graphics g) {
@@ -247,7 +247,7 @@ class DataViewUI extends JPanel {
                 g2d.setColor(getBackground());
                 g2d.fillRect(0, 0, getWidth(), getHeight());
                 g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-                g2d.drawImage(icon.getImage(), (getWidth() - iconSize) / 2, (getHeight() - iconSize) / 2, iconSize, iconSize, null);
+                icon.paintIcon(null, g2d, (getWidth() - iconSize) / 2, (getHeight() - iconSize) / 2);
             }
         };
         cornerButton.addActionListener(popupActionListener);

--- a/ide/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffSplitPaneDivider.java
+++ b/ide/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffSplitPaneDivider.java
@@ -35,6 +35,7 @@ import java.awt.geom.GeneralPath;
 import java.util.*;
 import java.util.List;
 import org.openide.awt.GraphicsUtils;
+import org.openide.util.ImageUtilities;
 
 /**
  * Split pane divider with Diff decorations.
@@ -43,8 +44,8 @@ import org.openide.awt.GraphicsUtils;
  */
 class DiffSplitPaneDivider extends BasicSplitPaneDivider implements MouseMotionListener, MouseListener, Accessible {
     
-    private final Image insertAllImage = org.openide.util.Utilities.loadImage("org/netbeans/modules/diff/builtin/visualizer/editable/move_all.png"); // NOI18N
-    private final Image insertAllActiveImage = org.openide.util.Utilities.loadImage("org/netbeans/modules/diff/builtin/visualizer/editable/move_all_active.png"); // NOI18N
+    private final Icon insertAllIcon = ImageUtilities.loadIcon("org/netbeans/modules/diff/builtin/visualizer/editable/move_all.png"); // NOI18N
+    private final Icon insertAllActiveIcon = ImageUtilities.loadIcon("org/netbeans/modules/diff/builtin/visualizer/editable/move_all_active.png"); // NOI18N
     private final int actionIconsHeight;
     private final int actionIconsWidth;
     private final Point POINT_ZERO = new Point(0, 0);
@@ -64,8 +65,8 @@ class DiffSplitPaneDivider extends BasicSplitPaneDivider implements MouseMotionL
         this.master = master;
         fontColor = new JLabel().getForeground();
 
-        actionIconsHeight = insertAllImage.getHeight(this);
-        actionIconsWidth = insertAllImage.getWidth(this);
+        actionIconsHeight = insertAllIcon.getIconHeight();
+        actionIconsWidth = insertAllIcon.getIconWidth();
         
         setBorder(null);
         setLayout(new BorderLayout());
@@ -254,9 +255,9 @@ class DiffSplitPaneDivider extends BasicSplitPaneDivider implements MouseMotionL
             if (master.isActionsEnabled() && everythingEditable) {
                 hotSpot = new Rectangle((getWidth() - actionIconsWidth) /2, editorsOffset, actionIconsWidth, actionIconsHeight);
                 if (hotSpot.contains(lastMousePosition)) {
-                    g.drawImage(insertAllActiveImage, hotSpot.x, hotSpot.y, this);
+                    insertAllActiveIcon.paintIcon(null, g, hotSpot.x, hotSpot.y);
                 } else {
-                    g.drawImage(insertAllImage, hotSpot.x, hotSpot.y, this);
+                    insertAllIcon.paintIcon(null, g, hotSpot.x, hotSpot.y);
                 }
                 rollbackAction.initRect(hotSpot);
                 newActionIcons.add(rollbackAction);

--- a/ide/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/LineNumbersActionsBar.java
+++ b/ide/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/LineNumbersActionsBar.java
@@ -25,7 +25,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
-import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Stroke;
@@ -43,6 +42,7 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeEvent;
 import java.util.ArrayList;
 import java.util.Map;
+import javax.swing.Icon;
 import javax.swing.JPanel;
 import javax.swing.Scrollable;
 import javax.swing.SwingUtilities;
@@ -59,6 +59,7 @@ import org.netbeans.editor.Coloring;
 import org.netbeans.editor.EditorUI;
 import org.netbeans.editor.Utilities;
 import org.netbeans.lib.editor.util.swing.DocumentUtilities;
+import org.openide.util.ImageUtilities;
 
 /**
  * Draws both line numbers and diff actions for a decorated editor pane.
@@ -71,11 +72,11 @@ class LineNumbersActionsBar extends JPanel implements Scrollable, MouseMotionLis
     private static final int LINES_BORDER_WIDTH = 4;
     private static final Point POINT_ZERO = new Point(0, 0);
     
-    private final Image insertImage = org.openide.util.Utilities.loadImage("org/netbeans/modules/diff/builtin/visualizer/editable/insert.png"); // NOI18N
-    private final Image removeImage = org.openide.util.Utilities.loadImage("org/netbeans/modules/diff/builtin/visualizer/editable/remove.png"); // NOI18N
+    private final Icon insertIcon = ImageUtilities.loadIcon("org/netbeans/modules/diff/builtin/visualizer/editable/insert.png"); // NOI18N
+    private final Icon removeIcon = ImageUtilities.loadIcon("org/netbeans/modules/diff/builtin/visualizer/editable/remove.png"); // NOI18N
 
-    private final Image insertActiveImage = org.openide.util.Utilities.loadImage("org/netbeans/modules/diff/builtin/visualizer/editable/insert_active.png"); // NOI18N
-    private final Image removeActiveImage = org.openide.util.Utilities.loadImage("org/netbeans/modules/diff/builtin/visualizer/editable/remove_active.png"); // NOI18N
+    private final Icon insertActiveIcon = ImageUtilities.loadIcon("org/netbeans/modules/diff/builtin/visualizer/editable/insert_active.png"); // NOI18N
+    private final Icon removeActiveIcon = ImageUtilities.loadIcon("org/netbeans/modules/diff/builtin/visualizer/editable/remove_active.png"); // NOI18N
     
     private final DiffContentPanel master;
     private final boolean actionsEnabled;
@@ -100,8 +101,8 @@ class LineNumbersActionsBar extends JPanel implements Scrollable, MouseMotionLis
         this.master = master;
         this.actionsEnabled = actionsEnabled;
         actionsWidth = actionsEnabled ? ACTIONS_BAR_WIDTH : 0;
-        actionIconsHeight = insertImage.getHeight(this);
-        actionIconsWidth = insertImage.getWidth(this);
+        actionIconsHeight = insertIcon.getIconHeight();
+        actionIconsWidth = insertIcon.getIconWidth();
         setOpaque(true);
         setToolTipText(""); // NOI18N
         master.getMaster().addPropertyChangeListener(this);
@@ -340,13 +341,13 @@ class LineNumbersActionsBar extends JPanel implements Scrollable, MouseMotionLis
             if (actionsEnabled && dd.canRollback()) {
                 if (master.isFirst() && dd.getDiff().getType() != Difference.ADD
                         || !master.isFirst() && dd.getDiff().getType() == Difference.ADD) {
-                    Image activeImage = master.isFirst() ? insertActiveImage : removeActiveImage;
-                    Image image = master.isFirst() ? insertImage : removeImage;
+                    Icon activeIcon = master.isFirst() ? insertActiveIcon : removeActiveIcon;
+                    Icon icon = master.isFirst() ? insertIcon : removeIcon;
                     Rectangle hotSpot = new Rectangle((master.isFirst() ? 0 : offset) + 1, top + actionsYOffset, actionIconsWidth, actionIconsHeight);
                     if (hotSpot.contains(lastMousePosition) || idx == currentDifference) {
-                        g.drawImage(activeImage, hotSpot.x, hotSpot.y, this);
+                        activeIcon.paintIcon(null, g, hotSpot.x, hotSpot.y);
                     } else {
-                        g.drawImage(image, hotSpot.x, hotSpot.y, this);
+                        icon.paintIcon(null, g, hotSpot.x, hotSpot.y);
                     }
                     newActionIcons.add(new HotSpot(hotSpot, dd.getDiff()));
                 }

--- a/ide/editor.completion/src/org/netbeans/modules/editor/completion/CompletionJList.java
+++ b/ide/editor.completion/src/org/netbeans/modules/editor/completion/CompletionJList.java
@@ -45,7 +45,7 @@ public class CompletionJList extends JList {
 
     private static final int DARKER_COLOR_COMPONENT = 5;
     private static final int SUB_MENU_ICON_GAP = 1;
-    private static final ImageIcon subMenuIcon = ImageUtilities.loadImageIcon("org/netbeans/modules/editor/completion/resources/suggestion.png", false); // NOI18N
+    private static final Icon subMenuIcon = ImageUtilities.loadIcon("org/netbeans/modules/editor/completion/resources/suggestion.png", false); // NOI18N
 
     private final RenderComponent renderComponent;
     
@@ -345,7 +345,7 @@ public class CompletionJList extends JList {
             item.render(g, CompletionJList.this.getFont(), getForeground(), bgColor,
                     itemRenderWidth, getHeight(), selected);
             if (selected && item instanceof CompositeCompletionItem && !((CompositeCompletionItem)item).getSubItems().isEmpty()) {
-                g.drawImage(subMenuIcon.getImage(), itemRenderWidth - subMenuIcon.getIconWidth() - SUB_MENU_ICON_GAP, (height - subMenuIcon.getIconHeight()) / 2, null);
+                subMenuIcon.paintIcon(null, g, itemRenderWidth - subMenuIcon.getIconWidth() - SUB_MENU_ICON_GAP, (height - subMenuIcon.getIconHeight()) / 2);
             }
             
             if (separator) {

--- a/ide/editor.lib/src/org/netbeans/editor/GlyphGutter.java
+++ b/ide/editor.lib/src/org/netbeans/editor/GlyphGutter.java
@@ -55,6 +55,7 @@ import java.util.prefs.PreferenceChangeListener;
 import java.util.prefs.Preferences;
 import javax.swing.Action;
 import javax.accessibility.*;
+import javax.swing.Icon;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.text.AbstractDocument;
@@ -99,7 +100,7 @@ public class GlyphGutter extends JComponent implements Annotations.AnnotationsLi
     private Annotations annos;
     
     /** Cycling button image */
-    private Image gutterButton;
+    private Icon gutterButton;
     
     /** Background color of the gutter */
     private Color backgroundColor;
@@ -252,7 +253,7 @@ public class GlyphGutter extends JComponent implements Annotations.AnnotationsLi
         if (editorUI == null)
             return ;
 
-        gutterButton = ImageUtilities.icon2Image(ImageUtilities.loadImageIcon("org/netbeans/editor/resources/glyphbutton.gif", false));
+        gutterButton = ImageUtilities.loadIcon("org/netbeans/editor/resources/glyphbutton.gif", false);
 
         setToolTipText ("");
         getAccessibleContext().setAccessibleName(NbBundle.getBundle(BaseKit.class).getString("ACSN_Glyph_Gutter")); // NOI18N
@@ -601,22 +602,18 @@ public class GlyphGutter extends JComponent implements Annotations.AnnotationsLi
                                     // draw the glyph only when the annotation type has its own icon (no the default one)
                                     // or in case there is more than one annotations on the line
                                     if (!(annoCount == 1 && annoDesc.isDefaultGlyph())) {
-                                        g.drawImage(
-                                                annoGlyph,
+                                        // Draw as Icon to get full resolution for SVG icons.
+                                        Icon annoGlyphIcon = ImageUtilities.image2Icon(annoGlyph);
+                                        annoGlyphIcon.paintIcon(null, g,
                                                 xPos,
-                                                (int) Math.round(pViewRect.y + (rowHeight - glyphHeight) / 2 + 1),
-                                                null
-                                        );
+                                                (int) Math.round(pViewRect.y + (rowHeight - glyphHeight) / 2 + 1));
                                     }
 
                                     // draw cycling button if there is more than one annotations on the line
                                     if (annoCount > 1) {
-                                        g.drawImage(
-                                                gutterButton,
+                                        gutterButton.paintIcon(null, g,
                                                 xPos + glyphWidth - 1,
-                                                (int) Math.round(pViewRect.y + (rowHeight - glyphHeight) / 2),
-                                                null
-                                        );
+                                                (int) Math.round(pViewRect.y + (rowHeight - glyphHeight) / 2));
                                     }
                                 }
                                 lineWithAnno = -1;

--- a/ide/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawGraphics.java
+++ b/ide/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawGraphics.java
@@ -29,6 +29,7 @@ import java.awt.Shape;
 import java.awt.Rectangle;
 import java.awt.font.FontRenderContext;
 import java.awt.font.TextLayout;
+import javax.swing.Icon;
 import javax.swing.JComponent;
 import javax.swing.text.View;
 import org.netbeans.editor.Analyzer;
@@ -37,6 +38,7 @@ import org.netbeans.editor.AnnotationTypes;
 import org.netbeans.editor.Annotations;
 import org.netbeans.editor.FontMetricsCache;
 import org.netbeans.editor.PrintContainer;
+import org.openide.util.ImageUtilities;
 
 /** Draw graphics functions as abstraction over various kinds of drawing. It's used
 * for drawing into classic graphics, printing and measuring.
@@ -587,8 +589,9 @@ public interface DrawGraphics {
                 graphics.setClip(clip);
 
                 for (int i=0; i < passiveAnnosAtY.length; i++) {
-                    g2d.drawImage(passiveAnnosAtY[i].getGlyph(), glyphX, y, null);
-                    glyphX += passiveAnnosAtY[i].getGlyph().getWidth(null)+1;
+                    Icon glyphIcon = ImageUtilities.image2Icon(passiveAnnosAtY[i].getGlyph());
+                    glyphIcon.paintIcon(null, g2d, glyphX, y);
+                    glyphX += glyphIcon.getIconWidth() + 1;
                 }
 
                 // restore original clip region

--- a/ide/spi.editor.hints/src/org/netbeans/modules/editor/hints/borrowed/ListCompletionView.java
+++ b/ide/spi.editor.hints/src/org/netbeans/modules/editor/hints/borrowed/ListCompletionView.java
@@ -358,9 +358,7 @@ public class ListCompletionView extends JList {
     private void renderHtml(Fix f, Graphics g, Font defaultFont, Color defaultColor,
     int width, int height, boolean selected) {
         if (icon != null) {
-            // The image of the ImageIcon should already be loaded
-            // so no ImageObserver should be necessary
-            g.drawImage(ImageUtilities.icon2Image(icon), BEFORE_ICON_GAP, (height - icon.getIconHeight()) /2, this);
+            icon.paintIcon(null, g, BEFORE_ICON_GAP, (height - icon.getIconHeight()) /2);
         }
         int iconWidth = BEFORE_ICON_GAP + icon.getIconWidth() + AFTER_ICON_GAP;
         int textEnd = width - AFTER_ICON_GAP - subMenuIcon.getIconWidth() - AFTER_TEXT_GAP;

--- a/java/form/src/org/netbeans/modules/form/HandleLayer.java
+++ b/java/form/src/org/netbeans/modules/form/HandleLayer.java
@@ -97,7 +97,7 @@ public class HandleLayer extends JPanel implements MouseListener, MouseMotionLis
     private boolean draggingSuspended;
 
     private SelectionDragger selectionDragger;
-    private Image resizeHandle;
+    private Icon resizeHandle;
 
     private DropTarget dropTarget;
     private DropTargetListener dropListener;
@@ -356,32 +356,32 @@ public class HandleLayer extends JPanel implements MouseListener, MouseMotionLis
             g.drawRect(x, y, width, height);
             g.setStroke(oldStroke);
             if (inLayout) {
-                Image resizeHandle = resizeHandle();
-                int iconHeight = resizeHandle.getHeight(null);
-                int iconWidth = resizeHandle.getWidth(null);
+                Icon resizeHandle = resizeHandle();
+                int iconHeight = resizeHandle.getIconHeight();
+                int iconWidth = resizeHandle.getIconWidth();
                 if ((resizable & LayoutSupportManager.RESIZE_LEFT) != 0) {
-                    g.drawImage(resizeHandle, x-iconWidth+1, y+(height-iconHeight)/2, null);
+                    resizeHandle.paintIcon(null, g, x-iconWidth+1, y+(height-iconHeight)/2);
                     if ((resizable & LayoutSupportManager.RESIZE_UP) != 0) {
-                        g.drawImage(resizeHandle, x-iconWidth+1, y-iconHeight+1, null);
+                        resizeHandle.paintIcon(null, g, x-iconWidth+1, y-iconHeight+1);
                     }
                     if ((resizable & LayoutSupportManager.RESIZE_DOWN) != 0) {
-                        g.drawImage(resizeHandle, x-iconWidth+1, y+height, null);
+                        resizeHandle.paintIcon(null, g, x-iconWidth+1, y+height);
                     }
                 }
                 if ((resizable & LayoutSupportManager.RESIZE_RIGHT) != 0) {
-                    g.drawImage(resizeHandle, x+width, y+(height-iconHeight)/2, null);
+                    resizeHandle.paintIcon(null, g, x+width, y+(height-iconHeight)/2);
                     if ((resizable & LayoutSupportManager.RESIZE_UP) != 0) {
-                        g.drawImage(resizeHandle, x+width, y-iconHeight+1, null);
+                        resizeHandle.paintIcon(null, g, x+width, y-iconHeight+1);
                     }
                     if ((resizable & LayoutSupportManager.RESIZE_DOWN) != 0) {
-                        g.drawImage(resizeHandle, x+width, y+height, null);
+                        resizeHandle.paintIcon(null, g, x+width, y+height);
                     }
                 }
                 if ((resizable & LayoutSupportManager.RESIZE_UP) != 0) {
-                    g.drawImage(resizeHandle, x+(width-iconWidth)/2, y-iconHeight+1, null);
+                    resizeHandle.paintIcon(null, g, x+(width-iconWidth)/2, y-iconHeight+1);
                 }
                 if ((resizable & LayoutSupportManager.RESIZE_DOWN) != 0) {
-                    g.drawImage(resizeHandle, x+(width-iconWidth)/2, y+height, null);
+                    resizeHandle.paintIcon(null, g, x+(width-iconWidth)/2, y+height);
                 }
             }
         }
@@ -701,9 +701,9 @@ public class HandleLayer extends JPanel implements MouseListener, MouseMotionLis
         counts[start ? 0 : 1]++;
     }
     
-    private Image resizeHandle() {
+    private Icon resizeHandle() {
         if (resizeHandle == null) {
-            resizeHandle = ImageUtilities.loadImageIcon("org/netbeans/modules/form/resources/resize_handle.png", false).getImage(); // NOI18N
+            resizeHandle = ImageUtilities.loadIcon("org/netbeans/modules/form/resources/resize_handle.png", false); // NOI18N
         }
         return resizeHandle;
     }

--- a/java/form/src/org/netbeans/modules/form/layoutdesign/LayoutPainter.java
+++ b/java/form/src/org/netbeans/modules/form/layoutdesign/LayoutPainter.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.form.layoutdesign;
 import java.awt.*;
 import java.util.*;
 import java.util.List;
+import javax.swing.Icon;
 import javax.swing.UIManager;
 import org.openide.util.ImageUtilities;
 import static org.netbeans.modules.form.layoutdesign.VisualState.GapInfo;
@@ -45,7 +46,7 @@ public class LayoutPainter implements LayoutConstants {
 
     private static final int BOTH_DIMENSIONS = 2;
 
-    private Image warningImage;
+    private Icon warningIcon;
 
     private static boolean PAINT_RES_GAP_MIN_SIZE;
 
@@ -171,15 +172,15 @@ public class LayoutPainter implements LayoutConstants {
     private void paintUnplacedWarningImage(Graphics2D g, LayoutComponent comp) {
         LayoutRegion region = comp.getCurrentSpace();
         Rectangle rect = region.toRectangle(new Rectangle());
-        Image image = getWarningImage();
-        g.drawImage(image, rect.x+rect.width-image.getWidth(null), rect.y, null);
+        Icon icon = getWarningIcon();
+        icon.paintIcon(null, g, rect.x+rect.width-icon.getIconWidth(), rect.y);
     }
 
-    private Image getWarningImage() {
-        if (warningImage == null) {
-            warningImage = ImageUtilities.loadImage("org/netbeans/modules/form/layoutsupport/resources/warning.png"); // NOI18N
+    private Icon getWarningIcon() {
+        if (warningIcon == null) {
+            warningIcon = ImageUtilities.loadIcon("org/netbeans/modules/form/layoutsupport/resources/warning.png"); // NOI18N
         }
-        return warningImage;
+        return warningIcon;
     }
     
     private void paintLinks(Graphics2D g, LayoutComponent component) {

--- a/java/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GlassPane.java
+++ b/java/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GlassPane.java
@@ -24,7 +24,6 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.Cursor;
 import java.awt.Graphics;
-import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
@@ -42,6 +41,7 @@ import java.util.List;
 import java.util.Set;
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
+import javax.swing.Icon;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
 import javax.swing.JPanel;
@@ -475,24 +475,24 @@ public class GlassPane extends JPanel implements GridActionPerformer {
             int w = rect.width/2+1;
             int h = rect.height/2+1;
             g.drawRect(x, y, rect.width+1, rect.height+1);
-            Image resizeHandle = GridDesigner.RESIZE_HANDLE;
-            int rw = resizeHandle.getWidth(null);
-            int rh = resizeHandle.getHeight(null);
-            g.drawImage(resizeHandle, x-rw, y-rh, null); // left-top
+            Icon resizeHandle = GridDesigner.RESIZE_HANDLE;
+            int rw = resizeHandle.getIconWidth();
+            int rh = resizeHandle.getIconHeight();
+            resizeHandle.paintIcon(null, g, x-rw, y-rh); // left-top
             x += w;
-            g.drawImage(resizeHandle, x-rw/2, y-rh, null); // top
+            resizeHandle.paintIcon(null, g, x-rw/2, y-rh); // top
             x += rect.width+2-w;
-            g.drawImage(resizeHandle, x, y-rh, null); // right-top
+            resizeHandle.paintIcon(null, g, x, y-rh); // right-top
             y += h;
-            g.drawImage(resizeHandle, x, y-rh/2, null); // right
+            resizeHandle.paintIcon(null, g, x, y-rh/2); // right
             y += rect.height+2-h;
-            g.drawImage(resizeHandle, x, y, null); // right-bottom
+            resizeHandle.paintIcon(null, g, x, y); // right-bottom
             x -= rect.width+2-w;
-            g.drawImage(resizeHandle, x-rw/2, y, null); // bottom
+            resizeHandle.paintIcon(null, g, x-rw/2, y); // bottom
             x -= w;
-            g.drawImage(resizeHandle, x-rw, y, null); // left-bottom
+            resizeHandle.paintIcon(null, g, x-rw, y); // left-bottom
             y -= rect.height+2-h;
-            g.drawImage(resizeHandle, x-rw, y-rh/2, null); // left
+            resizeHandle.paintIcon(null, g, x-rw, y-rh/2); // left
         }
         gClip.dispose();
     }
@@ -789,9 +789,9 @@ public class GlassPane extends JPanel implements GridActionPerformer {
         } else {
             int x = cursorLocation.x;
             int y = cursorLocation.y;
-            Image resizeHandle = GridDesigner.RESIZE_HANDLE;
-            int rw = resizeHandle.getWidth(null);
-            int rh = resizeHandle.getHeight(null);
+            Icon resizeHandle = GridDesigner.RESIZE_HANDLE;
+            int rw = resizeHandle.getIconWidth();
+            int rh = resizeHandle.getIconHeight();
             for (Component selComp : selection) {
                 Rectangle rect = fromComponentPane(selectionResizingBounds(selComp));
                 boolean w = (rect.x-rw<=x) && (x<=rect.x+rect.width+rw);

--- a/java/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridDesigner.java
+++ b/java/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GridDesigner.java
@@ -25,9 +25,6 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.EventQueue;
-import java.awt.GridBagLayout;
-import java.awt.Image;
-import java.awt.LayoutManager;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
@@ -41,6 +38,7 @@ import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.GroupLayout;
+import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -101,7 +99,7 @@ public class GridDesigner extends JPanel {
     /** Color of the selection. */
     public static final Color SELECTION_COLOR = FormLoaderSettings.getInstance().getSelectionBorderColor();
     /** Image of the resizing handle. */
-    public static final Image RESIZE_HANDLE = ImageUtilities.loadImageIcon("org/netbeans/modules/form/resources/resize_handle.png", false).getImage(); // NOI18N
+    public static final Icon RESIZE_HANDLE = ImageUtilities.loadIcon("org/netbeans/modules/form/resources/resize_handle.png", false); // NOI18N
     /** The "main" panel of the designer. */
     private JPanel innerPane;
     /** Glass pane of the designer. */

--- a/platform/openide.explorer/src/org/openide/explorer/view/IconPanel.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/IconPanel.java
@@ -26,14 +26,16 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.beans.BeanInfo;
+import javax.swing.Icon;
 import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.ListCellRenderer;
 import javax.swing.UIManager;
 import org.openide.nodes.Node;
+import org.openide.util.ImageUtilities;
 
 final class IconPanel extends JPanel implements ListCellRenderer {
-    private Image thumbImage;
+    private Icon thumbIcon;
     private boolean selected;
     private boolean focused;
 
@@ -44,7 +46,7 @@ final class IconPanel extends JPanel implements ListCellRenderer {
     @Override
     public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
         Node node = Visualizer.findNode(value);
-        thumbImage = node.getIcon(BeanInfo.ICON_COLOR_32x32);
+        thumbIcon = ImageUtilities.image2Icon(node.getIcon(BeanInfo.ICON_COLOR_32x32));
         this.selected = isSelected;
         label.setOpaque(selected);
         if (selected) {
@@ -111,17 +113,16 @@ final class IconPanel extends JPanel implements ListCellRenderer {
                 g.drawRect(18, 18, getWidth() - (2 * 18), getHeight() - (2 * 18));
                 g.setStroke(new BasicStroke(1f));
             }
-            g.drawImage(thumbImage,
-                getWidth() / 2 - thumbImage.getWidth(this) / 2,
-                getHeight() / 2 - thumbImage.getHeight(this) / 2, this
-            );
+            thumbIcon.paintIcon(this, g,
+                getWidth() / 2 - thumbIcon.getIconWidth() / 2,
+                getHeight() / 2 - thumbIcon.getIconHeight() / 2);
         }
 
         @Override
         public Dimension getPreferredSize() {
             return new Dimension(
-                thumbImage.getWidth(this) + getInsets().left + getInsets().right,
-                thumbImage.getHeight(this) + getInsets().top + getInsets().bottom
+                thumbIcon.getIconWidth() + getInsets().left + getInsets().right,
+                thumbIcon.getIconHeight() + getInsets().top + getInsets().bottom
             );
         }
     }


### PR DESCRIPTION
Here are a few more changes to ensure that [SVG icons](https://github.com/apache/netbeans/pull/8083) render at full resolution on HiDPI screens.

This PR handles the transformation from
`Graphics.drawImage(ImageIcon, x, y, null)`
to
`Icon.paintIcon(null, Graphics, x, y)`
at various places in the codebase.

This fixes e.g. poor-resolution lightbulb icons in the editor gutter on Windows at fractional HiDPI scale factors. See the before/after screenshot below, which was taken on Windows 11 with the 150% HiDPI scaling level.

![image](https://github.com/user-attachments/assets/b4106358-9163-488f-b9c4-f75a1ade0177)

All simple such cases were found by grepping for "drawImage" and reviewing each case. Test classes and NBI related classes were skipped.

This is mostly an improvement for screens with a fractional HiDPI scaling (e.g. 150%) on Windows. On 200% scaling (including on MacOS), icons are drawn properly even with drawImage, due to ImageUtilities returning MultiResolutionImage instances nowadays with 1x and 2x resolutions present. The latter is still a good fallback for cases that may not yet be covered otherwise.