### PR TITLE
Decrease "IDE Log" delay, and improve its output pane implementation

### DIFF
--- a/platform/o.n.core/src/org/netbeans/core/actions/LogAction.java
+++ b/platform/o.n.core/src/org/netbeans/core/actions/LogAction.java
@@ -37,6 +37,7 @@ import org.openide.util.NbBundle.Messages;
 @ActionReference(path = "Menu/View", position = 500)
 @Messages("MSG_LogTab_name=IDE &Log")
 public class LogAction implements ActionListener {
+    LogViewerSupport previousLogViewer;
 
     @Messages("MSG_ShortLogTab_name=IDE Log")
     @Override public void actionPerformed(ActionEvent evt) {
@@ -44,8 +45,15 @@ public class LogAction implements ActionListener {
         if (userDir == null) {
             return;
         }
+        if (previousLogViewer != null) {
+            /* Avoid starting multiple updater threads at the same time. I could have tried to
+            reuse the existing LogViewer, but it's safer to just create fresh state every time this
+            action is invoked. */
+            previousLogViewer.stopUpdatingLogViewer();
+        }
         File f = new File(userDir, "/var/log/messages.log");
         LogViewerSupport p = new LogViewerSupport(f, MSG_ShortLogTab_name());
+        previousLogViewer = p;
         try {
             p.showLogViewer();
         } catch (IOException e) {


### PR DESCRIPTION
The "IDE Log" pane, which can be opened from the "View" menu, can currently be up to 15 seconds behind actual events. This is very confusing when trying to use it to debug issues in the IDE.

The delay comes from two sources:
* NetBean's logger implementation waits 5 seconds between receiving events and writing them out to an associated text file. This delay is set in o.n.core.startup.TopLogging (`NbLogging.createDispatchHandler(h, 5000)`).
* The IDE Log output pane, in turn, polls the same text file only once per 10 seconds.

This PR deals with the second source of delay only, by decreasing the output pane polling interval from 10 seconds to 1 second. But to compensate for this extra work, the PR also ensures that this polling happens only when the IDE Log pane is actually open.

As it happens, previously the IDE Log action would start a new polling task every time it was invoked, and not actually stop the previous one. This is fixed here.

Summary of this PR:
* Properly stop the periodic I/O task when the user closes the Output TopComponent (rather than the specific IDE Log tab _within_ the Output TopComponent).
* Avoid starting a new parallel periodic I/O task thread every time the user invokes the IDE Log action.
* Refresh the output once per second rather than once every 10 seconds.

If desirable we could also decrease the 5-second interval in o.n.core.startup.TopLogging. But that change would impact the IDE always, as opposed to just when the IDE Log pane is open. So I haven't done that here yet.