### PR TITLE
[GH-8313] Allow use of custom HTML-Tags in PHP

### DIFF
--- a/ide/html.custom/src/org/netbeans/modules/html/custom/CustomHtmlExtension.java
+++ b/ide/html.custom/src/org/netbeans/modules/html/custom/CustomHtmlExtension.java
@@ -56,7 +56,8 @@ import org.openide.util.Pair;
  * @author marek
  */
 @MimeRegistrations({
-    @MimeRegistration(mimeType = "text/html", service = HtmlExtension.class)
+    @MimeRegistration(mimeType = "text/html", service = HtmlExtension.class),
+    @MimeRegistration(mimeType = "text/x-php5", service = HtmlExtension.class)
 })
 public class CustomHtmlExtension extends HtmlExtension {
 
@@ -76,7 +77,7 @@ public class CustomHtmlExtension extends HtmlExtension {
         if (cache == null) {
             //no cache - create
             FileObject sourceFileObject = source.getSourceFileObject();
-            Project project = sourceFileObject == null ? null : FileOwnerQuery.getOwner(sourceFileObject);  
+            Project project = sourceFileObject == null ? null : FileOwnerQuery.getOwner(sourceFileObject);
             Configuration conf = project == null ? Configuration.EMPTY : Configuration.get(project);
             cache = Pair.of(source, conf);
             return cache.second();

--- a/ide/html.custom/src/org/netbeans/modules/html/custom/hints/CheckerElementVisitor.java
+++ b/ide/html.custom/src/org/netbeans/modules/html/custom/hints/CheckerElementVisitor.java
@@ -43,10 +43,10 @@ public class CheckerElementVisitor {
         Collection<ElementVisitor> visitors = new ArrayList<>();
         visitors.add(new UnknownAttributesChecker(context, conf, snapshot, hints));
         visitors.add(new MissingRequiredAttributeChecker(context, conf, snapshot, hints));
-        
+
         return new AggregatedVisitor(visitors);
     }
-    
+
     public static class AggregatedVisitor implements ElementVisitor {
 
         private final Collection<ElementVisitor> visitors;
@@ -54,7 +54,7 @@ public class CheckerElementVisitor {
         public AggregatedVisitor(Collection<ElementVisitor> visitors) {
             this.visitors = visitors;
         }
-        
+
         @Override
         public void visit(Element node) {
             for(ElementVisitor visitor : visitors) {
@@ -63,9 +63,9 @@ public class CheckerElementVisitor {
         }
 
     }
-    
+
     protected abstract static class Checker implements ElementVisitor {
- 
+
         protected RuleContext context;
         protected Configuration conf;
         protected Snapshot snapshot;
@@ -116,7 +116,7 @@ public class CheckerElementVisitor {
                             boolean lineHint = false;
 
                             //use the whole element offsetrange so multiple unknown attributes can be handled
-                            OffsetRange range = new OffsetRange(snapshot.getEmbeddedOffset(ot.from()), snapshot.getEmbeddedOffset(ot.to()));
+                            OffsetRange range = new OffsetRange(snapshot.getOriginalOffset(ot.from()), snapshot.getOriginalOffset(ot.to()));
                             hints.add(new UnknownAttributes(unknownAttributeNames, tagModel.getName(), context, range, lineHint));
                         }
                     }
@@ -125,7 +125,7 @@ public class CheckerElementVisitor {
         }
     }
 
-     private static class MissingRequiredAttributeChecker extends Checker {
+    private static class MissingRequiredAttributeChecker extends Checker {
 
         public MissingRequiredAttributeChecker(RuleContext context, Configuration conf, Snapshot snapshot, List<Hint> hints) {
             super(context, conf, snapshot, hints);
@@ -157,6 +157,6 @@ public class CheckerElementVisitor {
             }
         }
     }
-    
-    
+
+
 }


### PR DESCRIPTION
- register CustomHtmlExtension to x-php5 mimeType
- UnknownAttribute hint used to be at wrong position in source when embedded in PHP

Example:
customs.json
```json
{
	"elements": {
		"y-customdefined": {
			"attributes": {
				"exists": {}
			}
		}
	},
	"attributes": {"globaldefined": {}}
}
```

PHP script including custom tags, so far none of the tags defined in customs.json will be valid
```php
<x-customnotdefined><?php echo 'test'; ?></x-customnotdefined>
<y-customdefined exists="" noexists=""><?php echo 'test'; ?></y-customdefined>
<y-customdefined exists=""></y-customdefined>
<y-customdefined globaldefined=""></y-customdefined>
<y-customdefined noexists=""><?php echo 'test'; ?></y-customdefined>

```