### PR TITLE
Improve quick search behavior in OutlineView, TreeTable, and ListView

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
@@ -91,6 +91,8 @@ public class FlatLFCustoms extends LFCustoms {
             EDITOR_TOOLBAR_BORDER, new CompoundBorder(DPISafeBorder.matte(0, 0, 1, 0, editorContentBorderColor), BorderFactory.createEmptyBorder(1, 0, 1, 0)),
             "NbExplorerView.quicksearch.border.instance",
                 new CompoundBorder(DPISafeBorder.matte(1, 0, 0, 0, editorContentBorderColor), BorderFactory.createEmptyBorder(2, 6, 2, 2)),
+            "NbExplorerView.quicksearch.listview.border.instance",
+                new CompoundBorder(DPISafeBorder.matte(1, 1, 1, 1, editorContentBorderColor), BorderFactory.createEmptyBorder(2, 6, 2, 2)),
             EDITOR_TAB_CONTENT_BORDER, DPISafeBorder.matte(0, 1, 1, 1, editorContentBorderColor),
             VIEW_TAB_CONTENT_BORDER, DPISafeBorder.matte(0, 1, 1, 1, UIManager.getColor("TabbedContainer.view.contentBorderColor")), // NOI18N
 

--- a/platform/openide.explorer/nbproject/project.xml
+++ b/platform/openide.explorer/nbproject/project.xml
@@ -26,6 +26,15 @@
             <code-name-base>org.openide.explorer</code-name-base>
             <module-dependencies>
                 <dependency>
+                    <code-name-base>org.netbeans.api.annotations.common</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.13</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.swing.outline</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/platform/openide.explorer/src/org/openide/explorer/view/TableQuickSearchSupport.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/TableQuickSearchSupport.java
@@ -87,8 +87,10 @@ class TableQuickSearchSupport implements QuickSearch.Callback {
                 quickSearchInitialColumn = 0;
             }
         }
-        quickSearchLastRow = quickSearchInitialRow;
-        quickSearchLastColumn = quickSearchInitialColumn;
+        if (quickSearchLastRow < 0 || quickSearchLastColumn < 0) {
+            quickSearchLastRow = quickSearchInitialRow;
+            quickSearchLastColumn = quickSearchInitialColumn;
+        }
         doSearch(searchText, true);
     }
 
@@ -152,14 +154,18 @@ class TableQuickSearchSupport implements QuickSearch.Callback {
         quickSearchInitialColumn = -1;
     }
 
+    private static final boolean RESTORE_PRIOR_SELECTION_AFTER_QUICK_SEARCH = false;
+
     @Override
     public void quickSearchCanceled() {
         // Check whether the cancel was explicit or implicit.
         // Implicit cancel has undefined focus owner
         // TODO: After switch to JDK 8, we can e.g. add a static method to Callback providing the info.
-        Component focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner();
-        if (focusOwner != null) {
-            displaySearchResult(quickSearchInitialRow, quickSearchInitialColumn);
+        if (RESTORE_PRIOR_SELECTION_AFTER_QUICK_SEARCH) {
+            Component focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner();
+            if (focusOwner != null) {
+                displaySearchResult(quickSearchInitialRow, quickSearchInitialColumn);
+            }
         }
         quickSearchInitialRow = -1;
         quickSearchInitialColumn = -1;

--- a/platform/openide.explorer/src/org/openide/explorer/view/TreeView.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/TreeView.java
@@ -1957,12 +1957,14 @@ public abstract class TreeView extends JScrollPane {
 
         @Override
         public void showNextSelection(boolean forward) {
-            if (forward) {
-                currentSelectionIndex++;
-            } else {
-                currentSelectionIndex--;
+            if (lastSearchText != null) {
+                if (forward) {
+                    currentSelectionIndex++;
+                } else {
+                    currentSelectionIndex--;
+                }
+                displaySearchResult();
             }
-            displaySearchResult();
         }
 
         @Override
@@ -2096,7 +2098,7 @@ public abstract class TreeView extends JScrollPane {
                 setSelectionPath(path);
                 scrollPathToVisible(path);
             } else {
-                if (lastSearchText.isEmpty() && origSelectionPaths != null) {
+                if ((lastSearchText == null || lastSearchText.isEmpty()) && origSelectionPaths != null) {
                     setSelectionPaths(origSelectionPaths);
                     scrollPathToVisible(origSelectionPaths[0]);
                 } else {


### PR DESCRIPTION
Quick search is the little search bar that pops up when you start typing in various NetBeans explorer view components:

<img width="252" alt="image" src="https://github.com/user-attachments/assets/f050a75e-a100-4527-851e-05b5dd9cc551" />

This PR unifies the search bar behavior in OutlineView, TreeTable, and ListView, with some adjustments and bug fixes. Mostly the search bar should work like a search bar in any other app, e.g. Chrome. Some common alternative keystrokes are handled for Find Next/Previous.

Details:
* For OutlineView and TreeTable, avoid changing the selection when pressing Escape. (TreeView already has the desired behavior.)
* Add F3 and Ctrl/Command+G as alternative keystrokes for next-match (and Shift variants for previous-match).
* Have QuickSearch select all when invoking Ctrl+F or alternative shortcuts while the search bar is already open.
* Make the ListView's quick search box look more modern, and consistent with that of OutlineView/TreeView. Use the magnifying glass icon instead of the text 'Search', and use a flat border style. Note that ListView has a "floating" search bar instead of one attached to the bottom of the box; I have not changed this.
  * <img width="254" alt="image" src="https://github.com/user-attachments/assets/41d04003-f294-4fef-b60a-0362acdb1914" />
* Add more alternative find-next/previous keystrokes for ListView, like I did in the QuickSearch class (which is used by TreeView and OutlineView but not ListView). On Ctrl+F or F3, open the search bar, or select-all the existing text if it is already open.
* In OutlineView and TreeTable, avoid backtracking to the first hit if backspace is pressed on a still-matching selection.

