### PR TITLE
Show dragged tab images at full HiDPI resolution

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/view/dnd/DragWindow.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/dnd/DragWindow.java
@@ -31,13 +31,10 @@ import java.awt.Image;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.Window;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import javax.swing.JWindow;
 import javax.swing.SwingUtilities;
-import javax.swing.Timer;
 import org.netbeans.core.windows.options.WinSysPrefs;
 import org.netbeans.swing.tabcontrol.customtabs.Tabbed;
 
@@ -46,45 +43,32 @@ import org.netbeans.swing.tabcontrol.customtabs.Tabbed;
  * @author sa
  */
 class DragWindow extends JWindow {
+    private static final float NO_DROP_ALPHA = 0.5f;
     /* Store buffers at 2x the logical resolution. Then scale them down by 50% when painting to the
     JWindow. This ensures full-resolution painting on HiDPI and Retina screens. */
     private static final int DPI_SCALE = 2;
 
-    private boolean useFadeEffects = !Boolean.getBoolean( "winsys.dnd.nofadeeffects" );
+    private final Tabbed container;
+    private final Rectangle tabRectangle;
+    private final BufferedImage tabImage;
+    private final BufferedImage contentImage;
+    private boolean dropEnabled = true;
 
-    private Tabbed container;
-    private Rectangle tabRectangle;
-    private BufferedImage tabImage;
-    private BufferedImage contentImage;
-    private BufferedImage imageBuffer;
-    private float contentAlpha = 0.15f;
-    private Color contentBackground = Color.white;
-    
-    private Timer currentEffect;
-    
     public DragWindow( Tabbed container, Rectangle tabRectangle, final Dimension contentSize, final Component content ) {
         this.tabRectangle = tabRectangle;
         this.container = container;
-        
+
         setAlwaysOnTop( true );
-        
+
         tabImage = createTabImage();
-        
         contentImage = createContentImage( content, contentSize );
-        if( useFadeEffects ) {
-            imageBuffer = createImageBuffer( contentImage );
-            currentEffect = createInitialEffect();
-            currentEffect.start();
-        } else {
-            contentAlpha = 1.0f;
-        }
     }
-    
+
     private BufferedImage createTabImage() {
         GraphicsConfiguration config = GraphicsEnvironment.getLocalGraphicsEnvironment()
                     .getDefaultScreenDevice().getDefaultConfiguration();
 
-        //the tab rectangle must be painted by top-level window otherwise the transparent 
+        //the tab rectangle must be painted by top-level window otherwise the transparent
         //button icons will be messed up
         Window parentWindow = SwingUtilities.getWindowAncestor(container.getComponent());
         Rectangle rect = SwingUtilities.convertRectangle(container.getComponent(), tabRectangle, parentWindow);
@@ -97,7 +81,7 @@ class DragWindow extends JWindow {
         parentWindow.paint(g);
         return res;
     }
-    
+
     private BufferedImage createContentImage( Component c, Dimension contentSize ) {
         GraphicsConfiguration config = GraphicsEnvironment.getLocalGraphicsEnvironment()
                     .getDefaultScreenDevice().getDefaultConfiguration();
@@ -115,18 +99,6 @@ class DragWindow extends JWindow {
             g.scale(xScale, yScale);
         }
         c.paint(g);
-        return res;
-    }
-    
-    private BufferedImage createImageBuffer( BufferedImage src ) {
-        GraphicsConfiguration config = GraphicsEnvironment.getLocalGraphicsEnvironment()
-                    .getDefaultScreenDevice().getDefaultConfiguration();
-        BufferedImage res = config.createCompatibleImage(src.getWidth(), src.getHeight());
-        Graphics2D g = res.createGraphics();
-        g.setColor( contentBackground );
-        g.fillRect(0, 0, res.getWidth(), res.getHeight());
-        g.setComposite( AlphaComposite.getInstance( AlphaComposite.SRC_OVER, contentAlpha) );
-        g.drawImage( src, 0, 0, null );
         return res;
     }
 
@@ -151,111 +123,31 @@ class DragWindow extends JWindow {
         g2d.fillRect(0,0,getWidth(),tabRectangle.height);
         g2d.setColor(Color.gray);
         g2d.drawRect(0, tabRectangle.height, getWidth()-1, getHeight()-tabRectangle.height-1);
-        
+
         if( WinSysPrefs.HANDLER.getBoolean(WinSysPrefs.DND_SMALLWINDOWS, true) ) {
             drawImageScaled(g2d, tabImage, 0, 0);
         } else {
             drawImageScaled(g2d, tabImage, tabRectangle.x, tabRectangle.y);
         }
-        if( !useFadeEffects || null == imageBuffer ) {
-            g2d.setColor( Color.black );
-            g2d.fillRect(1, tabRectangle.height+1, getWidth()-2, getHeight()-tabRectangle.height-2);
-            g2d.setComposite( AlphaComposite.getInstance(AlphaComposite.SRC_OVER, contentAlpha ));
-            drawImageScaled(g2d, contentImage, 1, tabRectangle.height+1);
-        } else if( null != imageBuffer ) {
-            drawImageScaled(g2d, imageBuffer, 1, tabRectangle.height+1);
+
+        g2d.setColor( Color.black );
+        g2d.fillRect(1, tabRectangle.height+1, getWidth()-2, getHeight()-tabRectangle.height-2);
+        if (!dropEnabled) {
+            g2d.setComposite( AlphaComposite.getInstance(AlphaComposite.SRC_OVER, NO_DROP_ALPHA));
         }
+        drawImageScaled(g2d, contentImage, 1, tabRectangle.height+1);
         g2d.dispose();
     }
 
-    private boolean dropEnabled = true;
     public void setDropFeedback( boolean dropEnabled ) {
-        boolean prevState = this.dropEnabled;
+        if (this.dropEnabled == dropEnabled) {
+            return;
+        }
         this.dropEnabled = dropEnabled;
-        if( prevState != this.dropEnabled ) {
-            if( null != currentEffect ) {
-                currentEffect.stop();
-            }
-            if( useFadeEffects ) {
-                contentBackground = Color.black;
-                currentEffect = dropEnabled ? createDropEnabledEffect() : createNoDropEffect();
-                currentEffect.start();
-                repaint();
-            } else {
-                contentAlpha = dropEnabled ? 1.0f : NO_DROP_ALPHA;
-                repaint();
-            }
-        }
-    }
-    
-    private Timer createInitialEffect() {
-        final Timer timer = new Timer(100, null);
-        timer.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                if( contentAlpha < 1.0f ) {
-                    contentAlpha += ALPHA_INCREMENT;
-                } else {
-                    timer.stop();
-                }
-                if( contentAlpha > 1.0f )
-                    contentAlpha = 1.0f;
-                repaintImageBuffer();
-                repaint();
-            }
-        });
-        timer.setInitialDelay(0);
-        return timer;
-    }
-    
-    private Timer createDropEnabledEffect() {
-        return createInitialEffect();
-    }
-    
-    private static final float NO_DROP_ALPHA = 0.5f;
-    private static final float ALPHA_INCREMENT = 0.085f;
-    
-    private Timer createNoDropEffect() {
-        final Timer timer = new Timer(100, null);
-        timer.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent e) {
-                if( contentAlpha > NO_DROP_ALPHA ) {
-                    contentAlpha -= ALPHA_INCREMENT;
-                } else {
-                    timer.stop();
-                }
-                if( contentAlpha < NO_DROP_ALPHA )
-                    contentAlpha = NO_DROP_ALPHA;
-                repaintImageBuffer();
-                repaint();
-            }
-        });
-        timer.setInitialDelay(0);
-        return timer;
-    }
-    
-    private void repaintImageBuffer() {
-        if( !useFadeEffects )
-            return;
-        // #128324 - image might not be created yet
-        if ( null == imageBuffer ) {
-            return;
-        }
-        Graphics2D g2d = imageBuffer.createGraphics();
-        g2d.setColor( contentBackground );
-        g2d.fillRect(0, 0, imageBuffer.getWidth(), imageBuffer.getHeight() );
-        g2d.setComposite( AlphaComposite.getInstance(AlphaComposite.SRC_OVER, contentAlpha ) );
-        g2d.drawImage(contentImage, 0, 0, null );
-        g2d.dispose();
-    }
-    
-    void abort() {
-        if( null != currentEffect ) {
-            currentEffect.stop();
-            currentEffect = null;
-        }
-        dropEnabled = true;
-        contentAlpha = 1.0f;
-        repaintImageBuffer();
         repaint();
+    }
+
+    void abort() {
+        setDropFeedback(true);
     }
 }


### PR DESCRIPTION
When dragging window system tabs, show the dragged tab image at full HiDPI resolution.

Before:
<img width="682" alt="Screenshot 2025-03-11 at 12 24 19 AM" src="https://github.com/user-attachments/assets/41b61e14-bfa7-40f0-9a19-ff32fcca0403" />

After:
<img width="682" alt="Screenshot 2025-03-11 at 12 22 58 AM" src="https://github.com/user-attachments/assets/fcdff150-0a66-421e-b13b-fb2bd72e0281" />

Tested on MacOS with a Retina screen (2x scaling) and Windows 11 with 150% HiDPI scaling.