### PR TITLE
Adjust focus behavior when closing the last editor in a window mode

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/WindowManagerImpl.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/WindowManagerImpl.java
@@ -1357,14 +1357,28 @@ public final class WindowManagerImpl extends WindowManager implements Workspace 
                 central.switchMaximizedMode( null );
                 topComponentClose( tc );
             } else {
-                TopComponent recentTc = null;
+                ModeImpl activateMode = null;
+                TopComponent activateTC = null;
                 if( mode.getKind() == Constants.MODE_KIND_EDITOR && !inCloseAll ) {
                     //an editor document is being closed so let's find the most recent editor to select
-                    recentTc = central.getRecentTopComponent( mode, tc );
+                    activateTC = central.getRecentTopComponent( mode, tc );
+                    if (activateTC != null) {
+                        activateMode = mode;
+                    } else {
+                        /* The closed TopComponent may have been the last one in its mode. Find the
+                        most recent TopComponent in the "editor" mode instead, if present. */
+                        Mode editorMode = findMode("editor");
+                        if (editorMode instanceof ModeImpl && mode != editorMode) {
+                          activateMode = (ModeImpl) editorMode;
+                          activateTC = central.getRecentTopComponent( activateMode, tc );
+                        }
+                    }
                 }
                 mode.close(tc);
-                if( !tc.isOpened() && null != recentTc )
-                    mode.setSelectedTopComponent(recentTc);
+                if( !tc.isOpened() && null != activateTC && null != activateMode ) {
+                    activateTC.requestActive();
+                    activateMode.setSelectedTopComponent(activateTC);
+                }
             }
         }
     }


### PR DESCRIPTION
When the user closes the last TopComponent in a window system mode other than the 'editor' one, move the focus to the 'editor' mode in preference to other modes (rather than e.g. the Output pane or Projects tab).

For example, in the following screenshot, if the user has the "Mavenproject1.java" editor selected, and then presses Ctrl+W (Command-W on Mac) to close that editor, the focus would previously end up on the Projects tab. With this PR in place, the focus instead goes to the NewClass editor. This is more useful, and consistent with the behavior that happens when the user closes an editor in a mode that have other tabs still open.

<img width="1190" alt="image" src="https://github.com/user-attachments/assets/14f3f379-8288-45e5-aa60-d22737f4968e" />
