### PR TITLE
apidoc html compliance part 2

### DIFF
--- a/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/package.html
+++ b/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/spi/package.html
@@ -30,7 +30,7 @@ libraries that may be needed for some optional tasks shipped with Ant.</p>
 {@link org.apache.tools.ant.module.spi.AntEvent}, and {@link org.apache.tools.ant.module.spi.TaskStructure}, provides a powerful way of controlling
 the appearance of Ant process output.</p>
 
-<h2><a name="register-defs">Registering Tasks and Types</a></h2>
+<h2 id="register-defs">Registering Tasks and Types</h2>
 
 <p>The Ant module provides a way for other modules to register custom Ant
 tasks and types that will automatically be available to any scripts running

--- a/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerEngine.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerEngine.java
@@ -33,9 +33,9 @@ import org.netbeans.spi.debugger.ContextProvider;
  * <table>
  * <caption>Description of DebuggerEngine</caption>
  * <tbody><tr>
- * <td colspan="2" style="background-color:#4D7A97"><font size="+2"><b>Description </b></font></td>
- * </tr><tr><td align="left" valign="top" width="1%"><font size="+1">
- * <b>Functionality</b></font></td><td>
+ * <td colspan="2" style="background-color:#4D7A97"><b>Description </b></td>
+ * </tr><tr><td>
+ * <b>Functionality</b></td><td>
  *
  * <b>Support for actions:</b>
  *    DebuggerEngine manages list of actions ({@link #getActionsManager}). 
@@ -74,15 +74,15 @@ import org.netbeans.spi.debugger.ContextProvider;
  *    {@link ActionsManagerListener}.
  *
  * <br>
- * </td></tr><tr><td align="left" valign="top" width="1%"><font size="+1">
- * <b>Clinents / Providers</b></font></td><td>
+ * </td></tr><tr><td>
+ * <b>Clinents / Providers</b></td><td>
  *
  * This class is final, so it does not have any external provider.
  * Debugger Plug-ins and UI modules are clients of this class.
  *
  * <br>
- * </td></tr><tr><td align="left" valign="top" width="1%"><font size="+1">
- * <b>Lifecycle</b></font></td><td>
+ * </td></tr><tr><td>
+ * <b>Lifecycle</b></td><td>
  *
  * A new instance(s) of DebuggerEngine class are created in Debugger Core 
  * module only, during the process of starting of debugging (see
@@ -91,8 +91,8 @@ import org.netbeans.spi.debugger.ContextProvider;
  * DebuggerEngine is removed automatically from {@link DebuggerManager} when the 
  * the last action is ({@link ActionsManager#ACTION_KILL}).
  *
- * </td></tr><tr><td align="left" valign="top" width="1%"><font size="+1">
- * <b>Evolution</b></font></td><td>
+ * </td></tr><tr><td>
+ * <b>Evolution</b></td><td>
  *
  * No method should be removed from this class, but some functionality can
  * be added in future.

--- a/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
@@ -51,9 +51,9 @@ import org.openide.util.Exceptions;
  * <table>
  * <caption>Description of DebuggerManager</caption>
  * <tbody><tr>
- * <td colspan="2" style="background-color:#4D7A97"><font size="+2"><b>Description </b></font></td>
- * </tr><tr><td align="left" valign="top" width="1%"><font size="+1">
- * <b>Functionality</b></font></td><td> 
+ * <td colspan="2" style="background-color:#4D7A97"><b>Description </b></td>
+ * </tr><tr><td>
+ * <b>Functionality</b></td><td> 
  *
  * <b>Start &amp; finish debugging:</b>
  *    DebuggerManager manages a process of starting a new debugging (
@@ -99,22 +99,22 @@ import org.openide.util.Exceptions;
  *    {@link org.netbeans.api.debugger.DebuggerManagerListener}.
  *
  * <br>
- * </td></tr><tr><td align="left" valign="top" width="1%"><font size="+1">
- * <b>Clinents / Providers</b></font></td><td> 
+ * </td></tr><tr><td>
+ * <b>Clinents / Providers</b></td><td> 
  *
  * DebuggerCore module should be the only one provider of this abstract class.
  * This class should be called from debugger plug-in modules and from debugger
  * UI modules. 
  * 
  * <br>
- * </td></tr><tr><td align="left" valign="top" width="1%"><font size="+1">
- * <b>Lifecycle</b></font></td><td> 
+ * </td></tr><tr><td>
+ * <b>Lifecycle</b></td><td> 
  *
  * The only one instance of DebuggerManager should exist, and it should be 
  * created in {@link #getDebuggerManager} method.
  * 
- * </td></tr><tr><td align="left" valign="top" width="1%"><font size="+1">
- * <b>Evolution</b></font></td><td>
+ * </td></tr><tr><td>
+ * <b>Evolution</b></td><td>
  *
  * No method should be removed from this class, but some functionality can 
  * be added.

--- a/ide/api.debugger/src/org/netbeans/api/debugger/Session.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/Session.java
@@ -34,9 +34,9 @@ import org.netbeans.spi.debugger.ContextProvider;
  * <table>
  * <caption>Description of Session</caption>
  * <tbody><tr>
- * <td colspan="2" style="background-color:#4D7A97"><font size="+2"><b>Description </b></font></td>
- * </tr><tr><td align="left" valign="top" width="1%"><font size="+1">
- * <b>Functionality</b></font></td><td>
+ * <td colspan="2" style="background-color:#4D7A97"><b>Description </b></td>
+ * </tr><tr><td>
+ * <b>Functionality</b></td><td>
  *
  * <b>Properties:</b>
  *    Session has two standard read only properties - name ({@link #getName}) and
@@ -83,15 +83,15 @@ import org.netbeans.spi.debugger.ContextProvider;
  *    {@link java.beans.PropertyChangeListener}.
  *
  * <br> 
- * </td></tr><tr><td align="left" valign="top" width="1%"><font size="+1">
- * <b>Clients / Providers</b></font></td><td>
+ * </td></tr><tr><td>
+ * <b>Clients / Providers</b></td><td>
  *
  * This class is final, so it does not have any external provider.
  * Debugger Core and UI modules are clients of this class.
  *
  * <br>
- * </td></tr><tr><td align="left" valign="top" width="1%"><font size="+1">
- * <b>Life-cycle</b></font></td><td>
+ * </td></tr><tr><td>
+ * <b>Life-cycle</b></td><td>
  *
  * A new instance of Session class can be created and registered to
  * {@link org.netbeans.api.debugger.DebuggerManager} during the process
@@ -102,8 +102,8 @@ import org.netbeans.spi.debugger.ContextProvider;
  * {@link org.netbeans.api.debugger.DebuggerManager} when the 
  * number of "supported languages" ({@link #getSupportedLanguages}) is zero.
  *
- * </td></tr><tr><td align="left" valign="top" width="1%"><font size="+1">
- * <b>Evolution</b></font></td><td>
+ * </td></tr><tr><td>
+ * <b>Evolution</b></td><td>
  *
  * No method should be removed from this class, but some functionality can
  * be added in future.

--- a/ide/api.debugger/src/org/netbeans/api/debugger/package.html
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/package.html
@@ -33,7 +33,7 @@ The NetBeans Debugger Core API definition. Debugger Core API interfaces
 allows to install differrent debugger inlementations to one IDE, and
 share some UI components among them.<br>
 <br>
-<h2><a name="Basic_debugger_model"></a>Basic debugger model<br>
+<h2 id="Basic_debugger_model">Basic debugger model<br>
 </h2>
 Debugger Core API represents debugger as some tree structure. {@link
 org.netbeans.api.debugger.DebuggerManager} represents root of this
@@ -67,7 +67,7 @@ org.netbeans.api.debugger.DebuggerManager#startDebugging(DebuggerInfo)}.
 The only method how to remove something is {@link
 org.netbeans.api.debugger.DebuggerEngine.Destructor}.<br>
 <br>
-<h2><a name="lookups"></a>Exension of basic model - lookups,
+<h2 id="lookups">Exension of basic model - lookups,
 Meta-inf/debugger<br>
 </h2>
 Basic debugger model is very simple, and it should be extended by some
@@ -107,7 +107,7 @@ Meta-inf/debugger folder. The way how to do it is described in <a
  href="../../spi/debugger/package-summary.html">Debugger
 SPI </a>documentation.<br>
 <br>
-<h2><a name="Debugger_Start_Process"></a>Debugger Start Process</h2>
+<h2 id="Debugger_Start_Process">Debugger Start Process</h2>
 The process which implements starting of debugger in Debugger Core
 module is very simple. There is one instance of {@link
 org.netbeans.api.debugger.DebuggerInfo} and {@link
@@ -135,7 +135,7 @@ new Sessions and new DebuggerEngines and registers them to the
 DebuggerManager.
 Thats all.<br>
 <br>
-<h2><a name="Debugger_Start_Process_-_advanced"></a>Debugger Start
+<h2 id="Debugger_Start_Process_-_advanced">Debugger Start
 Process - advanced version</h2>
 Debugger API supports two enhancements to the standard debugger start
 process:<br>
@@ -151,7 +151,7 @@ Session. <br>
 Second usecase is supported by interface {@link
 org.netbeans.spi.debugger.DelegatingDebuggerEngineProvider}.<br>
 <br>
-<h2><a name="Debugger_Actions"></a>Debugger Actions - how does it work</h2>
+<h2 id="Debugger_Actions">Debugger Actions - how does it work</h2>
 debuggercore-ui module installs some basic set of standard debugger
 actions to NetBeans toolbar and menu. Debugger actions
 (javax.swing.Action) are private. Each action is represented by some
@@ -159,7 +159,7 @@ constant in {@link
 org.netbeans.api.debugger.ActionsManager} (like {@link
 org.netbeans.api.debugger.ActionsManager#ACTION_STEP_INTO}). <br>
 ActionsManager manages list of registered {@link
-org.netbeans.spi.debugger.ActionProvider}s. It contains mapping between
+org.netbeans.spi.debugger.ActionsProvider}s. It contains mapping between
 action constant and ActionProvider registerred for this constant. For
 example:<br>
 <br>
@@ -217,8 +217,8 @@ org.netbeans.spi.debugger.ActionsProviderListener#actionStateChange(Object,boole
 for {@link org.netbeans.api.debugger.ActionsManager#ACTION_STEP_INTO}.</li>
   <li>{@link org.netbeans.api.debugger.DebuggerEngine} is listenning on
 all installed {@link org.netbeans.spi.debugger.ActionsProvider}s and
-fires all action state changes using {@link
-org.netbeans.api.debugger.DebuggerEngineListener#actionStateChanged(Object,boolean)}.</li>
+fires all action state changes using 
+{@code org.netbeans.api.debugger.DebuggerEngineListener#actionStateChanged(Object,boolean)}.</li>
   <li>StepIntoAction listens on {@link
 org.netbeans.api.debugger.DebuggerEngine}, and it updates its state
 when some actionStateChanged is fired.<br>
@@ -230,7 +230,7 @@ when some actionStateChanged is fired.<br>
  style="font-weight: bold;">ActionProvider</span><span
  style="font-weight: bold;">          DebuggerEngine.ActionsProviderListener                </span><span
  style="font-weight: bold;">StepIntoAction.DebuggerEngineListener</span><span
- style="font-weight: bold;"></span><br>                     (ActionsProvider)                            |                                           (javax.swing.Action)                 <span
+ style="font-weight: bold;">&nbsp;</span><br>                     (ActionsProvider)                            |                                           (javax.swing.Action)                 <span
  style="font-weight: bold;"><br></span>                            |                                     |                                                    |<br>   _  state of   -&gt;  fire action state                            |                                                    |<br>  |?|  action            change           --&gt;   <b>actionStateChange</b> (ACTION_STEP_INTO, enabled)                          |<br>   &macr;  should be             |                                     |                                                    |<br>      changed               |                         fire DebuggerEngineListener                                      |<br>                            |                            actionStateChanged                   --&gt;             <span
  style="font-weight: bold;">actionStateChanged</span><br>                            |                                     |                                             updates a state<br>                            |                                     |                                                of action<br>                            |&lt;--                                &lt;-|-                          <span
  style="font-weight: bold;">&lt;--</span>                      |<br></pre>

--- a/ide/api.debugger/src/org/netbeans/spi/debugger/package.html
+++ b/ide/api.debugger/src/org/netbeans/spi/debugger/package.html
@@ -42,8 +42,8 @@ to some Session</span>: {@link
 org.netbeans.spi.debugger.DebuggerEngineProvider}, {@link
 org.netbeans.spi.debugger.DelegatingDebuggerEngineProvider}</li>
   <li><b>install new watch evaluation engine:</b> You can register a
-new evaluator for watches - {@link
-org.netbeans.spi.debugger.WatchesProvider} and {@link
+new evaluator for watches - {@code
+org.netbeans.spi.debugger.WatchesProvider} and {@code
 org.netbeans.spi.debugger.WatchImpl}. </li>
   <li><b>add a new actions:</b> A support for some new debugger action
 (like Step Into Action) can be installed to some {@link
@@ -114,22 +114,23 @@ org.netbeans.modules.ant.debugger.ColumnModels.createBuiltInColumn()<br>
 <span style="font-weight: bold; text-decoration: underline;">List of
 all default service providers:</span><br>
 <br>
-<table cellpadding="3" cellspacing="0" border="1"
+<table border="1"
  style="text-align: left; width: 100%;">
+<caption>List of all default service providers</caption>
   <tbody>
     <tr>
       <td
- style="vertical-align: top; background-color: rgb(204, 204, 255); font-weight: bold;"><big><big>Service
+ style="vertical-align: top; background-color: rgb(204, 204, 255); font-weight: bold;">Service
 provider interface<br>
-      </big></big></td>
+      </td>
       <td
- style="vertical-align: top; background-color: rgb(204, 204, 255); font-weight: bold;"><big><big>Should
+ style="vertical-align: top; background-color: rgb(204, 204, 255); font-weight: bold;">Should
 be registerred to:<br>
-      </big></big></td>
+      </td>
       <td
- style="vertical-align: top; background-color: rgb(204, 204, 255); font-weight: bold;"><big><big>File
+ style="vertical-align: top; background-color: rgb(204, 204, 255); font-weight: bold;">File
 names:<br>
-      </big></big></td>
+      </td>
     </tr>
     <tr>
       <td style="vertical-align: top;">{@link
@@ -171,7 +172,7 @@ Meta-inf/debugger/{Session type name}<br>
 file name: org.netbeans.spi.debugger.DelegatingDebuggerEngineProvider </td>
     </tr>
     <tr>
-      <td style="vertical-align: top;">{@link
+      <td style="vertical-align: top;">{@code
 org.netbeans.spi.debugger.WatchesProvider}&nbsp;</td>
       <td style="vertical-align: top;">{@link
 org.netbeans.api.debugger.DebuggerEngine}&nbsp;</td>

--- a/ide/core.ide/arch.xml
+++ b/ide/core.ide/arch.xml
@@ -114,12 +114,10 @@
         </question>
 -->
  <answer id="arch-usecases">
-  <p>
    <usecase id="services-tab-node" name="Register Node in Services tab">
         Use <a href="@TOP@/org/netbeans/api/core/ide/ServicesTabNodeRegistration.html">
         ServicesTabNodeRegistration</a> to register your nodes into <em>Services</em> in the IDE.
    </usecase>
-  </p>
  </answer>
 
 

--- a/ide/diff/src/org/netbeans/api/diff/Difference.java
+++ b/ide/diff/src/org/netbeans/api/diff/Difference.java
@@ -54,8 +54,8 @@ public class Difference extends Object implements Serializable {
     
     /**
      * Creates a new instance of Difference
-     * @param type The type of the difference. Must be one of the {@link Part#DELETE DELETE},
-     *             {@link Part#ADD ADD} or {@link Part#CHANGE CHANGE}
+     * @param type The type of the difference. Must be one of the {@link #DELETE DELETE},
+     *             {@link #ADD ADD} or {@link #CHANGE CHANGE}
      * @param firstStart The line number on which the difference starts in the first file.
      * @param firstEnd The line number on which the difference ends in the first file.
      * @param secondStart The line number on which the difference starts in the second file.
@@ -67,8 +67,8 @@ public class Difference extends Object implements Serializable {
     
     /**
      * Creates a new instance of Difference
-     * @param type The type of the difference. Must be one of the {@link Part#DELETE DELETE},
-     *             {@link Part#ADD ADD} or {@link Part#CHANGE CHANGE}
+     * @param type The type of the difference. Must be one of the {@link #DELETE DELETE},
+     *             {@link #ADD ADD} or {@link #CHANGE CHANGE}
      * @param firstStart The line number on which the difference starts in the first file.
      * @param firstEnd The line number on which the difference ends in the first file.
      * @param secondStart The line number on which the difference starts in the second file.
@@ -83,8 +83,8 @@ public class Difference extends Object implements Serializable {
     
     /**
      * Creates a new instance of Difference
-     * @param type The type of the difference. Must be one of the {@link Part#DELETE DELETE},
-     *             {@link Part#ADD ADD} or {@link Part#CHANGE CHANGE}
+     * @param type The type of the difference. Must be one of the {@link #DELETE DELETE},
+     *             {@link #ADD ADD} or {@link #CHANGE CHANGE}
      * @param firstStart The line number on which the difference starts in the first file.
      * @param firstEnd The line number on which the difference ends in the first file.
      * @param secondStart The line number on which the difference starts in the second file.
@@ -115,8 +115,8 @@ public class Difference extends Object implements Serializable {
     }
 
     /**
-     * Get the difference type. It's one of {@link Part#DELETE DELETE},
-     * {@link Part#ADD ADD} or {@link Part#CHANGE CHANGE} meaning
+     * Get the difference type. It's one of {@link #DELETE DELETE},
+     * {@link #ADD ADD} or {@link #CHANGE CHANGE} meaning
      * respective change in second source.
      */
     public int getType() {
@@ -210,8 +210,8 @@ public class Difference extends Object implements Serializable {
     
         /**
           * Creates a new instance of LineDiff
-          * @param type The type of the difference. Must be one of the {@link Part#DELETE DELETE},
-          *             {@link Part#ADD ADD} or {@link Part#CHANGE CHANGE}
+          * @param type The type of the difference. Must be one of the {@link #DELETE DELETE},
+          *             {@link #ADD ADD} or {@link #CHANGE CHANGE}
           * @param line The line number
           * @param pos1 The position on which the difference starts on this line.
           * @param pos2 The position on which the difference ends on this line.
@@ -227,8 +227,8 @@ public class Difference extends Object implements Serializable {
         }
         
         /**
-          * Get the difference type. It's one of {@link Part#DELETE DELETE},
-          * {@link Part#ADD ADD} or {@link Part#CHANGE CHANGE}.
+          * Get the difference type. It's one of {@link #DELETE DELETE},
+          * {@link #ADD ADD} or {@link #CHANGE CHANGE}.
           */
         public int getType() {
             return this.type;

--- a/ide/editor.bracesmatching/arch.xml
+++ b/ide/editor.bracesmatching/arch.xml
@@ -65,14 +65,14 @@
   <code>org.netbeans.editor.ExtSyntaxSupport</code>.
   </p>
   
-  <h3>The infrastructure overview</h3>
+  <h2>The infrastructure overview</h2>
   
   <p>
   The following paragraphs give an overview of the infrastructure used for braces
   matching and explain the essential terminology and ideas behind it.
   </p>
   
-  <h4>Original and matching areas</h4>
+  <h3>Original and matching areas</h3>
   
   <p>
   The whole task of finding matching areas can be split in two parts. First we need
@@ -98,7 +98,7 @@
   cases, however, the matchers will only report none or one matching are as well.
   </p>
   
-  <h4>Caret Bias</h4>
+  <h3>Caret Bias</h3>
   
   <p>
   Normally when typing or moving a caret in the editor one of the characters is
@@ -149,7 +149,7 @@
   finding the areas.)
   </p>
   
-  <h4>Search direction</h4>
+  <h3>Search direction</h3>
   
   <p>
   In general when looking for the original area we not only want to look right
@@ -176,7 +176,7 @@
   </li>
   </ul>
   
-  <h4>Maximum lookahead</h4>
+  <h3>Maximum lookahead</h3>
   
   <p>
   The maximum distance, measured in characters from the position of a caret, that
@@ -196,7 +196,7 @@
   from searching through the important character (ie. the character right next to the caret).
   </p>
   
-  <h4><a name="controlling-parameters">Controlling the parameters</a></h4>
+  <h3 id="controlling-parameters">Controlling the parameters</h3>
   
   <p>
   There is no API for controlling caret bias, search direction and maximum lookaheads
@@ -234,7 +234,7 @@
   </ul>
   
   
-  <h3>Key parts of the SPI</h3>
+  <h2>Key parts of the SPI</h2>
   
   <p>Modules implementing the SPI are shielded from most of the complexity of
   the braces matching infrastructure as it was described earlier. Thier job is
@@ -272,7 +272,7 @@
   </p>
 
   
-  <h3>BracesMatcher registration</h3>
+  <h2>BracesMatcher registration</h2>
   
   <p>
   The registration of <code>BracesMatcher</code>s has to be done through an
@@ -305,7 +305,7 @@
   </p>
 
   
-  <h3>Languages embedding</h3>
+  <h2>Languages embedding</h2>
   
   <p>
   The registration mechanism described earlier and the general concept of MIME lookup
@@ -343,7 +343,7 @@
   any other languages that may potentially be embedded in the document.
   </p>
   
-  <h3>Threading</h3>
+  <h2>Threading</h2>
 
   <p>
   While finding the original brace is relatively simle task, because it's always
@@ -366,7 +366,7 @@
   </p>
 
   
-  <h3>Constraints and limitations</h3>
+  <h2>Constraints and limitations</h2>
   
   <p>
   The current design does not cover searching for areas in right-to-left documents. This
@@ -498,12 +498,12 @@
   
   <ul style="list-style-type : upper-alpha">
   <li>
-      <a name="search-scenario-A"><code>MBL = 0, MFL = 0, SD = ?, CB = F</code></a> : Check only the right hand side
+      <a id="search-scenario-A"><code>MBL = 0, MFL = 0, SD = ?, CB = F</code></a> : Check only the right hand side
       character of the caret. This is the default for Netbeans overwrite mode (ie. the
       block shaped caret).
   </li>
   <li>
-      <a name="search-scenario-B"><code>MBL = 1, MFL = 1, SD = ?, CB = B</code></a> : Check characters right next to
+      <a id="search-scenario-B"><code>MBL = 1, MFL = 1, SD = ?, CB = B</code></a> : Check characters right next to
       the caret on both its sides. This is the default for Netbeans normal mode (ie.
       the I-beam shaped caret).
   </li>

--- a/ide/editor.guards/arch.xml
+++ b/ide/editor.guards/arch.xml
@@ -125,7 +125,6 @@
         </question>
 -->
  <answer id="arch-usecases">
-  <p>
    <usecase name="Add new section" id="AddingNewSection">
        In order to add a new section after the existing section, which seems to be most frequent, use:
        <pre>
@@ -198,7 +197,6 @@
         OpenIDE-Module-Requires: org.netbeans.api.editor.guards.Java
        </pre>
    </usecase>
-  </p>
  </answer>
 
 

--- a/ide/editor.indent/arch.xml
+++ b/ide/editor.indent/arch.xml
@@ -124,9 +124,9 @@
 API Usecases
 </h1>
 
-<h3>
+<h2>
 Fix indentation of a single or multiple lines of a document.
-</h3>
+</h2>
 <p>
 Altghough there are formatting actions already there may be clients
 wishing to explicitly fix indentation of e.g. a newly inserted code into a Swing document.
@@ -152,9 +152,9 @@ try {
 }
 </pre>
 
-<h3>
+<h2>
 Code beautification of a selected area of a document.
-</h3>
+</h2>
 <p>
 Code beautification should not only fix line indentation but it may also perform
 extra changes to code according to formatting rules. For example add newlines

--- a/ide/editor.lib/arch.xml
+++ b/ide/editor.lib/arch.xml
@@ -128,7 +128,7 @@ that they operate without loading other openide classes
 (if they need an implementation class they get it from Lookup).
 </p>
 
-<h4>Hyperlink SPI</h4>
+<h2>Hyperlink SPI</h2>
 <api group="java" name="EditorHyperlinkSPI" type="export" category="devel">
     Hyperlink SPI in <code>org.netbeans.lib.editor.hyperlink.spi</code>
     allows the editors for a particular mime-type to respond to the situation

--- a/ide/editor.lib/src/org/netbeans/editor/AdjustFinder.java
+++ b/ide/editor.lib/src/org/netbeans/editor/AdjustFinder.java
@@ -21,18 +21,18 @@ package org.netbeans.editor;
 
 /**
 * Advanced finder that can adjust the start and limit position
-* of the search. The finder can be used in the <tt>BaseDocument.find()</tt>
+* of the search. The finder can be used in the <code>BaseDocument.find()</code>
 * which calls its adjust-methods automatically.
 * The order of the methods called for the search is
 * <br>
-* 1. <tt>adjustStartPos()</tt> is called<br>
-* 2. <tt>adjustStartPos()</tt> is called<br>
-* 3. <tt>reset()</tt> is called<br>
-* If the search is void i.e. <tt>doc.find(finder, pos, pos)</tt>
-* is called, no adjust-methods are called, only the <tt>reset()</tt>
+* 1. <code>adjustStartPos()</code> is called<br>
+* 2. <code>adjustStartPos()</code> is called<br>
+* 3. <code>reset()</code> is called<br>
+* If the search is void i.e. <code>doc.find(finder, pos, pos)</code>
+* is called, no adjust-methods are called, only the <code>reset()</code>
 * is called.
 * For backward search the start-position is higher than the limit-position.
-* The relation <tt>startPos &lt; endPos</tt> defines whether the search
+* The relation <code>startPos &lt; endPos</code> defines whether the search
 * will be forward or backward. The adjust-methods could in fact
 * revert this relation turning the forward search into the backward one
 * and vice versa. This is not allowed. If that happens the search
@@ -52,7 +52,7 @@ public interface AdjustFinder extends Finder {
     * Although it's not specifically checked the finder should NOT in any case
     * return the position that is lower than the original 
     * @param doc document to search on
-    * @param startPos start position originally requested in <tt>BaseDocument.find()</tt>.
+    * @param startPos start position originally requested in <code>BaseDocument.find()</code>.
     * @return possibly modified start position. The returned position must be
     *   the same or lower than the original start position for forward search
     *   and the same or high.
@@ -62,7 +62,7 @@ public interface AdjustFinder extends Finder {
     /** Adjust the limit position of the search
     * (it's the position where the search will end) to be either the same or greater.
     * @param doc document to search on
-    * @param limitPos limit position originally requested in <tt>BaseDocument.find()</tt>
+    * @param limitPos limit position originally requested in <code>BaseDocument.find()</code>
     * @return possibly modified limit position. The returned position must be
     *   the same or greater than the original limit position.
     */

--- a/ide/editor.lib/src/org/netbeans/editor/BaseDocument.java
+++ b/ide/editor.lib/src/org/netbeans/editor/BaseDocument.java
@@ -1076,7 +1076,7 @@ public class BaseDocument extends AbstractDocument implements AtomicLockDocument
 
     /** This method is called automatically before the document
     * insertion occurs and can be used to revoke the insertion before it occurs
-    * by throwing the <tt>BadLocationException</tt>.
+    * by throwing the <code>BadLocationException</code>.
     * @param offset position where the insertion will be done
     * @param text string to be inserted
     * @param a attributes of the inserted text
@@ -1087,7 +1087,7 @@ public class BaseDocument extends AbstractDocument implements AtomicLockDocument
 
     /** This method is called automatically before the document
     * removal occurs and can be used to revoke the removal before it occurs
-    * by throwing the <tt>BadLocationException</tt>.
+    * by throwing the <code>BadLocationException</code>.
     * @param offset position where the insertion will be done
     * @param len length of the removal
     */

--- a/ide/editor.lib/src/org/netbeans/editor/BaseImageTokenID.java
+++ b/ide/editor.lib/src/org/netbeans/editor/BaseImageTokenID.java
@@ -21,7 +21,7 @@ package org.netbeans.editor;
 
 /**
 * Token-id with the fixed token image. The image text is provided
-* in constructor and can be retrieved by <tt>getImage()</tt>.
+* in constructor and can be retrieved by <code>getImage()</code>.
 *
 * @author Miloslav Metelka
 * @version 1.00

--- a/ide/editor.lib/src/org/netbeans/editor/CharSeq.java
+++ b/ide/editor.lib/src/org/netbeans/editor/CharSeq.java
@@ -42,7 +42,7 @@ public interface CharSeq {
 
     /**
      * Returns the character at the specified index.  An index ranges from zero
-     * to <tt>length() - 1</tt>.  The first character of the sequence is at
+     * to <code>length() - 1</code>.  The first character of the sequence is at
      * index zero, the next at index one, and so on, as for array
      * indexing.
      *
@@ -51,8 +51,8 @@ public interface CharSeq {
      * @return  the specified character
      *
      * @throws  IndexOutOfBoundsException
-     *          if the <tt>index</tt> argument is negative or not less than
-     *          <tt>length()</tt>
+     *          if the <code>index</code> argument is negative or not less than
+     *          <code>length()</code>
      */
     char charAt(int index);
     

--- a/ide/editor.lib/src/org/netbeans/editor/Coloring.java
+++ b/ide/editor.lib/src/org/netbeans/editor/Coloring.java
@@ -41,7 +41,7 @@ import org.netbeans.modules.editor.lib.drawing.DrawContext;
 * by using the modes. There are two modes - font-mode and color-mode.
 * The deafult font-mode simply overwrites the whole font. The font-mode
 * constants allow to change the underlying font by only changing some
-* of the font-name, style or size. The <tt>FONT_MODE_APPLY_STYLE</tt>
+* of the font-name, style or size. The <code>FONT_MODE_APPLY_STYLE</code>
 * for example will only apply the style of the coloring's font.
 * The "rest" of the coloring's font (name and size in this case)
 * is not used so there can be any valid values ("Monospaced" and 12 for example).

--- a/ide/editor.lib/src/org/netbeans/editor/EditorUI.java
+++ b/ide/editor.lib/src/org/netbeans/editor/EditorUI.java
@@ -158,7 +158,7 @@ public class EditorUI implements ChangeListener, PropertyChangeListener, MouseLi
     /** Should the search words be colored? */
     boolean highlightSearch;
     
-    /** Enable displaying line numbers. Both this flag and <tt>lineNumberVisibleSetting</tt>
+    /** Enable displaying line numbers. Both this flag and <code>lineNumberVisibleSetting</code>
     * must be true to have the line numbers visible in the window. This flag is false
     * by default. It's turned on automatically if the getExtComponent is called.
     */
@@ -330,7 +330,7 @@ public class EditorUI implements ChangeListener, PropertyChangeListener, MouseLi
         updateLineHeight(c);
     }
 
-    /** Called when the <tt>BaseTextUI</tt> is being installed
+    /** Called when the <code>BaseTextUI</code> is being installed
     * into the component.
     */
     protected void installUI(JTextComponent c) {
@@ -381,7 +381,7 @@ public class EditorUI implements ChangeListener, PropertyChangeListener, MouseLi
         }
     }
 
-    /** Called when the <tt>BaseTextUI</tt> is being uninstalled
+    /** Called when the <code>BaseTextUI</code> is being uninstalled
     * from the component.
     */
     protected void uninstallUI(JTextComponent c) {
@@ -444,9 +444,9 @@ public class EditorUI implements ChangeListener, PropertyChangeListener, MouseLi
     }
 
     /** Get the lock assuring the component will not be changed
-    * by <tt>installUI()</tt> or <tt>uninstallUI()</tt>.
+    * by <code>installUI()</code> or <code>uninstallUI()</code>.
     * It's useful for the classes that want to listen for the
-    * component change in <tt>EditorUI</tt>.
+    * component change in <code>EditorUI</code>.
     */
     public Object getComponentLock() {
         if (componentLock == null) {

--- a/ide/editor.lib/src/org/netbeans/editor/ImageTokenID.java
+++ b/ide/editor.lib/src/org/netbeans/editor/ImageTokenID.java
@@ -21,7 +21,7 @@ package org.netbeans.editor;
 
 /**
 * Token-id with the fixed token image. The image text
-* can be retrieved by <tt>getImage()</tt>.
+* can be retrieved by <code>getImage()</code>.
 * The image token-ids are treated specially in some
 * editor parts for example in the indentation engine.
 *

--- a/ide/editor.lib/src/org/netbeans/editor/Mark.java
+++ b/ide/editor.lib/src/org/netbeans/editor/Mark.java
@@ -62,7 +62,7 @@ public class Mark {
     * @param backwardBias whether the inserts performed right at the position
     *   of this mark will go after this mark i.e. this mark will not move
     *   forward when inserting right at its position. This flag corresponds
-    *   to <tt>Position.Bias.Backward</tt>.
+    *   to <code>Position.Bias.Backward</code>.
     */
     public Mark(boolean backwardBias) {
         this(backwardBias ? Position.Bias.Backward : Position.Bias.Forward);

--- a/ide/editor.lib/src/org/netbeans/editor/ObjectArrayUtilities.java
+++ b/ide/editor.lib/src/org/netbeans/editor/ObjectArrayUtilities.java
@@ -45,10 +45,10 @@ public class ObjectArrayUtilities {
      * @param  objectArray object array to be searched.
      * @param  key the key to be searched for.
      * @return index of the search key, if it is contained in the object array;
-     *	       otherwise, <tt>(-(<i>insertion point</i>) - 1)</tt>.  The
+     *	       otherwise, <code>(-(<i>insertion point</i>) - 1)</code>.  The
      *	       <i>insertion point</i> is defined as the point at which the
      *	       key would be inserted into the object array: the index of the first
-     *	       element greater than the key, or <tt>objectArray.getItemCount()</tt>, if all
+     *	       element greater than the key, or <code>objectArray.getItemCount()</code>, if all
      *	       elements in the object array are less than the specified key.  Note
      *	       that this guarantees that the return value will be &gt;= 0 if
      *	       and only if the key is found.
@@ -85,7 +85,7 @@ public class ObjectArrayUtilities {
      * @param key key to search for.
      * @param c comparator to be used to compare the items.
      * @return index of the search key, if it is contained in the object array;
-     *	       otherwise, <tt>(-(<i>insertion point</i>) - 1)</tt>.
+     *	       otherwise, <code>(-(<i>insertion point</i>) - 1)</code>.
      * @see #binarySearch(ObjectArray, Object)
      */
     public static int binarySearch(ObjectArray objectArray, Object key, Comparator c) {

--- a/ide/editor.lib/src/org/netbeans/editor/Syntax.java
+++ b/ide/editor.lib/src/org/netbeans/editor/Syntax.java
@@ -22,30 +22,30 @@ package org.netbeans.editor;
 /**
 * Lexical analyzer that works on a given text buffer. It allows
 * to sequentially parse a given character buffer by calling
-* <tt>nextToken()</tt> that returns the token-ids.
+* <code>nextToken()</code> that returns the token-ids.
 *
-* After the token is found by calling the <tt>nextToken</tt> method,
-* the <tt>getTokenOffset()</tt> method can be used
+* After the token is found by calling the <code>nextToken</code> method,
+* the <code>getTokenOffset()</code> method can be used
 * to get the starting offset of the current
-* token in the buffer. The <tt>getTokenLength()</tt> gives the length
+* token in the buffer. The <code>getTokenLength()</code> gives the length
 * of the current token.
 *
-* The heart of the analyzer is the <tt>parseToken()</tt> method which
+* The heart of the analyzer is the <code>parseToken()</code> method which
 * parses the text and returns the token-id of the last token found.
-* The <tt>parseToken()</tt> method is called from the <tt>nextToken()</tt>.
-* It operates with two important variables. The <tt>offset</tt>
+* The <code>parseToken()</code> method is called from the <code>nextToken()</code>.
+* It operates with two important variables. The <code>offset</code>
 * variable identifies the currently scanned character in the buffer.
-* The <tt>tokenOffset</tt> is the begining of the current token.
-* The <tt>state</tt> variable that identifies the current internal
+* The <code>tokenOffset</code> is the begining of the current token.
+* The <code>state</code> variable that identifies the current internal
 * state of the analyzer is set accordingly when the characters are parsed.
-* If the <tt>parseToken()</tt> recognizes a token, it returns its ID
-* and the <tt>tokenOffset</tt> is its begining in the buffer and
-* <tt>offset - tokenOffset</tt> is its length. When the token is processed
-* the value of <tt>tokenOffset</tt> is set to be the same as current
-* value of the <tt>offset</tt> and the parsing continues.
+* If the <code>parseToken()</code> recognizes a token, it returns its ID
+* and the <code>tokenOffset</code> is its begining in the buffer and
+* <code>offset - tokenOffset</code> is its length. When the token is processed
+* the value of <code>tokenOffset</code> is set to be the same as current
+* value of the <code>offset</code> and the parsing continues.
 *
 * Internal states are the integer constants used internally by analyzer.
-* They are assigned to the <tt>state</tt> variable to express
+* They are assigned to the <code>state</code> variable to express
 * that the analyzer has moved from one state to another.
 * They are usually numbered starting from zero but they don't
 * have to. The only reserved value is -1 which is reserved
@@ -56,19 +56,19 @@ package org.netbeans.editor;
 * to restore the parsing from some particular state instead of
 * parsing from the begining of the buffer. This feature is very
 * useful if there are the modifications performed in the document.
-* The info is stored in the <tt>StateInfo</tt> interface
-* with the <tt>BaseStateInfo</tt> as the basic implementation.
+* The info is stored in the <code>StateInfo</code> interface
+* with the <code>BaseStateInfo</code> as the basic implementation.
 * It enables to get and set the two important values
 * from the persistent point of view.
-* The first one is the value of the <tt>state</tt> variable.
-* The other one is the difference <tt>offset - tokenOffset</tt>
+* The first one is the value of the <code>state</code> variable.
+* The other one is the difference <code>offset - tokenOffset</code>
 * which is called pre-scan. The particular analyzer can define
 * additional values important for the persistent storage.
-* The <tt>createStateInfo()</tt> can be overriden to create
-* custom state-info and <tt>loadState()</tt> and <tt>storeState()</tt>
+* The <code>createStateInfo()</code> can be overriden to create
+* custom state-info and <code>loadState()</code> and <code>storeState()</code>
 * can be overriden to get/set the additional values.
 *
-* The <tt>load()</tt> method sets the buffer to be parsed.
+* The <code>load()</code> method sets the buffer to be parsed.
 * There is a special parameter in the load() method called position
 * that allows a relation of the character buffer passed to the load()
 * method and the position of the buffer's data in the document.
@@ -95,7 +95,7 @@ public class Syntax {
 
 
     /** Internal state of the lexical analyzer. At the begining
-    * it's set to INIT value but it is changed by <tt>parseToken()</tt>
+    * it's set to INIT value but it is changed by <code>parseToken()</code>
     * as the characters are processed one by one.
     */
     protected int state = INIT;
@@ -113,7 +113,7 @@ public class Syntax {
     protected int tokenLength;
 
     /** Path from which the found token-id comes from.
-    * The <tt>TokenContext.getContextPath()</tt> can be used
+    * The <code>TokenContext.getContextPath()</code> can be used
     * to get the path. If the lexical analyzer doesn't use
     * any children token-contexts it can assign
     * the path in the constructor.
@@ -223,12 +223,12 @@ public class Syntax {
     *   If there is no relation to the document data, the stopPosition parameter
     *   must be filled with -1 which means an invalid value.
     *   The stop-position is passed (instead of start-position) because it doesn't
-    *   change through the analyzer operation. It corresponds to the <tt>stopOffset</tt>
+    *   change through the analyzer operation. It corresponds to the <code>stopOffset</code>
     *   that also doesn't change through the analyzer operation so any
     *   buffer-offset can be transferred to position by computing
-    *   <tt>stopPosition + buffer-offset - stopOffset</tt>
+    *   <code>stopPosition + buffer-offset - stopOffset</code>
     *   where stopOffset is the instance variable that is assigned
-    *   to <tt>offset + len</tt> in the body of relocate().
+    *   to <code>offset + len</code> in the body of relocate().
     */
     public void load(StateInfo stateInfo, char buffer[], int offset, int len,
                      boolean lastBuffer, int stopPosition) {
@@ -270,12 +270,12 @@ public class Syntax {
     *   If there is no relation to the document data, the stopPosition parameter
     *   must be filled with -1 which means an invalid value.
     *   The stop-position is passed (instead of start-position) because it doesn't
-    *   change through the analyzer operation. It corresponds to the <tt>stopOffset</tt>
+    *   change through the analyzer operation. It corresponds to the <code>stopOffset</code>
     *   that also doesn't change through the analyzer operation so any
     *   buffer-offset can be transferred to position by computing
-    *   <tt>stopPosition + buffer-offset - stopOffset</tt>
+    *   <code>stopPosition + buffer-offset - stopOffset</code>
     *   where stopOffset is the instance variable that is assigned
-    *   to <tt>offset + len</tt> in the body of relocate().
+    *   to <code>offset + len</code> in the body of relocate().
     */
     public void relocate(char buffer[], int offset, int len,
     boolean lastBuffer, int stopPosition) {

--- a/ide/editor.lib/src/org/netbeans/editor/TokenContext.java
+++ b/ide/editor.lib/src/org/netbeans/editor/TokenContext.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 /**
 * Token context defines the environment in which only a limited set
 * of tokens can be used. This set can be retrieved by calling
-* the <tt>getTokenIDs()</tt> method. The context can contain other
+* the <code>getTokenIDs()</code> method. The context can contain other
 * contexts which means that the context can possibly switch
 * into one of its children contexts during lexing.
 * The child context can also have other children that can
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 * In this way context-paths can be created. They describe
 * the way how was the token lexically recognized.
 * The context can be retrieved when the syntax-class is known
-* using the <tt>get</tt> method.
+* using the <code>get</code> method.
 * 
 *
 * @author Miloslav Metelka
@@ -114,7 +114,7 @@ public class TokenContext {
     }
 
     /** Add all static-final token-id fields declared
-    * in this token-context using <tt>Class.getDeclaredFields()</tt> call.
+    * in this token-context using <code>Class.getDeclaredFields()</code> call.
     */
     protected void addDeclaredTokenIDs() throws IllegalAccessException, SecurityException {
         Field[] fields = this.getClass().getDeclaredFields();

--- a/ide/editor.lib/src/org/netbeans/editor/TokenContextPath.java
+++ b/ide/editor.lib/src/org/netbeans/editor/TokenContextPath.java
@@ -28,10 +28,10 @@ import java.util.HashMap;
 * and ending with the target context from which the token
 * is being returned.
 * It is final and has no public constructor.
-* The only entrypoint is through the <tt>get()</tt> method.
+* The only entrypoint is through the <code>get()</code> method.
 * It's guaranteed that the two context-paths containing
 * the same contexts in the same order are the same objects
-* and the equal-operator can be used instead of calling <tt>equals()</tt>.
+* and the equal-operator can be used instead of calling <code>equals()</code>.
 *
 * @author Miloslav Metelka
 * @version 1.00

--- a/ide/editor.lib/src/org/netbeans/editor/TokenID.java
+++ b/ide/editor.lib/src/org/netbeans/editor/TokenID.java
@@ -26,9 +26,9 @@ package org.netbeans.editor;
 * The common place where the tokens should be defined is
 * the appropriate token-context for which they are being
 * created.
-* The fact that <tt>TokenID</tt> extends <tt>TokenCategory</tt>
+* The fact that <code>TokenID</code> extends <code>TokenCategory</code>
 * helps to treat the colorings more easily by working with
-* <tt>TokenCategory</tt> only (it can be <tt>TokenID</tt> too).
+* <code>TokenCategory</code> only (it can be <code>TokenID</code> too).
 *
 * @author Miloslav Metelka
 * @version 1.00

--- a/ide/editor.lib/src/org/netbeans/editor/TokenItem.java
+++ b/ide/editor.lib/src/org/netbeans/editor/TokenItem.java
@@ -44,14 +44,14 @@ public interface TokenItem {
 
     /** Get next token-item in the text. It returns null
     * if there's no more next tokens in the text. It can throw
-    * <tt>IllegalStateException</tt> in case the document
+    * <code>IllegalStateException</code> in case the document
     * was changed so the token-item chain becomes invalid.
     */
     public TokenItem getNext();
 
     /** Get previous token-item in the text. It returns null
     * if there's no more previous tokens in the text. It can throw
-    * <tt>IllegalStateException</tt> in case the document
+    * <code>IllegalStateException</code> in case the document
     * was changed so the token-item chain becomes invalid.
     */
     public TokenItem getPrevious();

--- a/ide/editor.lib/src/org/netbeans/editor/TokenProcessor.java
+++ b/ide/editor.lib/src/org/netbeans/editor/TokenProcessor.java
@@ -32,7 +32,7 @@ public interface TokenProcessor {
     * @param tokenID ID of the token found
     * @param tokenContextPath Context-path in which the token that was found.
     * @param tokenBufferOffset Offset of the token in the buffer. The buffer
-    *  is provided in the <tt>nextBuffer()</tt> method.
+    *  is provided in the <code>nextBuffer()</code> method.
     * @param tokenLength Length of the token found
     * @return true if the next token should be searched or false if the scan should
     *   be stopped completely.
@@ -57,18 +57,18 @@ public interface TokenProcessor {
     * @param offset offset in the buffer with the first character to be scanned.
     *   If doesn't reflect the possible preScan. If the preScan would be non-zero
     *   then the first buffer offset that contains the valid data is
-    *   <tt>offset - preScan</tt>.
+    *   <code>offset - preScan</code>.
     * @param len count of the characters that will be scanned. It doesn't reflect
     *   the ppossible reScan.
     * @param startPos starting position of the scanning in the document. It
-    *   logically corresponds to the <tt>offset</tt> because of the same
+    *   logically corresponds to the <code>offset</code> because of the same
     *   text data both in the buffer and in the document.
-    *   It again doesn't reflect the possible preScan and the <tt>startPos - preScan</tt>
+    *   It again doesn't reflect the possible preScan and the <code>startPos - preScan</code>
     *   gives the real start of the first token. If it's necessary to know
     *   the position of each token, it's a good idea to store the value
-    *   <tt>startPos - offset</tt> in an instance variable that could be called
-    *   <tt>bufferStartPos</tt>. The position of the token can be then computed
-    *   as <tt>bufferStartPos + tokenBufferOffset</tt>.
+    *   <code>startPos - offset</code> in an instance variable that could be called
+    *   <code>bufferStartPos</code>. The position of the token can be then computed
+    *   as <code>bufferStartPos + tokenBufferOffset</code>.
     * @param preScan preScan needed for the scanning.
     * @param lastBuffer whether this is the last buffer to scan in the document
     *   so there are no more characters in the document after this buffer.

--- a/ide/editor.lib/src/org/netbeans/editor/Utilities.java
+++ b/ide/editor.lib/src/org/netbeans/editor/Utilities.java
@@ -276,7 +276,7 @@ public class Utilities {
 
     /** Get indentation on the current line. If this line is white then
     * go either up or down an return indentation of the first non-white row.
-    * The <tt>getRowFirstNonWhite()</tt> is used to find the indentation
+    * The <code>getRowFirstNonWhite()</code> is used to find the indentation
     * on particular line.
     * @param doc document to operate on
     * @param offset position in document anywhere on the line
@@ -1199,7 +1199,7 @@ public class Utilities {
 
     /** Helper method to obtain instance of editor kit from existing JTextComponent.
     * If the kit of the component is not an instance
-    * of the <tt>org.netbeans.editor.BaseKit</tt> the method returns null.
+    * of the <code>org.netbeans.editor.BaseKit</code> the method returns null.
     * The method doesn't require any document locking.
     * @param target JTextComponent for which the editor kit should be obtained
     * @return BaseKit instance or null
@@ -1238,7 +1238,7 @@ public class Utilities {
 
     /** Helper method to obtain instance of BaseDocument from JTextComponent.
     * If the document of the component is not an instance
-    * of the <tt>org.netbeans.editor.BaseDocument</tt> the method returns null.
+    * of the <code>org.netbeans.editor.BaseDocument</code> the method returns null.
     * The method doesn't require any document locking.
     * @param target JTextComponent for which the document should be obtained
     * @return BaseDocument instance or null
@@ -1249,8 +1249,8 @@ public class Utilities {
     }
 
     /** Get the syntax-support class that belongs to the document of the given
-    * component. Besides using directly this method, the <tt>SyntaxSupport</tt>
-    * can be obtained by calling <tt>doc.getSyntaxSupport()</tt>.
+    * component. Besides using directly this method, the <code>SyntaxSupport</code>
+    * can be obtained by calling <code>doc.getSyntaxSupport()</code>.
     * The method can return null in case the document is not
     * an instance of the BaseDocument.
     * The method doesn't require any document locking.

--- a/ide/editor.lib/src/org/netbeans/editor/WeakEventListenerList.java
+++ b/ide/editor.lib/src/org/netbeans/editor/WeakEventListenerList.java
@@ -33,14 +33,14 @@ import javax.swing.event.EventListenerList;
 * Class that can hold the list of event listeners
 * in a "weak" manner. The advantage is that the listener
 * doesn't need to be explicitly removed. Because of the use
-* of the <tt>WeakReference</tt> it gets forgotten
+* of the <code>WeakReference</code> it gets forgotten
 * automatically if it was garbage collected. There must
 * be at least one non-weak reference to the listener
 * (otherwise it would become garbage-collected).
 * One of the ways is to store the listener in some instance
 * variable in the class that adds the listener.
-* Please note that the methods <tt>getListenerCount()</tt>
-* and <tt>getListenerCount(Class t)</tt> give the count
+* Please note that the methods <code>getListenerCount()</code>
+* and <code>getListenerCount(Class t)</code> give the count
 * that doesn't reflect whether some listeners were garbage
 * collected.
 *

--- a/ide/editor.lib/src/org/netbeans/editor/ext/ExtFinderFactory.java
+++ b/ide/editor.lib/src/org/netbeans/editor/ext/ExtFinderFactory.java
@@ -35,7 +35,7 @@ import org.netbeans.editor.Utilities;
 public class ExtFinderFactory {
 
     /** Finder that collects the whole lines and calls
-    * the <tt>lineFound()</tt> method that can do a local find.
+    * the <code>lineFound()</code> method that can do a local find.
     * !!! Udelat to poradne i s vice bufferama
     */
     public abstract static class LineFwdFinder extends FinderFactory.AbstractFinder {
@@ -94,7 +94,7 @@ public class ExtFinderFactory {
         }
 
         /** Line was found and is present in the given buffer. The given
-        * buffer is either the original buffer passed to the <tt>find()</tt>
+        * buffer is either the original buffer passed to the <code>find()</code>
         * or constructed buffer if the line is at the border of the previous
         * and next buffer.
         * @return non-negative number means the target string was found and
@@ -108,7 +108,7 @@ public class ExtFinderFactory {
     }
 
     /** Finder that collects the whole lines and calls
-    * the <tt>lineFound()</tt> method that can do a local find.
+    * the <code>lineFound()</code> method that can do a local find.
     * !!! Udelat to poradne i s vice bufferama
     */
     public abstract static class LineBwdFinder extends FinderFactory.AbstractFinder {
@@ -174,7 +174,7 @@ public class ExtFinderFactory {
         }
 
         /** Line was found and is present in the given buffer. The given
-        * buffer is either the original buffer passed to the <tt>find()</tt>
+        * buffer is either the original buffer passed to the <code>find()</code>
         * or constructed buffer if the line is at the border of the previous
         * and next buffer.
         * @return non-negative number means the target string was found and
@@ -188,7 +188,7 @@ public class ExtFinderFactory {
     }
 
     /** Finder that collects the whole lines and calls
-    * the <tt>lineFound()</tt> method that can do a local find.
+    * the <code>lineFound()</code> method that can do a local find.
     * !!! Udelat to poradne i s vice bufferama
     */
     public abstract static class LineBlocksFinder extends FinderFactory.AbstractBlocksFinder {
@@ -247,7 +247,7 @@ public class ExtFinderFactory {
         }
 
         /** Line was found and is present in the given buffer. The given
-        * buffer is either the original buffer passed to the <tt>find()</tt>
+        * buffer is either the original buffer passed to the <code>find()</code>
         * or constructed buffer if the line is at the border of the previous
         * and next buffer.
         * @return non-negative number means the target string was found and

--- a/ide/editor.lib/src/org/netbeans/editor/ext/ExtKit.java
+++ b/ide/editor.lib/src/org/netbeans/editor/ext/ExtKit.java
@@ -295,7 +295,7 @@ public class ExtKit extends BaseKit {
          * @param popupMenu popup menu to which this method should add
          *  the item corresponding to the action-name.
          * @param actionName name of the action to add. The real action
-         *  can be retrieved from the kit by calling <tt>getActionByName()</tt>.
+         *  can be retrieved from the kit by calling <code>getActionByName()</code>.
          */
         protected void addAction(JTextComponent target, JPopupMenu popupMenu,
         String actionName) {

--- a/ide/editor.lib/src/org/netbeans/editor/ext/ExtSyntaxSupport.java
+++ b/ide/editor.lib/src/org/netbeans/editor/ext/ExtSyntaxSupport.java
@@ -95,12 +95,12 @@ public class ExtSyntaxSupport extends SyntaxSupport {
     * as they occur in the text and therefore the first token
     * can start at the slightly lower position than the requested one.
     * The chain itself can be extended automatically when
-    * reaching the first chain item and calling <tt>getPrevious()</tt>
+    * reaching the first chain item and calling <code>getPrevious()</code>
     * on it. Another chunk of the tokens will be parsed and
     * the head of the chain will be extended. However this happens
     * only in case there was no modification performed to the document
     * between the creation of the chain and this moment. Otherwise
-    * this call throws <tt>IllegalStateException</tt>.
+    * this call throws <code>IllegalStateException</code>.
     * 
     * @param startOffset starting position of the block
     * @param endOffset ending position of the block
@@ -233,7 +233,7 @@ public class ExtSyntaxSupport extends SyntaxSupport {
     /** Gets the token-id of the token at the given position.
     * @param offset position at which the token should be returned
     * @return token-id of the token at the requested position. If there's no more
-    *   tokens in the text, the <tt>Syntax.INVALID</tt> is returned.
+    *   tokens in the text, the <code>Syntax.INVALID</code> is returned.
     */
     public TokenID getTokenID(int offset) throws BadLocationException {
         FirstTokenTP fttp = new FirstTokenTP();

--- a/ide/editor.lib2/src/org/netbeans/api/editor/caret/package.html
+++ b/ide/editor.lib2/src/org/netbeans/api/editor/caret/package.html
@@ -30,7 +30,7 @@
   and to manipulate them.
   </p>
   
-  <h3>Key parts of the API</h3>
+  <h2>Key parts of the API</h2>
   
   <p>
   The whole API is organized around the
@@ -54,7 +54,7 @@
   <code><a href="@org-netbeans-modules-editor-lib2@/org/netbeans/spi/editor/caret/CaretMoveHandler.html">CaretMoveHandler</a></code>
   to manipulate carets. The following code shows how all carets are moved to the
   end of the word they are currently on.
-  
+  </p>
   <pre><code>
     editorCaret.moveCarets((CaretMoveContext context) -> {
         for (CaretInfo ci : context.getOriginalCarets()) {
@@ -64,9 +64,9 @@
     });
   </code>
   </pre>
-  </p>
 
-  <h3>Locking and <code>Document</code> changes</h3>
+
+  <h2>Locking and <code>Document</code> changes</h2>
   
   <p>
   The basics of the locking and events model of Swing documents is
@@ -109,7 +109,7 @@
   concurrently.
   </p>
   
-  <h3><a name="movement-origins">Reason of Caret Movement</a></h3>
+  <h2 id="movement-origins">Reason of Caret Movement</h2>
   <p>
       It may be desirable (especially for <a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/javax/swing/text/NavigationListener.html">NavigationListeners</a>, but possibly for 
       <a href="EditorCaretListener.html">EditorCaretListeners</a> too) to determine
@@ -126,7 +126,7 @@
   which position caret as a part of larger task (i.e. search, goto type, ...).
   </p>
   
-  <h3><a name="navigation-filters">Navigation Filters</a></h3>
+  <h2 id="navigation-filters">Navigation Filters</h2>
   <p>
   The Caret API implements and extends the concept of swing 
   <a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/javax/swing/text/NavigationFilter.html">NavigationFilters</a>. The Filter
@@ -199,9 +199,9 @@
   which allows to chain individual filters. Implementors are encouraged to use it, or otherwise
   pass the control to previously registered <code>NavigationFilter</code> in case the movement
   event is not handled by the custom implementation.
-  <p/>
+  </p>
   
-  <h3><a name="compatibilty">Backwards compatibility</a></h3>
+  <h2 id="compatibilty">Backwards compatibility</h2>
   <p>
   As a technical limitation, <code>EditorCaret</code> has to implement <code>Caret</code>
   to be able to work with Swings Text API. The <code>Caret</code> interface is not
@@ -220,7 +220,7 @@
   and use its extended functionality.
   </p>
   
-  <h3><a name="usecases">Use cases</a></h3>
+  <h2 id="usecases">Use cases</h2>
   <p>
   Use cases are shown in javadoc documentation of particular methods.
   </p>

--- a/ide/editor.lib2/src/org/netbeans/spi/editor/caret/package.html
+++ b/ide/editor.lib2/src/org/netbeans/spi/editor/caret/package.html
@@ -30,7 +30,7 @@
   in order to manipulate the editor carets.
   </p>
   
-  <h3>Key parts of the SPI</h3>
+  <h2>Key parts of the SPI</h2>
   
   <p>
   <code><a href="@org-netbeans-modules-editor-lib2@/org/netbeans/spi/editor/caret/CaretMoveHandler.html">CaretMoveHandler</a></code>
@@ -50,7 +50,7 @@
   </code>
   </pre>
   
-  <h3><a name="navigation-filters">Navigation Filters</a></h3>
+  <h2 id="navigation-filters">Navigation Filters</h2>
   <p>
   A boilerplate <a href="CascadingNavigationFilter.html">CascadingNavigationFilter</a> is provided to 
   make implementation of <a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/javax/swing/text/NavigationFilter.html">NavigationFilters</a> easier. The boilerplate
@@ -66,9 +66,9 @@
   <a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/javax/swing/text/NavigationFilter.html">NavigationFilter</a> can be downcasted to <a href="NavigationFilterBypass.html">NavigationFilterBypass</a>,
   which provides this extended information.
   </p>
-  <h3><a name="compatibilty">Backwards compatibility</a></h3>
+  <h2 id="compatibilty">Backwards compatibility</h2>
   
-  <h3><a name="usecases">Use cases</a></h3>
+  <h2 id="usecases">Use cases</h2>
   <p>
   Use cases are shown in javadoc documentation of particular methods.
   </p>

--- a/ide/editor.lib2/src/org/netbeans/spi/editor/codegen/package.html
+++ b/ide/editor.lib2/src/org/netbeans/spi/editor/codegen/package.html
@@ -19,7 +19,7 @@
 
 -->
 
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 
 <html>
   <head>
@@ -33,7 +33,7 @@
   </p>
 
 
-  <h3>Key parts of the SPI</h3>
+  <h2>Key parts of the SPI</h2>
 
   <p>
   The whole SPI is organized around the
@@ -55,7 +55,7 @@
   </p>
   
   
-  <h3>CodeGenerator and CodeGeneratorContextProvider registration</h3>
+  <h2>CodeGenerator and CodeGeneratorContextProvider registration</h2>
   
   <p>
   The registration of <code>CodeGenerator</code>s has to be done through an
@@ -123,7 +123,7 @@
   created context. 
   </p>
 
-  <h3><a name="usecases">Use cases</a></h3>
+  <h2 id="usecases">Use cases</h2>
 
   <p style="color:red">TBD</p>
 

--- a/ide/editor.lib2/src/org/netbeans/spi/editor/highlighting/package.html
+++ b/ide/editor.lib2/src/org/netbeans/spi/editor/highlighting/package.html
@@ -19,7 +19,7 @@
 
 -->
 
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 
 <html>
   <head>
@@ -45,7 +45,7 @@
   </p>
 
 
-  <h3>Key parts of the SPI</h3>
+  <h2>Key parts of the SPI</h2>
   
   <p>
   The very basic idea behind the SPI is to render a document as a sandwich of
@@ -90,7 +90,7 @@
   </p>
   
   
-  <h3>HighlightsLayer registration</h3>
+  <h2>HighlightsLayer registration</h2>
   
   <p>
   The registration of <code>HighlightsLayer</code>s has to be done through an
@@ -123,7 +123,7 @@
   </p>
 
   
-  <h3>HighlightsLayer lifecycle</h3>
+  <h2>HighlightsLayer lifecycle</h2>
   
   <p>The lifecycle of <code>HighlightsLayer</code>s is tied to the lifecycle of
   <code>Document</code>. The infrastructure creates new instances of layers by calling
@@ -138,7 +138,7 @@
   </p>
   
   
-  <h3>Locking and <code>Document</code> changes</h3>
+  <h2>Locking and <code>Document</code> changes</h2>
   
   <p>
   The basics of the locking and events model of Swing documents is
@@ -205,7 +205,7 @@
   </p>
   
   
-  <h3>Z-order</h3>
+  <h2>Z-order</h2>
   <p>
   Since there can be multiple layers suplying highlights for one document and the
   highlights can generally overlap it is important to sort the layers according
@@ -250,7 +250,7 @@
   -->
 
   
-  <h3>Using <code>AttributeSet</code></h3>
+  <h2>Using <code>AttributeSet</code></h2>
   <p>
   The Highlighting SPI uses <code>javax.swing.text.AttributeSet</code> to define
   attributes for particular highlights. These attributes can be anything,
@@ -308,9 +308,9 @@
   </p>
   
   
-  <h3><a name="usecases">Use cases</a></h3>
+  <h2 id="usecases">Use cases</h2>
   
-  <h4>Use case 1. - Caret selection</h4>
+  <h3>Use case 1. - Caret selection</h3>
 
   <p>
   The Netbeans editor as any other modern editor allows selecting blocks of text
@@ -339,7 +339,7 @@
   a visual appearance of the highlighted text as possible.
   </p>
   
-  <h4>Use case 2. - Syntax highlighting</h4>
+  <h3>Use case 2. - Syntax highlighting</h3>
   
   <p>
   This type of a document coloring shows 'words' or characters in different colors
@@ -373,7 +373,7 @@
   the bottom of the hierarchy of highlighting layers.
   </p>
   
-  <h4>Use case 3. - Semantic highlighting</h4>
+  <h3>Use case 3. - Semantic highlighting</h3>
   
   <p>
   In fact semantic coloring regardless of the language it is provided for is
@@ -399,7 +399,7 @@
   are available they should be accepted and re-used by the Highlighting SPI.
   </p>
   
-  <h4>Use case 4. - Embedded languages</h4>
+  <h3>Use case 4. - Embedded languages</h3>
 
   <p>
   An embedded language is a language of a part of a document that is different
@@ -426,7 +426,7 @@
   no text they recognize.
   </p>
   
-  <h4><a name="usecase5">Use case 5. - Filtering layers used for JTextComponent</a></h4>
+  <h3 id="usecase5">Use case 5. - Filtering layers used for JTextComponent</h3>
   
   <p>
   In certain situations <code>JTextComponent</code> or <code>JEditorPane</code>
@@ -499,7 +499,7 @@
   </pre>
   
   
-  <h4>Other usecases</h4>
+  <h3>Other usecases</h3>
   
   <p>
   The main usecases described above are certainly not the only usecases of the

--- a/ide/editor.lib2/src/org/netbeans/spi/editor/typinghooks/package.html
+++ b/ide/editor.lib2/src/org/netbeans/spi/editor/typinghooks/package.html
@@ -19,7 +19,7 @@
 
 -->
 
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!DOCTYPE html>
 
 <html>
   <head>
@@ -44,7 +44,7 @@
   </p>
 
 
-  <h3>Keyboard input processing</h3>
+  <h2>Keyboard input processing</h2>
 
   <p>
   Netbeans editor panes are ordinary <code>JTextComponent</code>s and therefore
@@ -82,7 +82,7 @@
   </ul>
 
 
-  <h3>Registering interceptors</h3>
+  <h2>Registering interceptors</h2>
   
   <p>
   Interceptors are created by calling a factory implementation registered in
@@ -110,7 +110,7 @@
   </p>
 
   
-  <h3>Interceptors lifecycle</h3>
+  <h2>Interceptors lifecycle</h2>
 
   <p>
   In general interceptors are created as they are needed. However, unlike in other editor SPIs where SPI
@@ -137,7 +137,7 @@
   </p>
 
 
-  <h3>Threading and synchronization</h3>
+  <h2>Threading and synchronization</h2>
 
   <p>
   As explained earlier Netbeans editors follow swing concepts for handling keyboard
@@ -163,9 +163,9 @@
   </p>
 
 
-  <h3><a name="usecases">Use cases</a></h3>
+  <h2 id="usecases">Use cases</h2>
   
-  <h4>Use case 1. - Automated indentation</h4>
+  <h3>Use case 1. - Automated indentation</h3>
 
   <p>
   Many languages need to automatically reindent lines as user types certain
@@ -202,7 +202,7 @@
   class for more details.
   </p>
 
-  <h4>Use case 2. - Pair characters completion</h4>
+  <h3>Use case 2. - Pair characters completion</h3>
   
   <p>
   It can safe a lot of typing if the editor correctly completes pair characters
@@ -223,7 +223,7 @@
 <!--
   
   
-  <h4>Other usecases</h4>
+  <h3>Other usecases</h3>
 -->
   
   </body>

--- a/ide/editor.settings/src/org/netbeans/api/editor/settings/CodeTemplateSettings.java
+++ b/ide/editor.settings/src/org/netbeans/api/editor/settings/CodeTemplateSettings.java
@@ -39,7 +39,7 @@ import javax.swing.KeyStroke;
  * module. If you are retrieving this class from <code>MimeLookup</code> you should
  * should probably use the Editor Code Templates API instead.
  * 
- * <p><font color="red">This class must NOT be extended by any API clients.</font>
+ * <p><span style="color:red">This class must NOT be extended by any API clients.</span>
  *
  * @author Martin Roskanin
  */

--- a/ide/editor.settings/src/org/netbeans/api/editor/settings/FontColorSettings.java
+++ b/ide/editor.settings/src/org/netbeans/api/editor/settings/FontColorSettings.java
@@ -50,7 +50,7 @@ import javax.swing.text.AttributeSet;
  *
  * <p>Instances of this class should be retrieved from <code>MimeLookup</code>.
  * 
- * <p><font color="red">This class must NOT be extended by any API clients.</font>
+ * <p><span style="color:red">This class must NOT be extended by any API clients.</span>
  *
  * @author Martin Roskanin
  */

--- a/ide/editor.settings/src/org/netbeans/api/editor/settings/KeyBindingSettings.java
+++ b/ide/editor.settings/src/org/netbeans/api/editor/settings/KeyBindingSettings.java
@@ -26,7 +26,7 @@ package org.netbeans.api.editor.settings;
  * 
  * <p>Instances of this class should be retrieved from <code>MimeLookup</code>.
  * 
- * <p><font color="red">This class must NOT be extended by any API clients.</font>
+ * <p><span style="color:red">This class must NOT be extended by any API clients.</span>
  *
  * @author Martin Roskanin
  */

--- a/ide/editor.settings/src/org/netbeans/api/editor/settings/SimpleValueNames.java
+++ b/ide/editor.settings/src/org/netbeans/api/editor/settings/SimpleValueNames.java
@@ -62,8 +62,8 @@ public final class SimpleValueNames {
 
     /**
      * Shift-width says how many spaces should the formatter use
-     * to indent the more inner level of code. This setting is independent of <tt>TAB_SIZE</tt>
-     * and <tt>SPACES_PER_TAB</tt>.
+     * to indent the more inner level of code. This setting is independent of <code>TAB_SIZE</code>
+     * and <code>SPACES_PER_TAB</code>.
      * Values: java.lang.Integer instances
      */
     public static final String INDENT_SHIFT_WIDTH = "indent-shift-width"; // NOI18N

--- a/ide/editor/src/org/netbeans/modules/editor/NbEditorUtilities.java
+++ b/ide/editor/src/org/netbeans/modules/editor/NbEditorUtilities.java
@@ -97,8 +97,8 @@ public class NbEditorUtilities {
         return null;
     }
 
-    /** This method is a composition of <tt>Utilities.getIdentifierBlock()</tt>
-    * and <tt>SyntaxSupport.getFunctionBlock()</tt>.
+    /** This method is a composition of <code>Utilities.getIdentifierBlock()</code>
+    * and <code>SyntaxSupport.getFunctionBlock()</code>.
     * @return null if there's no identifier at the given position.
     *   identifier block if there's identifier but it's not a function call.
     *   three member array for the case that there is an identifier followed

--- a/ide/libs.graalsdk/arch.xml
+++ b/ide/libs.graalsdk/arch.xml
@@ -121,7 +121,6 @@
         </question>
 -->
  <answer id="arch-usecases">
-  <p>
       <usecase id="createScriptEngineManager" name="Create ScriptEngineManager">
           To access <a href="https://graalvm.org">GraalVM</a> languages
           use
@@ -154,7 +153,6 @@
               wrapper isn't enough.
           </api>
       </usecase>
-  </p>
  </answer>
 
 

--- a/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/package-info.java
+++ b/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/package-info.java
@@ -19,9 +19,7 @@
 
 /** Polyglot scripting tutorial.
  *
- * <a name="tutorial">
- * <h1>Polyglot Scripting Tutorial</h1>
- * </a>
+ * <h2 id="tutorial">Polyglot Scripting Tutorial</h2>
  *
  * This tutorial shows how to embed the various languages in a
  * NetBeans or even plain Java application via {@link org.netbeans.api.scripting.Scripting} helper methods. This
@@ -38,12 +36,12 @@
  * different interoperation scenarios with (working) code examples.
  *
  *
- * <h2>Contents</h2>
+ * <h3>Contents</h3>
  *
  * <div id="toc"></div>
  * <div id="contents">
  *
- * <h2>Setup</h2>
+ * <h3>Setup</h3>
  *
  * The most advanced features that this API provides work in cooperation with
  * <a href="https://graalvm.org">GraalVM</a>.
@@ -55,7 +53,7 @@
  * NetBeans modules are <a href="https://search.maven.org/search?q=org.netbeans.api">
  * uploaded to Maven central</a>. You can use them from your <em>pom.xml</em>
  * file as:
- * <p>
+ * </p>
  * <pre>
 &lt;dependency&gt;
     &lt;groupId&gt;<b>org.netbeans.api</b>&lt;/groupId&gt;
@@ -64,9 +62,9 @@
 &lt;/dependency&gt;
  * </pre>
  *
- * <h2>Get started</h2>
+ * <h3>Get started</h3>
  *
- * <h3>Guest language "Hello World!"</h3>
+ * <h4>Guest language "Hello World!"</h4>
  *
  * Integrating scripting into your Java application starts with building
  * an instance of {@link javax.script.ScriptEngineManager} via
@@ -80,11 +78,11 @@
  *
  * {@snippet file="org/netbeans/libs/graalsdk/ScriptingTutorial.java" region="testHelloWorld"}
  *
- * <h3>It's a polyglot world</h3>
+ * <h4>It's a polyglot world</h4>
  *
  * How to list all available languages? To obtain all registered engine
  * factories in the system use:
- * <p>
+ *
  * {@snippet file="org/netbeans/libs/graalsdk/ScriptingTutorial.java" region="listAll"}
  * <p>
  * When the above code snippet is executed on <a href="https://graalvm.org">GraalVM</a> it may print:
@@ -100,7 +98,7 @@ Found GraalVM:python
  * via dedicated implementation of {@link org.netbeans.spi.scripting.EngineProvider}
  * interface
  *
- * <h3>Add a language</h3>
+ * <h4>Add a language</h4>
  *
  * <a href="https://graalvm.org">GraalVM</a>
  * download comes with highly efficient implementations of <em>JavaScript</em>.
@@ -109,7 +107,7 @@ Found GraalVM:python
  * the <a href="https://github.com/graalvm/fastr">R</a> and
  * <a href="https://github.com/graalvm/graalpython">Python</a>
  * can be installed via the <code>bin/gu</code> <em>Graal Updater</em> tool:
- * <p>
+ *
  * <pre>
  * $ /graalvm/bin/gu available
  * Downloading: Component catalog
@@ -126,41 +124,41 @@ Found GraalVM:python
  * After invoking this command and downloading the bits, the JVM will be
  * ready to execute Python scripts.
  *
- * <h3>Hello World in Python and JavaScript</h3>
+ * <h4>Hello World in Python and JavaScript</h4>
  *
- * The {@link org.netbeans.libs.graalsdk.Scripting Scripting.createManager()} method
+ * The {@link org.netbeans.api.scripting.Scripting#createManager()} Scripting.createManager()} method
  * is your gateway to polyglot world! Just create a manager and it can serve
  * as a hub where various language engines connect together. Following example
  * shows JavaScript and Python interacting with each other:
- * <p>
+ *
  * {@snippet file="org/netbeans/libs/graalsdk/ScriptingTutorial.java" region="testHelloWorldInPythonAndJavaScript"}
  * <p>
  * Languages provided by <a href="https://graalvm.org">GraalVM</a> use the
  * {@link javax.script.ScriptEngineManager} created by
- * {@link org.netbeans.libs.graalsdk.Scripting#createManager()} factory
+ * {@link org.netbeans.api.scripting.Scripting#createManager()} factory
  * method as a connection point to talk to each other and mutually share
  * and use its objects, functions and other services.
  *
- * <h3>Cast Array to List</h3>
+ * <h4>Cast Array to List</h4>
  *
  * Dynamic languages may represent array in their own special ways.
  * However the
- * {@link org.netbeans.libs.graalsdk.Scripting} interoperation let's you
+ * {@link org.netbeans.api.scripting.Scripting} interoperation let's you
  * view each array-like object as {@link java.util.List}. Just
  * "{@linkplain javax.script.Invocable#getInterface(java.lang.Object, java.lang.Class) cast it}"
  * like in following example:
- * <p>
+ *
  * {@snippet file="org/netbeans/libs/graalsdk/ScriptingTutorial.java" region="testCastJsArray"}
  *
  *
- * <h2>Call guest language functions from Java</h2>
+ * <h3>Call guest language functions from Java</h3>
  *
- * {@link org.netbeans.libs.graalsdk.Scripting} interoperation lets Java call
+ * {@link org.netbeans.api.scripting.Scripting} interoperation lets Java call
  * <em>foreign functions</em> that guest language code <em>exports</em>
  * (details vary across languages).
  * This section presents a few examples.
  *
- * <h3>Define and call a JavaScript function</h3>
+ * <h4>Define and call a JavaScript function</h4>
  *
  * A function exported from a dynamic language becomes a callable <em>foreign function</em>
  * by giving it a Java type, for example the Java interface {@code Multiplier} in the following code.
@@ -177,7 +175,7 @@ Found GraalVM:python
  * global scope, so the Java object holds the only reference to it.</li>
  * </ul>
  *
- * <h3>Define and call a Python function</h3>
+ * <h4>Define and call a Python function</h4>
  *
  * The same example can be rewritten to Python:
  * <p>
@@ -192,7 +190,7 @@ Found GraalVM:python
  * it to a <em>foreign function</em> with a given Java type.</li>
  * </ul>
  *
- * <h3>Call an existing R function</h3>
+ * <h4>Call an existing R function</h4>
  *
  * In this sample we use a reference to existing R function {@code qbinom} from the built-in <em>stats</em> package.
  * <p>
@@ -201,12 +199,12 @@ Found GraalVM:python
  *
  * Don't forget to install support for the R language into your <a href="https://graalvm.org">GraalVM</a>
  * instance:
- * <p>
+ *
  * <pre>
  * $ /graalvm/bin/gu install
  * </pre>
  *
- * <h2>Call multiple guest language functions with shared state from Java</h2>
+ * <h3>Call multiple guest language functions with shared state from Java</h3>
  *
  * Often it is necessary to export multiple dynamic language functions that work
  * together, for example by sharing variables.  This can be done by giving
@@ -229,12 +227,12 @@ Found GraalVM:python
  * global scope, so the Java object holds the only reference to it.</li>
  * </ul>
  *
- * <h2>Access guest language classes from Java</h2>
+ * <h3>Access guest language classes from Java</h3>
  *
- * <h3>Access a JavaScript class</h3>
+ * <h4>Access a JavaScript class</h4>
  *
  * The ECMAScript 6 specification adds the concept of typeless classes to JavaScript.
- * NetBeans {@link org.netbeans.libs.graalsdk.Scripting}
+ * NetBeans {@link org.netbeans.api.scripting.Scripting}
  * interoperation allows Java to access fields and functions of a JavaScript class,
  * for example the <em>foreign function</em> factory and class given the Java type
  * {@code Incrementor} in the following code.
@@ -256,14 +254,14 @@ Found GraalVM:python
  * global scope, so the Java object holds the only reference to it.</li>
  * </ul>
  *
- * <h2>Access guest language data structures from Java</h2>
+ * <h3>Access guest language data structures from Java</h3>
  *
  * The method {@link javax.script.Invocable#getInterface invocable.getInterface(Class)}
  * plays an essential role supporting interoperation between Java and guest language data
  * structures.
  * This section presents a few examples.
  *
- * <h3>Access a JavaScript Array</h3>
+ * <h4>Access a JavaScript Array</h4>
  *
  * The following example demonstrates type-safe Java foreign access
  * to members of a JavaScript array with members of a known type,
@@ -284,7 +282,7 @@ Found GraalVM:python
  * global scope, so the Java object holds the only reference to it.</li>
  * </ul>
  *
- * <h3>Access a JavaScript JSON structure</h3>
+ * <h4>Access a JavaScript JSON structure</h4>
  *
  * This example demonstrates type-safe Java foreign access to a JavaScript JSON-like
  * structure, based on JSON data returned by a GitHub API.
@@ -313,7 +311,7 @@ Found GraalVM:python
  * global scope, so the Java object holds the only reference to it.</li>
  * </ul>
  *
- * <h3>View any Object as Map</h3>
+ * <h4>View any Object as Map</h4>
  *
  * Each dynamic object coming from a <a href="https://graalvm.org">GraalVM</a>
  * language can be "cast" to a {@link java.util.Map}. Here is an example:
@@ -324,13 +322,13 @@ Found GraalVM:python
  * While not type-safe, it is a generic approach able to inspect objects
  * of unknown structure.
  *
- * <h2>Access Java from guest languages</h2>
+ * <h3>Access Java from guest languages</h3>
  *
  * Just like Java can access guest language objects, the guest languages may
  * access Java objects, their fields and call their methods. Few examples
  * follow.
  *
- * <h3>Access Java fields and methods from JavaScript</h3>
+ * <h4>Access Java fields and methods from JavaScript</h4>
  *
  * <em>Public</em> members of Java objects can be exposed to guest language code
  * as <em>foreign objects</em>, for example Java objects of type {@code Moment} in
@@ -343,7 +341,7 @@ Found GraalVM:python
  * <li>Evaluating the JS source returns an anonymous JS function of one argument
  * assigned to {@code jsFunction} that can be executed directly with one argument.</li>
  * <li>The Java argument {@code javaMoment} is seen by the JS function as a
- * <em>foreign object</em> whose public fields are visible.</em>
+ * <em>foreign object</em> whose public fields are visible.
  * <li>Executing {@code jsFunction} returns a JS number
  * that can be
  * {@linkplain javax.script.Invocable#getInterface "cast"}
@@ -359,10 +357,10 @@ Found GraalVM:python
  * {@linkplain javax.script.Invocable#getInterface "cast"}
  * the JS function to a Java foreign function (of type {@code MomentConverter}) that
  * returns the desired Java type directly, as shown in the following variation.
- * <p>
+ *
  * {@snippet file="org/netbeans/libs/graalsdk/ScriptingTutorial.java" region="accessFieldsOfJavaObjectWithConverter"}
  *
- * <h3>Access Java constructors and static methods from JavaScript</h3>
+ * <h4>Access Java constructors and static methods from JavaScript</h4>
  *
  * Dynamic languages can also access the <em>public constructors</em> and <em>public static methods</em>
  * of any Java class for which they are provided a reference.
@@ -376,7 +374,7 @@ Found GraalVM:python
  * <li>Evaluating the JS source returns an anonymous JS function of one argument
  * assigned to {@code jsFunction} that can be executed directly with one argument.</li>
  * <li>The Java class argument {@code Moment.class} is seen by the JS function as a
- * <em>foreign class</em> whose public constructor is visible.</em>
+ * <em>foreign class</em> whose public constructor is visible.
  * <li>Executing {@code jsFunction} with the Java class argument returns
  * a JS "factory" function (for the Java class) that can be
  * {@linkplain javax.script.Invocable#getInterface "cast"}
@@ -385,7 +383,7 @@ Found GraalVM:python
  * global scope, so the Java object holds the only reference to it.</li>
  * </ul>
  *
- * <h2>Exception handling</h2>
+ * <h3>Exception handling</h3>
  * Exceptions are thrown in different way, depending on whether <b>the script</b>
  * (guest language) raised the error, or the error came from the host language, e.g.
  * a java object called from the script. 

--- a/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/ScriptingTutorial.java
+++ b/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/ScriptingTutorial.java
@@ -226,7 +226,7 @@ public class ScriptingTutorial extends NbTestCase {
     }
 
     public void callRFunctionFromJava() throws Exception {
-        // @start region="allowAllAccess
+        // @start region="allowAllAccess"
         // FastR currently needs access to native libraries:
         final ScriptEngineManager manager = Scripting.newBuilder().allowAllAccess(true).build();
         ScriptEngine rEngine = manager.getEngineByMimeType("application/x-r");

--- a/ide/project.ant/src/org/netbeans/spi/project/support/ant/SourcesHelper.java
+++ b/ide/project.ant/src/org/netbeans/spi/project/support/ant/SourcesHelper.java
@@ -1097,9 +1097,9 @@ public final class SourcesHelper {
      * Creates new {@link SourceGroupModifierImplementation} that can be put into project lookup.
      * <p>
      * Only source roots added with a {@link SourceRootConfig#hint(String) hint} can be created
-     * with this <tt>SourceGroupModifierImplementation</tt>.
+     * with this <code>SourceGroupModifierImplementation</code>.
      * </p>
-     * @return <tt>SourceGroupModifierImplementation</tt> implementation.
+     * @return <code>SourceGroupModifierImplementation</code> implementation.
      * @see #sourceRoot(String)
      * @since org.netbeans.modules.project.ant/1 1.33
      */

--- a/ide/project.ant/src/org/netbeans/spi/project/support/ant/package.html
+++ b/ide/project.ant/src/org/netbeans/spi/project/support/ant/package.html
@@ -133,7 +133,7 @@ build scripts and
 to recreate them.</p>
 
 <p>To allow third-party extensions to build scripts, use {@link org.netbeans.spi.project.ant.AntBuildExtenderImplementation} and
-{@link org.netbeans.spi.project.support.ant.AntBuildExtenderFactory}.
+{@link org.netbeans.spi.project.ant.AntBuildExtenderFactory}.
 </p>
 
 <p>{@link org.netbeans.spi.project.support.ant.EditableProperties} is a

--- a/ide/project.libraries/src/org/netbeans/api/project/libraries/package.html
+++ b/ide/project.libraries/src/org/netbeans/api/project/libraries/package.html
@@ -34,9 +34,9 @@
 </head>
 <body>
 <p>Representation of a library, and the ability to find the installed libraries.</p>
-<h1>
+<h2>
 Contents
-</h1>
+</h2>
 <ul>
 <li><a href="#overview">Overview</a>
 <li><a href="#manager">How to obtain a list of installed libraries</a>
@@ -44,14 +44,14 @@ Contents
 <li><a href="#dtd">Library definition format</a>
 </ul>
 
-<h1>Libraries API</h1>
-<h2><a name="overview">Overview</a></h2>
+<h2>Libraries API</h2>
+<h3 id="overview">Overview</h3>
 <p>The libraries API provides a client API of the Libraries framework. The <strong>Library</strong> itself is a typed set of
-volumes. The <a name="volumeType"><strong>volume</strong></a> is a ordered list of <strong>resources</strong>. The type of library implies the volumes contained
+volumes. The <a id="volumeType"><strong>volume</strong></a> is a ordered list of <strong>resources</strong>. The type of library implies the volumes contained
 in it. For example the Java SE library contains three volumes (sources, classpath and javadoc). The resource is a
 valid URL of the physical resource.
 </p>
-<h2><a name="manager">How to obtain a list of installed libraries or given library</a></h2>
+<h3 id="manager">How to obtain a list of installed libraries or given library</h3>
 <p>
 To obtain a list of installed libraries you want to call
 {@link org.netbeans.api.project.libraries.LibraryManager#getLibraries}
@@ -70,16 +70,16 @@ Library library = LibraryManager.getDefault().getLibrary (<span CLASS="STR">"Ant
     System.out.println(library.getName()+<span CLASS="STR">" : "</span>+libraries[i].getType());
 }
 </pre>
-<h2><a name="customizer">Managing libraries</a></h2>
+<h3 id="customizer">Managing libraries</h3>
 <p>
 Libraries module provides graphical manager of libraries. The manager allows you to create a new library
 of a given type, to delete existing library or to change content of volumes. It is not possible to create
 or delete a volume in the library since the volumes are implied by the library type.</p>
 <p>
 To open the graphical libraries manager you need to call
-{@link org.netbeans.api.project.libraries.LibrariesCustomizer#showCustomizer} method.
+<a href="@org-netbeans-modules-project-libraries-ui@/org/netbeans/api/project/libraries/LibrariesCustomizer.html#showCustomizer-org.netbeans.api.project.libraries.Library-">LibrariesCustomizer#showCustomizer</a> method.
 </p>
-<h2><a name="dtd">Library definition format</a></h2>
+<h3 id="dtd">Library definition format</h3>
 <p>
 A module is able to register the predefined library. For example the junit module installs
 the junit library. The library definition is placed in the <strong>org-netbeans-api-project-libraries/Libraries</strong> folder

--- a/ide/projectuiapi/src/org/netbeans/spi/project/ui/templates/support/package.html
+++ b/ide/projectuiapi/src/org/netbeans/spi/project/ui/templates/support/package.html
@@ -27,7 +27,7 @@ Support for providing own templates visible in <b>New File</b> action.
 with a path as a subfolder of <code>Projects/</code>.
 Registering project type templates is similar to registering
 file templates described below. The wizard for a project can return {@link org.openide.loaders.DataObject}s or
-{@link org.openide.loaders.FileObject}s corresponding to the project directories of created files and/or files
+{@link org.openide.filesystems.FileObject}s corresponding to the project directories of created files and/or files
 to be selected in newly created projects.
 </p>
 

--- a/ide/spi.editor.hints/arch.xml
+++ b/ide/spi.editor.hints/arch.xml
@@ -115,7 +115,6 @@
         </question>
 -->
  <answer id="arch-usecases">
-  <p>
       <usecase name="redunderline" id="1">
           Assume that you have a module using e.g. Parsing API to parse the source
           files and wants to mark the errors in the editor to be shown as red
@@ -162,7 +161,6 @@ for (&lt;all places where the warning should be displayed&gt;) {
 HintsController.setErrors(doc, "mywarnings", warnings);
 </pre>
       </usecase>
-  </p>
  </answer>
 
 

--- a/ide/spi.editor.hints/src/org/netbeans/spi/editor/hints/package.html
+++ b/ide/spi.editor.hints/src/org/netbeans/spi/editor/hints/package.html
@@ -27,7 +27,7 @@
 <body>
 <p>.</p>
 
-<p> There are 2 main entry points to the SPI:
+<p> There are 2 main entry points to the SPI: </p>
     <ul>
         <li><a href="@TOP@/org/netbeans/spi/editor/hints/HintsController.html"></a>
             - HintsController allows to set editor hints for a given document/file.
@@ -37,7 +37,6 @@
               and possible fixes.
         </li>
     </ul>
-</p>
 
 </body>
 </html>

--- a/ide/spi.palette/arch.xml
+++ b/ide/spi.palette/arch.xml
@@ -120,7 +120,6 @@ question-version="1.25"
         </question>
 -->
  <answer id="arch-usecases">
-  <p>
     <usecase id="content" name="Palette Content" >
         <p>The Common Palette content is a two-level hierarchy. The top-most level
         are <b>Categories</b>, the Category children are <b>Items</b>. It's 
@@ -285,8 +284,6 @@ question-version="1.25"
               or leave the item selected to implement 'multi drop' insertion scenario.
           </p>
       </usecase>
-  </p>
-  <p>
     <usecase id="filter" name="Filtering" >
         <p>It is possible to filter palette content and hide some categories and/or
            items from the user by extending <a href="@TOP@/org/netbeans/spi/palette/PaletteFilter.html">PaletteFilter</a> class.
@@ -331,8 +328,6 @@ question-version="1.25"
               paletteController.refresh();
           </pre>
     </usecase>
-  </p>
-  <p>
     <usecase id="settings" name="Default Settings" >
         <p>The initial state of the palette can be overridden by setting appropriate
            attributes to palette model. The list of supported attributes is defined
@@ -371,9 +366,6 @@ question-version="1.25"
       &lt;/filesystem&gt;
             </pre>
     </usecase>
-  </p>
-
-    <p>
     <usecase id="newcontentatruntime" name="Adding categories and items at runtime" >
         <p>It is possible to add new palette categories and/or palette item at runtime
         when the palette window is already visible.</p>
@@ -395,9 +387,6 @@ question-version="1.25"
         <p>Please refer to Nodes API in case the palette content is defined as a 
         hierarchy of arbitrary Nodes.</p>
     </usecase>
-  </p>
-
-  <p>
     <usecase id="items" name="Palette content for text-based editors" >
         <p>The following steps must be taken when writing the item using the support provided by this module:</p>
             <ol>
@@ -414,7 +403,6 @@ question-version="1.25"
                 </li>
             </ol>
     </usecase>
-  </p>
  </answer>
 
 

--- a/ide/spi.viewmodel/src/org/netbeans/spi/viewmodel/package.html
+++ b/ide/spi.viewmodel/src/org/netbeans/spi/viewmodel/package.html
@@ -1,4 +1,4 @@
-<!DOCTYPE doctype PUBLIC "-//w3c//dtd html 4.0 transitional//en">
+<!DOCTYPE html>
 <html>
 <head>
   <meta http-equiv="Content-Type"
@@ -52,38 +52,46 @@ Following example shows how to use viewmodel API to create simple files
 view.<br>
 <h3>Step 1.</h3>
 In the first step we should create plain tree model (TreeModel).<br>
-<pre style="background-color: rgb(255, 255, 102);">public class TreeModelImpl implements TreeModel {<br><img
- src="doc-files/TreeModelExample1.JPG" title=""
- alt="Tree Model Example 1" style="width: 401px; height: 355px;"
- align="right"><br>    public Object getRoot () {<br>        return ROOT;<br>    }<br>    <br>    public Object[] getChildren (Object parent, int from, int to) {<br>        if (parent == ROOT)<br>            return File.listRoots ();<br>        return ((File) parent).listFiles ();<br>    }<br>    <br>    public boolean isLeaf (Object node) {<br>        if (node == ROOT)<br>            return false;<br>        return ((File) node).isFile ();<br>    }<br>}<br></pre>
+<img
+ src="doc-files/TreeModelExample1.JPG"
+ alt="Tree Model Example 1" style="width: 401px; height: 355px;float:right">
+<div>
+<pre style="background-color: rgb(255, 255, 102);">public class TreeModelImpl implements TreeModel {<br><br>    public Object getRoot () {<br>        return ROOT;<br>    }<br>    <br>    public Object[] getChildren (Object parent, int from, int to) {<br>        if (parent == ROOT)<br>            return File.listRoots ();<br>        return ((File) parent).listFiles ();<br>    }<br>    <br>    public boolean isLeaf (Object node) {<br>        if (node == ROOT)<br>            return false;<br>        return ((File) node).isFile ();<br>    }<br>}<br></pre>
 And create a TreeView for this model:
 <pre style="background-color: rgb(255, 255, 102);">    JComponent treeView = Models.createView (<br>        Models.createCompoundModel (<br>	    Arrays.asList (new Model[] {<br>                new TreeModelImpl (),      // TreeModel<br>                new ArrayList ()           // list of ColumnModel s<br>            })<br>        )<br>    );</pre>
+</div>
 <h3>Step 2.</h3>
 NodeModel implementation can define name, icon and tooltip for tree
 nodes produced by TreeModel.<br>
-<pre style="background-color: rgb(255, 255, 102);">public class NodeModelImpl implements NodeModel {<img
- src="doc-files/TreeModelExample2.JPG" title=""
- alt="Tree Model Example 2" style="width: 355px; height: 329px;"
- align="right"><br><br>    public String getDisplayName (Object node) {<br>        if (node == ROOT) return "Name";<br>        String name = ((File) node).getName ();<br>        if (name.length () &lt; 1) return ((File) node).getAbsolutePath ();<br>        return name;<br>    }<br>    <br>    public String getIconBase (Object node) {<br>        if (node == ROOT) return "folder";<br>        if (((File) node).isDirectory ()) return "folder";<br>        return "file";<br>    }<br>    <br>    public String getShortDescription (Object node) {<br>        if (node == ROOT) return "Name";<br>        return ((File) node).getAbsolutePath ();<br>    }<br>}</pre>
+<img
+ src="doc-files/TreeModelExample2.JPG"
+ alt="Tree Model Example 2" style="width: 355px; height: 329px;float:right"
+ >
+<div>
+<pre style="background-color: rgb(255, 255, 102);">public class NodeModelImpl implements NodeModel {<br><br>    public String getDisplayName (Object node) {<br>        if (node == ROOT) return "Name";<br>        String name = ((File) node).getName ();<br>        if (name.length () &lt; 1) return ((File) node).getAbsolutePath ();<br>        return name;<br>    }<br>    <br>    public String getIconBase (Object node) {<br>        if (node == ROOT) return "folder";<br>        if (((File) node).isDirectory ()) return "folder";<br>        return "file";<br>    }<br>    <br>    public String getShortDescription (Object node) {<br>        if (node == ROOT) return "Name";<br>        return ((File) node).getAbsolutePath ();<br>    }<br>}</pre>
+</div>
 <h3>Step 3.</h3>
 NodeActionsProvider defines set of Actions for each node, and default
-action..<br>
+action.
+<img
+ src="doc-files/TreeModelExample3.JPG"
+ alt="Tree Model Example 3" style="width: 642px; height: 438px;float:right">
+<div>
 <pre style="background-color: rgb(255, 255, 102);">public class NodeActionsProviderImpl implements NodeActionsProvider {<br><br>    public Action[] getActions (final Object node) {<br>        return new Action [] {<br>            new AbstractAction ("Open") {<br>                public void actionPerformed (ActionEvent e) {<br>                    performDefaultAction (node);<br>                }<br>            },<br>            new AbstractAction ("Delete") {<br>                public void actionPerformed (ActionEvent e) {<br>                    ((File) node).delete ();<br>                }<br>            }<br>        };<br>    }<br>    <br>    public void performDefaultAction (Object node) {<br>        try {<br>            JFrame f = new JFrame ("View");<br>            f.getContentPane ().add (new JEditorPane (((File) node).toURL ()));<br>            f.pack ();<br>            f.show ();<br>        } catch (Exception e) {<br>            e.printStackTrace();<br>        }<br>    }<br>}</pre>
 <br>
-<div style="text-align: center;"><img
- src="doc-files/TreeModelExample3.JPG" title=""
- alt="Tree Model Example 3" style="width: 642px; height: 438px;"><br>
 </div>
 <h3>Step 4.</h3>
 TableModel and ColumnModel adds support for additional columns to tree
 view.<br>
+<img
+ src="doc-files/TreeModelExample4.JPG"
+ alt="Tree Model Example 4" style="width: 384px; height: 278px;float:right"
+>
+<div>
 <pre style="background-color: rgb(255, 255, 102);">public class TableModelImpl implements TableModel {<br><br>    <br>    public Object getValueAt (Object node, String columnID) {<br>        try {<br>            if (node == ROOT) return null;<br>            if (columnID.equals ("sizeID")) {<br>                if (((File) node).isDirectory ()) return "&lt;dir&gt;";<br>                return "" + new FileInputStream ((File) node).getChannel ().size ();<br>            }<br>        } catch (Exception e) {<br>            e.printStackTrace ();<br>        }<br>        return "";<br>    }<br>    <br>    public boolean isReadOnly (Object node, String columnID) {<br>        return true;<br>    }<br>    <br>    public void setValueAt (Object node, String columnID, Object value) {<br>    }<br>}</pre>
 And initialization of columns looks like:<br>
-<pre style="background-color: rgb(255, 255, 102);">    ArrayList columns = new ArrayList ();<img
- src="doc-files/TreeModelExample4.JPG" title=""
- alt="Tree Model Example 4" style="width: 384px; height: 278px;"
- align="right"><br>    columns.add (new ColumnModel () {<br>        public String getID () { return "sizeID"; }<br>        public String getDisplayName () { return "size"; }<br>        public Class getType () { return String.class; }<br>    });<br>    JComponent treeTableView = Models.createView (<br>        Models.createCompoundModel (<br>            Arrays.asList (new Model[] {<br>                new TreeModelImpl (),           // TreeModel<br>                new NodeModelImpl (),           // NodeModel<br>                new TableModelImpl (),          // TableModel<br>                new NodeActionsProviderImpl (), // NodeActionsProvider<br>                columns                         // list of ColumnModel s<br>            })<br>        )<br>    );<br><br></pre>
-<br>
+<pre style="background-color: rgb(255, 255, 102);">    ArrayList columns = new ArrayList ();<br>    columns.add (new ColumnModel () {<br>        public String getID () { return "sizeID"; }<br>        public String getDisplayName () { return "size"; }<br>        public Class getType () { return String.class; }<br>    });<br>    JComponent treeTableView = Models.createView (<br>        Models.createCompoundModel (<br>            Arrays.asList (new Model[] {<br>                new TreeModelImpl (),           // TreeModel<br>                new NodeModelImpl (),           // NodeModel<br>                new TableModelImpl (),          // TableModel<br>                new NodeActionsProviderImpl (), // NodeActionsProvider<br>                columns                         // list of ColumnModel s<br>            })<br>        )<br>    );<br><br></pre>
+</div>
 <br>
 <br>
 <h3>How to use Filters</h3>

--- a/java/api.debugger.jpda/src/org/netbeans/spi/debugger/jpda/package.html
+++ b/java/api.debugger.jpda/src/org/netbeans/spi/debugger/jpda/package.html
@@ -33,8 +33,8 @@ JPDA Debugger SPIs defines support for Smart Stepping, Variables Filtering
 and filtering of all Debugger Views.
 
 <br>
-<h3><a name="Smart_Stepping_Support"></a>Smart Stepping Support</h3>
-<h4><span style="font-weight: bold;">Interfaces involved:</span></h4>
+<h2 id="Smart_Stepping_Support">Smart Stepping Support</h2>
+<h3><span style="font-weight: bold;">Interfaces involved:</span></h3>
 <ul>
   <li>{@link org.netbeans.api.debugger.jpda.SmartSteppingFilter} :
 Defines list of class exclusion filters to be used to filter stepping
@@ -46,7 +46,7 @@ can stop in. </li>
 context for SmartSteppingCallback (class name, method name, line
 number, ...).</li>
 </ul>
-<h4><span style="font-weight: bold;">Functionality supported:</span></h4>
+<h3><span style="font-weight: bold;">Functionality supported:</span></h3>
 <div style="margin-left: 40px;">Set of SmartSteppingCallback installed
 to JPDA Debugger defines scope for Step Into / Over / Out Actions. When
 user press some Step action, debugging is resumed. And when debugger
@@ -65,7 +65,7 @@ all sourceless classes (packages). So, if user does not have mounted
 sources for Java default libraries, this SSListener adds patterns like:
 java.*, javax.* and com.sun.*. <br>
 </div>
-<h4>How to implement some new Smart Stepping Listener:</h4>
+<h3>How to implement some new Smart Stepping Listener:</h3>
 <div style="margin-left: 40px;">Lets say we have some xxx module which
 generates some code to standard Java classes. The generated code is
 always in some methods, which name is prefixed with "xxx" like:<br>
@@ -81,21 +81,20 @@ To register this implementation, add following annotation before the class decla
 Or register the full implementation class name (packagename.SmartSteppingCallbackImpl) into the file named:<br>
 <pre style="background-color: rgb(255, 255, 102);">META-INF\debugger\netbeans-JPDASession\org.netbeans.spi.debugger.jpda.SmartSteppingCallback</pre>
 </div>
-<h3><a name="Variables_Filtering_Support"></a>Variables Filtering
-Support</h3>
+<h2 id="Variables_Filtering_Support">Variables Filtering
+Support</h2>
 <br>
-<h3><a name="Filtering_of_Debugger_Views"></a>Filtering of Debugger
-Views</h3>
-<ul>
-</ul>
+<h2 id="Filtering_of_Debugger_Views">Filtering of Debugger
+Views</h2>
+
 <div style="margin-left: 40px;">Content of all Debugger Views (like
 Breakpoints View, Threads View, ...) can be changed by
 viewmodel.*Filters. Folowing example shows how to filter Callstack
 View. We would hide all frames associated with some "java.*" packages.
 Some dummy node will be displayed in the place of this frames.<br>
-<h4>Step 1.</h4>
-<div style="margin-left: 40px;">We should implement {@link
-org.netbeans.spi.viewmodel.TreeModelFilter} first:<br>
+<h3>Step 1.</h3>
+<div style="margin-left: 40px;">We should implement <a href="@org-netbeans-spi-viewmodel@/org/netbeans/spi/viewmodel/TreeModelFilter.html">
+org.netbeans.spi.viewmodel.TreeModelFilter</a> first:<br>
 <pre style="background-color: rgb(255, 255, 102);">public class CallStackFilter implements TreeModelFilter {<br>    <br>    public Object[] getChildren (TreeModel original, Object parent, int from, int to) {<br>        Object[] originalCh = original.getChildren (parent, from, to);<br>        int i, k = originalCh.length;<br>        ArrayList newCh = new ArrayList ();<br>        boolean in = false;<br>        for (i = 0; i &lt; k; i++) {<br>            if (! (originalCh [i] instanceof CallStackFrame)) {<br>                newCh.add (originalCh [i]);<br>
                 continue;<br>            }<br>            CallStackFrame f = (CallStackFrame) originalCh [i];<br>            String className = f.getClassName ();<br>            if (className.startsWith ("java")) {<br>                if (!in) {<br>                    newCh.add (new JavaxSwing ());<br>                    in = true;<br>                }<br>            } else {<br>                in = false;<br>                newCh.add (f);<br>            }<br>        }<br>        return newCh.toArray ();<br>    }<br>    <br>    public Object getRoot (TreeModel original) {<br>        return original.getRoot ();<br>    }<br>    <br>    public boolean isLeaf (TreeModel original, Object node) <br>    throws UnknownTypeException {<br>        if (node instanceof JavaxSwing) return true;<br>        return original.isLeaf (node);<br>    }<br>    <br>    private static class JavaFrames {}<br>}<br></pre>
 And register it in file:<br>
@@ -107,7 +106,7 @@ by some dummy node.<br>
  alt="Callstack Filtering 2" width="559" height="285">
 </div>
  
-<h4>Step 2.</h4>
+<h3>Step 2.</h3>
 </div>
 <div style="margin-left: 80px;">We should provide NodeModel (at least)
 for our new node type (JavaFrames) now.<br>
@@ -116,7 +115,7 @@ for our new node type (JavaFrames) now.<br>
 And registration:<br>
 <pre style="background-color: rgb(255, 255, 102);">Meta-inf\debugger\netbeans-JPDASession\CallStackView\org.netbeans.spi.viewmodel.TreeModelFilter</pre>
 <img
- src="doc-files/CallStackViewFilterring3.JPG" title=""
+ src="doc-files/CallStackViewFilterring3.JPG"
  alt="Callstack View Filtering 3" style="width: 322px; height: 285px;">
 <br>
 <br>

--- a/java/api.maven/arch.xml
+++ b/java/api.maven/arch.xml
@@ -97,6 +97,7 @@
        that represent archetypes. The archetypes are defined by the following file attributes:
      </p>
        <table>
+           <caption>Archetype attributes</caption>
            <tbody>
                <tr><td>groupId</td><td>mandatory</td><td></td></tr>
                <tr><td>artifactId</td><td>mandatory</td><td></td></tr>

--- a/java/api.maven/src/org/netbeans/api/maven/MavenActions.java
+++ b/java/api.maven/src/org/netbeans/api/maven/MavenActions.java
@@ -36,9 +36,9 @@ import org.netbeans.modules.maven.spi.actions.AbstractMavenActionsProvider;
  * A API allows to <b>declaratively register actions</b> using project's Lookup. Action descriptions
  * must be provided in {@code nbactions.xml} format and referenced from the Layer XML using URL (i.e. nbres: protocol).
  * The {@code nbactions.xml} may contain descriptors of actions and even <b>profiles</b> which will be turned into
- * {@link ProjectConfiguration}s. Actions in profiles may override the default action mappings, or supply completely new
+ * {@link org.netbeans.spi.project.ProjectConfiguration}s. Actions in profiles may override the default action mappings, or supply completely new
  * actions.
- * <p/>
+ * </p>
  * <div class="nonnormative">
  * This example shows how to declare actions in a modules' layer, and register actions when <code>org.netbeans.modules.maven:test.plugin</code>
  * plugin is used by the maven project:

--- a/java/api.maven/test/unit/src/META-INF/generated-layer.xml
+++ b/java/api.maven/test/unit/src/META-INF/generated-layer.xml
@@ -23,7 +23,8 @@
 
 <!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
 <filesystem>
-    <!-- @start region="LayerActionsRegistration" -->
+    <!-- // @start region="LayerActionsRegistration" 
+    -->
     <folder name="Projects">
         <folder name="org-netbeans-modules-maven">
             <folder name="org.ntebeans.modules.maven:test.plugin">
@@ -42,5 +43,6 @@
             </folder>
         </folder>
     </folder>
-    <!-- @end region="LayerActionsRegistration" -->
+    <!-- // @end region="LayerActionsRegistration" 
+    -->
 </filesystem>

--- a/java/api.maven/test/unit/src/org/netbeans/api/maven/test-maven-actions.xml
+++ b/java/api.maven/test/unit/src/org/netbeans/api/maven/test-maven-actions.xml
@@ -16,7 +16,8 @@
     under the License.
 -->
 
-<!-- @start region="ActionsExample" -->
+<!-- // @start region="ActionsExample" 
+-->
 <actions>
     <actions>
         <action>
@@ -58,4 +59,5 @@
         </profile>
     </profiles>
 </actions>
-<!-- @end region="ActionsExample" -->
+<!-- // @end region="ActionsExample" 
+-->

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeMaker.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeMaker.java
@@ -1369,7 +1369,7 @@ public final class TreeMaker {
     ////////////////////////////////////////////////////////////////////////////
     // AnnotationTree
     /**
-     * Appends specified element <tt>attrValue</tt> to the end of attribute 
+     * Appends specified element <code>attrValue</code> to the end of attribute 
      * values list.
      *
      * @param   annotation  annotation tree containing attribute values list.
@@ -1381,7 +1381,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>attrValue</tt> at the specified 
+     * Inserts the specified element <code>attrValue</code> at the specified 
      * position in attribute values list.
      *
      * @param  annotation  annotation tree with attribute values list.
@@ -1426,7 +1426,7 @@ public final class TreeMaker {
     
     // BlockTree
     /**
-     * Appends specified element <tt>statement</tt> to the end of statements
+     * Appends specified element <code>statement</code> to the end of statements
      * list.
      *
      * @param   block      block tree containing statements list.
@@ -1438,7 +1438,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>statement</tt> at the specified 
+     * Inserts the specified element <code>statement</code> at the specified 
      * position in statements list.
      *
      * @param  block       block tree with statements list
@@ -1483,7 +1483,7 @@ public final class TreeMaker {
     
     // CaseTree
     /**
-     * Appends specified element <tt>statement</tt> to the end of statements
+     * Appends specified element <code>statement</code> to the end of statements
      * list.
      *
      * @param  kejs      case tree containing statements list.
@@ -1495,7 +1495,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>statement</tt> at the specified 
+     * Inserts the specified element <code>statement</code> at the specified 
      * position in statements list.
      *
      * @param  kejs      case tree containing statements list.
@@ -1540,7 +1540,7 @@ public final class TreeMaker {
 
     // ModuleTree
     /**
-     * Appends specified <tt>directive</tt> to the end of directives list.
+     * Appends specified <code>directive</code> to the end of directives list.
      * 
      * @param modle  module tree with directives list
      * @param directive  directive to be added to the list
@@ -1553,7 +1553,7 @@ public final class TreeMaker {
     
     
     /**
-     * Inserts the specified <tt>directive</tt> at the specified position
+     * Inserts the specified <code>directive</code> at the specified position
      * in directives list.
      *
      * @param  modle     module tree with directives list
@@ -1601,7 +1601,7 @@ public final class TreeMaker {
     
     // ClassTree
     /**
-     * Appends specified element <tt>member</tt> to the end of members
+     * Appends specified element <code>member</code> to the end of members
      * list. Consider you want to add such a method to the end of class:
      * <pre>
      *   public void newlyCreatedMethod(int a, float b) throws java.io.IOException {
@@ -1647,7 +1647,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>member</tt> at the specified 
+     * Inserts the specified element <code>member</code> at the specified 
      * position in members list.
      *
      * @param  clazz     class tree with members list
@@ -1691,7 +1691,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Appends specified element <tt>typeParameter</tt> to the end of type parameters
+     * Appends specified element <code>typeParameter</code> to the end of type parameters
      * list.
      *
      * @param   clazz    class tree containing type parameters list.
@@ -1703,7 +1703,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>member</tt> at the specified 
+     * Inserts the specified element <code>member</code> at the specified 
      * position in type parameters list.
      *
      * @param  clazz     class tree with type parameters list
@@ -1747,7 +1747,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Appends specified element <tt>implementsClause</tt> to the end of implements
+     * Appends specified element <code>implementsClause</code> to the end of implements
      * list.
      *
      * @param   clazz    class tree containing implements list.
@@ -1759,7 +1759,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>implementsClause</tt> at the specified 
+     * Inserts the specified element <code>implementsClause</code> at the specified 
      * position in implements list.
      *
      * @param  clazz     class tree with implements list
@@ -1804,7 +1804,7 @@ public final class TreeMaker {
         
     // CompilationUnitTree
     /**
-     * Appends specified element <tt>typeDeclaration</tt> to the end of type 
+     * Appends specified element <code>typeDeclaration</code> to the end of type 
      * declarations list.
      *
      * @param  compilationUnit compilation unit tree containing type declarations list.
@@ -1816,7 +1816,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>typeDeclaration</tt> at the specified 
+     * Inserts the specified element <code>typeDeclaration</code> at the specified 
      * position in type declarations list.
      *
      * @param  compilationUnit  compilation unit tree containing type declarations list.
@@ -1860,7 +1860,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Appends specified element <tt>importt</tt> to the end of imports list.
+     * Appends specified element <code>importt</code> to the end of imports list.
      *
      * @param  compilationUnit compilation unit tree containing imports list.
      * @param  importt element to be appended to list of imports.
@@ -1871,7 +1871,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>importt</tt> at the specified 
+     * Inserts the specified element <code>importt</code> at the specified 
      * position in imports list.
      *
      * @param  compilationUnit  compilation unit tree containing imports list.
@@ -1915,7 +1915,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Appends specified element <tt>annotation</tt> to the end of package annotations
+     * Appends specified element <code>annotation</code> to the end of package annotations
      * list.
      *
      * @param  cut  compilation unit tree containing package annotations list.
@@ -1928,7 +1928,7 @@ public final class TreeMaker {
     }
 
     /**
-     * Inserts the specified element <tt>annotation</tt> at the specified
+     * Inserts the specified element <code>annotation</code> at the specified
      * position in package annotations list.
      *
      * @param  cut  compilation unit tree containing package annotations list.
@@ -1978,7 +1978,7 @@ public final class TreeMaker {
     
     // ForLoopInitializer
     /**
-     * Appends specified element <tt>initializer</tt> to the end of initializers
+     * Appends specified element <code>initializer</code> to the end of initializers
      * list.
      *
      * @param  forLoop    for loop tree containing initializers list.
@@ -1990,7 +1990,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>initializer</tt> at the specified 
+     * Inserts the specified element <code>initializer</code> at the specified 
      * position in initializers list.
      *
      * @param  forLoop  for loop tree containing initializers list.
@@ -2035,7 +2035,7 @@ public final class TreeMaker {
     
     // ForLoopUpdate
     /**
-     * Appends specified element <tt>update</tt> to the end of updates
+     * Appends specified element <code>update</code> to the end of updates
      * list.
      *
      * @param  forLoop    for loop tree containing updates list.
@@ -2047,7 +2047,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>update</tt> at the specified 
+     * Inserts the specified element <code>update</code> at the specified 
      * position in updates list.
      *
      * @param  forLoop  for loop tree containing updates list.
@@ -2092,7 +2092,7 @@ public final class TreeMaker {
     
     // MethodInvocation
     /**
-     * Appends specified element <tt>argument</tt>.
+     * Appends specified element <code>argument</code>.
      *
      * @param  methodInvocation method invocation tree containing arguments list.
      * @param  argument     element to be appended to arguments list.
@@ -2103,7 +2103,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>argument</tt>.
+     * Inserts the specified element <code>argument</code>.
      *
      * @param  methodInvocation method invocation tree containing arguments list.
      * @param  index  index at which the specified elements is to be inserted.
@@ -2146,7 +2146,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Appends specified element <tt>type argument</tt> 
+     * Appends specified element <code>type argument</code> 
      * to the end of type arguments list.
      *
      * @param  methodInvocation method invocation tree containing arguments list.
@@ -2158,7 +2158,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>typeArgument</tt>
+     * Inserts the specified element <code>typeArgument</code>
      * at the specified position in type arguments list.
      *
      * @param  methodInvocation method invocation tree containing arguments list.
@@ -2203,7 +2203,7 @@ public final class TreeMaker {
     
     // Method
     /**
-     * Appends specified element <tt>parameter</tt>
+     * Appends specified element <code>parameter</code>
      * to the end of parameters list.
      *
      * @param  method        method tree containing parameters list.
@@ -2215,7 +2215,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>parameter</tt> 
+     * Inserts the specified element <code>parameter</code> 
      * at the specified position in parameters list.
      *
      * @param  method method tree containing parameters list.
@@ -2259,7 +2259,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Appends specified element <tt>typeParameter</tt>
+     * Appends specified element <code>typeParameter</code>
      * to the end of type parameters list.
      *
      * @param  method        method tree containing type parameters list.
@@ -2271,7 +2271,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>typeParameter</tt> 
+     * Inserts the specified element <code>typeParameter</code> 
      * at the specified position in type parameters list.
      *
      * @param  method method tree containing parameters list.
@@ -2315,7 +2315,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Appends specified element <tt>throwz</tt> to the end of throws
+     * Appends specified element <code>throwz</code> to the end of throws
      * list.
      *
      * @param  method     method tree containing throws list.
@@ -2327,7 +2327,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>throws</tt> at the specified 
+     * Inserts the specified element <code>throws</code> at the specified 
      * position in throws list.
      *
      * @param  method  method tree containing throws list.
@@ -2372,7 +2372,7 @@ public final class TreeMaker {
     
     // Modifiers
     /**
-     * Appends specified element <tt>annotation</tt> to the end of annotations
+     * Appends specified element <code>annotation</code> to the end of annotations
      * list.
      *
      * @param  modifiers   modifiers tree containing annotations list.
@@ -2384,7 +2384,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>annotation</tt> at the specified 
+     * Inserts the specified element <code>annotation</code> at the specified 
      * position in annotations list.
      *
      * @param  modifiers  modifiers tree containing annotations list.
@@ -2471,7 +2471,7 @@ public final class TreeMaker {
     
     // NewArray
     /**
-     * Appends specified element <tt>dimension</tt> to the end of dimensions
+     * Appends specified element <code>dimension</code> to the end of dimensions
      * list.
      *
      * @param  newArray   new array tree containing dimensions list.
@@ -2483,7 +2483,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>dimension</tt> at the specified 
+     * Inserts the specified element <code>dimension</code> at the specified 
      * position in dimensions list.
      *
      * @param  newArray   new array tree containing dimensions list.
@@ -2528,7 +2528,7 @@ public final class TreeMaker {
 
     // NewArrayTree
     /**
-     * Appends specified element <tt>initializer</tt> to the end of initializers
+     * Appends specified element <code>initializer</code> to the end of initializers
      * list.
      *
      * @param  newArray   new array tree containing initializers list.
@@ -2540,7 +2540,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>initializer</tt> at the specified 
+     * Inserts the specified element <code>initializer</code> at the specified 
      * position in initializers list.
      *
      * @param  newArray   new array tree containing initializers list.
@@ -2585,7 +2585,7 @@ public final class TreeMaker {
     
     // NewClass
     /**
-     * Appends specified element <tt>argument</tt> 
+     * Appends specified element <code>argument</code> 
      * to the end of arguments list.
      *
      * @param  newClass     new class tree containing arguments list.
@@ -2597,7 +2597,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>argument</tt> 
+     * Inserts the specified element <code>argument</code> 
      * at the specified position in type arguments list.
      *
      * @param  newClass   new class tree containing type arguments list.
@@ -2640,7 +2640,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Appends specified element <tt>typeArgument</tt> 
+     * Appends specified element <code>typeArgument</code> 
      * to the end of type arguments list.
      *
      * @param  newClass     new class tree containing arguments list.
@@ -2652,7 +2652,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>typeArgument</tt> 
+     * Inserts the specified element <code>typeArgument</code> 
      * at the specified position in type arguments list.
      *
      * @param  newClass   new class tree containing type arguments list.
@@ -2696,7 +2696,7 @@ public final class TreeMaker {
 
     // ParameterizedType
     /**
-     * Appends specified element <tt>argument</tt> to the end of type arguments
+     * Appends specified element <code>argument</code> to the end of type arguments
      * list.
      *
      * @param  parameterizedType   parameterized type tree containing type arguments list.
@@ -2708,7 +2708,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>argument</tt> at the specified 
+     * Inserts the specified element <code>argument</code> at the specified 
      * position in type arguments list.
      *
      * @param  parameterizedType   parameterized type tree containing type arguments list.
@@ -2753,7 +2753,7 @@ public final class TreeMaker {
 
     // Switch
     /**
-     * Appends specified element <tt>kejs</tt> to the end of cases
+     * Appends specified element <code>kejs</code> to the end of cases
      * list.
      *
      * @param   swic    switch tree containing cases list.
@@ -2765,7 +2765,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>kejs</tt> at the specified 
+     * Inserts the specified element <code>kejs</code> at the specified 
      * position in cases list.
      *
      * @param  swic   switch tree containing cases list.
@@ -2810,7 +2810,7 @@ public final class TreeMaker {
     
     // Try
     /**
-     * Appends specified element <tt>kec</tt> to the end of catches
+     * Appends specified element <code>kec</code> to the end of catches
      * list.
      *
      * @param   traj   try tree containing catches list.
@@ -2822,7 +2822,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>kec</tt> at the specified 
+     * Inserts the specified element <code>kec</code> at the specified 
      * position in catches list.
      *
      * @param  traj   try tree containing catches list.
@@ -2866,7 +2866,7 @@ public final class TreeMaker {
     }
             
     /**
-     * Appends specified element <tt>bound</tt> to the end of bounds
+     * Appends specified element <code>bound</code> to the end of bounds
      * list.
      *
      * @param   typeParameter     type parameter tree containing bounds list.
@@ -2878,7 +2878,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>bound</tt> at the specified 
+     * Inserts the specified element <code>bound</code> at the specified 
      * position in bounds list.
      *
      * @param  typeParameter   type parameter tree containing bounds list.
@@ -2922,14 +2922,14 @@ public final class TreeMaker {
     }
     
     /**
-     * Replaces the original <tt>node</tt>'s label with new one provided in
-     * <tt>aLabel</tt> argument. Throws <tt>IllegalArgumentException</tt> if
-     * <tt>node</tt>'s kind is invalid. Valid <tt>node</tt>'s kinds are:<br>
+     * Replaces the original <code>node</code>'s label with new one provided in
+     * <code>aLabel</code> argument. Throws <code>IllegalArgumentException</code> if
+     * <code>node</code>'s kind is invalid. Valid <code>node</code>'s kinds are:<br>
      * BREAK, CLASS, CONTINUE, IDENTIFIER, LABELED_STATEMENT,
      * MEMBER_SELECT, METHOD, TYPE_PARAMETER, VARIABLE, MEMBER_REFERENCE (since 0.112).<p>
      *
-     * Consider you want to change name of  method <tt>fooMet</tt> to
-     * <tt>fooMethod</tt>:
+     * Consider you want to change name of  method <code>fooMet</code> to
+     * <code>fooMethod</code>:
      *
      * <pre>
      *   public void fooMet() throws java.io.IOException {
@@ -2952,12 +2952,12 @@ public final class TreeMaker {
      * </pre>
      *
      * @param node    argument will be duplicated and its label replaced
-     *                with <tt>aLabel</tt>
-     * @param aLabel  represents new <tt>node</tt>'s name or other label
+     *                with <code>aLabel</code>
+     * @param aLabel  represents new <code>node</code>'s name or other label
      * @throws java.lang.IllegalArgumentException  if the user provides
-     *         illegal <tt>node</tt>'s kind, i.e. if the provided
-     *         <tt>node</tt> does not contain any name or <tt>String</tt>.
-     * @return  duplicated <tt>node</tt> with a new name
+     *         illegal <code>node</code>'s kind, i.e. if the provided
+     *         <code>node</code> does not contain any name or <code>String</code>.
+     * @return  duplicated <code>node</code> with a new name
      */
     public <N extends Tree> N setLabel(final N node, final CharSequence aLabel)
             throws IllegalArgumentException {
@@ -3390,11 +3390,11 @@ public final class TreeMaker {
     }
     
     /**
-     * Creates a new BlockTree for provided <tt>bodyText</tt>.
+     * Creates a new BlockTree for provided <code>bodyText</code>.
      * 
      * @param   method    figures out the scope for attribution.
      * @param   bodyText  text which will be used for method body creation.
-     * @return  a new tree for <tt>bodyText</tt>.
+     * @return  a new tree for <code>bodyText</code>.
      */
     public BlockTree createMethodBody(MethodTree method, String bodyText) {
         SourcePositions[] positions = new SourcePositions[1];
@@ -3409,11 +3409,11 @@ public final class TreeMaker {
     }
 
     /**
-     * Creates a new BlockTree for provided <tt>bodyText</tt>.
+     * Creates a new BlockTree for provided <code>bodyText</code>.
      * 
      * @param   lambda    figures out the scope for attribution.
      * @param   bodyText  text which will be used for lambda body creation.
-     * @return  a new tree for <tt>bodyText</tt>.
+     * @return  a new tree for <code>bodyText</code>.
      * @since 2.19
      */
     public BlockTree createLambdaBody(LambdaExpressionTree lambda, String bodyText) {
@@ -3429,11 +3429,11 @@ public final class TreeMaker {
     }
 
     /**
-     * Creates a new ExpressionTree for provided <tt>bodyText</tt>.
+     * Creates a new ExpressionTree for provided <code>bodyText</code>.
      * 
      * @param   lambda    figures out the scope for attribution.
      * @param   bodyText  text which will be used for lambda body creation.
-     * @return  a new tree for <tt>bodyText</tt>.
+     * @return  a new tree for <code>bodyText</code>.
      * @since 2.54
      */
     public ExpressionTree createLambdaExpression(LambdaExpressionTree lambda, String bodyText) {
@@ -3895,7 +3895,7 @@ public final class TreeMaker {
     }
 
     /**
-     * Appends specified element <tt>parameter</tt>
+     * Appends specified element <code>parameter</code>
      * to the end of parameters list.
      *
      * @param  method        lambda expression tree containing parameters list.
@@ -3908,7 +3908,7 @@ public final class TreeMaker {
     }
     
     /**
-     * Inserts the specified element <tt>parameter</tt> 
+     * Inserts the specified element <code>parameter</code> 
      * at the specified position in parameters list.
      *
      * @param  method lambda expression tree containing parameters list.

--- a/java/maven/arch.xml
+++ b/java/maven/arch.xml
@@ -155,6 +155,7 @@
        that represent archetypes. The archetypes are defined by the following file attributes:
      </p>
        <table>
+           <caption>Archetype attributes</caption>
            <tbody>
                <tr><td>groupId</td><td>mandatory</td><td></td></tr>
                <tr><td>artifactId</td><td>mandatory</td><td></td></tr>

--- a/java/maven/src/org/netbeans/modules/maven/api/NbMavenProject.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/NbMavenProject.java
@@ -73,11 +73,11 @@ import org.openide.util.Utilities;
 /**
  * an instance resides in project lookup, allows to get notified on project and 
  * relative path changes.
- * <p/>
+ * <p>
  * <b>From version 2.148</b> plugin-specific services can be registered using {@link ProjectServiceProvider} 
  * annotation in subfolders of the project Lookup registration area whose names follow a Plugin group and 
  * artifact ID. 
- * <p/>
+ * </p>
  * <div class="nonnormative">
  * {@snippet file="org/netbeans/modules/maven/NbMavenProjectImplTest.java" region="ProjectServiceProvider.pluginSpecific"}
  * Shows a service, that will become available from project Lookup whenever the project uses {@code org.netbeans.modules.maven:test.plugin}

--- a/java/maven/src/org/netbeans/modules/maven/api/execute/PrerequisitesChecker.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/execute/PrerequisitesChecker.java
@@ -37,7 +37,7 @@ package org.netbeans.modules.maven.api.execute;
  * <li><i>_any</i> services. Provide a fallback if no packaging (or other specific) service created the necessary data. 
  * These are also run for all packaging types.
  * </ol>
- * <p>
+ *
  * <div class="nonnormative">
  * Let's have some examples:
  * {@snippet file="org/netbeans/modules/maven/api/execute/RunUtilsTest.java" region="GeneralPrerequisiteChecker"}

--- a/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
@@ -110,8 +110,8 @@ import org.openide.windows.OutputListener;
  * Example use:
  * {@snippet file="org/netbeans/modules/maven/execute/MavenExecutionTestBase.java" region="samplePassAdditionalVMargs"}
  * The example will <b>append</b> <code>-DvmArg2=2</code> to VM arguments and <b>replaces</b> all user
- * program arguments with <code>"paramY"</code>. Append mode can be controlled using {@link ExplicitProcessParameters.Builder#appendArgs} or
- * {@link ExplicitProcessParameters.Builder#appendPriorityArgs}.
+ * program arguments with <code>"paramY"</code>. Append mode can be controlled using {@link ExplicitProcessParameters.Builder#replaceArgs(boolean) } or
+ * {@link ExplicitProcessParameters.Builder#replaceLauncherArgs(boolean) }.
  *
  * @author  Milos Kleint (mkleint@codehaus.org)
  * @author  Svata Dedic (svatopluk.dedic@gmail.com)

--- a/java/maven/src/org/netbeans/modules/maven/spi/actions/MavenActionsProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/spi/actions/MavenActionsProvider.java
@@ -44,10 +44,11 @@ import org.openide.util.lookup.ServiceProvider;
  * recognizes them and allows to configure vm, application arguments and main class name for the goal. It is a responsibility
  * of action mapping to remap the properties used by exec:exec to goal-specific properties, if it uses different naming. See the
  * following example:
+ * </span>
  * <div class="nonnormative">
  * {@snippet file="org/netbeans/modules/maven/runjar/example-rungoals-config.xml" region="register-run-goals"}
  * </div>
- * </span>
+ * 
  * @author  Milos Kleint
  */
 public interface MavenActionsProvider {

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/runjar/example-rungoals-config.xml
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/runjar/example-rungoals-config.xml
@@ -21,7 +21,8 @@
 -->
 <!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
 <filesystem>
-    <!-- @start region="register-run-goals" -->
+    <!-- // @start region="register-run-goals" 
+    -->
     <folder name="Projects">
         <folder name="org-netbeans-modules-maven">
             <!-- Register in Projects/org-netbeans-modules-maven/RunGoals area -->
@@ -46,5 +47,6 @@
             </folder>
         </folder>
     </folder>
-    <!-- @end region="register-run-goals" -->
+    <!-- // @end region="register-run-goals" 
+    -->
 </filesystem>

--- a/nbbuild/antsrc/org/netbeans/nbbuild/Arch-default-arch-where.xsl
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/Arch-default-arch-where.xsl
@@ -25,11 +25,9 @@
 
     <!-- print out <api /> dependencies on all needed netbeans subprojects -->
     <xsl:template match="/" >
-        <p>
             The sources for the module are in the
             <a href="https://gitbox.apache.org/repos/asf?p=netbeans.git">Apache Git repositories</a> 
             or in the <a href="https://github.com/apache/netbeans">GitHub repositories</a>.
-        </p>
     </xsl:template>    
-        </xsl:stylesheet> 
+</xsl:stylesheet> 
 

--- a/nbbuild/antsrc/org/netbeans/nbbuild/Arch.xsl
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/Arch.xsl
@@ -284,13 +284,12 @@
         <xsl:param name="generate-export" />
         <xsl:param name="generate-import" />
         
-    
-        <a>
-            <xsl:attribute name="name" >
+        <xsl:element name="h3">
+            <xsl:attribute name="id" >
                 <xsl:text>group-</xsl:text><xsl:value-of select="$group" />
             </xsl:attribute>
-            <h5>Group of <xsl:value-of select="$group"/> interfaces</h5>
-        </a>
+            Group of <xsl:value-of select="$group"/> interfaces
+        </xsl:element>       
         
         <xsl:variable 
             name="all_interfaces" 
@@ -303,15 +302,20 @@
                           )
                   ]" 
         />
-        <table cellpadding="1" cellspacing="0" border="0" class="tablebg" width="100%"><tr><td>
-          <table border="0" cellpadding="3" cellspacing="1" width="100%">   
+        <!--<table class="tablebg"><tr><td>-->
+        <table class="tableapigroup">
+            <caption>
+                Group of <xsl:value-of select="$group"/> interfaces
+            </caption>
+            <thead>
             <tr class="tablersh">
-                <td align="CENTER" width="25%"><span class="titlectable">Interface Name</span></td>
-                <td align="CENTER" width="10%"><span class="titlectable">In/Out</span></td>
-                <td align="CENTER" width="10%"><span class="titlectable">Stability</span></td>
-                <td align="CENTER" ><span class="titlectable">Specified in What Document?</span></td>
+                <th><span class="titlectable">Interface Name</span></th>
+                <th><span class="titlectable">In/Out</span></th>
+                <th><span class="titlectable">Stability</span></th>
+                <th><span class="titlectable">Specified in What Document?</span></th>
             </tr>
-
+            </thead>
+            <tbody>
             <xsl:for-each select="$all_interfaces ">
                 <xsl:call-template name="api-group-name" >
                     <xsl:with-param name="name" select="@name" />
@@ -320,9 +324,9 @@
                     <xsl:with-param name="type" select="@type" />
                 </xsl:call-template>
             </xsl:for-each>
+            </tbody>
           </table>
-        </td></tr></table>
-        <p/>
+        <!--</td></tr></table>-->        
     </xsl:template>    
     
     <!-- the template to convert an instances of API into an HTML line in a table 
@@ -435,14 +439,11 @@
                         </xsl:otherwise>
                     </xsl:choose>
                     
-                </a>
-                <p/>
+                </a>                
             </xsl:if>
             
             <xsl:if test="$describe.node" >
-                <p/>
                 <xsl:apply-templates select="$describe.node" />
-                <p/>
             </xsl:if>
        </xsl:for-each>
     </xsl:template>

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
@@ -144,7 +144,7 @@ public class CheckLinks extends MatchingTask {
         JUnitReportWriter.writeReport(this, null, report, Collections.singletonMap("testBrokenLinks", testMessage));
     }
     
-    private static Pattern hrefOrAnchor = Pattern.compile("<(a|img|link|h2|h3|h4|span)(\\s+shape=\"rect\")?(?:\\s+rel=\"stylesheet\")?\\s+(href|name|id|src)=\"([^\"#]*)(#[^\"$]+)?\"(\\s+shape=\"rect\")?(?:\\s+type=\"text/css\")?\\s*/?>", Pattern.CASE_INSENSITIVE);
+    private static Pattern hrefOrAnchor = Pattern.compile("<(a|img|link|h1|h2|h3|h4|li|span)(\\s+shape=\"rect\")?(?:\\s+rel=\"stylesheet\")?\\s+(href|name|id|src)=\"([^\"#]*)(#[^\"$]+)?\"(\\s+shape=\"rect\")?(?:\\s+type=\"text/css\")?\\s*/?>", Pattern.CASE_INSENSITIVE);
     private static Pattern lineBreak = Pattern.compile("^", Pattern.MULTILINE);
     
     /**

--- a/nbbuild/javadoctools/exportOverview.xsl
+++ b/nbbuild/javadoctools/exportOverview.xsl
@@ -37,11 +37,11 @@
           <title>Overview</title><!-- note this is ignored -->
          </head>
          <body>
-          <p>
-            <xsl:apply-templates select="api-answers/answer[@id='arch-overall']/node()" mode="description"/>
-          </p>
+          <h1>Overview of <xsl:value-of select="api-answers/@module" /><xsl:text> module</xsl:text></h1>
+          <xsl:apply-templates select="api-answers/answer[@id='arch-overall']/node()" mode="description"/>
+          
 
-          <h3>What is New (see <a href="apichanges.html">all changes</a>)?</h3>
+          <h2>What is New (see <a href="apichanges.html">all changes</a>)?</h2>
 
           <ul>
               <xsl:call-template name="api-changes" >
@@ -50,11 +50,11 @@
               </xsl:call-template>
           </ul>
           
-          <h3>Use Cases</h3>
+          <h2>Use Cases</h2>
           
-          <xsl:apply-templates select="//answer[@id='arch-usecases']" mode="description" />
+          <xsl:apply-templates select="//answer[@id='arch-usecases']/node()" mode="description" />
           
-          <h3>Exported Interfaces</h3>
+          <h2>Exported Interfaces</h2>
           
                 This table lists all of the module exported APIs 
                 with 
@@ -68,15 +68,15 @@
                     <xsl:with-param name="generate-import" select="'false'" />
                 </xsl:call-template>
         
-            <h3>Implementation Details</h3>
+            <h2>Implementation Details</h2>
 
             <xsl:if test="api-answers/answer[@id='arch-where']/node()" >
-                <h5>Where are the sources for the module?</h5>
+                <h3>Where are the sources for the module?</h3>
                 <xsl:apply-templates select="api-answers/answer[@id='arch-where']/node()" mode="description"/>
             </xsl:if>
             
             <xsl:if test="api-answers/answer[@id='deploy-dependencies']/node()" >
-                <h5>What do other modules need to do to declare a dependency on this one, in addition to or instead of a plain module dependency?</h5>
+                <h3>What do other modules need to do to declare a dependency on this one, in addition to or instead of a plain module dependency?</h3>
                 <xsl:apply-templates select="api-answers/answer[@id='deploy-dependencies']/node()" mode="description"/>
             </xsl:if>
 
@@ -147,9 +147,10 @@
     </xsl:template>
 
     <xsl:template match="usecase" mode="description" >
-        <h5><xsl:value-of select="@name" /></h5>
-        <xsl:apply-templates select="./node()" />
+        <h3><xsl:value-of select="@name" /></h3>
+        <xsl:apply-templates select="./node()" mode="description" />
     </xsl:template>
+    
     <xsl:template match="@*|node()" mode="description" >
        <xsl:copy  >
           <xsl:apply-templates select="@*|node()" mode="description" />
@@ -163,7 +164,13 @@
        </xsl:copy>
     </xsl:template>
 
-  
+    <!-- special html 5 rewrite -->
+    <xsl:template match="a/@shape" />
+    <xsl:template match="a/@shape" mode="description" />
+    <xsl:template match="pre/@space" />
+    <xsl:template match="pre/@space" mode="description"/>
+    
+    
     <!-- format the API table -->
     <xsl:template name="export-api">
         <xsl:param name="arch.target" />
@@ -266,9 +273,9 @@
             <a><xsl:attribute name="href">apichanges.html#<xsl:call-template name="change-id"/></xsl:attribute>
                 <xsl:apply-templates select="summary/node()"/>
             </a>
-            <p>
+            <!--<p> -->
                 <xsl:apply-templates select="description/node()" mode="description" />
-            </p>
+            <!-- </p> -->
         </li>
     </xsl:template>
     

--- a/nbbuild/javadoctools/netbeans-lite.css
+++ b/nbbuild/javadoctools/netbeans-lite.css
@@ -110,3 +110,43 @@ if you need make some changes please edit into netbeans.css*/
   color: #0000ff;
   }
 
+:root {
+  /* Background color for subnavigation and various headers */
+  --subnav-background-color: #dee3e9;
+  /* Background and text colors for selected tabs and navigation items */
+  --selected-background-color: #f8981d;
+  --selected-text-color: #253441;
+}
+
+table.tableapigroup {
+   table-layout: fixed;
+   width: 100%;
+   border-spacing: 4px;
+   border-collapse: collapse;
+   border: 4px solid var(--selected-background-color);
+}
+
+table.tableapigroup caption {
+    color: var(--selected-text-color);
+    background: var(--selected-background-color);
+}
+table.tableapigroup td {border: 1px solid var(--selected-background-color);}
+table.tableapigroup  th:first-child {
+  background: var(--subnav-background-color);
+  width: 20%;
+}
+
+table.tableapigroup   th:nth-child(n+2) {
+  background: var(--subnav-background-color);
+  width: 10%;
+}
+
+table.tableapigroup  th:nth-child(n+3) {
+  background: var(--subnav-background-color);
+  width: 10%;
+}
+
+table.tableapigroup  th:nth-child(n+4) {
+  background: var(--subnav-background-color);
+  width: 60%;
+}

--- a/platform/autoupdate.services/arch.xml
+++ b/platform/autoupdate.services/arch.xml
@@ -130,7 +130,6 @@
     </question>
     -->
     <answer id="arch-usecases">
-        <p>
             <usecase id="browse" name="Browse all available units">
                 Give overview of IDE installation to users, it involve overview of installed modules (grouped together as feature),
                 overview of available updates, overview of available new features.
@@ -138,7 +137,7 @@
                 all its available updates, optionlly its backup instance.
                 <code>UpdateUnit</code> can represent either a feature (e.g. group
                 of modules), a single module or a localization.
-                <p></p>
+                <br/>
                 <i>Proposed usage of API:</i> Call <code>List&lt;UpdateUnit&gt; UpdateManager.getDefault().getUpdateUnits()</code>
                 <!-- JST:UpdateManager cannot be singleton because it has mutable
                   state with apply method. Imho, there should be UpdateManager.create(...).
@@ -149,12 +148,12 @@
             <usecase id="browse-by-style" name="Browse all units by chosen style (e.g. modules, features, localization)">
                 Sometimes there can be a need to get overview of units
                 by chosen style, e.g. feature, module or localization.
-                <p></p>
+                <br/>
                 <i>Proposed usage of API:</i> Call <code>List&lt;UpdateUnit&gt; UpdateManager.getDefault().getUpdateUnits(UpdateStyle style)</code>
             </usecase>
             <usecase id="browse-installed" name="Browse installed modules">
                 When an API client needs to get overview of installed modules.
-                <p></p>
+                <br/>
                 <i>Proposed usage of API:</i> Call <code>List&lt;UpdateUnit&gt; UpdateManager.getDefault().getUpdateUnits(UpdateStyle style)</code>
                 and filter units which haven't been installed yet.
                 <!-- JST: The comment by Tonda was that this may be too slow.
@@ -173,14 +172,14 @@
                 which are applicable to active IDE. <code>UpdateManager</code> will
                 search all available <code>UpdateUnit</code> given attribute.
             </usecase>
-            <a name="install-new-functionality"></a>
+            <a id="install-new-functionality"></a>
             <usecase id="install-new-functionality" name="Install new functionality">
                 An client needs to install new functionality into the IDE installation.
                 She knows what unit and what version wants to install.
                 Needs to identify if the functionality is ready to install,
                 resolve its dependencies, identify possible problems and locate
                 other unit what have to be installed together with asked functionality.
-                <p></p>
+                <br/>
                 <i>Proposed usage of API:</i>
                 <ul>
                     <li>Client needs install NetBeans module in required minimal specification version.</li>
@@ -198,14 +197,14 @@
                 already installed. She knows what unit and what update element (by version) wants to install.
                 Needs to identify possible problems with update install, resolve its dependencies, identify possible problems and locate
                 other unit what have to be installed together with asked functionality.
-                <p></p>
+                <br/>
                 <i>Proposed usage of API:</i> See above <a href="#install-new-functionality">Install new functionality</a>
             </usecase>
             <usecase id="uninstall-unit" name="Uninstall functionality">
                 An client needs to uninstall some functionality from IDE installation. She knows what unit wants to uninstall.
                 Needs to identify if the functionality is ready to uninstall, resolve its dependencies, identify possible problems and locate
                 other unit what will be disabled together.
-                <p></p>
+                <br/>
                 <i>Proposed usage of API:</i>
                 <ul>
                     <li>Client knows <code>UpdateElement</code> which wants to uninstall.</li>
@@ -215,11 +214,11 @@
                     <li>If all okay, then uninstall the unit: <code>OperationContainer.doOperation()</code></li>
                 </ul>
             </usecase>
-            <a name="disable-unit"/>
+            <a id="disable-unit"/>
             <usecase id="disable-unit" name="Switch off functionality">
                 An client needs to switch off (disable) some functionality in IDE installation. Needs to resolve its dependencies,
                 identify possible problems and locate other unit what will be disabled together.
-                <p></p>
+                <br/>
                 <i>Proposed usage of API:</i>
                 <ul>
                     <li>Client knows <code>UpdateElement</code> which wants to uninstall.</li>
@@ -236,7 +235,7 @@
                 Sometimes an client needs to rollback of installed update of unit to previous version.
                 Needs to resolve its dependencies, identify possible problems and locate
                 other unit what are affected by rollback.
-                <p></p>
+                <br/>
                 <i>Proposed usage of API:</i> Like above  <a href="#disable-unit">Switch off functionality</a>
                 <ul>
                     <li>Client knows <code>UpdateElement</code> which wants to uninstall.</li>
@@ -283,7 +282,6 @@
             </usecase>
             <usecase id="specify-target-cluster" name="Specify the cluster where to install">TBD</usecase>
             <usecase id="get-installed-files" name="Get all installed files of given unit">TBD</usecase>
-        </p>
     </answer>
 
 
@@ -609,7 +607,9 @@
     </question>
     -->
     <answer id="deploy-dependencies">
-        <defaultanswer generate="here"/>
+        <p>
+            default anwser deploy-dependencies XXX non existing
+        </p>
     </answer>
 
 

--- a/platform/autoupdate.services/src/org/netbeans/api/autoupdate/OperationContainer.java
+++ b/platform/autoupdate.services/src/org/netbeans/api/autoupdate/OperationContainer.java
@@ -200,11 +200,13 @@ public final class OperationContainer<Support> {
     }
     
     /**
+     * <p>See the difference between {@link #createForInstall} and {@link #createForDirectInstall} for example</p>
+     * 
      * @return either {@link OperationSupport} or {@link InstallSupport} depending on type parameter of <code>OperationContainer&lt;Support&gt;</code> or
      * <code>null</code> if the <code>OperationContainer</code> is empty or contains any invalid elements
      * @see #listAll
      * @see #listInvalid
-     * <br><p>See the difference between {@link #createForInstall} and {@link #createForDirectInstall} for example</p>
+     *
      */                        
     public Support getSupport() {
         if (upToDate != null && upToDate) {
@@ -227,7 +229,7 @@ public final class OperationContainer<Support> {
      * Check if <code>updateElement</code> can be added ({@link #add})
      * @param updateUnit
      * @param updateElement to be inserted.
-     * @return <tt>true</tt> if chosen operation upon <code>updateElement</code> is allowed
+     * @return <code>true</code> if chosen operation upon <code>updateElement</code> is allowed
      */
     public boolean canBeAdded(UpdateUnit updateUnit, UpdateElement updateElement) {
         return impl.isValid(updateUnit, updateElement);
@@ -295,7 +297,7 @@ public final class OperationContainer<Support> {
     /**
      * Removes <code>updateElement</code>
      * @param updateElement
-     * @return <tt>true</tt> if successfully added
+     * @return <code>true</code> if successfully added
      */
     public boolean remove(UpdateElement updateElement) {
         if (upToDate != null) {
@@ -307,7 +309,7 @@ public final class OperationContainer<Support> {
     
     /**
      * @param updateElement
-     * @return <tt>true</tt> if this instance of <code>OperationContainer</code> 
+     * @return <code>true</code> if this instance of <code>OperationContainer</code> 
      * contains the specified <code>updateElement</code>.     
      */
     public boolean contains(UpdateElement updateElement) {

--- a/platform/core.multiview/src/org/netbeans/core/api/multiview/package.html
+++ b/platform/core.multiview/src/org/netbeans/core/api/multiview/package.html
@@ -46,6 +46,5 @@ not.</li>
   <li>Etc.</li>
 </ul>
 <br>
-<span style="font-weight: bold;"></span>
 </body>
 </html>

--- a/platform/core.multiview/src/org/netbeans/core/spi/multiview/package.html
+++ b/platform/core.multiview/src/org/netbeans/core/spi/multiview/package.html
@@ -27,8 +27,8 @@ MultiView SPI provides infrastructure for creating components that dock
 multiple views into one consistent component. Developers define what
 shall be included into the component and are given opportunity to
 influence the overall behaviour of the component.<br>
-This SPI handles the lifecycle of a multiview component.<p>
-<h3>Creation</h3>
+This SPI handles the lifecycle of a multiview component.
+<h2>Creation</h2>
 New instance of MultiView TopComponent can be created by calling
 <a href="@TOP@/org/netbeans/core/spi/multiview/MultiViewFactory.html#createMultiView-org.netbeans.core.spi.multiview.MultiViewDescription:A-org.netbeans.core.spi.multiview.MultiViewDescription-">
     MultiViewFactory.createMultiView
@@ -48,7 +48,7 @@ The multiview component is cloneable by default. If any of your
 embedded elements cannot be cloned, or you don't intend to allow the
 users to clone the component, please use the appropriate factory method
 to create a non-cloneable instance.
-<h3>Lifecycle</h3>
+<h2>Lifecycle</h2>
 Once the multiview component is opened, the element for the default
 MultiViewDescription is created. Creation of other Elements is delayed
 to the moment these are required.<br>
@@ -82,7 +82,7 @@ by asking the user) in
   </li>
 </ul>
 <br>
-<h3>Persistence</h3>
+<h2>Persistence</h2>
 TopComponents decide about persistence based on the <a
  href="@org-openide-windows@/org/openide/windows/TopComponent.html">TopComponent.getPersistenceType()</a>&nbsp;
 return values. Possible values are:
@@ -133,7 +133,7 @@ MultiViewElements are deserialized.&nbsp; These are kept and the
 createElement() method is not called on the matching
 MultiViewDescription.<br>
 <br>
-<h3>Manipulating the multiview</h3>
+<h2>Manipulating the multiview</h2>
 MultiViewElements get a chance to manipulate the enclosed topcomponent.
 Each of them is passed an instance of 
 {@link org.netbeans.core.spi.multiview.MultiViewElementCallback} on
@@ -147,8 +147,7 @@ lifecycle of the element. <br>
 contruct the Element's getActions() array).</li>
   <li>To change the title for the topcomponent.</li>
 </ul>
-<span style="font-weight: bold;"><br>
-</span>
+
 If your MultiViewElement is a TopComponent or provides a TopComponent
 in getVisualRepresentation(), you can manipulate
 the activatedNodes of the whole multiview component by setting the
@@ -156,7 +155,7 @@ appropriate nodes on your own TopComponent.
 when elements are switched, the activated nodes get updated as well
 according to the shown element.
 <br>
-<h3><span style="font-weight: bold;"></span>Embedding editors</h3>
+<h2><span style="font-weight: bold;"></span>Embedding editors</h2>
 A typical MultiViewElement for embedding editor extends 
 <a href="@org-openide-text@/org/openide/text/CloneableEditor.html">CloneableEditor</a>
 and delegates some of the functionality to the multiview component. <br>

--- a/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/api.html
+++ b/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/api.html
@@ -34,7 +34,7 @@
 This API module makes that possible. It also includes the JavaHelp standard
 extension library itself.</p>
 
-<h2><a name="helpctx-layer">JavaHelp installation</a></h2>
+<h2 id="helpctx-layer">JavaHelp installation</h2>
 
 <h3>Helpset registration</h3>
 
@@ -100,7 +100,7 @@ accessible via the presenters of this kind of XML file.
 <p class="nonnormative">Note that usage of help shortcuts is no longer recommended by NetBeans style
 guidelines.</p>
 
-<h2><a name="helpctx-context-help">Context Help</a></h2>
+<h2 id="helpctx-context-help">Context Help</h2>
 
 <p>When the help set is specified in the module, this permits the
 IDE to associate context help with various features associated with
@@ -280,7 +280,7 @@ and look in your log file for details.
 further information on association between help IDs and GUI
 components, and so on.</p>
 
-<h2><a name="external-links">External links in JavaHelp</a></h2>
+<h2 id="external-links">External links in JavaHelp</h2>
 <div class="nonnormative">
 Most of external links are not displayed correctly in internal java help viewer.
 This lightweight component was added to invoke default IDE HTML browser
@@ -364,7 +364,7 @@ in a css termonolgy. Acceptable values are as follows:
 
 </div>
 
-<h2><a name="extension">Extension of nbdocs protocol</a></h2>
+<h2 id="extension">Extension of nbdocs protocol</h2>
 <div class="nonnormative">
 As documentation is modular ie. it is defined across modules it is possible to define
 link in documentation from one module to another module. When referred module is not

--- a/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/help-guide.html
+++ b/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/help-guide.html
@@ -69,7 +69,7 @@ help into the IDE and correctly setting
   </li>
 </ul>
 
-<h2><a name="intro">Introduction</a></h2>
+<h2 id="intro">Introduction</h2>
 <p>The IDE's architecture enables you to:</p>
 <ul>
   <li> Create separate help sets and associate them with given modules.</li>
@@ -94,13 +94,13 @@ the order in which topics appear within the table of contents.</li>
   <li> How to specify how the help set is built during the IDE's build process </li>
 </ul>
 
-<h2><a name="adding">Adding Help to GUI components</a></h2>
+<h2 id="adding">Adding Help to GUI components</h2>
 <p>There is an overview of adding help to various GUI NetBeans components in the
 <a href="api.html#helpctx-context-help">JavaHelp Integration API</a>.
 This section expands a bit on the information 
 provided there.</p>
 
-<h3><a name="nodes">Explorer Nodes</a></h3>
+<h3 id="nodes">Explorer Nodes</h3>
 <p>If your node extends <code>AbstractNode</code> or one of its subclasses, you should 
   implement the <code>getHelpCtx</code> method to return a <a href="@org-openide-util-ui@/org/openide/util/HelpCtx.html"> 
   <code>HelpCtx</code></a> for the node. The <code>HelpCtx</code> includes the specific 
@@ -117,7 +117,7 @@ provided there.</p>
 </span>}
 </pre>
 
-<h3><a name="wizards">Wizards</a></h3>
+<h3 id="wizards">Wizards</h3>
 <p>Wizards are basically a series of Swing Components that are displayed via a 
   <a href="@org-openide-dialogs@/org/openide/WizardDescriptor.Iterator.html"> 
   <code>WizardDescriptor.Iterator</code></a> object. The object that the developer 
@@ -149,7 +149,7 @@ provided there.</p>
 </span>}
 </pre>
 
-<h3><a name="dialogs">Dialogs</a></h3>
+<h3 id="dialogs">Dialogs</h3>
 <p>There are two different ways in which you can set help on a NetBeans dialog. 
   If you wish to display a dialog of some sort, you typically create the Swing 
   components you wish to display and then create a <a href="@org-openide-dialogs@/org/openide/DialogDescriptor.html"> 
@@ -194,7 +194,7 @@ dd.setHelpCtx(<span class="keyword">new</span> <span class="type">HelpCtx</span>
 <p>If you do not supply a <code>HelpCtx</code> object for the <code>DialogDescriptor</code>
 or set the help ID string for the displayed Swing Component, then no <i>Help</i> 
 button will be displayed on the <code>JDialog</code> that is displayed for this <code>DialogDescriptor</code>.</p>
-<h3><a name="propsheets"></a>Property Sheets </h3>
+<h3 id="propsheets">Property Sheets </h3>
 <p>When creating a Property Sheet, the developer creates a <a href="@org-openide-nodes@/org/openide/nodes/Sheet.Set.html"> 
   <code>Sheet.Set</code></a> object. To populate the <code>Sheet.Set</code> the developer 
   creates and adds a number of <a href="@org-openide-nodes@/org/openide/nodes/Node.Property.html"> 
@@ -208,7 +208,7 @@ button will be displayed on the <code>JDialog</code> that is displayed for this 
 ps.setValue(<span class="string">"helpID"</span>, <span class="string">"org.netbeans.modules.xml.tree.nodes.XMLDataNode.Properties"</span>);  
 </pre>
 
-<h3><a name="tabpropsheets">Tabbed Property Sheets</a></h3>
+<h3 id="tabpropsheets">Tabbed Property Sheets</h3>
 <p> Property sheets can actually contain multiple tabs, each having their own 
   help associated with them. The method described above to set the help id of 
   a Property Sheet still applies, the only difference is the way in which the 
@@ -222,12 +222,12 @@ referenceTab.setName(<span class="string">"referenceTab"</span>); <span class="c
 </span>sheet.put(referenceTab);
 </pre>
 
-<h3><a name="props">Individual Properties</a></h3>
+<h3 id="props">Individual Properties</h3>
 <p> You can also set an individual help ID for each property (<code>Node.Property</code>) 
   in a property sheet. Presently Sun Java Studio and NetBeans help is not provided on a per-property 
   basis - help on individual properties is provided in the form of a tooltip. 
 </p>
-<h3><a name="propeditor"></a>Custom Property Editors</h3>
+<h3 id="propeditor">Custom Property Editors</h3>
 <p>Some Properties displayed on a Property Sheet require a custom editor. The 
   user accesses the editor by selecting the "..." button on an entry for a specific 
   Property when the user selects that Property. The developer of the custom editor 
@@ -247,7 +247,7 @@ referenceTab.setName(<span class="string">"referenceTab"</span>); <span class="c
 </span>}
 </pre>
 
-<h3><a name="tabpropeditors"><b>Tabbed Custom Property Editor</b>s</a></h3>
+<h3 id="tabpropeditors"><b>Tabbed Custom Property Editor</b>s</h3>
 <p>Some Custom Property Editors display a number of tabs. Depending on the tab 
   that is displayed, different Help may need to be displayed. In this case, you 
   should set the help ID on the property editor's JTabbedPane. If you want the 
@@ -289,7 +289,7 @@ referenceTab.setName(<span class="string">"referenceTab"</span>); <span class="c
 }
 </pre>
 
-<h2><a name="toc-index">Merge Hints for TOC and Index</a></h2>
+<h2 id="toc-index">Merge Hints for TOC and Index</h2>
 <p>In NetBeans IDE 3.6, the help system has been upgraded to use v. 2.0 of JavaHelp 
 software. The most visible benefit of the upgrade is better merging of TOC and index. 
 NetBeans IDE uses the Unite-Append merge type for the table of contents and the Sort 
@@ -351,7 +351,7 @@ look like the following:
  </li>
 </ul>
 
-<h2><a name="makeknown">Making the Help Set Known to the IDE</a></h2>
+<h2 id="makeknown">Making the Help Set Known to the IDE</h2>
 <p>In order to use the result help set within the IDE at runtime, a couple of things
 need to be added to various files associated with the module. These are outlined 
 in part in the <a href="api.html#helpctx-layer">reference documentation</a>.
@@ -361,7 +361,7 @@ This description assumes you are using a NetBeans module project.</p>
     and adding the <code>@HelpSetRegistration</code> annotation to it. You will want to specify a position for the help set;
     this mainly affects the order into which help sets are merged into the table of contents.
 
-<h2><a name="putfiles">Where to Put Help Files in the Module Source</a></h2>
+<h2 id="putfiles">Where to Put Help Files in the Module Source</h2>
 <p>Help files should be kept under the regular <samp>src</samp> subdirectory
   off of the module root directory. Like source code, all JavaHelp documentation 
   must be placed into a globally unique package to avoid conflicts. If two modules 
@@ -371,12 +371,12 @@ This description assumes you are using a NetBeans module project.</p>
   e.g. for a module named <code>org.netbeans.modules.foo</code>, place the JavaHelp
   into <code>org.netbeans.modules.foo.docs</code> (plus perhaps subpackages).
 
-<h2><a name="notes">Additional Notes</a></h2>
+<h2 id="notes">Additional Notes</h2>
 <p>This section includes any additional comments or issues regarding Help for IDE
 modules.</p>
 <ul>
 
-  <li><a name="helpids"></a> <b>Making Help IDs Unique</b> - When a Help request 
+  <li id="helpids"> <b>Making Help IDs Unique</b> - When a Help request 
     is initiated with a specific Help ID, the code that looks for the corresponding 
     html file to display starts checking the help sets that have been loaded. As 
     soon as a match is made, the html file is loaded in the JavaHelp viewer. There 
@@ -395,7 +395,7 @@ modules.</p>
       <br>
   </li>
 
-  <li><a name="i18n"></a><b>I18N of Help IDs -</b> All of the <code>HelpCtx</code> 
+  <li id="i18n"><b>I18N of Help IDs -</b> All of the <code>HelpCtx</code> 
     methods that take strings as parameters are included in the IDE's list of 
     NOI18N patterns and therefore are not internationalized. You do not need to 
     add <samp>//&nbsp;NOI18N</samp> to lines containing these strings.

--- a/platform/javahelp/src/org/netbeans/api/javahelp/package.html
+++ b/platform/javahelp/src/org/netbeans/api/javahelp/package.html
@@ -33,7 +33,7 @@ Used to add help to a module or display help.
 
 <li class="nonnormative"><p><a href="@TOP@org/netbeans/api/javahelp/doc-files/help-guide.html">Help Guide</a> (friendlier)</p></li>
 
-<li><p><a href="https://docs.oracle.com/cd/E19253-01/819-0913/819-0913.pdf">JavaHelp Standard Extension</p></li>
+<li><p><a href="https://docs.oracle.com/cd/E19253-01/819-0913/819-0913.pdf">JavaHelp Standard Extension</a></p></li>
 
 </ol>
 

--- a/platform/openide.actions/apichanges.xml
+++ b/platform/openide.actions/apichanges.xml
@@ -52,7 +52,7 @@
           layer, don't use the deprecated manifest style.
       </description>
       <class package="org.openide.actions" name="ToolsAction"/>
-      <issue number="180979 "/>
+      <issue number="180979"/>
 </change>
 <change>
       <api name="actions"/>

--- a/platform/openide.actions/arch.xml
+++ b/platform/openide.actions/arch.xml
@@ -875,6 +875,7 @@ it belongs to <em>Window system module</em>.
 <answer id="resources-preferences">
     <api group="preferences" name="org.openide.actions.HeapView" type="export" category="private">
       <table>
+          <caption>resources preferences</caption>
           <tbody>
               <tr>
                   <th>key</th>

--- a/platform/openide.actions/src/org/openide/actions/doc-files/api.html
+++ b/platform/openide.actions/src/org/openide/actions/doc-files/api.html
@@ -74,7 +74,7 @@ what is selected).
 The Actions API allows users to interact with module code, by invoking
 actions via menus, toolbars or keyboard shortcuts.
 
-<h2><a name="standard">Using Standard Swing Actions</a></h2>
+<h2 id="standard">Using Standard Swing Actions</h2>
 For uncomplicated cases (such as adding an always-enabled action to the main
 menu or the context menu of a <code>Node</code>), it is not necessary to use
 any of the Actions API classes at all - just register an instance of the action class into
@@ -87,9 +87,8 @@ Actions are typically either presented in popup menus, or otherwise
 <a href="#attach">attached</a> to a component such as a window, node,
 data object, or filesystem, or installed globally in the main menu or
 toolbars.
-<p>
 
-<h2><a name="intro">Introduction to NetBeans' Action classes</a></h2>
+<h2 id="intro">Introduction to NetBeans' Action classes</h2>
 For historical reasons, the action subclasses available in NetBeans' APIs 
 are subclasses of
 <a href="@org-openide-util-ui@/org/openide/util/actions/SystemAction.html"><code>SystemAction</code></a>.
@@ -107,7 +106,7 @@ important thing to note is that <code>SystemAction</code> objects should be
 <em>singletons</em>, meaning that any instance of the class is
 interchangeable, and all useful state should be static. For this
 reason, actions are commonly specified by class name only.
-<p>
+
 <blockquote><strong>Important:
 For historical reasons, by default, all <code>SystemAction</code> classes run
 their <code>actionPerformed</code> method <i>off</i> the AWT event dispatch thread.  For 
@@ -120,7 +119,7 @@ Watch your console (or <code>var/log/messages.log</code> file) - if you forget t
 override this method on some action, you will be warned when it is run.
 </strong></blockquote>
 
-<h3><a name="intro-callback">Callback Actions</a></h3>
+<h3 id="intro-callback">Callback Actions</h3>
 
 Some global actions should perform a different function depending on which
 component has focus.  For example, Ctrl-F runs a generic &quot;Find&quot; action.
@@ -142,7 +141,7 @@ actionMap.put("the-key", new MyAction());
 </pre>
 if the key has been made publicly known and the action is not accessible.
 
-<h3><a name="intro-sense">Context-sensitive actions</a></h3>
+<h3 id="intro-sense">Context-sensitive actions</h3>
 
 Often you will want to have actions be enabled or disabled based on what
 is selected.  Historically this was based on the activated <code>Node</code>;  in more
@@ -176,7 +175,7 @@ requested classes in their <code>Lookup</code> or if the presence of the classes
 on any of the selected <code>Node</code>s is enough, or if the action should
 be disabled if more than one <code>Node</code> is selected.
 
-<h3><a name="intro-present">Presenters</a></h3>
+<h3 id="intro-present">Presenters</h3>
 Sometimes an action needs to provide a custom component to be used in menus
 or toolbars.  For example, the memory meter (enabled in development builds
 of NetBeans) provides a custom component that shows the amount of memory
@@ -198,7 +197,7 @@ Apple Macintosh, which expects all menu contents to be <code>JMenuItem</code>
 or <code>JMenu</code> instances.</strong>
 </blockquote>
 
-<h2><a name="using-callback">Using <code>CallbackSystemAction</code></a></h2>
+<h2 id="using-callback">Using <code>CallbackSystemAction</code></h2>
 <a href="@org-openide-util-ui@/org/openide/util/actions/CallbackSystemAction.html">
 <code>CallbackSystemAction</code></a> makes it possible for a single action to have
 multiple implementations, depending on what is selected.  A <code>CallbackSystemAction</code>
@@ -309,7 +308,7 @@ be implemented, for example:
 it will be enabled automatically whenever the node selection includes
 at least one "scannable" object.</p>
 
-<h3><a name="install">Installation</a></h3>
+<h3 id="install">Installation</h3>
 
 Global installation of an action may be accomplished by
 adding it to the <code>Actions</code> folder of the system filesystem,
@@ -331,7 +330,7 @@ them into appropriate editor kits (content types). Actions may be
 bound to keyboard shortcuts active only in the editor window; added to
 the editor toolbar; or added to the editor's context menu. </p>
 
-<h2><a name="use-std">Using Standard Actions Found in NetBeans' APIs</a></h2>
+<h2 id="use-std">Using Standard Actions Found in NetBeans' APIs</h2>
 
 Many of the commonly-used actions available in NetBeans are located in
 the
@@ -341,7 +340,7 @@ the
 package.  Typically you don't subclass one of these actions - you simply
 find the default instance (via <code>SystemAction.findAction()</code>and use it.
 
-<h3><a name="attach">Attaching to an Existing Object</a></h3>
+<h3 id="attach">Attaching to an Existing Object</h3>
 An action that does not have global scope and sensitivity should
 usually be explicitly attached to components that can use it. For
 example,
@@ -408,14 +407,14 @@ Editor tab, such as Save and Close.
 
 </ol>
 
-<h2><a name="adv-install">Installation and Maintenance</a></h2>
+<h2 id="adv-install">Installation and Maintenance</h2>
 Except for programmatic uses (overriding <code>Node.getActions()</code> and the
 like), actions are installed via module XML layer files - by placing a JavaBean
 &quot;instance&quot; of a given action class into a folder in the system 
 filesystem which represents a menu or a toolbar.
 For details see <a href="@org-openide-util@/org/openide/util/doc-files/api.html#instances">Working with Instances</a>.
 
-<h3><a name="install-menu">Menu installation</a></h3>
+<h3 id="install-menu">Menu installation</h3>
 The main menu in NetBeans is constructed from a set of folders in the 
 system filesystem.  There is a folder called <samp>Menu</samp>.  Each
 child folder of it is one menu;  child folders may contain additional child
@@ -480,7 +479,7 @@ to separate items in the menu.</li>
 for a precise list of what kinds of instances are permitted and how
 they will be treated.</p>
 
-<h3><a name="install-toolbar">Toolbar installation</a></h3>
+<h3 id="install-toolbar">Toolbar installation</h3>
 
 Installing items into toolbars can be done in a similar fashion to
 that available for menu installation, but with more options for
@@ -495,7 +494,7 @@ entirely replace a toolbar with your choice of components;  read
 about advanced Toolbar configuration <a href="toolbarsAdvanced.html">here</a>.
 
 
-<h3><a name="install-pool">The Global Actions Pool</a></h3>
+<h3 id="install-pool">The Global Actions Pool</h3>
 
 The <samp>Actions/</samp> folder in the system filesystem
 contains a list of standard actions, as instances in the same style
@@ -513,9 +512,8 @@ users to customize menus and toolbars - meaning that a user can delete your
 action, effectively making it inaccessible.  The actions pool provides a way
 to restore an action that has been deleted, so any global action should be
 found here as well as in whatever toolbar or menu it is displayed in.
-<p>
 
-<h3><a name="keymap">Installing Keyboard Shortcuts</a></h3>
+<h3 id="keymap">Installing Keyboard Shortcuts</h3>
 
 <p>The way to install keyboard shortcuts is to make an instance of
 the action in question, and place it in the <samp>Shortcuts/</samp>

--- a/platform/openide.dialogs/src/org/openide/DialogDisplayer.java
+++ b/platform/openide.dialogs/src/org/openide/DialogDisplayer.java
@@ -114,11 +114,11 @@ public abstract class DialogDisplayer {
      * <p>
      * It is possible to call {@link CompletableFuture#cancel(boolean)} on the returned value.
      * The implementation may (through it is not guaranteed) abort and hide the UI. If cancel() is 
-     * called, the returned Future always completes exceptionally, with a {@link CancellationException}.
+     * called, the returned Future always completes exceptionally, with a {@link java.util.concurrent.CancellationException}.
      * <p>
      * The thread that will execute the continuation or exception handler is undefined. Use usual
      * precautions against EDT blocking and use {@link CompletableFuture#thenAcceptAsync(java.util.function.Consumer, java.util.concurrent.Executor)}
-     * or similar to execute in a specific thread. Prefer usage of {@link RequestProcessor} to the
+     * or similar to execute in a specific thread. Prefer usage of <a href="@org-openide-util@/org/openide/util/RequestProcessor.html" >RequestProcessor</a> to the
      * builtin thread pool.
      * <div class="nonnormative">
      * The following snippet is an example of chained dialogs (can be any other processing): 

--- a/platform/openide.dialogs/src/org/openide/NotifyDescriptor.java
+++ b/platform/openide.dialogs/src/org/openide/NotifyDescriptor.java
@@ -329,7 +329,7 @@ public class NotifyDescriptor extends Object {
     * usage, the message is just a <code>String</code>.  However, the type
     * of this parameter is actually <code>Object</code>.  Its interpretation depends on
     * its type:
-    * <dl compact>
+    * <dl>
     * <dt><code>Object[]</code><dd> A recursively interpreted series of messages.
     * <dt>{@link Component}<dd> The <code>Component</code> is displayed in the dialog.
     * <dt>{@link javax.swing.Icon}<dd> The <code>Icon</code> is wrapped in a {@link JLabel} and displayed in the dialog.
@@ -481,7 +481,7 @@ public class NotifyDescriptor extends Object {
     * The usual value for the options parameter is an array of
     * <code>String</code>s.  But the parameter type is an array of <code>Object</code>s.  Its
     * interpretation depends on its type:
-    * <dl compact>
+    * <dl>
     * <dt>{@link Component}<dd>The component is added to the button row directly.
     * <dt>{@link javax.swing.Icon}<dd>A {@link javax.swing.JButton} is created with this icon as its label.
     * <dt>anything else<dd>The <code>Object</code> is {@link Object#toString converted} to a string and the result is used to
@@ -521,7 +521,7 @@ public class NotifyDescriptor extends Object {
     * The usual value for the options parameter is an array of
     * <code>String</code>s.  But the parameter type is an array of <code>Object</code>s.  Its
     * interpretation depends on its type:
-    * <dl compact>
+    * <dl>
     * <dt>{@link Component}<dd>The component is added to the button row directly.
     * <dt>{@link javax.swing.Icon}<dd>A {@link javax.swing.JButton} is created with this icon as its label.
     * <dt>anything else<dd>The <code>Object</code> is {@link Object#toString converted} to a string and the result is used to

--- a/platform/openide.dialogs/src/org/openide/doc-files/wizard-guidebook.html
+++ b/platform/openide.dialogs/src/org/openide/doc-files/wizard-guidebook.html
@@ -19,7 +19,7 @@
 
 -->
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 
 <head>
@@ -36,10 +36,8 @@
     </style>
 </head>
 
-<h1>Wizard Descriptor API</h1>
-
 <body>
-
+<h1>Wizard Descriptor API</h1>
 Class <a href="../WizardDescriptor.html"><code>WizardDescriptor</code></a>
 
 allows developer to create wizard from supplied 
@@ -84,7 +82,7 @@ Use
 <code>WizardDescriptor.putProperty()</code></a> to set following initialization 
 properties.
 <ul>
-<li><tt>
+<li>
 Name <b> <code>"WizardPanel_autoWizardStyle"</code></b>, type <b> <code>Boolean</code></b>
 
 <br>
@@ -117,21 +115,16 @@ Default subtitle format is <code>"{0} wizard ({1})"</code> and name of default
 where <code>{0}</code> is number of current panel and <code>{1}</code> is size of iterator. 
 <br>
 
-</tt></li>
-<br><br>
+</li>
 
-<li><tt>
+<li>
 Name <b> <code>"WizardPanel_contentDisplayed"</code></b>, type <b> <code>Boolean</code></b>
 <br>
 Set to <code>Boolean.TRUE</code> to turn on displaying of steps pane 
 (content, behind which can be displayed image).
 Content will be constructed from not initialization property <code>"WizardPanel_contentData"</code>.
-
-</tt></li>
-
-<br><br>
-
-<li><tt>
+</li>
+<li>
 Name <b> <code>"WizardPanel_helpDisplayed"</code></b>, type <b> <code>Boolean</code></b>
 <br>
 Set to <code>Boolean.TRUE</code> to turn on displaying of help (html browser)
@@ -143,25 +136,22 @@ If also steps are displayed then put help and content panes into tabbed pane.
 <i>Note: If do you need a help on invoking the Help button then ensure
 a <code>WizardDescriptor.Panel</code> supply a non-default <code>HelpCtx</code>.</i>
 
-</tt></li>
-
-<br><br>
-
-<li><tt>
+</li>
+<li>
 Name <b> <code>"WizardPanel_contentNumbered"</code></b>, type <b> <code>Boolean</code></b>
 <br>
 Set to <code>Boolean.TRUE</code> to turn on numbering of steps (before every step
 is placed it's sequence number). 
 
-</tt></li>
+</li>
 
-<br><br>
 
-<li><tt>
+
+<li>
 Name <b> <code>"WizardPanel_leftDimension"</code></b>, type <b> <code>Dimension</code></b>
 <br>
 Set size of left pane (steps and help pane). 
-</tt></li>
+</li>
 </ul>
 
 That was initialization part. All <code>Boolean</code> properties are <code>Boolean.FALSE</code>
@@ -180,39 +170,28 @@ Follow properties which could be changed at wizard runtime.
 These properties could be changed dynamically.
 
 <ul>
-<li><tt>
+<li>
 Name <b> <code>"WizardPanel_contentData"</code></b>, type <b> <code>String[]</code></b>
 <br>
 Set step names which will be displayed in the content pane.
-
-<br><br>
-
-<li><tt>
+</li>
+<li>
 Name <b> <code>"WizardPanel_image"</code></b>, type <b> <code>java.awt.Image</code></b>
 
 <br>
 Set image displayed as background of content. 
-</tt></li>
-
-<br><br>
-
-<li><tt>
+</li>
+<li>
 Set subtitle (!!!) format with 
 <a href="../WizardDescriptor.html#setTitleFormat-java.text.MessageFormat-">
 <code>WizardDescriptor.setTitleFormat()</code></a>.
-</tt></li>
-
-<br><br>
-
-<li><tt>
+</li>
+<li>
 Set title of the wizard with 
-
 <a href="../NotifyDescriptor.html#setTitle-java.lang.String-">
 <code>WizardDescriptor.setTitle()</code></a>. 
-</tt></li>
-<br><br>
-
-<li><tt>
+</li>
+<li>
 Name <b><code>"WizardPanel_errorMessage"</code></b>, type <b> <code>String</code></b>
 <br>
 Set the localized message which is then shown at the bottom of the wizard panel.
@@ -220,7 +199,7 @@ This message should be set when panel becomes invalid and Next/Finish
 buttons are disabled. It helps user to understand what is wrong. The property
 must be set to null value to clear the message. This property is supported since
 NetBeans 3.5.
-</tt></li>
+</li>
 
 </ul>
 
@@ -228,38 +207,29 @@ In every
 panel set these client properties (<code>JComponent.putClientProperty()</code>): 
 
 <ul>
-<li><tt>
+<li>
 Name <b> <code>"WizardPanel_helpURL"</code></b>, type <b> <code>java.net.URL</code></b>
 <br>
 Help url which explains your pane. 
-</tt></li>
-
-<br><br>
-
-<li><tt>
+</li>
+<li>
 Name <b> <code>"WizardPanel_contentSelectedIndex"</code></b>, type <b> <code>java.lang.Integer</code></b>
 <br>
 Index of highlighted step in the content, the index is zero-based.
-</tt></li>
-
-<br><br>
-
-<li><tt>
+</li>
+<li>
 Name <b> <code>"WizardPanel_contentBackgroundColor"</code></b>, type <b> <code>java.awt.Color</code></b>
 <br>
 Color used as background of content pane. 
-</tt></li>
-
-<br><br>
-
-<li><tt>
+/li>
+<li>
 Set name of panel <code>JComponent.setName("First wizard panel")</code>, 
 used as first part of subtitle, second
 is 
 
 <a href="../WizardDescriptor.Iterator.html#name--">
 <code>WizardDescriptor.Panel.name()</code></a> when you use <code>"{0}{1}"</code> message format.
-</tt></li>
+</li>
 
 </ul>
 

--- a/platform/openide.explorer/arch.xml
+++ b/platform/openide.explorer/arch.xml
@@ -400,7 +400,7 @@ No.
         </question>
 -->
 <answer id="exec-property">
-    <api name="netbeans.dnd.enabled" group="systemproperty" category="private" type="export" url="">
+    <api name="netbeans.dnd.enabled" group="systemproperty" category="private" type="export">
     Checks by Drag &amp; Drop support for views. True is regard as default
     (no matter what jdk's version). False value disallows Drag &amp; Drop in
     all views.

--- a/platform/openide.explorer/src/org/openide/explorer/doc-files/api.html
+++ b/platform/openide.explorer/src/org/openide/explorer/doc-files/api.html
@@ -65,13 +65,13 @@ A set of standard Explorer Views is available in
 <ul>
     <li><a href="#customps">Customizing the Property Sheet</a></li>
     <li><a href="#customeds">Property Editors</a></li>
-    </ul></li>
-    </li>
+</ul>
+</li>
 </ul>
 
 <h1>Explorer API</h1>
 
-<h2><a name="overview">Overview of the Explorer</a></h2>
+<h2 id="overview">Overview of the Explorer</h2>
 
 Explorer views are UI components which render <em>nodes</em> - the most 
 prominent in NetBeans being the Project and Files tabs on the left side of
@@ -80,9 +80,8 @@ in trees, lists, combo boxes, menus, tree tables.  These components
 handle things like cut/copy/paste, drag and drop, displaying popup menus
 for nodes, which contain the actions the clicked node provides from
 <code>getActions()</code>.
-<p>
 
-<h3><a name="intro-node">The Explorer and Nodes</a></h3>
+<h3 id="intro-node">The Explorer and Nodes</h3>
 
 An Explorer view is solely a user-interface component: it has no particular 
 knowledge of <i>what</i> it is displaying.  Rather, it provides the 
@@ -97,12 +96,12 @@ be the <em>root</em> of the Explorer.
 <p>The API permits you to use the prebuilt views, and also to <a href="customExplorerViews.html">create
 your own</a> if you need to.
 
-<h2><a name="use-expl">Using the Explorer API</a></h2>
+<h2 id="use-expl">Using the Explorer API</h2>
 
 It is rather easy to use the Explorer API to just display an Explorer
 window of some type, browsing some set of nodes.
 
-<h3><a name="show-expl">Displaying a new Explorer window</a></h3>
+<h3 id="show-expl">Displaying a new Explorer window</h3>
 
 Probably the easiest way to show an Explorer window is just to call
 <a href="@org-openide-nodes@/org/openide/nodes/NodeOperation.html#explore-org.openide.nodes.Node-"><code>NodeOperation.explore(...)</code></a>.
@@ -193,7 +192,7 @@ might build, is probably to create an <code>ExplorerPanel</code> which
 adds some or all of them; the views will be automatically
 synchronized, which will be helpful in understanding how they behave.
 
-<h3><a name="show-prop">Displaying a Property Sheet</a></h3>
+<h3 id="show-prop">Displaying a Property Sheet</h3>
 
 Adding a <em>Property Sheet</em> (which just shows the properties of
 the selected node(s), and may allow editing of those properties) is
@@ -211,7 +210,7 @@ Explorer view and a Property Sheet to the same container will result
 in the Property Sheet being sensitive to the node selection in the
 regular view, which is usually the desired effect.
 
-<h3><a name="node-aspect">Aspects of Nodes affecting the Explorer</a></h3>
+<h3 id="node-aspect">Aspects of Nodes affecting the Explorer</h3>
 
 Particular Explorer views are of course free to display the node
 hierarchy any way they wish; however, there are a few common aspects
@@ -304,11 +303,11 @@ or
 
 </ul>
 
-<h2><a name="cust-expl">Customizing the Explorer</a></h2>
+<h2 id="cust-expl">Customizing the Explorer</h2>
 Though rarely necessary, the API allows you to create your own Explorer views,
 as described <a href="customExplorerViews.html">here</a>.
 
-<h2><a name="propsheet">The Property Sheet</a></h2>
+<h2 id="propsheet">The Property Sheet</h2>
 Older versions of NetBeans relied heavily on the Property Sheet as a primary
 element of the user interface.  However, this turned out not to be terribly
 user-friendly, and the Property Sheet is used considerably less today (it is
@@ -317,8 +316,8 @@ no longer even displayed by default on startup).
 Consider providing a custom UI where possible, rather than relying on the
 user having the Property Sheet visible to work with your module.
 
-<h3><a name="customps">Customizing the Property Sheet</a></h3>
-<P>
+<h3 id="customps">Customizing the Property Sheet</h3>
+
 <div class="nonnormative">
 The Property Sheet displays property sets in expandable
 categories inside a single tree, rather than using tabs as the old
@@ -326,25 +325,25 @@ Property Sheet did.  However, there are some cases where tabs are
 desirable.  A mechanism exists by which an instance of
 <code>Node.PropertySet</code> can specify that it should be displayed in
 a tab:  It must return an internationalized string from
-<code>PropertySet.getValue(&quot;tabName&quot)</code>.  If multiple
+<code>PropertySet.getValue(&quot;tabName&quot;)</code>.  If multiple
 property sets belonging to a single node specify the same tab name
 in this manner, all of them will be included on a tab with the specified
-name<sup><font size="-2">*</font></sup>.
-<p>
+name <em>*</em>.
+
 <blockquote>
-<sup><font size="-1">*</font></sup><font size="-1">
+    <em>*</em>
 Note that for this functionality to function properly, the
 NetBeans Window System must be installed.  Further information on how to
 work use this functionality in a stand-alone application can be found
 <a href="propertySheetReference.html#tabs">here</a>.
-</font></blockquote>
+</blockquote>
 </div>
 
 A number of system properties, UI manager keys and such also affect
 the way Property Sheets are displayed and behave.  A complete reference
 can be found <a href="propertySheetReference.html">here</a>.
 
-<h3><a name="customeds">Property Editors</a></h3>
+<h3 id="customeds">Property Editors</h3>
 The NetBeans core installs a variety of property editors for standard JDK
 classes and some NetBeans classes.  A number of these can have their behavior
 altered by passing &quot;hints&quot; from <code>Node.Property</code> or

--- a/platform/openide.explorer/src/org/openide/explorer/doc-files/customExplorerViews.html
+++ b/platform/openide.explorer/src/org/openide/explorer/doc-files/customExplorerViews.html
@@ -26,7 +26,7 @@
 </head>
 <body>
 
-<h1><a name="cust-view">Creating a new Explorer view</a></h1>
+<h1 id="cust-view">Creating a new Explorer view</h1>
 
 Anyone may create a new Explorer view and use it for special purposes
 with a custom UI, to provide an alternate representation of nodes
@@ -70,7 +70,7 @@ certain changes.
 <p>Other than these requirements, nearly any visual representation is
 possible, and so the API does not specify any more than this.
 
-<h3><a name="cust-treeview">Subclassing the tree views</a></h3>
+<h2 id="cust-treeview">Subclassing the tree views</h2>
 
 The abstract base class
 

--- a/platform/openide.explorer/src/org/openide/explorer/doc-files/propertySheetReference.html
+++ b/platform/openide.explorer/src/org/openide/explorer/doc-files/propertySheetReference.html
@@ -30,7 +30,7 @@ This document details a few ways in which the Property Sheet can be customized
 or affected by system properties, UI manager keys, non-normative hints from
 Nodes and such.
 
-<h2><a name="jvmflags">System properties that affect the behavior of the Property Sheet</a></h2>
+<h2 id="jvmflags">System properties that affect the behavior of the Property Sheet</h2>
 <p>Note that generally these flags may or may not be supported in
 future versions.  The following flags may be passed to the JVM
 in the form <code>runide -J-Dsome.property=true</code> which
@@ -59,9 +59,8 @@ is the most effective.
 <LI><b>netbeans.ps.forcetabs</b> - debugging flag which forces the property
     sheet to use tabs instead of expandable sets for all property sets</LI>
 </UL>
-</div>
 
-<h2><a name="uimanager">UIManager settings that affect Property Sheet display characteristics</a></h2>
+<h2 id="uimanager">UIManager settings that affect Property Sheet display characteristics</h2>
 <div class="nonnormative">
 <p>The Property Sheet will look for a number of custom values in UIManager,
 which may be supplied to affect its appearance, either by a themes.xml file
@@ -91,7 +90,7 @@ enhancing the presentation of the Property Sheet:
 </UL>
 </div>
 
-<h2><a name="customps">Customization of PropertyPanel</a></h2>
+<h2 id="custompspsr">Customization of PropertyPanel</h2>
 <div class="nonnormative">
 <P>The PropertyPanel component is a generic component which will display a 
 property editor for a single property - rather like a single cell of the 
@@ -112,7 +111,7 @@ be set on it to change its behavior, via <code>putClientProperty()</code>.</P>
 </ul>
 </div>  
 
-<h2><a name="tabs">Using Tabs in a Property Sheet in a stand-alone application</a></h2>
+<h2 id="tabs">Using Tabs in a Property Sheet in a stand-alone application</h2>
 The Property Sheet can display different property sets in different tabs -
 all sets that return the same value from <code>PropertySet.getValue("tabName")</code>
 will be aggregated together on the same tab.

--- a/platform/openide.explorer/src/org/openide/explorer/doc-files/propertyViewCustomization.html
+++ b/platform/openide.explorer/src/org/openide/explorer/doc-files/propertyViewCustomization.html
@@ -26,7 +26,7 @@
 </head>
   <body>
   <h1>Customizing how Properties are displayed</h1>
-<H2><A name="custom_property_editors"> Customizing property editors </a></H2>
+<h2 id="custom_property_editors"> Customizing property editors </h2>
 The core implementation provides a set of property editors for common types
 of properties. These editors implement the <EM> org.openide.explorer.propertysheet.ExPropertyEditor </EM>
 interface. It allows passing custom values to the property editor instances.
@@ -34,7 +34,7 @@ This can be useful for customizing the property editors appearance.
 <P>
 You may want to customize the property editor behavior in different situations:
 
-<H3><A name="new_bean"> When creating a new bean </a></H3>
+<h3 id="new_bean"> When creating a new bean </h3>
 The properties can be passed to BeanInfo. They are propagated through
 BeanNode to the property editor. For example if you have a java.io.File property
 in your bean you can use this in the BeanInfo:
@@ -50,7 +50,7 @@ properties[PROPERTY_testFile].setValue("files", Boolean.FALSE);
 // (the property editor will not allow selecting files)
 </PRE>
 
-<H3><A name="new_node"> When creating a new node </a></H3>
+<h3 id="new_node"> When creating a new node </h3>
 You can directly pass the custom parameters to the properties. One 
 example is when overriding method createSheet - you can use the property there.
 Or anywhere where you have access to the org.openide.nodes.Node.Property 
@@ -89,7 +89,7 @@ is an example from NetBeans sources, though this module is now obsolete.</p>
 <p class="nonnormative"><a href="http://www.netbeans.org/source/browse/~checkout~/core/src/org/netbeans/core/ui/MountIterator.java"><code>MountIterator</code></a>
 is an example from NetBeans sources.</p>
 -->
-<H3><A name="disabling_ok"> When do you want to disable/enable OK when displaying custom property editor </a></H3>
+<h3 id="disabling_ok"> When do you want to disable/enable OK when displaying custom property editor </h3>
 If you provide your own property editor implementation which supplies a GUI custom editor, that
 component will be displayed in a separate window with OK and Cancel buttons.
 Implement <a href="../propertysheet/ExPropertyEditor.html">ExPropertyEditor</a> on
@@ -100,7 +100,7 @@ that is passed to it.  To enable the OK button, call
 <code>env.setState(PropertyEnv.STATE_INVALID)</code>.
 
 
-<H3><A name="core_editors_custom_parameters"> Custom parameters in core editors </a></H3>
+<h3 id="core_editors_custom_parameters"> Custom parameters in core editors </h3>
 <p>
 Following table presents all property editors in core that can be
 used with the mechanism of passing named properties. If you pass a
@@ -108,7 +108,8 @@ property that is not supported in the editor (or if you pass wrong argument
 type) the custom parameter is ignored.
 </p>
 
-    <TABLE border="1" summary="custom parameter list">
+    <TABLE border="1">
+        <caption>custom parameter list</caption>
         <TR>
             <TH> Property type
             </TH>
@@ -270,7 +271,8 @@ implementation. They can be used with any property, they are not
 bound to one editor.
 </p>
 
-    <TABLE border="1" summary="general parameters">
+    <TABLE border="1">
+        <caption>general parameters</caption>
         <TR>
             <TH>
                 Affected part
@@ -395,7 +397,7 @@ bound to one editor.
         </TR>
     </TABLE>
 
-<h3><a name="other-prop-eds">Other available property editors</a></h3>
+<h3 id="other-prop-eds">Other available property editors</h3>
 
 NetBeans includes a number of
 

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropertyPanel.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropertyPanel.java
@@ -949,7 +949,7 @@ public class PropertyPanel extends JComponent implements javax.accessibility.Acc
      * not valid states just if it implements the {@link ExPropertyEditor}
      * and changes state by the <code>setState</code> method of the {@link PropertyEnv}
      * environment.
-     * <P>
+     *
      * @return <code>PropertyEnv.STATE_VALID</code> if the editor is not the <code>ExPropertyEditor</code>
      *    one or other constant from <code>PropertyEnv.STATE_*</code> that was assigned to <code>PropertyEnv</code>
      * @since 2.20

--- a/platform/openide.filesystems.nb/src/org/openide/filesystems/FileChooserBuilder.java
+++ b/platform/openide.filesystems.nb/src/org/openide/filesystems/FileChooserBuilder.java
@@ -52,13 +52,13 @@ import org.openide.util.*;
  * it is possible to chain invocations to simplify setting up a file chooser.
  * Example usage:
  * <pre>
- *      <font color="gray">//The default dir to use if no value is stored</font>
+ *      <span style="color:gray">//The default dir to use if no value is stored</span>
  *      File home = new File (System.getProperty("user.home") + File.separator + "lib");
- *      <font color="gray">//Now build a file chooser and invoke the dialog in one line of code</font>
- *      <font color="gray">//&quot;libraries-dir&quot; is our unique key</font>
+ *      <span style="color:gray">//Now build a file chooser and invoke the dialog in one line of code</span>
+ *      <span style="color:gray">//&quot;libraries-dir&quot; is our unique key</span>
  *      File toAdd = new FileChooserBuilder ("libraries-dir").setTitle("Add Library").
  *              setDefaultWorkingDirectory(home).setApproveText("Add").showOpenDialog();
- *      <font color="gray">//Result will be null if the user clicked cancel or closed the dialog w/o OK</font>
+ *      <span style="color:gray">//Result will be null if the user clicked cancel or closed the dialog w/o OK</span>
  *      if (toAdd != null) {
  *          //do something
  *      }

--- a/platform/openide.loaders/arch.xml
+++ b/platform/openide.loaders/arch.xml
@@ -64,7 +64,7 @@
             processing
         </a>
         do some advanced changes to it using either 
-        <a name="loaders-script">scripting or templating</a> languages.
+        <a id="loaders-script">scripting or templating</a> languages.
         </p>
         
         <p>

--- a/platform/openide.loaders/src/org/openide/loaders/InstanceDataObject.java
+++ b/platform/openide.loaders/src/org/openide/loaders/InstanceDataObject.java
@@ -50,14 +50,14 @@ import org.openide.util.lookup.*;
 * <p>Use {@link #create} and {@link #remove} to make the objects.
 * Better yet, use an XML filesystem to install them declaratively.
 * <p>
-* Instance data object by default recognizes all files with <tt>.instance</tt>
+* Instance data object by default recognizes all files with <code>.instance</code>
 * suffix. Such file can have associated optional file attributes:
 * <dl>
-* <!--  <dt><tt>instanceClass</tt> <dd><code>String</code> identifing class of created instance
+* <!--  <dt><code>instanceClass</tt> <dd><code>String</code> identifing class of created instance
 *   (otherwise class name is derived from file name). -->
-*   <dt><tt>instanceCreate</tt> <dd>instantionalized <code>Object</code> (e.g. created by
-*     <tt>methodvalue</tt> at XML filesystem)
-*   <dt><tt>instanceOf</tt> <dd><code>String</code> that is tokenized at ':', ',', ';' and
+*   <dt><code>instanceCreate</code> <dd>instantionalized <code>Object</code> (e.g. created by
+*     <code>methodvalue</code> at XML filesystem)
+*   <dt><code>instanceOf</code> <dd><code>String</code> that is tokenized at ':', ',', ';' and
 *   whitespace boundaries. Resulting tokens represent class names that created
 *   instance is <code>instanceof</code>. Utilizing it may improve performance.
 * </dl>

--- a/platform/openide.loaders/src/org/openide/loaders/doc-files/api.html
+++ b/platform/openide.loaders/src/org/openide/loaders/doc-files/api.html
@@ -90,7 +90,7 @@ implements some extensions to the clipboard.
 
 <h1>Datasystems API</h1>
 
-<h2><a name="loader-do">Loaders and Data Objects</a></h2>
+<h2 id="loader-do">Loaders and Data Objects</h2>
 
 <div class="nonnormative">
 
@@ -117,7 +117,7 @@ to recognize a file takes ownership of it, and creates a matching
 
 to represent it to the rest of NetBeans.
 
-<h3><a name="intro-loader">What is a loader used for?</a></h3>
+<h3 id="intro-loader">What is a loader used for?</h3>
 
 There are a few reasons why loaders are used in NetBeans, rather than
 just accessing raw files (and perhaps typing them by extension or MIME
@@ -162,7 +162,7 @@ are interpreted using Datasystems, not Filesystems.
 
 </div>
 
-<h3><a name="multi">Multiple-file loaders</a></h3>
+<h3 id="multi">Multiple-file loaders</h3>
 
 These typically subclass
 
@@ -196,7 +196,7 @@ When other files in the cluster are passed to the loader, it must
 create new entries in the <em>same</em> multi data object, to indicate
 their association.
 
-<h3><a name="single">Single-file loaders</a></h3>
+<h3 id="single">Single-file loaders</h3>
 
 These typically subclass
 
@@ -225,7 +225,7 @@ you had some reason to avoid using this kind of data object, you could
 of course subclass <code>DataLoader</code> and <code>DataObject</code>
 directly.
 
-<h3><a name="entry">Entries</a></h3>
+<h3 id="entry">Entries</h3>
 
 Entries represent a single file in a <code>MultiDataObject</code>, and
 thus are commonly used in all loaders (even single-file
@@ -253,7 +253,7 @@ templates such as this is to make the entry a
 
 <a href="../FileEntry.Format.html"><code>FileEntry.Format</code></a>.)
 
-<h3><a name="do-get">Getting a data object</a></h3>
+<h3 id="do-get">Getting a data object</h3>
 
 Normally you do not need to explicitly retrieve a data object - the
 loader pool will create them on demand, present them to the user in
@@ -270,7 +270,7 @@ otherwise will return the existing one. (Catch
 
 in case the file is not recognizable to any loader.)
 
-<h3><a name="delegate">Node Delegates</a></h3>
+<h3 id="delegate">Node Delegates</h3>
 
 Data objects have separate, but associated,
 
@@ -283,7 +283,7 @@ interface to the user. You may use
 
 to retrieve the node delegate for a data object, if necessary.
 
-<h3><a name="write-loader">Writing a loader and data object</a></h3>
+<h3 id="write-loader">Writing a loader and data object</h3>
 
 This section is the most important for most people: after a loader has
 been correctly written and installed, the system takes care of
@@ -291,8 +291,7 @@ providing files for it to recognize; constructing nodes for the files;
 etc.; and most further implementation of a module will be callbacks
 run in response to some aspect of the objects created here.
 
-<h4>Module installation</h4>
-<a name="register"></a>
+<h4 id="register">Module installation</h4>
 <p>First of all, you must be able to register your loader in the
 module so that NetBeans knows about it. The preferred way since version
 7.0 of <code>org.openide.loaders</code> module is to assign the loader
@@ -659,7 +658,7 @@ and if true, provide
 
 as the result.
 
-<h4><a name="create-delegate">Creating a node delegate</a></h4>
+<h4 id="create-delegate">Creating a node delegate</h4>
 
 You must create a
 
@@ -688,7 +687,7 @@ structure of the form (as displayed in the Component Inspector).
 special node subclass for the delegate, as you may provide an icon,
 cookies, and common actions without doing so.
 
-<h3><a name="sys-loaders">System loaders</a></h3>
+<h3 id="sys-loaders">System loaders</h3>
 
 NetBeans installs a few extra "hidden" loaders into the loader pool, as
 are returned by
@@ -753,7 +752,7 @@ cooperate with the loader in this regard).
 -->
 
 
-<h2><a name="cookie">Cookies</a></h2>
+<h2 id="cookie">Cookies</h2>
 
 <!-- XXX this ss should maybe be in Services/Lookup API -->
 
@@ -762,7 +761,7 @@ NetBeans in a flexible fashion what types of (usually user-initiated)
 operations they are capable of supporting, and even to dynamically add
 and remove these capabilities.
 
-<h3><a name="intro-cookie">What is a cookie?</a></h3>
+<h3 id="intro-cookie">What is a cookie?</h3>
 
 A <em>cookie</em> is a design pattern used to separate the
 presentation of implementation of some interface from the actual
@@ -804,7 +803,7 @@ that looks inside
 
 <a href="../MultiDataObject.html#getCookieSet--"><code>MultiDataObject.getCookieSet()</code></a>.
 
-<h4><a name="attach-retrieve">Attaching and retrieving cookies</a></h4>
+<h4 id="attach-retrieve">Attaching and retrieving cookies</h4>
 
 <p>In short, there are a number of ways to attach cookies to either a
 node or data object (and you may listen for changes in the set of
@@ -854,19 +853,19 @@ which demonstrate their flexibility. In the examples that follow,
 this:</p>
 
 <pre>
-<font class="keyword">public</font> <font class="keyword">interface</font> C {
-    <font class="type">void</font> foo();
+<span class="keyword">public</span> <span class="keyword">interface</span> C {
+    <span class="type">void</span> foo();
 }
-<font class="keyword">public</font> <font class="keyword">class</font> S <font class="keyword">implements</font> C {
-    <font class="keyword">private</font> <font class="type">String</font> param;
-    <font class="keyword">public</font> S(<font class="type">String</font> param) {
-        <font class="keyword">this</font>.param = param;
+<span class="keyword">public</span> <span class="keyword">class</span> S <span class="keyword">implements</span> C {
+    <span class="keyword">private</span> <span class="type">String</span> param;
+    <span class="keyword">public</span> S(<span class="type">String</span> param) {
+        <span class="keyword">this</span>.param = param;
     }
-    <font class="keyword">public</font> <font class="type">void</font> foo() {
-        System.out.println(<font class="string">"foo: "</font> + param);
+    <span class="keyword">public</span> <span class="type">void</span> foo() {
+        System.out.println(<span class="string">"foo: "</span> + param);
     }
 }
-<font class="keyword">public</font> <font class="keyword">class</font> O <font class="keyword">extends</font> <font class="type">DataObject</font> {<font class="comment">/* ... */</font>}
+<span class="keyword">public</span> <span class="keyword">class</span> O <span class="keyword">extends</span> <span class="type">DataObject</span> {<span class="comment">/* ... */</span>}
 </pre>
 
 
@@ -877,21 +876,21 @@ this:</p>
 <dd><p>Using cookies in the common way is pretty easy.</p>
 
 <pre>
-<font class="keyword">public</font> <font class="keyword">class</font> O <font class="keyword">extends</font> <font class="type">DataObject</font> {
-    <font class="keyword">public</font> O(<font class="type">FileObject</font> fo) {
-        <font class="comment">// super...
-</font>        getCookieSet().assign(C1.class, <font class="keyword">new</font> S1(fo));
-        getCookieSet().assign(C2.class, <font class="keyword">new</font> S2(<font class="keyword">this</font>));
+<span class="keyword">public</span> <span class="keyword">class</span> O <span class="keyword">extends</span> <span class="type">DataObject</span> {
+    <span class="keyword">public</span> O(<span class="type">FileObject</span> fo) {
+        <span class="comment">// super...
+</span>        getCookieSet().assign(C1.class, <span class="keyword">new</span> S1(fo));
+        getCookieSet().assign(C2.class, <span class="keyword">new</span> S2(<span class="keyword">this</span>));
     }
 }
-<font class="keyword">public</font> <font class="keyword">class</font> S1 <font class="keyword">implements</font> C1 {<font class="comment">/* ... */</font>}
-<font class="keyword">public</font> <font class="keyword">class</font> S2 <font class="keyword">implements</font> C2 {<font class="comment">/* ... */</font>}
-<font class="comment">// ...
-</font><font class="type">DataObject</font> o = DataObject.find(someFileObject);
-<font class="comment">// o instanceof O, in fact
-</font>C1 c1 = o.getLookup().lookup(C1.<font class="keyword">class</font>);
-<font class="comment">// c1 instanceof S1
-</font><font class="keyword">if</font> (c1 != <font class="constant">null</font>) {
+<span class="keyword">public</span> <span class="keyword">class</span> S1 <span class="keyword">implements</span> C1 {<span class="comment">/* ... */</span>}
+<span class="keyword">public</span> <span class="keyword">class</span> S2 <span class="keyword">implements</span> C2 {<span class="comment">/* ... */</span>}
+<span class="comment">// ...
+</span><span class="type">DataObject</span> o = DataObject.find(someFileObject);
+<span class="comment">// o instanceof O, in fact
+</span>C1 c1 = o.getLookup().lookup(C1.<span class="keyword">class</span>);
+<span class="comment">// c1 instanceof S1
+</span><span class="keyword">if</span> (c1 != <span class="constant">null</span>) {
     c1.foo();
 }
 </pre>
@@ -904,61 +903,61 @@ this:</p>
 inheritance, you can use subclassing naturally on supports.</p>
 
 <pre>
-<font class="keyword">public</font> <font class="keyword">class</font> S1 <font class="keyword">implements</font> C1 {
-    <font class="keyword">private</font> <font class="type">String</font> param;
-    <font class="keyword">public</font> S1(<font class="type">String</font> param) {
-        <font class="keyword">this</font>.param = param;
+<span class="keyword">public</span> <span class="keyword">class</span> S1 <span class="keyword">implements</span> C1 {
+    <span class="keyword">private</span> <span class="type">String</span> param;
+    <span class="keyword">public</span> S1(<span class="type">String</span> param) {
+        <span class="keyword">this</span>.param = param;
     }
-    <font class="keyword">public</font> <font class="type">void</font> foo1() {
-        System.out.println(<font class="string">"foo: "</font> + transform(param));
+    <span class="keyword">public</span> <span class="type">void</span> foo1() {
+        System.out.println(<span class="string">"foo: "</span> + transform(param));
     }
-    <font class="comment">/** Subclasses may customize. */</font>
-    <font class="keyword">protected</font> <font class="type">String</font> transform(<font class="type">String</font> in) {
-        <font class="keyword">return</font> in;
-    }
-}
-<font class="keyword">public</font> <font class="keyword">abstract</font> <font class="keyword">class</font> S2 <font class="keyword">implements</font> C2 {
-    <font class="keyword">private</font> <font class="type">String</font> param;
-    <font class="keyword">public</font> S2(<font class="type">String</font> param) {
-        <font class="keyword">this</font>.param = param;
-    }
-    <font class="keyword">public</font> <font class="type">void</font> foo2() {
-        <font class="keyword">if</font> (active()) {
-            System.out.println(<font class="string">"foo: "</font> + param);
-        }
-    }
-    <font class="comment">/** Subclasses must implement. */</font>
-    <font class="keyword">protected</font> <font class="keyword">abstract</font> <font class="type">boolean</font> active();
-}
-<font class="keyword">public</font> <font class="keyword">class</font> O {
-    <font class="keyword">private</font> <font class="type">int</font> state;
-    <font class="keyword">public</font> O(<font class="type">String</font> p) {
-        state = INACTIVE; <font class="comment">// initially
-</font>        getCookieSet().assign(C1.class, <font class="keyword">new</font> <font class="type">MyS1</font>(p));
-        getCookieSet().assign(C2.class, <font class="keyword">new</font> <font class="type">MyS2</font>(p));
-    }
-    <font class="keyword">private</font> <font class="keyword">static</font> <font class="keyword">final</font> <font class="keyword">class</font> <font class="type">MyS1</font> <font class="keyword">extends</font> S1 {
-        <font class="keyword">public</font> <font class="type">MyS1</font>(<font class="type">String</font> p) {<font class="keyword">super</font>(p);}
-        <font class="keyword">protected</font> <font class="type">String</font> transform(<font class="type">String</font> in) {
-            <font class="keyword">return</font> in.toLowerCase();
-        }
-    }
-    <font class="keyword">private</font> <font class="keyword">final</font> <font class="keyword">class</font> <font class="type">MyS2</font> <font class="keyword">extends</font> S2 {
-        <font class="keyword">public</font> <font class="type">MyS2</font>(<font class="type">String</font> p) {<font class="keyword">super</font>(p);}
-        <font class="keyword">protected</font> <font class="type">boolean</font> active() {
-            <font class="keyword">return</font> O.<font class="keyword">this</font>.state == ACTIVE;
-        }
+    <span class="comment">/** Subclasses may customize. */</span>
+    <span class="keyword">protected</span> <span class="type">String</span> transform(<span class="type">String</span> in) {
+        <span class="keyword">return</span> in;
     }
 }
-<font class="comment">// ...
-</font>O o = <font class="keyword">new</font> O(<font class="string">"Hello"</font>);
-C1 c1 = o.getLookup().lookup(C1.<font class="keyword">class</font>);
-<font class="keyword">if</font> (c1 != <font class="constant">null</font>) c1.foo1();
-<font class="comment">// prints "foo: hello"
-</font>C2 c2 = o.getLookup().lookup(C2.<font class="keyword">class</font>);
-<font class="keyword">if</font> (c2 != <font class="constant">null</font>) c2.foo2();
-<font class="comment">// does nothing: o is not yet active
-</font></pre>
+<span class="keyword">public</span> <span class="keyword">abstract</span> <span class="keyword">class</span> S2 <span class="keyword">implements</span> C2 {
+    <span class="keyword">private</span> <span class="type">String</span> param;
+    <span class="keyword">public</span> S2(<span class="type">String</span> param) {
+        <span class="keyword">this</span>.param = param;
+    }
+    <span class="keyword">public</span> <span class="type">void</span> foo2() {
+        <span class="keyword">if</span> (active()) {
+            System.out.println(<span class="string">"foo: "</span> + param);
+        }
+    }
+    <span class="comment">/** Subclasses must implement. */</span>
+    <span class="keyword">protected</span> <span class="keyword">abstract</span> <span class="type">boolean</span> active();
+}
+<span class="keyword">public</span> <span class="keyword">class</span> O {
+    <span class="keyword">private</span> <span class="type">int</span> state;
+    <span class="keyword">public</span> O(<span class="type">String</span> p) {
+        state = INACTIVE; <span class="comment">// initially
+</span>        getCookieSet().assign(C1.class, <span class="keyword">new</span> <span class="type">MyS1</span>(p));
+        getCookieSet().assign(C2.class, <span class="keyword">new</span> <span class="type">MyS2</span>(p));
+    }
+    <span class="keyword">private</span> <span class="keyword">static</span> <span class="keyword">final</span> <span class="keyword">class</span> <span class="type">MyS1</span> <span class="keyword">extends</span> S1 {
+        <span class="keyword">public</span> <span class="type">MyS1</span>(<span class="type">String</span> p) {<span class="keyword">super</span>(p);}
+        <span class="keyword">protected</span> <span class="type">String</span> transform(<span class="type">String</span> in) {
+            <span class="keyword">return</span> in.toLowerCase();
+        }
+    }
+    <span class="keyword">private</span> <span class="keyword">final</span> <span class="keyword">class</span> <span class="type">MyS2</span> <span class="keyword">extends</span> S2 {
+        <span class="keyword">public</span> <span class="type">MyS2</span>(<span class="type">String</span> p) {<span class="keyword">super</span>(p);}
+        <span class="keyword">protected</span> <span class="type">boolean</span> active() {
+            <span class="keyword">return</span> O.<span class="keyword">this</span>.state == ACTIVE;
+        }
+    }
+}
+<span class="comment">// ...
+</span>O o = <span class="keyword">new</span> O(<span class="string">"Hello"</span>);
+C1 c1 = o.getLookup().lookup(C1.<span class="keyword">class</span>);
+<span class="keyword">if</span> (c1 != <span class="constant">null</span>) c1.foo1();
+<span class="comment">// prints "foo: hello"
+</span>C2 c2 = o.getLookup().lookup(C2.<span class="keyword">class</span>);
+<span class="keyword">if</span> (c2 != <span class="constant">null</span>) c2.foo2();
+<span class="comment">// does nothing: o is not yet active
+</span></pre>
 
 </dd>
 
@@ -968,30 +967,30 @@ C1 c1 = o.getLookup().lookup(C1.<font class="keyword">class</font>);
 after its creation.</p>
 
 <pre>
-<font class="keyword">public</font> <font class="keyword">class</font> <font class="type">O</font> {
-    <font class="keyword">private</font> <font class="type">boolean</font> <font class="variable-name">modified</font>;
-    <font class="keyword">public</font> <font class="function-name">O</font>(<font class="type">String</font> <font class="variable-name">param</font>) {
-        modified = <font class="constant">false</font>;
-        <font class="comment">// ...
-</font>    }
-    <font class="keyword">private</font> <font class="keyword">synchronized</font> <font class="type">void</font> <font class="function-name">markModified</font>() {
-        <font class="keyword">if</font> (!modified) {
-            <font class="comment">// Newly modified, make it possible to save.
-</font>            <font class="comment">// Note this will automatically fire a cookie change.
-</font>            getCookieSet().assign(SaveCookie.class, <font class="keyword">new</font> <font class="type">SaveCookie</font>() {
-                <font class="keyword">public</font> <font class="type">void</font> <font class="function-name">save</font>() {
+<span class="keyword">public</span> <span class="keyword">class</span> <span class="type">O</span> {
+    <span class="keyword">private</span> <span class="type">boolean</span> <span class="variable-name">modified</span>;
+    <span class="keyword">public</span> <span class="function-name">O</span>(<span class="type">String</span> <span class="variable-name">param</span>) {
+        modified = <span class="constant">false</span>;
+        <span class="comment">// ...
+</span>    }
+    <span class="keyword">private</span> <span class="keyword">synchronized</span> <span class="type">void</span> <span class="function-name">markModified</span>() {
+        <span class="keyword">if</span> (!modified) {
+            <span class="comment">// Newly modified, make it possible to save.
+</span>            <span class="comment">// Note this will automatically fire a cookie change.
+</span>            getCookieSet().assign(SaveCookie.class, <span class="keyword">new</span> <span class="type">SaveCookie</span>() {
+                <span class="keyword">public</span> <span class="type">void</span> <span class="function-name">save</span>() {
                     doSave();
                 }
             });
-            modified = <font class="constant">true</font>;
+            modified = <span class="constant">true</span>;
         }
     }
-    <font class="keyword">private</font> <font class="keyword">synchronized</font> <font class="type">void</font> <font class="function-name">doSave</font>() {
-        <font class="keyword">if</font> (modified) {
-            <font class="comment">// actually save...then:
-</font>            
+    <span class="keyword">private</span> <span class="keyword">synchronized</span> <span class="type">void</span> <span class="function-name">doSave</span>() {
+        <span class="keyword">if</span> (modified) {
+            <span class="comment">// actually save...then:
+</span>            
             getCookieSet().assign(SaveCookie.class);
-            modified = <font class="constant">false</font>;
+            modified = <span class="constant">false</span>;
         }
     }
 }
@@ -1002,9 +1001,8 @@ after its creation.</p>
 
 </dl>
 
-</div>
 
-<h3><a name="std-cookie">Standard cookies and supports</a></h3>
+<h3 id="std-cookie">Standard cookies and supports</h3>
 
 Most standard cookies you would want to use exist in the
 
@@ -1052,7 +1050,7 @@ according to the needs of its subclass and holders.
 for instance, uses only <code>OpenCookie</code> and
 <code>CloseCookie</code>.
 
-<h3><a name="write-cookie">Writing a cookie</a></h3>
+<h3 id="write-cookie">Writing a cookie</h3>
 
 Writing a new cookie requires no special knowledge - just extend create
 an interface and add its methods according to whatever you need done.
@@ -1065,7 +1063,7 @@ the current selection provides the cookie.</p>
 
 <div class="nonnormative">
 
-<h3><a name="write-support">Writing a support for an existing cookie</a></h3>
+<h3 id="write-support">Writing a support for an existing cookie</h3>
 
 Writing a support also does not require anything non-apparent. It should
 be a concrete class, its name conventionally ending in
@@ -1091,7 +1089,7 @@ prerequisites.
 
 </div>
 
-<h3><a name="use-support">Using an existing support</a></h3>
+<h3 id="use-support">Using an existing support</h3>
 
 Using an existing support is generally straightforward - assuming your
 data object is a subclass of <code>MultiDataObject</code>, you may
@@ -1105,7 +1103,7 @@ in the constructor, passing in the primary entry (most likely) from
 
 
 
-<h2><a name="clipboard">Extended Clipboard</a></h2>
+<h2 id="clipboard">Extended Clipboard</h2>
 
 NetBeans implements an extended clipboard, which enhances the functions
 provided in the
@@ -1124,7 +1122,7 @@ can be confusing; the
 contains a detailed description of these operations as they pertain to
 nodes, which may be helpful.
 
-<h3><a name="convertor">Convertors</a></h3>
+<h3 id="convertor">Convertors</h3>
 
 The extended clipboard,
 
@@ -1144,7 +1142,7 @@ of it to
 
 <a href="@org-openide-util-ui@/org/openide/util/doc-files/api.html#instance-folders">lookup</a>.
 
-<h3><a name="clipboard-ev">Event notification</a></h3>
+<h3 id="clipboard-ev">Event notification</h3>
 
 The extended clipboard supports Java Event-based notification of
 changes in the contents of the clipboard. Just register your listener
@@ -1152,7 +1150,7 @@ with
 
 <a href="@org-openide-util-ui@/org/openide/util/datatransfer/ExClipboard.html#addClipboardListener-org.openide.util.datatransfer.ClipboardListener-"><code>ExClipboard.addClipboardListener(...)</code></a>.
 
-<h3><a name="multi-transfer">Multi-transfers</a></h3>
+<h3 id="multi-transfer">Multi-transfers</h3>
 
 <a href="@org-openide-util-ui@/org/openide/util/datatransfer/ExTransferable.Multi.html"><code>ExTransferable.Multi</code></a>
 
@@ -1173,13 +1171,13 @@ It is designed to permit access to its constituent real
 
 <div class="nonnormative">
 
-<h2><a name="diagrams">UML Diagrams</a></h2>
+<h2 id="diagrams">UML Diagrams</h2>
 
-<h3><a name="diagram_data_objects">Data objects</a></h3>
+<h3 id="diagram_data_objects">Data objects</h3>
 
 <img src="data_objects.gif" alt="DataObject UML">
 
-<h3><a name="diagram_data_loaders">Data loaders</a></h3>
+<h3 id="diagram_data_loaders">Data loaders</h3>
 
 <img src="data_loaders.gif" alt="DataLoader UML">
 

--- a/platform/openide.modules/src/org/openide/modules/doc-files/api.html
+++ b/platform/openide.modules/src/org/openide/modules/doc-files/api.html
@@ -85,7 +85,7 @@ authors.
 
 <div class="nonnormative">
 
-<h2><a name="what-are">What are Modules?</a></h2>
+<h2 id="what-are">What are Modules?</h2>
 
 <em>Modules</em> permit NetBeans to be extended
 dynamically. All of the NetBeans APIs are designed to be used for purposes
@@ -100,7 +100,7 @@ format should be rather familiar; classes constituting the module are
 <a href="#how-jar">archived in the JAR</a>, and special entries in the
 <a href="#how-manifest">manifest file</a> are recognized.
 
-<h3><a name="rel-std">Related Standards</a></h3>
+<h3 id="rel-std">Related Standards</h3>
 
 To the greatest extent possible, NetBeans has designed the module
 system to reuse standard technologies when they are sufficient, and to
@@ -137,12 +137,12 @@ giving additional more specific deployment information.
 
 </div>
 
-<h2><a name="how-to">How to Create a New Module</a></h2>
+<h2 id="how-to">How to Create a New Module</h2>
 
 <p>For basic cases, you should need to do very little to create a module
 besides writing the basic source code.</p>
 
-<h3><a name="how-jar">Build a JAR</a></h3>
+<h3 id="how-jar">Build a JAR</h3>
 
 <p>All module implementation classes must reside in a JAR file. If you
 want to split up a large application into several pieces, perhaps
@@ -150,7 +150,7 @@ so as to make independent upgrades possible, you should do so by
 creating multiple modules and relating them using <a
 href="#how-vers">versioning</a>.</p>
 
-<h3><a name="how-manifest">Writing the manifest</a></h3>
+<h3 id="how-manifest">Writing the manifest</h3>
 
 A module is recognized as such by NetBeans, by virtue of its having
 a special magic tag in the global section of the manifest:
@@ -279,7 +279,7 @@ parsing it otherwise.
 
 </div>
 
-<h3><a name="how-main">Using a custom module class</a></h3>
+<h3 id="how-main">Using a custom module class</h3>
 
 With the <code>OpenIDE-Module-Install</code> attribute, you may specify
 a custom class which will handle any complex aspects of the module's
@@ -381,7 +381,7 @@ called, as it may be done when deciding whether to even begin loading.</p>
 
 <div class="nonnormative">
 
-<h4><a name="installation-clean">"Installation-clean" modules</a></h4>
+<h4 id="installation-clean">"Installation-clean" modules</h4>
 
 Since NetBeans can better manage modules when their resources are
 declared to exist, rather than procedurally installed, it is desirable
@@ -459,7 +459,7 @@ complicates ad-hoc module installation though Auto Update may be fine.
 
 </div>
 
-<h3><a name="how-layer">Using an installation layer</a></h3>
+<h3 id="how-layer">Using an installation layer</h3>
 
 <p>You may specify the global tag
 <code>OpenIDE-Module-Layer</code> in addition to or instead of a
@@ -639,7 +639,7 @@ its initial state as defined in XML layers. Please note that is <strong>*not*</s
 possible to reset <code>FileObject</code>'s attributes.
 </p>
 
-<h3><a name="how-vers">Using versioning</a></h3>
+<h3 id="how-vers">Using versioning</h3>
 
 Module <em>versioning</em> provides a way for modules to specify
 which module they are (i.e. that one JAR is an upgrade from
@@ -690,7 +690,7 @@ may also <em>require</em> one or more tokens. A module which requires some token
 may only be enabled by the system if for each such token, there is at least one other
 module which provides that token and is already enabled. 
 
-<a name="7.1"></a>
+<a id="7.1"></a>
 Since version 7.1 there is also support for <code>OpenIDE-Module-Needs</code>
 which is a weaker version of requires as it does not impose any restriction on
 the ordering of module. The <code>OpenIDE-Module-Needs</code> is useful for
@@ -798,7 +798,8 @@ equal to</strong> the requested version. Note that you may not request
 an exact specification version. This is the preferred form for module
 dependencies.
 
-<p>Remember, if requesting a dependency on a module which has a
+<br>
+Remember, if requesting a dependency on a module which has a
 release number, you <em>must</em> give that release number as part of
 the feature name, whether or not you also ask for a specification
 version.
@@ -939,7 +940,7 @@ defining and handling a custom XML DTD.)
 may still be accessed using reflection from the system classloader,
 just not from a module classloader.</p>
 
-<a name="friend"></a>
+<a id="friend"></a>
 <p>Additionally, sometimes a module with an API in public packages wishes to
 provide access only to certain "friend" modules. This is
 possible if the module declares public packages together with a list
@@ -964,7 +965,7 @@ classes, as if both modules formed part of the same code base.</p>
 
 document which gives a fuller, more informal explanation.</p>
 
-<h3><a name="how-os-specific">Writing an OS dependent module</a></h3>
+<h3 id="how-os-specific">Writing an OS dependent module</h3>
 
 <em>Since 4.44</em> a module can request to be enabled only on certain class
 of an operating system 
@@ -1003,7 +1004,7 @@ enabling it only on Mac OS X (as is the case of the NetBeans
 applemenu module).
 </p>
 
-<h3><a name="how-i18n-branding">Localization and branding support</a></h3>
+<h3 id="how-i18n-branding">Localization and branding support</h3>
 
 <p>
     Existing <a href="i18n-branding.html">Internationalization, Localization, and Branding</a>
@@ -1012,17 +1013,17 @@ applemenu module).
 </p>
 
 
-<h2><a name="std-sec">Standard Module Sections</a></h2>
+<h2 id="std-sec">Standard Module Sections</h2>
 
 <p>Formerly some items in NetBeans were installed via JAR manifest sections using
 the <code>OpenIDE-Module-Class</code> attribute. All such registrations are now
 deprecated, generally replaced with layer-based registrations.</p>
 
-<h2><a name="deploy">Deployment of Modules</a></h2>
+<h2 id="deploy">Deployment of Modules</h2>
 
 <p>This section describes how a module may be deployed to a user's NetBeans instance.</p>
 
-<h3><a name="enablement">Enablement</a></h3>
+<h3 id="enablement">Enablement</h3>
 
 <p>
     The standard module system permits modules to be in several states, controlled
@@ -1070,7 +1071,7 @@ deprecated, generally replaced with layer-based registrations.</p>
     </p>
 </div>
 
-<h3><a name="related-files">Related Files</a></h3>
+<h3 id="related-files">Related Files</h3>
 
 <p>Sometimes a module may need to bundle other files besides the
 module JAR alongside it. No concrete mechanism for doing so is
@@ -1095,7 +1096,7 @@ structure might however change in the future, so
 <code>InstalledFileLocator</code> is the only safe way to find such
 bundled resources.</p>
 
-<h3><a name="deprecation">Deprecation</a></h3>
+<h3 id="deprecation">Deprecation</h3>
 
 <p>Sometimes you may have an API module which you wish to deprecate in its
 entirely - it is only available for purposes of backwards compatibility.
@@ -1108,7 +1109,7 @@ This
 message may be displayed somehow if a non-deprecated module depending on your
 deprecated module is enabled.</p>
 
-<h3><a name="refactoring">Refactoring</a></h3>
+<h3 id="refactoring">Refactoring</h3>
 
 <p>Sometimes as the developer of an API module, you may wish to make
 major changes in how your APIs are laid out physically in modules.
@@ -1133,7 +1134,7 @@ must be available before any module is even loaded.</p>
 
 <p><em>As of 3.33</em></p>
 
-<h3><a name="order">Module install order</a></h3>
+<h3 id="order">Module install order</h3>
 
 It may be possible for multiple modules to be installed at once, or
 for a module to specify a dependency which is not satisfied. How
@@ -1168,7 +1169,7 @@ means that you should "factor out" the common required
 functionality into a new module which the original ones will then
 specify legal dependencies on.
 
-<h3><a name="listing">List of all modules</a></h3>
+<h3 id="listing">List of all modules</h3>
 
 Though a module should not generally need to know or care what other
 modules are installed - anything it needs should be a dependency, and
@@ -1251,7 +1252,7 @@ prevent file changes from being fired halfway through.</p>
 
 <div class="nonnormative">
 
-<h3><a name="security">Security</a></h3>
+<h3 id="security">Security</h3>
 
 In the current API there is no particular provision for security in
 modules: all modules are assumed to be trusted, and have access to
@@ -1279,7 +1280,7 @@ creation.
 
 </div>
 
-<h3><a name="jni">JNI</a></h3>
+<h3 id="jni">JNI</h3>
 
 <p>It is possible to run modules making use of JNI native implementations inside
 NetBeans. You may place the native libraries (DLL or shared-object) beneath

--- a/platform/openide.modules/src/org/openide/modules/doc-files/classpath.html
+++ b/platform/openide.modules/src/org/openide/modules/doc-files/classpath.html
@@ -46,7 +46,7 @@
    <li><a href="#q-and-a">Common Problems and Solutions</a></li>
   </ul>
 
-  <h1><a name="intro">Introduction</a></h1>
+  <h1 id="intro">Introduction</h1>
 
   <p>
    NetBeans, as a large Java application with a sophisticated module system and a
@@ -79,7 +79,7 @@
    <a href="api.html">Modules API</a>.
   </p>
 
-  <h1><a name="loader-hier">The Class Loader Hierarchy</a></h1>
+  <h1 id="loader-hier">The Class Loader Hierarchy</h1>
 
   <p>
    The basic thing you need to understand about how modules control class loading
@@ -160,7 +160,7 @@ OpenIDE-Module-Module-Dependencies: org.netbeans.modules.a
    -->
   </p>
 
-  <h2><a name="class-path">Extensions using <code>Class-Path</code></a></h2>
+  <h2 id="class-path">Extensions using <code>Class-Path</code></h2>
 
   <p>
    Commonly a NetBeans module will serve as a wrapper for an independent library,
@@ -241,7 +241,7 @@ Class-Path: ext/library-a-1.0.jar ext/library-b-1.1.jar
    </p>
   </blockquote>
 
-  <h2><a name="libs">Startup Libraries</a></h2>
+  <h2 id="libs">Startup Libraries</h2>
 
   <p>
    In a given NetBeans release, there are several libraries placed in the
@@ -250,7 +250,7 @@ Class-Path: ext/library-a-1.0.jar ext/library-b-1.1.jar
    If you need to use classes from them, just declare regular module dependencies.
   </p>
 
-  <h2><a name="patches-l10n">Patches and Localizations</a></h2>
+  <h2 id="patches-l10n">Patches and Localizations</h2>
 
   <p>
    In addition to use of <code>Class-Path</code>, there are a couple of other
@@ -300,7 +300,7 @@ Class-Path: ext/library-a-1.0.jar ext/library-b-1.1.jar
    at runtime (according to the current locale and branding) will be loaded.
   </p>
 
-  <h2><a name="prov-req">Provide-Require Dependencies</a></h2>
+  <h2 id="prov-req">Provide-Require Dependencies</h2>
 
   <p>
    In addition to regular dependencies using
@@ -321,7 +321,7 @@ Class-Path: ext/library-a-1.0.jar ext/library-b-1.1.jar
    </p>
   </blockquote>
 
-  <h2><a name="public-packages">Dependencies and Package Restrictions</a></h2>
+  <h2 id="public-packages">Dependencies and Package Restrictions</h2>
 
   <p>
    By default when a module B declares a direct dependency on another module A,
@@ -420,7 +420,7 @@ OpenIDE-Module-Module-Dependencies: org.netbeans.modules.a = 1.0-alpha-2
    </p>
   </blockquote>
 
-  <h1><a name="syscl">The System Class Loader, Thread Context Class Loading, and <code>nbres:</code></a></h1>
+  <h1 id="syscl">The System Class Loader, Thread Context Class Loading, and <code>nbres:</code></h1>
 
   <p>
    There is a special class loader in NetBeans referred to as the <em>system
@@ -532,7 +532,7 @@ OpenIDE-Module-Module-Dependencies: org.netbeans.modules.a = 1.0-alpha-2
    <code>nbresloc</code> in place of <code>nbres</code>.
   </p>
 
-  <h1><a name="overlaps">"Parallel" Libraries</a></h1>
+  <h1 id="overlaps">"Parallel" Libraries</h1>
 
   <p>
       It is possible for two modules to include classes with the same (fully-qualified) names, so long as the modules have distinct code name bases.
@@ -571,7 +571,7 @@ OpenIDE-Module-Module-Dependencies: org.netbeans.modules.a = 1.0-alpha-2
       </li>
   </ul>
 
-  <h1><a name="q-and-a">Common Problems and Solutions</a></h1>
+  <h1 id="q-and-a">Common Problems and Solutions</h1>
 
   <p>
    This section is an attempt to gather a number of the problems, questions, and
@@ -582,7 +582,7 @@ OpenIDE-Module-Module-Dependencies: org.netbeans.modules.a = 1.0-alpha-2
    The developer's FAQ is likely to have more recent answers to your questions.
   </p>
 
-  <h2><a name="default_package">I am getting warnings when trying to access resources from the default (root, unnamed) package</a></h2>
+  <h2 id="default_package">I am getting warnings when trying to access resources from the default (root, unnamed) package</h2>
 
   <p>Loading classes from the default (root) package is disabled. You can load resources from
      that package but a warning is printed. It is strongly discouraged to use the default package.

--- a/platform/openide.modules/src/org/openide/modules/doc-files/i18n-branding.html
+++ b/platform/openide.modules/src/org/openide/modules/doc-files/i18n-branding.html
@@ -55,7 +55,7 @@
   <dd><a href="#discussion">Discussion</a></dd>
 </dl>
 
-<h1><a name="overview">Overview and How to Test</a></h1>
+<h1 id="overview">Overview and How to Test</h1>
 
 <p>This document gives recommendations on how to organize I18N (localization)
 of modules in the IDE or platform.</p>
@@ -98,12 +98,12 @@ code which confuses
 locale-sensitive and -insensitive operations is likely to display
 errors in Turkish locale.</p>
 
-<h1><a name="features">I18N Features</a></h1>
+<h1 id="features">I18N Features</h1>
 
 <p>Most of this document describes specific I18N features in NetBeans and
 how they are intended to be used.</p>
 
-<h2><a name="bundles">Bundle messages</a></h2>
+<h2 id="bundles">Bundle messages</h2>
 
 <p>All message strings should be contained in a <samp>Bundle.properties</samp>
 file (containing default message strings - i.e. in US English).
@@ -171,7 +171,7 @@ finding I18N violations like this, and correcting them. There is a setting to us
 <code>NbBundle.getMessage</code> as the localization device, which is
 suited to module code.</p>
 
-<h3><a name="bundle-debug">Bundle debugging</a></h3>
+<h3 id="bundle-debug">Bundle debugging</h3>
 
 <p>It is possible to start the IDE with the special command-line option
 
@@ -209,7 +209,7 @@ name.</p>
 <p>Currently localized files (such as HTML pages which may be selected
 by locale, or JavaHelp helpsets) are not annotated in any way.</p>
 
-<h3><a name="bundle-recommendations">How to write good <samp>*.properties</samp> files</a></h3>
+<h3 id="bundle-recommendations">How to write good <samp>*.properties</samp> files</h3>
 
 <p>There are some rules for how to write good <samp>*.properties</samp> files for easy
 localization, starting with the most important.</p>
@@ -297,7 +297,7 @@ base locale value will be used; the localizers will notice the change of key nam
 when refreshing the localization and be able to confirm that they are using the
 correct new format.</p>
 
-<h2><a name="misc-i18nable">Other localized text (not in source code)</a></h2>
+<h2 id="misc-i18nable">Other localized text (not in source code)</h2>
 
 <p>There are files named <samp>README.html</samp> and <samp>LICENSE.txt</samp>
 and localized versions should exist in the same directories:
@@ -324,14 +324,14 @@ tags, for example:</p>
 
 <p>For textual files not used at runtime (such as licenses), please use UTF-8.</p>
 
-<h2><a name="templates">Templates</a></h2>
+<h2 id="templates">Templates</h2>
 
 <p>Templates can be localized too, if desired. Localized templates would have modified file contents (e.g. code
 comments in a different language). The simplest way to localize template content is to use the
 <code>nbresloc</code> URL protocol in the location of the content when specifying the template in the module's
 XML layer.</p>
 
-<h3><a name="template-descs">Template descriptions</a></h3>
+<h3 id="template-descs">Template descriptions</h3>
 
 <p>Most templates, especially frequently-used ones, should have template
 descriptions. These are small blocks of HTML to be displayed to a user
@@ -351,7 +351,7 @@ template's <em>contents</em> just to localize its description.) The URL used may
 runtime. When doing this, the naming scheme for localized template
 descriptions becomes a requirement rather than a convention.</p>
 
-<h2><a name="loc-file-names">Localized file names</a></h2>
+<h2 id="loc-file-names">Localized file names</h2>
 
 <p>The <em>system filesystem</em> is composed principally of files
 installed by XML layers in enabled modules, sometimes modified by
@@ -382,11 +382,13 @@ to use instead of the default icon for that file type.
 <p>Here then is an example of a module adding a menu with a bookmark,
 and a template:</p>
 
-<table class="tablebg" cellpadding="1" cellspacing="0" border="0" >
+<table class="tablebg" >
+<caption>Localizing Bundle and Icon Example</caption>
 <tr><td>
-<table border="0" cellpadding="3" cellspacing="1" width="100%">
+<table>
+<caption>Localizing Bundle and Icon Example</caption>
 <tr class="tablehbg">
-<td colspan="2" align="center"><span class="tablehfont">Localizing Bundle and Icon Example</span></td>
+<td colspan="2"><span class="tablehfont">Localizing Bundle and Icon Example</span></td>
 </tr>
 <tr class="tablecbg">
 <td style="text-align: middle"><span class="tablecfont">File Path in JAR</span></td>
@@ -429,7 +431,7 @@ and a template:</p>
 </td>
 </tr>
 <tr class="tablerbg">
-<td align="center"><samp>com/power/module/<br/>resources/home-page.url</samp></td>
+<td><samp>com/power/module/<br/>resources/home-page.url</samp></td>
 <td>
 <pre>
 http://www.power.com/powerbuilder/
@@ -437,7 +439,7 @@ http://www.power.com/powerbuilder/
 </td>
 </tr>
 <tr class="tablerbg">
-<td align="center"><samp>com/power/module/<br/>Bundle.properties</samp></td>
+<td><samp>com/power/module/<br/>Bundle.properties</samp></td>
 <td>
 <pre>
 # Mnemonic: Alt-W
@@ -450,13 +452,13 @@ Templates/Power/thing.pwr=Blank Power Builder Widget
 </td>
 </tr>
 <tr class="tablerbg">
-<td align="center"><samp>com/power/module/<br/>resources/power.gif</samp></td>
+<td><samp>com/power/module/<br/>resources/power.gif</samp></td>
 <td>
 <em>a 16x16 color GIF icon</em>
 </td>
 </tr>
 <tr class="tablerbg">
-<td align="center"><samp>com/power/module/<br/>resources/power.html</samp></td>
+<td><samp>com/power/module/<br/>resources/power.html</samp></td>
 <td>
 <pre>
 <span class="variable-name">&lt;html&gt;&lt;body&gt;</span>
@@ -467,7 +469,7 @@ Not really very exciting.
 </td>
 </tr>
 <tr class="tablerbg">
-<td align="center"><samp>com/power/module/<br/>resources/thing.pwr.template</samp></td>
+<td><samp>com/power/module/<br/>resources/thing.pwr.template</samp></td>
 <td>
 <em>contents of the template</em>
 </td>
@@ -476,7 +478,7 @@ Not really very exciting.
 </td></tr>
 </table>
 
-<h2><a name="layers">Localizing layers</a></h2>
+<h2 id="layers">Localizing layers</h2>
 
 <p>
  XML layers themselves can be localized in the expected way: <samp>layer_<i>LOCALE</i>.xml</samp> can contain
@@ -490,7 +492,7 @@ Not really very exciting.
  menu items in an application based on the NetBeans Platform.
 </p>
 
-<h2><a name="images">Images</a></h2>
+<h2 id="images">Images</h2>
 
 <p>Images which are localized should be saved as <samp>imageName_<i>LOCALE</i>.gif</samp> or
 <samp>imageName_<i>LOCALE</i>.png</samp>. As usual, the localized image should be stored alongside that in the
@@ -501,7 +503,7 @@ accesses a resource by path (searching all enabled modules) considering also loc
 automatic localization <em>will not</em> change the extension of the image file, so it is preferable to use PNG
 format consistently in place of GIF, and name the base resource with the <samp>.png</samp> extension.</p>
 
-<h2><a name="javahelp">Help documentation</a></h2>
+<h2 id="javahelp">Help documentation</h2>
 
 <p>Help documentation should be localized according to the JavaHelp
 specification.
@@ -532,7 +534,7 @@ files need to be branded or otherwise localized.</p>
 <p>Note that XML files used by JavaHelp can specify a file encoding if
 localized text is required in these files (helpset title, etc.).</p>
 
-<h2><a name="module-metainfo">Module names</a></h2>
+<h2 id="module-metainfo">Module names</h2>
 
 <p>
  Modules have several attributes which contain localizable text. They must be placed in a bundle file in the
@@ -553,7 +555,7 @@ OpenIDE-Module-Localizing-Bundle: org/foo/mymodule/Bundle.properties
  Also, the bundle debug mode (above) will display special annotations for localizable manifest-derived text.
 </p>
 
-<h1><a name="placement">Physical Placement of Localized Resources</a></h1>
+<h1 id="placement">Physical Placement of Localized Resources</h1>
 
 <p>In the simplest case, localized resources may simply be placed
 directly inside a module's JAR, distinguished only by their locale
@@ -631,7 +633,7 @@ the JAR as before. But seeing all localizable resources split off this
 way may be helpful to localizers, as it presents a compact summary of
 what is and is not localizable in the module.</p>
 
-<h1><a name="l10n-list">Lists of files to be localized</a></h1>
+<h1 id="l10n-list">Lists of files to be localized</h1>
 
 <p>In each module root directory there should be an
 <samp>l10n.list</samp> file. This file should be kept up to date by
@@ -674,7 +676,7 @@ ant -f nbbuild/build.xml display-l10n-list-matches
 <p>and enter a module name when prompted. If run inside NetBeans, you can also click on each match to open the
 file.</p>
 
-<h1><a name="branding">Branded Localization</a></h1>
+<h1 id="branding">Branded Localization</h1>
 
 <p>There is a special feature of <code>NbBundle</code> that permits
 people making distributions of the IDE to conveniently "brand" it,
@@ -779,7 +781,7 @@ clusters like <samp>platform</samp> and <samp>ide</samp>, and then
 <samp>/opt/product1/modules/locale/foo_brand.jar</samp> if you pass <samp>--branding&nbsp;brand</samp> and
 <samp>/opt/product1</samp> is a cluster included in the NetBeans-based product.</p>
 
-<h1><a name="discussion">Discussion</a></h1>
+<h1 id="discussion">Discussion</h1>
 
 <p>If you have comments or questions on this document, or wish to discuss
 localization in the IDE in general, please use the mailing list

--- a/platform/openide.nodes/src/org/openide/nodes/doc-files/api.html
+++ b/platform/openide.nodes/src/org/openide/nodes/doc-files/api.html
@@ -93,7 +93,7 @@ features.</p>
 
 <div class="nonnormative">
 
-<h2><a name="node-intro">What is a Node?</a></h2>
+<h2 id="node-intro">What is a Node?</h2>
 
 A node provides the visual representation and apparent behavior of
 most objects in NetBeans. It may be used to represent a data object
@@ -109,7 +109,7 @@ be stored in a data object, or in some other appropriate storage
 mechanism. Rather, they provide a presentation device for existing
 data.
 
-<h3><a name="javabean-intro">JavaBeans and nodes</a></h3>
+<h3 id="javabean-intro">JavaBeans and nodes</h3>
 
 A node is a sort of extension to the JavaBeans concept, adding some
 features that were necessary for the full functioning of explorer views. Some
@@ -151,7 +151,7 @@ implementations</a> are available which wrap around standard JavaBeans
 and present them as nodes, including handling any Bean Context
 available, introspected properties, and so on.
 
-<h3><a name="explorer">Nodes in the Explorer</a></h3>
+<h3 id="explorer">Nodes in the Explorer</h3>
 
 Using the
 
@@ -180,7 +180,7 @@ Environment subtree has immediate effect). These capabilities owe to
 the <a href="#event">rich event notification</a> supported by the
 Nodes API.
 
-<h3><a name="common-types">Common node types</a></h3>
+<h3 id="common-types">Common node types</h3>
 
 This is a partial list of common types of nodes, some more apparent
 than others, to give an idea of what is possible with the API:
@@ -238,7 +238,7 @@ and probably be easier to write as well.
 </div>
 
 
-<h2><a name="create">Creating Custom Nodes</a></h2>
+<h2 id="create">Creating Custom Nodes</h2>
 
 This section details the steps you must take to create various kinds
 of customized nodes. In simple cases, you need do very little, as
@@ -248,7 +248,7 @@ particular type (as is the case with e.g. the Active Processes list),
 some more work is necessary, but again much of it will involve
 subclassing existing supports.
 
-<h3><a name="create-genl">General Aspects</a></h3>
+<h3 id="create-genl">General Aspects</h3>
 
 All nodes must subclass the general
 
@@ -321,7 +321,7 @@ to set the base name for the icon image resources.
 
 </ul>
 
-<h3><a name="create-prop">Properties, sets, and sheets</a></h3>
+<h3 id="create-prop">Properties, sets, and sheets</h3>
 
 There are three levels of organization for node properties:
 
@@ -481,7 +481,7 @@ a completely different editor when it is bound to a SQL rowset), or to
 keep an initialized editor associated with a node that may have some
 UI state not kept in the node itself.
 
-<h3><a name="create-hier">Hierarchy nodes and their children</a></h3>
+<h3 id="create-hier">Hierarchy nodes and their children</h3>
 
 Creating a leaf node - a node with no children - is fairly
 straightforward, since the child list may simply be specified as
@@ -543,7 +543,7 @@ frequently - the provided support classes should handle the common
 cases. If it is necessary to subclass, the documentation for
 <code>Children</code> should suffice.
 
-<h3><a name="create-order">Indexing and reordering children</a></h3>
+<h3 id="create-order">Indexing and reordering children</h3>
 
 Many structural constraints on children are probably satisfied by the
 children class itself - i.e. using <code>Children.SortedArray</code>
@@ -576,7 +576,7 @@ implementation such as
 This implementation stores a list of children and makes it
 straightforward for the user to manipulate the order in several ways.
 
-<h3><a name="create-cookie-act">Cookie and action support</a></h3>
+<h3 id="create-cookie-act">Cookie and action support</h3>
 
 One important ability provided by the Nodes API is to associate
 cookies and actions with nodes. What cookies are and how to create
@@ -656,7 +656,7 @@ action presentation can override
 
 to define a particular UI for this presentation.
 
-<h3><a name="create-mod">Installing special nodes from modules</a></h3>
+<h3 id="create-mod">Installing special nodes from modules</h3>
 
 Frequently nodes will be created secondarily, especially as a result
 of being delegates to data objects (in which case their creation is
@@ -703,13 +703,13 @@ placed in the <samp>UI/Services/</samp> folder, again using
 <a href="@org-openide-util-ui@/org/openide/util/doc-files/api.html#settings">Services API</a>.
 
 
-<h2><a name="special">Special Node Usage</a></h2>
+<h2 id="special">Special Node Usage</h2>
 
 There are a few sorts of special operations and techniques which it
 may be useful to apply to nodes, either in the course of implementing
 a node or node hierarchy, or just using nodes from other code.
 
-<h3><a name="serial">Serialization and traversal</a></h3>
+<h3 id="serial">Serialization and traversal</h3>
 
 If you need to store (serialize) a node for any reason, this is
 generally impossible due to the welter of Java-level references
@@ -741,7 +741,7 @@ reconstructing your root from scratch, and return it from
 may also be used for general-purpose navigation along the hierarchy,
 should this be necessary.
 
-<h3><a name="javabean-bridge">JavaBean bridging</a></h3>
+<h3 id="javabean-bridge">JavaBean bridging</h3>
 
 It is possible to create a node which picks up its node behavior from
 an underlying JavaBean. That is, Bean introspection will be used to
@@ -763,7 +763,7 @@ file is found to be a JavaBean (serialized, or as a class) - this
 latter type of node behaves in most respects like any other data node,
 and just adds a couple of features like a Customize action.
 
-<h3><a name="delegate">Data object delegates</a></h3>
+<h3 id="delegate">Data object delegates</h3>
 
 Many nodes serve primarily to represent a data object, which would
 otherwise be invisible to the user. While such data nodes may be
@@ -775,7 +775,7 @@ and supports for creating these. Please refer to the
 
 for details.
 
-<h3><a name="filter">Filters and cloning</a></h3>
+<h3 id="filter">Filters and cloning</h3>
 
 Under some circumstances, it may be useful to create a node which does
 nothing except serve as a sort of symbolic link to another primary
@@ -804,7 +804,7 @@ as such behavior would be contrary to the UI goal of having a data
 node live in one place in the Repository according to the position of
 the data object and primary file object.
 
-<h3><a name="event">Event model</a></h3>
+<h3 id="event">Event model</h3>
 
 Every interesting aspect of nodes may be listened to using the Java
 Event Model, as is routine in the IDE:
@@ -845,7 +845,7 @@ is easier just to listen to the node holding them.
 
 </ul>
 
-<h3><a name="edit">Edit operations on nodes</a></h3>
+<h3 id="edit">Edit operations on nodes</h3>
 
 Nodes can support a variety of mechanisms for the basic edit
 operations.
@@ -1004,7 +1004,7 @@ public class Shortcuts extends AbstractNode {
       ls.add (new PasteType () {
         public Transferable paste () throws IOException {
           Node[] nue = new Node[ns.length];
-          for (int i = 0; i < nue.length; i++)
+          for (int i = 0; i &lt; nue.length; i++)
             nue[i] = ns[i].cloneNode ();
           getChildren ().add (nue);
           return null;
@@ -1152,28 +1152,28 @@ an existing one (several levels of inner classes would be required!).
 
 <div class="nonnormative">
 
-<h2><a name="diagrams">UML Diagrams</a></h2>
+<h2 id="diagrams">UML Diagrams</h2>
 
 First class diagram listed shows structure of the API in general, all other
 diagrams provides specialized view of specific section of the API.
 
-<h3><a name="diagram_nodes">General node structure class diagram</a></h3>
+<h3 id="diagram_nodes">General node structure class diagram</h3>
 
 <img src="nodes.gif" alt="general UML">
 
-<h3><a name="diagram_children">Node children class diagram</a></h3>
+<h3 id="diagram_children">Node children class diagram</h3>
 
 <img src="children.gif" alt="children UML">
 
-<h3><a name="diagram_events">Node events class diagram</a></h3>
+<h3 id="diagram_events">Node events class diagram</h3>
 
 <img src="events.gif" alt="events UML">
 
-<h3><a name="diagram_ordering">Node ordering class diagram</a></h3>
+<h3 id="diagram_ordering">Node ordering class diagram</h3>
 
 <img src="ordering.gif" alt="ordering UML">
 
-<h3><a name="diagram_properties">Node properties class diagram</a></h3>
+<h3 id="diagram_properties">Node properties class diagram</h3>
 
 <img src="properties.gif" alt="properties UML">
 

--- a/platform/openide.text/src/org/openide/text/PrintPreferences.java
+++ b/platform/openide.text/src/org/openide/text/PrintPreferences.java
@@ -279,7 +279,7 @@ public final class PrintPreferences {
     
     /** 
      * @param correction the amount of vertical space to print between lines.
-     * @exception IllegalArgumentException if <tt>correction</tt> is less than 0.
+     * @exception IllegalArgumentException if <code>correction</code> is less than 0.
      */
     public static void setLineAscentCorrection(float correction) {
         if (getLineAscentCorrection() == correction) return;

--- a/platform/openide.text/src/org/openide/text/UndoRedoManager.java
+++ b/platform/openide.text/src/org/openide/text/UndoRedoManager.java
@@ -48,18 +48,18 @@ import org.openide.awt.UndoRedo;
  *     when "coming out of the savepoint" and redone when "coming to a savepoint".</li>
  * </ul>
  * <p>
- * <tt>Undo Grouping</tt> allows explicit control of what
- * <tt>UndoableEdit</tt>s are coalesced into compound edits, rather than using
+ * <code>Undo Grouping</code> allows explicit control of what
+ * <code>UndoableEdit</code>s are coalesced into compound edits, rather than using
  * the rules defined by the edits themselves. Groups are defined using
  * BEGIN_COMMIT_GROUP and END_COMMIT_GROUP. Send these to UndoableEditListener.
  * These must always be paired. <p> These use cases are supported. </p> <ol>
  * <li> Default behavior is defined by {@link UndoManager}.</li> <li>
- * <tt>UnddoableEdit</tt>s issued between {@link #BEGIN_COMMIT_GROUP} and {@link #END_COMMIT_GROUP}
+ * <code>UnddoableEdit</code>s issued between {@link #BEGIN_COMMIT_GROUP} and {@link #END_COMMIT_GROUP}
  * are placed into a single
- * {@link CompoundEdit}. Thus <tt>undo()</tt> and <tt>redo()</tt> treat them as
+ * {@link CompoundEdit}. Thus <code>undo()</code> and <code>redo()</code> treat them as
  * a single undo/redo.</li> <li>BEGIN/END nest.</li> <li> Issue
- * MARK_COMMIT_GROUP to commit accumulated <tt>UndoableEdit</tt>s into a single
- * <tt>CompoundEdit</tt> and to continue accumulating; an application could do
+ * MARK_COMMIT_GROUP to commit accumulated <code>UndoableEdit</code>s into a single
+ * <code>CompoundEdit</code> and to continue accumulating; an application could do
  * this at strategic points, such as EndOfLine input or cursor movement.</li>
  * </ol>
  * 
@@ -481,7 +481,7 @@ final class UndoRedoManager extends UndoRedo.Manager {
     }
     
     /**
-     * Begin coalescing <tt>UndoableEdit</tt>s that are added into a <tt>CompoundEdit</tt>.
+     * Begin coalescing <code>UndoableEdit</code>s that are added into a <code>CompoundEdit</code>.
      * <p>If edits are already being coalesced and some have been 
      * accumulated, they are flagged for commitment as an atomic group and
      * a new group will be started.
@@ -496,11 +496,11 @@ final class UndoRedoManager extends UndoRedo.Manager {
     }
 
     /**
-     * Stop coalescing edits. Until <tt>beginUndoGroupManager</tt> is invoked,
-     * any received <tt>UndoableEdit</tt>s are added singly.
+     * Stop coalescing edits. Until <code>beginUndoGroupManager</code> is invoked,
+     * any received <code>UndoableEdit</code>s are added singly.
      * <p>
      * This has no effect if edits are not being coalesced, for example
-     * if <tt>beginUndoGroup</tt> has not been called.
+     * if <code>beginUndoGroup</code> has not been called.
      */
     private void endUndoGroup() {
         buildUndoGroup--;
@@ -517,14 +517,14 @@ final class UndoRedoManager extends UndoRedo.Manager {
     }
 
     /**
-     * Commit any accumulated <tt>UndoableEdit</tt>s as an atomic
-     * <tt>undo</tt>/<tt>redo</tt> group. {@link CompoundEdit#end}
-     * is invoked on the <tt>CompoundEdit</tt> and it is added as a single
-     * <tt>UndoableEdit</tt> to this <tt>UndoManager</tt>.
+     * Commit any accumulated <code>UndoableEdit</code>s as an atomic
+     * <code>undo</code>/<code>redo</code> group. {@link CompoundEdit#end}
+     * is invoked on the <code>CompoundEdit</code> and it is added as a single
+     * <code>UndoableEdit</code> to this <code>UndoManager</code>.
      * <p>
      * If edits are currently being coalesced, a new undo group is started.
      * This has no effect if edits are not being coalesced, for example
-     * <tt>beginUndoGroup</tt> has not been called.
+     * <code>beginUndoGroup</code> has not been called.
      */
     private void commitUndoGroup() {
         if(undoGroup == null) {

--- a/platform/openide.text/src/org/openide/text/doc-files/api.html
+++ b/platform/openide.text/src/org/openide/text/doc-files/api.html
@@ -121,7 +121,7 @@ is planned to make creation of new editor kits easier.</p></li>
 
 </div>
 
-<h2><a name="overview">Overview</a></h2>
+<h2 id="overview">Overview</h2>
 
 <p>The Editor API may be used at a first cut for two purposes: accessing
 editor-related functionality from within NetBeans for use by other
@@ -131,7 +131,7 @@ the NetBeans-supplied one.</p>
 
 <div class="nonnormative">
 
-<h3><a name="typical-use">Typical use scenario</a></h3>
+<h3 id="typical-use">Typical use scenario</h3>
 
 Here is an example sequence of events describing how an editor is used
 with Java source code and cooperates with the Form Editor.
@@ -262,13 +262,13 @@ before the text is written to file.
 
 
 
-<h2><a name="accessing">Accessing an Open Document</a></h2>
+<h2 id="accessing">Accessing an Open Document</h2>
 
 Starting from other APIs, it is not difficult to make use of the
 Editor API to get access to an editor window displaying a particular
 file.
 
-<h3><a name="get-doc-obj">Getting the document object for a data object</a></h3>
+<h3 id="get-doc-obj">Getting the document object for a data object</h3>
 
 Here is an example of how to find a file by name stored in some
 filesystem in the Repository; get its data object (assuming you do not
@@ -287,7 +287,7 @@ ec.<a href="../../cookies/EditorCookie.html#open--">open</a>();
 <span class="type">StyledDocument</span> <span class="variable-name">doc</span> = ec.<a href="../../cookies/EditorCookie.html#openDocument--">openDocument</a>();
 </pre>
 
-<h3><a name="modification">Common operations on resulting document</a></h3>
+<h3 id="modification">Common operations on resulting document</h3>
 
 You can check such things as whether or not the file is modified in the Editor:
 
@@ -333,13 +333,13 @@ All done! Prompt to save the file, and close the editor window:
 ec.<a href="../../cookies/EditorCookie.html#close--">close</a>();
 </pre>
 
-<h2><a name="automation">Advanced Editor Automation</a></h2>
+<h2 id="automation">Advanced Editor Automation</h2>
 
 For advanced modules on a level with the Form Editor or the
 Compiler and Debugger, it is necessary to take more complete control
 over the actions and content of an editor.
 
-<h3><a name="auto-guard">Using guard blocks</a></h3>
+<h3 id="auto-guard">Using guard blocks</h3>
 
 Manipulating guarded blocks should not be very difficult, if your
 application requires it. They are used by the FormEditor, but any
@@ -400,7 +400,7 @@ instead.
 
 </ul>
 
-<h3><a name="auto-ann">Using annotations</a></h3>
+<h3 id="auto-ann">Using annotations</h3>
 
 <p>In order to provide richer interactions between the editor and
 other modules, the APIs provide for a system of <em>annotations</em>
@@ -438,17 +438,17 @@ XML file
 distinctive to prevent collisions between modules):
 
 <pre>
-&lt;?<font class="keyword">xml</font> <font class="variable-name">version</font>=<font class="string">"1.0"</font> <font class="variable-name">encoding</font>=<font class="string">"UTF-8"</font>?&gt;
-&lt;!<font class="keyword">DOCTYPE</font> <font class="type">type</font> <font class="keyword">PUBLIC</font>
-          <font class="string">"-//NetBeans//DTD annotation type 1.0//EN"</font>
-          <font class="string">"http://www.netbeans.org/dtds/annotation-type-1_0.dtd"</font>&gt;
-&lt;<font class="function-name">type</font> <font class="variable-name">name</font>=<font class="string">"org-nb-modules-foo-some-annotation"</font>
-      <font class="variable-name">description_key</font>=<font class="string">"LBL_some-annotation"</font>
-      <font class="variable-name">localizing_bundle</font>=<font class="string">"org.nb.modules.foo.Bundle"</font>
-      <font class="variable-name">visible</font>=<font class="string">"true"</font> 
-      <font class="variable-name">glyph</font>=<font class="string">"nbresloc:/org/nb/modules/foo/some-annotation-glyph.gif"</font>
-      <font class="variable-name">highlight</font>=<font class="string">"#FFFF00"</font>
-      <font class="variable-name">type</font>=<font class="string">"line"</font>/&gt;
+&lt;?<span class="keyword">xml</span> <span class="variable-name">version</span>=<span class="string">"1.0"</span> <span class="variable-name">encoding</span>=<span class="string">"UTF-8"</span>?&gt;
+&lt;!<span class="keyword">DOCTYPE</span> <span class="type">type</span> <span class="keyword">PUBLIC</span>
+          <span class="string">"-//NetBeans//DTD annotation type 1.0//EN"</span>
+          <span class="string">"http://www.netbeans.org/dtds/annotation-type-1_0.dtd"</span>&gt;
+&lt;<span class="function-name">type</span> <span class="variable-name">name</span>=<span class="string">"org-nb-modules-foo-some-annotation"</span>
+      <span class="variable-name">description_key</span>=<span class="string">"LBL_some-annotation"</span>
+      <span class="variable-name">localizing_bundle</span>=<span class="string">"org.nb.modules.foo.Bundle"</span>
+      <span class="variable-name">visible</span>=<span class="string">"true"</span> 
+      <span class="variable-name">glyph</span>=<span class="string">"nbresloc:/org/nb/modules/foo/some-annotation-glyph.gif"</span>
+      <span class="variable-name">highlight</span>=<span class="string">"#FFFF00"</span>
+      <span class="variable-name">type</span>=<span class="string">"line"</span>/&gt;
 </pre>
 
 <p>As you can see the definition of the annotation type consists of the highlight
@@ -468,17 +468,17 @@ description - and a short description, which can form tool-tip text for
 the annotation. For example:
 
 <pre>
-<font class="keyword">public</font> <font class="keyword">final</font> <font class="keyword">class</font> <font class="type">SomeAnnotation</font> <font class="keyword">extends</font> <font class="type">Annotation</font> {
-    <font class="keyword">private</font> <font class="keyword">final</font> <font class="type">String</font> <font class="variable-name">error</font>;
-    <font class="keyword">public</font> <font class="type">SomeAnnotation</font>(<font class="type">String</font> <font class="variable-name">error</font>) {
-        <font class="keyword">this</font>.error = error;
+<span class="keyword">public</span> <span class="keyword">final</span> <span class="keyword">class</span> <span class="type">SomeAnnotation</span> <span class="keyword">extends</span> <span class="type">Annotation</span> {
+    <span class="keyword">private</span> <span class="keyword">final</span> <span class="type">String</span> <span class="variable-name">error</span>;
+    <span class="keyword">public</span> <span class="type">SomeAnnotation</span>(<span class="type">String</span> <span class="variable-name">error</span>) {
+        <span class="keyword">this</span>.error = error;
     }
-    <font class="keyword">public</font> <font class="type">String</font> <a href="../Annotation.html#getAnnotationType--"><font class="function-name">getAnnotationType</font></a>() {
-        <font class="keyword">return</font> <font class="string">"org-nb-modules-foo-some-annotation"</font>;
+    <span class="keyword">public</span> <span class="type">String</span> <a href="../Annotation.html#getAnnotationType--"><span class="function-name">getAnnotationType</span></a>() {
+        <span class="keyword">return</span> <span class="string">"org-nb-modules-foo-some-annotation"</span>;
     }
-    <font class="keyword">public</font> <font class="type">String</font> <a href="../Annotation.html#getShortDescription--"><font class="function-name">getShortDescription</font></a>() {
-        <font class="comment">// Localize this with NbBundle:</font>
-        <font class="keyword">return</font> <font class="string">"The error was: "</font> + error;
+    <span class="keyword">public</span> <span class="type">String</span> <a href="../Annotation.html#getShortDescription--"><span class="function-name">getShortDescription</span></a>() {
+        <span class="comment">// Localize this with NbBundle:</span>
+        <span class="keyword">return</span> <span class="string">"The error was: "</span> + error;
     }
 }
 </pre>
@@ -488,7 +488,7 @@ or dynamically: you may return <code>null</code> for no tooltip, and
 you may later return a new or changed tooltip - just use:
 
 <pre>
-firePropertyChange(PROP_SHORT_DESCRIPTION, <font class="constant">null</font>, <font class="constant">null</font>);
+firePropertyChange(PROP_SHORT_DESCRIPTION, <span class="constant">null</span>, <span class="constant">null</span>);
 </pre>
 
 to inform the editor of the change. The tooltip should be refreshed
@@ -509,13 +509,13 @@ representing a whole line of text, or a
 representing a section of a line. For example:
 
 <pre>
-<font class="comment">// Given error output like: "pkg/Name.java:123: You made a mistake"
-</font><font class="type">FileObject</font> <font class="variable-name">fileWithError</font> = fs.findResource(<font class="string">"pkg/Name.java"</font>);
-<font class="type">DataObject</font> <font class="variable-name">objWithError</font> = DataObject.find(fileWithError);
-<a href="../../cookies/LineCookie.html"><font class="type">LineCookie</font></a> <font class="variable-name">cookie</font> = (<font class="type">LineCookie</font>)objWithError.getCookie(LineCookie.<font class="keyword">class</font>);
-<a href="../Line.Set.html"><font class="type">Line.Set</font></a> <font class="variable-name">lineSet</font> = cookie.getLineSet();
-<font class="keyword">final</font> <a href="../Line.html"><font class="type">Line</font></a> <font class="variable-name">line</font> = lineSet.<a href="../Line.Set.html#getOriginal-int-">getOriginal</a>(123);
-<font class="keyword">final</font> <font class="type">Annotation</font> <font class="variable-name">ann</font> = <font class="keyword">new</font> <font class="type">SomeAnnotation</font>(<font class="string">"You made a mistake"</font>);
+<span class="comment">// Given error output like: "pkg/Name.java:123: You made a mistake"
+</span><span class="type">FileObject</span> <span class="variable-name">fileWithError</span> = fs.findResource(<span class="string">"pkg/Name.java"</span>);
+<span class="type">DataObject</span> <span class="variable-name">objWithError</span> = DataObject.find(fileWithError);
+<a href="../../cookies/LineCookie.html"><span class="type">LineCookie</span></a> <span class="variable-name">cookie</span> = (<span class="type">LineCookie</span>)objWithError.getCookie(LineCookie.<span class="keyword">class</span>);
+<a href="../Line.Set.html"><span class="type">Line.Set</span></a> <span class="variable-name">lineSet</span> = cookie.getLineSet();
+<span class="keyword">final</span> <a href="../Line.html"><span class="type">Line</span></a> <span class="variable-name">line</span> = lineSet.<a href="../Line.Set.html#getOriginal-int-">getOriginal</a>(123);
+<span class="keyword">final</span> <span class="type">Annotation</span> <span class="variable-name">ann</span> = <span class="keyword">new</span> <span class="type">SomeAnnotation</span>(<span class="string">"You made a mistake"</span>);
 ann.<a href="../Annotation.html#attach-org.openide.text.Annotatable-">attach</a>(line);
 </pre>
 
@@ -532,13 +532,13 @@ this; of course you need to know when it is appropriate, so for
 example:</p>
 
 <pre>
-line.addPropertyChangeListener(<font class="keyword">new</font> <font class="type">PropertyChangeListener</font>() {
-    <font class="keyword">public</font> <font class="type">void</font> <font class="function-name">propertyChange</font>(<font class="type">PropertyChangeEvent</font> <font class="variable-name">ev</font>) {
-        <font class="type">String</font> <font class="variable-name">type</font> = ev.getPropertyName();
-        <font class="keyword">if</font> (type == <font class="constant">null</font> || type == Annotatable.PROP_TEXT) {
-            <font class="comment">// User edited the line, assume error should be cleared.
-</font>            ann.detach();
-            line.removePropertyChangeListener(<font class="keyword">this</font>);
+line.addPropertyChangeListener(<span class="keyword">new</span> <span class="type">PropertyChangeListener</span>() {
+    <span class="keyword">public</span> <span class="type">void</span> <span class="function-name">propertyChange</span>(<span class="type">PropertyChangeEvent</span> <span class="variable-name">ev</span>) {
+        <span class="type">String</span> <span class="variable-name">type</span> = ev.getPropertyName();
+        <span class="keyword">if</span> (type == <span class="constant">null</span> || type == Annotatable.PROP_TEXT) {
+            <span class="comment">// User edited the line, assume error should be cleared.
+</span>            ann.detach();
+            line.removePropertyChangeListener(<span class="keyword">this</span>);
         }
     }
 });
@@ -567,7 +567,7 @@ and background color. Remember however that some editor implementations
 may find it difficult or impossible to accurately display all of these
 settings (for example display of arbitrary glyphs may be infeasible).</p>
 
-<h4><a name="auto-ann-detail">Detailed description of annotation XML files</a></h4>
+<h4 id="auto-ann-detail">Detailed description of annotation XML files</h4>
 
 Attributes of the <code>&lt;type&gt;</code> element are:
 
@@ -626,9 +626,9 @@ example. The actions may be defined by
 <a href="@org-openide-actions@/org/openide/actions/doc-files/api.html#adv-install">listing instances</a>:
 
 <pre>
-&lt;<font class="function-name">folder</font> <font class="variable-name">name</font>=<font class="string">"YourAnnotationTypeActions"</font>&gt;
-  &lt;<font class="function-name">file</font> <font class="variable-name">name</font>=<font class="string">"org-foo-BarAction.instance"</font>/&gt;
-&lt;/<font class="function-name">folder</font>&gt;
+&lt;<span class="function-name">folder</span> <span class="variable-name">name</span>=<span class="string">"YourAnnotationTypeActions"</span>&gt;
+  &lt;<span class="function-name">file</span> <span class="variable-name">name</span>=<span class="string">"org-foo-BarAction.instance"</span>/&gt;
+&lt;/<span class="function-name">folder</span>&gt;
 </pre>
 </dd>
 
@@ -677,10 +677,10 @@ this type. For example the combination of program counter with
 breakpoint could be defined as follows:</p>
 
 <pre>
-&lt;<font class="function-name">combinations</font> <font class="variable-name">tiptext_key</font>=<font class="string">"PC_BREAKPOINT_COMBINATION_TOOLTIP_TEXT"</font>&gt;
-  &lt;<font class="function-name">combine</font> <font class="variable-name">annotationtype</font>=<font class="string">"NameOfTheBreakpointAnnotationType"</font>/&gt;
-  &lt;<font class="function-name">combine</font> <font class="variable-name">annotationtype</font>=<font class="string">"NameOfTheCurrentPCAnnotationType"</font>/&gt;
-&lt;/<font class="function-name">combinations</font>&gt;
+&lt;<span class="function-name">combinations</span> <span class="variable-name">tiptext_key</span>=<span class="string">"PC_BREAKPOINT_COMBINATION_TOOLTIP_TEXT"</span>&gt;
+  &lt;<span class="function-name">combine</span> <span class="variable-name">annotationtype</span>=<span class="string">"NameOfTheBreakpointAnnotationType"</span>/&gt;
+  &lt;<span class="function-name">combine</span> <span class="variable-name">annotationtype</span>=<span class="string">"NameOfTheCurrentPCAnnotationType"</span>/&gt;
+&lt;/<span class="function-name">combinations</span>&gt;
 </pre>
 
 <p>It is the responsibility of the editor to display combinations
@@ -722,11 +722,11 @@ breakpoint and disabled breakpoint and wish to combine either of them
 with the current program counter. You can define it as follows:
 
 <pre>
-&lt;<font class="function-name">combinations</font> <font class="variable-name">tiptext_key</font>=<font class="string">"COMBINATION_TOOLTIP_TEXT"</font> <font class="variable-name">min_optionals</font>=<font class="string">"1"</font>&gt;
-  &lt;<font class="function-name">combine</font> <font class="variable-name">annotationtype</font>=<font class="string">"debugger-disabledbreakpoint"</font> <font class="variable-name">optional</font>=<font class="string">"true"</font>/&gt;
-  &lt;<font class="function-name">combine</font> <font class="variable-name">annotationtype</font>=<font class="string">"debugger-conditionalbreakpoint"</font> <font class="variable-name">optional</font>=<font class="string">"true"</font>/&gt;
-  &lt;<font class="function-name">combine</font> <font class="variable-name">annotationtype</font>=<font class="string">"debugger-currentpc"</font>/&gt;
-&lt;/<font class="function-name">combinations</font>&gt;
+&lt;<span class="function-name">combinations</span> <span class="variable-name">tiptext_key</span>=<span class="string">"COMBINATION_TOOLTIP_TEXT"</span> <span class="variable-name">min_optionals</span>=<span class="string">"1"</span>&gt;
+  &lt;<span class="function-name">combine</span> <span class="variable-name">annotationtype</span>=<span class="string">"debugger-disabledbreakpoint"</span> <span class="variable-name">optional</span>=<span class="string">"true"</span>/&gt;
+  &lt;<span class="function-name">combine</span> <span class="variable-name">annotationtype</span>=<span class="string">"debugger-conditionalbreakpoint"</span> <span class="variable-name">optional</span>=<span class="string">"true"</span>/&gt;
+  &lt;<span class="function-name">combine</span> <span class="variable-name">annotationtype</span>=<span class="string">"debugger-currentpc"</span>/&gt;
+&lt;/<span class="function-name">combinations</span>&gt;
 </pre>
 
 This way you specify that both breakpoints are optional, but that at
@@ -765,7 +765,7 @@ breakpoints.</dd>
 
 </dl>
 
-<h2><a name="loader">Loader Interactions with Guard Blocks</a></h2>
+<h2 id="loader">Loader Interactions with Guard Blocks</h2>
 
 The NetBeans-supplied
 
@@ -801,7 +801,7 @@ Now just provide appropriate implementations of
 
 
 
-<h2><a name="new-editor">Implementing a Custom Editor</a></h2>
+<h2 id="new-editor">Implementing a Custom Editor</h2>
 
 It is possible to integrate a custom editor (presumably for textual
 content types) into NetBeans, in place of the default
@@ -827,12 +827,12 @@ request.
 
 </ul>
 
-<h3><a name="create-ed-kit">Creating editor kit</a></h3>
+<h3 id="create-ed-kit">Creating editor kit</h3>
 
 You should not need to do anything special to create the editor kit
 beyond what is normally required by Swing.
 
-<h3><a name="create-stydoc">Creating styled document</a></h3>
+<h3 id="create-stydoc">Creating styled document</h3>
 
 You will need to create an implementation of
 
@@ -852,7 +852,7 @@ be used instead<!--you only need to implement a few aspects of styling
 pertaining to these two issues, so full support for changing font and
 so on is completely optional-->.
 
-<h3><a name="handle-guard">Handling guards</a></h3>
+<h3 id="handle-guard">Handling guards</h3>
 
 This is really the central problem in creating a compliant editor. If
 you want to completely skip this step, it is possible to return a
@@ -1039,7 +1039,7 @@ doc.setCharacterAttributes(0, 100, sas, false);
 
 </div>
 
-<h3><a name="handle-lines">Lines and elements</a></h3>
+<h3 id="handle-lines">Lines and elements</h3>
 
 <p>You should make sure that lines in the editor are separated by
 exactly one text character - a newline. The APIs may rely on this to
@@ -1061,7 +1061,7 @@ offsets and line numbers. It is fine to have additional element
 structures not corresponding to lines so long as the two conditions
 above are met.</p>
 
-<h3><a name="handle-ann">Handling annotations</a></h3>
+<h3 id="handle-ann">Handling annotations</h3>
 
 An editor must do two things to support annotations:
 
@@ -1082,7 +1082,7 @@ This
 has two methods. One adds an annotation to the document:
 
 <pre>
-<font class="keyword">public</font> <font class="type">void</font> <font class="function-name">addAnnotation</font>(<font class="type">Position</font> <font class="variable-name">startPos</font>, <font class="type">int</font> <font class="variable-name">length</font>, <font class="type">Annotation</font> <font class="variable-name">annotation</font>);
+<span class="keyword">public</span> <span class="type">void</span> <span class="function-name">addAnnotation</span>(<span class="type">Position</span> <span class="variable-name">startPos</span>, <span class="type">int</span> <span class="variable-name">length</span>, <span class="type">Annotation</span> <span class="variable-name">annotation</span>);
 </pre>
 
 The method is called with a <code>Position</code> in the document; the
@@ -1098,7 +1098,7 @@ editor displays it in the left gutter.
 <p>The second method removed an annotation previously added:
 
 <pre>
-<font class="keyword">public</font> <font class="type">void</font> <font class="function-name">removeAnnotation</font>(<font class="type">Annotation</font> <font class="variable-name">annotation</font>);
+<span class="keyword">public</span> <span class="type">void</span> <span class="function-name">removeAnnotation</span>(<span class="type">Annotation</span> <span class="variable-name">annotation</span>);
 </pre>
 
 This method will be called when the annotation is programmatically
@@ -1114,7 +1114,7 @@ the XML files in the <samp>Editors/AnnotationTypes/</samp> directory.
 The NetBeans standard editor can serve as a source of examples for how to do this.
 In the future there may be shared parsing support.
 
-<h3><a name="printing">Printing</a></h3>
+<h3 id="printing">Printing</h3>
 
 <p>If you want your editor to support printing of its contents,
 you might just provide no special support. In this case,
@@ -1158,7 +1158,7 @@ not satisfactorily capture everything that you are interested in
 printing - for example, if your editor is working on HTML and it is
 desired to print embedded images.
 
-<h3><a name="locking">Locking</a></h3>
+<h3 id="locking">Locking</h3>
 
 It is desirable for your <code>StyledDocument</code> implementation to
 be able to lock the document against write access, as this will make
@@ -1231,7 +1231,7 @@ closely tied to how guard blocks are implemented in that particular
 editor - e.g. in Emacs there will be a quite idiosyncratic
 implementation.
 
-<h3><a name="biases">Biases</a></h3>
+<h3 id="biases">Biases</h3>
 
 Please consider implementing
 
@@ -1248,7 +1248,7 @@ position.
 
 <p>If this is not done, NetBeans creates its own replacement.
 
-<h3><a name="scrolling">Scrolling to display</a></h3>
+<h3 id="scrolling">Scrolling to display</h3>
 
 <p>NetBeans sometimes asks the editor to scroll the display so that a
 given line will be displayed. You should not need to do anything
@@ -1258,7 +1258,7 @@ special to support this;
 
 will be called and ought to perform the scrolling appropriately.
 
-<h3><a name="actions">Presentable actions</a></h3>
+<h3 id="actions">Presentable actions</h3>
 
 It is desirable for the editor to present actions to the user that may
 be invoked on the document and may be accessed in various ways. For
@@ -1328,7 +1328,8 @@ recognized based on a call to
 
 <code><a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/javax/swing/Action.html#getValue-java.lang.String-">getValue</a>(<a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/javax/swing/Action.html#NAME">Action.NAME</a>)</code>:</p>
 
-<table border=1 summary="action name to DefaultEditorKit field mappings">
+<table border=1>
+<caption>name to DefaultEditorKit field mappings</caption>
 <tr><th>Name</th><th>Static field in
 <a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/javax/swing/text/DefaultEditorKit.html"><code>DefaultEditorKit</code></a></th></tr>
 <tr><td><code>copy-to-clipboard</code></td><td><code>copyAction</code></td></tr>
@@ -1345,7 +1346,8 @@ possible want to say: undo/redo supported by your undo impl in the document
 all others are CallbackSystemAction's -> you must specifically enable them
 -->
 
-<table border=1 summary="action names and their meanings">
+<table border=1>
+<caption>action names and their meanings</caption>
 <tr><th>Name</th><th>Description</th></tr>
 <tr><td><code>find</code></td><td>Pop up dialog to find a string in the text.</td></tr>
 <tr><td><code>replace</code></td><td>Pop up dialog to find &amp;
@@ -1370,7 +1372,7 @@ them. You should use
 to indicate whether your action is ready, and thus whether or not the
 corresponding UI elements should be grayed out.
 
-<h3><a name="undo">Undo/redo support</a></h3>
+<h3 id="undo">Undo/redo support</h3>
 
 It is desirable for your document's user-level edit actions to implement
 
@@ -1383,13 +1385,13 @@ from the standard places (e.g. in the Edit menu). Note that
 
 for example, already provides this support.
 
-<h3><a name="cust">Customization</a></h3>
+<h3 id="cust">Customization</h3>
 
 This API does not provide any special mechanism for allowing the user
 to customize aspects of the editor's operation from the GUI; if you
 want to do this, please use <code>NbPreferences</code> or similar.
 
-<h3><a name="install">Installing</a></h3>
+<h3 id="install">Installing</h3>
 
 It should be straightforward to install the new editor -
 you will make a JAR file containing a manifest with attributes

--- a/platform/openide.windows/src/org/openide/windows/Mode.java
+++ b/platform/openide.windows/src/org/openide/windows/Mode.java
@@ -40,7 +40,7 @@ import java.io.Serializable;
  * Each mode must have a unique name.
  *
  * <p>
- * <b><font color="red"><em>Important note: Do not provide implementation of this interface unless you are window system provider!</em></font></b>
+ * <b><span style="color:red"><em>Important note: Do not provide implementation of this interface unless you are window system provider!</em></span></b>
  */
 public interface Mode extends Serializable {
     /** Name of property for bounds of the mode */

--- a/platform/openide.windows/src/org/openide/windows/TopComponentGroup.java
+++ b/platform/openide.windows/src/org/openide/windows/TopComponentGroup.java
@@ -27,7 +27,7 @@ import java.util.Set;
  * The concept of window group explains <a href="https://netbeans.apache.org/projects/platform/core/windowsystem/changes#s23">API changes document</a>.
  *
  * <p>
- * <b><font color="red"><em>Importatnt note: Do not provide implementation of this interface unless you are window system provider!</em></font></b>
+ * <b><span style="color:red"><em>Important note: Do not provide implementation of this interface unless you are window system provider!</em></span></b>
  *
  * @author  Peter Zavadsky
  * @since 4.13

--- a/platform/openide.windows/src/org/openide/windows/WindowManager.java
+++ b/platform/openide.windows/src/org/openide/windows/WindowManager.java
@@ -41,7 +41,7 @@ import org.openide.util.Lookup;
  * Allows the work with window system components, i.e. <code>Mode</code>s, <code>TopComponentGroup</code>s
  * and provides handling of operations provided over <code>TopComponent</code>s.
  * <p>
- * <b><font color="red"><em>Important note: Do not provide implementation of this abstract class unless you are window system provider!</em></font></b>
+ * <b><span style="color:red"><em>Important note: Do not provide implementation of this abstract class unless you are window system provider!</em></span></b>
  *
  * @author Jaroslav Tulach
  */

--- a/platform/openide.windows/src/org/openide/windows/Workspace.java
+++ b/platform/openide.windows/src/org/openide/windows/Workspace.java
@@ -36,7 +36,7 @@ import java.util.Set;
  * stores the content of the workspace (it is responsibility of window manager).
  *
  * <p>
- * <b><font color="red"><em>Important note: Do not provide implementation of this interface unless you are window system provider!</em></font></b>
+ * <b><span style="color:red"><em>Important note: Do not provide implementation of this interface unless you are window system provider!</em></span></b>
  *
  * @author Jaroslav Tulach
  * @deprecated Do not use any more. Use {@link WindowManager} methods directly,

--- a/platform/openide.windows/src/org/openide/windows/doc-files/api.html
+++ b/platform/openide.windows/src/org/openide/windows/doc-files/api.html
@@ -25,11 +25,11 @@
 </head>
 <body>
 
-<p></p><p>
+<br>
 <em>Note: See the <a href="https://netbeans.apache.org/projects/platform/core/windowsystem/changes">changes document</a>. Window system implementation
 changed is major version. Comparing to the older version it has changed its
 laout significantly, introduced group, and released support of workspaces</em>
-</p>
+<br>
 
 <p class="overviewlink"><a href="../../../../overview-summary.html">Overview</a></p>
 
@@ -97,7 +97,7 @@ The Window System API provides fairly abstract support for creating
 windows or window-like container components that may be handled
 smoothly by the NetBeans window manager implementation.
 
-<h2><a name="overview">Overview of the Window System</a></h2>
+<h2 id="overview">Overview of the Window System</h2>
 
 As a rule, modules should not create their own top-level windows
 (e.g.
@@ -111,7 +111,7 @@ tabbed frames, and making the window configuration persistent across
 sessions. Well-behaved modules will use the API so as to integrate
 nicely into the feel of the rest of the application.
 
-<h3><a name="overview-top">Top components and docking</a></h3>
+<h3 id="overview-top">Top components and docking</h3>
 
 A <em>top component</em> is a Swing component (usually a panel or
 the like, though not necessarily); it might be <em>docked</em> (added into
@@ -138,7 +138,7 @@ be in the selected tab. This component serves as the base for a number
 of things in NetBeans; for example, the <em>current node
 selection</em> is controlled by the active component.
 
-<h3><a name="overview-clone">Cloning</a></h3>
+<h3 id="overview-clone">Cloning</h3>
 
 Some top components can be <em>cloned</em>, meaning that a new top
 component created which initially shares the same contents. Exactly
@@ -147,7 +147,7 @@ the same data will be referred to and the cloned component will
 simply be a new view on it. For example, Editor panes can be cloned
 with the effect that the same file will be open in each view.
 
-<h3><a name="overview-group">Groups</a></h3>
+<h3 id="overview-group">Groups</h3>
 
 NetBeans starts off with the groups "form", "debugger", etc.
 to group windows according to their expected
@@ -162,12 +162,12 @@ exits, including the positions of all modes, the arrangement of
 modes, and the components present in each mode; and grouos, their state; and
 then restore this configuration when next started.
 
-<h2><a name="create">Creating a Top Component</a></h2>
+<h2 id="create">Creating a Top Component</h2>
 
 Creating a custom top component, including assigning it to the
 proper docking mode, is not generally difficult.
 
-<h3><a name="create-top">Subclassing <code>TopComponent</code></a></h3>
+<h3 id="create-top">Subclassing <code>TopComponent</code></h3>
 
 To create a simple top component, it suffices to subclass
 
@@ -231,7 +231,7 @@ describes how to write these.
 
 </ul>
 
-<h3><a name="find-mode">Finding modes</a></h3>
+<h3 id="find-mode">Finding modes</h3>
 
 Finding <a href="#overview-top">modes</a> is straightforward.
 
@@ -251,25 +251,25 @@ a mode wouldn't achieve desired goal.
 For example:
 
 <pre>
-<font class="keyword">public</font> <font class="keyword">static</font> <font class="keyword">class</font> <font class="type">MyComponent</font> <font class="keyword">extends</font> <font class="type">TopComponent</font> {
-    <font class="keyword">public</font> <font class="type">MyComponent</font>(<font class="type">Object</font> <font class="variable-name">data</font>, <font class="type">Image</font> <font class="variable-name">icon</font>) {
-        setName(NbBundle.getMessage(This.<font class="keyword">class</font>, <font class="string">"LBL_widget_tree"</font>));
+<span class="keyword">public</span> <span class="keyword">static</span> <span class="keyword">class</span> <span class="type">MyComponent</span> <span class="keyword">extends</span> <span class="type">TopComponent</span> {
+    <span class="keyword">public</span> <span class="type">MyComponent</span>(<span class="type">Object</span> <span class="variable-name">data</span>, <span class="type">Image</span> <span class="variable-name">icon</span>) {
+        setName(NbBundle.getMessage(This.<span class="keyword">class</span>, <span class="string">"LBL_widget_tree"</span>));
         setIcon(icon);
-        setLayout(<font class="keyword">new</font> <font class="type">BorderLayout</font>());
-        add(<font class="keyword">new</font> <font class="type">JTree</font>(createModel(data)), BorderLayout.CENTER);
+        setLayout(<span class="keyword">new</span> <span class="type">BorderLayout</span>());
+        add(<span class="keyword">new</span> <span class="type">JTree</span>(createModel(data)), BorderLayout.CENTER);
     }
-    <font class="keyword">public</font> <font class="type">Action</font>[] <font class="function-name">getActions</font>() {
-        <font class="type">List</font>[] <font class="variable-name">actions</font> = Arrays.asList(<font class="keyword">super</font>.getctions());
-        <font class="variable-name">actions</font>.add(<font class="keyword">new</font> WidgetReparseAction());
-        <font class="keyword">return</font> (<font class="type">Action</font>[])<font class="variable-name">actions</font>.toArray(<font class="keyword">new</font> <font class="type">Action</font>[0]);
+    <span class="keyword">public</span> <span class="type">Action</span>[] <span class="function-name">getActions</span>() {
+        <span class="type">List</span>[] <span class="variable-name">actions</span> = Arrays.asList(<span class="keyword">super</span>.getctions());
+        <span class="variable-name">actions</span>.add(<span class="keyword">new</span> WidgetReparseAction());
+        <span class="keyword">return</span> (<span class="type">Action</span>[])<span class="variable-name">actions</span>.toArray(<span class="keyword">new</span> <span class="type">Action</span>[0]);
     }
 }
 
 // ...
-<font class="type">TopComponent</font> <font class="variable-name">myComponent1</font> = <font class="keyword">new</font> <font class="type">MyComponent</font>(firstData, firstIcon);
-<font class="type">TopComponent</font> <font class="variable-name">myComponent2</font> = <font class="keyword">new</font> <font class="type">MyComponent</font>(secondData, secondIcon);
-<font class="type">Mode</font> <font class="variable-name">myMode</font> = WindowManager.getDefault().findMode(<font class="string">"myWidgetsMode"</font>);
-<font class="keyword">if</font> (myMode != <font class="constant">null</font>) {
+<span class="type">TopComponent</span> <span class="variable-name">myComponent1</span> = <span class="keyword">new</span> <span class="type">MyComponent</span>(firstData, firstIcon);
+<span class="type">TopComponent</span> <span class="variable-name">myComponent2</span> = <span class="keyword">new</span> <span class="type">MyComponent</span>(secondData, secondIcon);
+<span class="type">Mode</span> <span class="variable-name">myMode</span> = WindowManager.getDefault().findMode(<span class="string">"myWidgetsMode"</span>);
+<span class="keyword">if</span> (myMode != <span class="constant">null</span>) {
     myMode.dockInto(myComponent);
     myMode.dockInto(myComponent2);
 } else {
@@ -281,7 +281,7 @@ myComponent2.open();
 myComponent2.requestActive();
 </pre>
 
-<h3><a name="create-clone">Creating a cloneable component</a></h3>
+<h3 id="create-clone">Creating a cloneable component</h3>
 
 Just by subclassing
 
@@ -323,7 +323,7 @@ which would cause all visible clones to display a different part of
 the content of the data simultaneously, so the user could use the
 screen more effectively.
 
-<h3><a name="create-misc">Handling focus, and the node selection</a></h3>
+<h3 id="create-misc">Handling focus, and the node selection</h3>
 
 There are several more ways in which top components can interact
 with the desktop smoothly.
@@ -378,7 +378,7 @@ view, as you would expect. Also, any top component associated with
 a data object will automatically select that object's node
 delegate, which is usually the intuitive behavior as well.
 
-<h3><a name="create-ser">Special support for serialization</a></h3>
+<h3 id="create-ser">Special support for serialization</h3>
 
 If you are writing a top component with a complex configuration or
 other instance state not associated with a data object, you may
@@ -388,18 +388,18 @@ restart. This is not difficult to do; you just need to hook into
 the externalization methods of <code>TopComponent</code>:
 
 <pre>
-<font class="keyword">public</font> <font class="keyword">class</font> <font class="type">FlippableView</font> <font class="keyword">extends</font> <font class="type">TopComponent</font> {
-    <font class="keyword">public</font> <font class="keyword">static</font> <font class="type">int</font> <font class="variable-name">HORIZ_ORIENT</font> = 1;
-    <font class="keyword">public</font> <font class="keyword">static</font> <font class="type">int</font> <font class="variable-name">VERT_ORIENT</font> = 2;
-    <font class="keyword">private</font> <font class="type">int</font> <font class="variable-name">orient</font> = HORIZ_ORIENT;
-    <font class="keyword">public</font> <font class="type">int</font> <font class="function-name">getOrientation</font>() { <font class="comment">/* ... */</font> }
-    <font class="keyword">public</font> <font class="type">void</font> <font class="function-name">setOrientation</font>(<font class="type">int</font> <font class="variable-name">ornt</font>) { <font class="comment">/* ... */</font> }
-    <font class="keyword">public</font> <font class="type">void</font> <font class="function-name">writeExternal</font>(<font class="type">ObjectOutput</font> <font class="variable-name">oo</font>) <font class="keyword">throws</font> <font class="type">IOException</font> {
-        <font class="keyword">super</font>.writeExternal(oo);
+<span class="keyword">public</span> <span class="keyword">class</span> <span class="type">FlippableView</span> <span class="keyword">extends</span> <span class="type">TopComponent</span> {
+    <span class="keyword">public</span> <span class="keyword">static</span> <span class="type">int</span> <span class="variable-name">HORIZ_ORIENT</span> = 1;
+    <span class="keyword">public</span> <span class="keyword">static</span> <span class="type">int</span> <span class="variable-name">VERT_ORIENT</span> = 2;
+    <span class="keyword">private</span> <span class="type">int</span> <span class="variable-name">orient</span> = HORIZ_ORIENT;
+    <span class="keyword">public</span> <span class="type">int</span> <span class="function-name">getOrientation</span>() { <span class="comment">/* ... */</span> }
+    <span class="keyword">public</span> <span class="type">void</span> <span class="function-name">setOrientation</span>(<span class="type">int</span> <span class="variable-name">ornt</span>) { <span class="comment">/* ... */</span> }
+    <span class="keyword">public</span> <span class="type">void</span> <span class="function-name">writeExternal</span>(<span class="type">ObjectOutput</span> <span class="variable-name">oo</span>) <span class="keyword">throws</span> <span class="type">IOException</span> {
+        <span class="keyword">super</span>.writeExternal(oo);
         oo.writeInt(getOrientation());
     }
-    <font class="keyword">public</font> <font class="type">void</font> <font class="function-name">readExternal</font>(<font class="type">ObjectInput</font> <font class="variable-name">oi</font>) <font class="keyword">throws</font> <font class="type">IOException</font>, <font class="type">ClassNotFoundException</font> {
-        <font class="keyword">super</font>.readExternal(oi);
+    <span class="keyword">public</span> <span class="type">void</span> <span class="function-name">readExternal</span>(<span class="type">ObjectInput</span> <span class="variable-name">oi</span>) <span class="keyword">throws</span> <span class="type">IOException</span>, <span class="type">ClassNotFoundException</span> {
+        <span class="keyword">super</span>.readExternal(oi);
         setOrientation(oi.readInt());
     }
 }
@@ -421,27 +421,27 @@ wrapping the data, which will protect the object streams from being
 corrupted just because of one component. For example:
 
 <pre>
-<font class="comment">// Possible that you may break serialization of this class accidentally:
-</font><font class="keyword">private</font> <font class="type">MySerObject</font> <font class="variable-name">state</font>;
-<font class="comment">// ...
-</font><font class="keyword">public</font> <font class="type">void</font> <font class="function-name">writeExternal</font>(<font class="type">ObjectOutput</font> <font class="variable-name">oo</font>) <font class="keyword">throws</font> <font class="type">IOException</font> {
-    <font class="keyword">super</font>.writeExternal(oo);
-    <font class="type">Object</font> <font class="variable-name">toWrite</font>;
-    <font class="keyword">try</font> {
-        toWrite = <font class="keyword">new</font> <font class="type">NbMarshalledObject</font>(state);
-    } <font class="keyword">catch</font> (<font class="type">Exception</font> <font class="variable-name">e</font>) {
+<span class="comment">// Possible that you may break serialization of this class accidentally:
+</span><span class="keyword">private</span> <span class="type">MySerObject</span> <span class="variable-name">state</span>;
+<span class="comment">// ...
+</span><span class="keyword">public</span> <span class="type">void</span> <span class="function-name">writeExternal</span>(<span class="type">ObjectOutput</span> <span class="variable-name">oo</span>) <span class="keyword">throws</span> <span class="type">IOException</span> {
+    <span class="keyword">super</span>.writeExternal(oo);
+    <span class="type">Object</span> <span class="variable-name">toWrite</span>;
+    <span class="keyword">try</span> {
+        toWrite = <span class="keyword">new</span> <span class="type">NbMarshalledObject</span>(state);
+    } <span class="keyword">catch</span> (<span class="type">Exception</span> <span class="variable-name">e</span>) {
         ErrorManager.getDefault().notify(ErrorManager.WARNING, e);
-        toWrite = <font class="constant">null</font>;
+        toWrite = <span class="constant">null</span>;
     }
     oo.writeObject(toWrite);
 }
-<font class="keyword">public</font> <font class="type">void</font> <font class="function-name">readExternal</font>(<font class="type">ObjectInput</font> <font class="variable-name">oi</font>) <font class="keyword">throws</font> <font class="type">IOException</font>, <font class="type">ClassNotFoundException</font> {
-    <font class="keyword">super</font>.readExternal(oi);
-    <font class="type">NbMarshalledObject</font> <font class="variable-name">read</font> =(<font class="type">NbMarshalledObject</font>)oi.readObject();
-    <font class="keyword">if</font> (read != <font class="constant">null</font>) {
-        <font class="keyword">try</font> {
-            state = (<font class="type">MySerObject</font>)read.get();
-        } <font class="keyword">catch</font> (<font class="type">Exception</font> <font class="variable-name">e</font>) {
+<span class="keyword">public</span> <span class="type">void</span> <span class="function-name">readExternal</span>(<span class="type">ObjectInput</span> <span class="variable-name">oi</span>) <span class="keyword">throws</span> <span class="type">IOException</span>, <span class="type">ClassNotFoundException</span> {
+    <span class="keyword">super</span>.readExternal(oi);
+    <span class="type">NbMarshalledObject</span> <span class="variable-name">read</span> =(<span class="type">NbMarshalledObject</span>)oi.readObject();
+    <span class="keyword">if</span> (read != <span class="constant">null</span>) {
+        <span class="keyword">try</span> {
+            state = (<span class="type">MySerObject</span>)read.get();
+        } <span class="keyword">catch</span> (<span class="type">Exception</span> <span class="variable-name">e</span>) {
             ErrorManager.getDefault().notify(ErrorManager.WARNING, e);
         }
     }
@@ -458,10 +458,10 @@ original exception from it to the <code>writeExternal</code> or
 system stream be treated as corrupt and discarded! Instead, use:
 
 <pre>
-<font class="keyword">try</font> {
-    <font class="comment">// new NbMarshalledObject(obj) or nbmo.get()
-</font>} <font class="keyword">catch</font> (<font class="type">Exception</font> <font class="variable-name">e</font>) {
-    <font class="keyword">throw</font> <font class="keyword">new</font> <font class="type">SafeException</font>(e);
+<span class="keyword">try</span> {
+    <span class="comment">// new NbMarshalledObject(obj) or nbmo.get()
+</span>} <span class="keyword">catch</span> (<span class="type">Exception</span> <span class="variable-name">e</span>) {
+    <span class="keyword">throw</span> <span class="keyword">new</span> <span class="type">SafeException</span>(e);
 }
 </pre>
 
@@ -543,13 +543,13 @@ on default but to set persistence type explicitely as described above.</p>
 
 </div>
 
-<h2><a name="manip">Manipulating Existing Windows</a></h2>
+<h2 id="manip">Manipulating Existing Windows</h2>
 
 Most manipulation of existing windows should be kept to a minimum,
 of course, to avoid disrupting the user needlessly. Occasionally it
 makes sense to do a few things to top components externally.
 
-<h3><a name="find">Finding modes, top components and groups</a></h3>
+<h3 id="find">Finding modes, top components and groups</h3>
 
 A few method calls may be used to find modes, groups and top components:
 
@@ -595,7 +595,7 @@ You can also get all opened components with
 
 </ul>
 
-<h3><a name="manip-misc">Activating and closing</a></h3>
+<h3 id="manip-misc">Activating and closing</h3>
 
 Any top component may be activated just by calling
 
@@ -605,7 +605,7 @@ Any top component may be activated just by calling
 
 <a href="../TopComponent.html#close--"><code>TopComponent.close()</code></a>.
 
-<h3><a name="listen">Listening to window system events</a></h3>
+<h3 id="listen">Listening to window system events</h3>
 
 Most interesting aspects of the Window System may be listened to
 using the Java Event model. Most commonly, this is done to listen
@@ -640,13 +640,13 @@ to listen to.
 
 
 
-<h2><a name="xml">XML Persistence Format and Installation</a></h2>
+<h2 id="xml">XML Persistence Format and Installation</h2>
 
 
 
 <div class="nonnormative">
 
-<h3><a name="xml-overview">Overview</a></h3>
+<h3 id="xml-overview">Overview</h3>
 
 <P>The window system layout used by NetBeans is based on modes.</P>
 
@@ -716,7 +716,7 @@ is already supported by Netbeans' Open APIs.</P>
 <P>Example of simple window system content expressed as merge of
 modes layouts from different modules is shown on picture below:</P>
 
-<P ALIGN=CENTER><IMG SRC="layers-example.gif" alt="Modes in layering schema"></P>
+<IMG SRC="layers-example.gif" alt="Modes in layering schema" style="display:block;margin-left:auto;margin-right:auto;">
 <BR>
 <p>
 Note: The same applies for groups, but those are not dealing with laout, but
@@ -733,7 +733,7 @@ organized and granularized, as described in next paragraph.
 
 
 
-<h3><a name="xml-layout">Physical Layout and File Formats</a></h3>
+<h3 id="xml-layout">Physical Layout and File Formats</h3>
 
 <P>In first part of this chapter, overall structure of layout configuration is
  discussed. XML layers architecture uses directory-like structure for storing
@@ -905,28 +905,28 @@ They are always defined by a folder <samp>Windows/WindowManager/</samp> and data
 of global properties for win sys. Format of data file is simple:
 
 <pre>
-&lt;?<font class="keyword">xml</font> <font class="variable-name">version</font>=<font class="string">"1.0"</font> <font class="variable-name">encoding</font>=<font class="string">"UTF-8"</font>?&gt;
-&lt;!<font class="keyword">DOCTYPE</font> <font class="type">windowmanager</font> <font class="keyword">PUBLIC</font>
-          <font class="string">"-//NetBeans//DTD Window Manager Properties 2.0//EN"</font>
-          <font class="string">"<a href="http://www.netbeans.org/dtds/windowmanager-properties2_0.dtd">http://www.netbeans.org/dtds/windowmanager-properties2_0.dtd</a>"</font>&gt;
-&lt;<font class="function-name">windowmanager</font> <font class="variable-name">version</font>=<font class="string">"2.0"</font>&gt;
-    <font class="comment">&lt;!-- size and location of the main window --&gt;</font>
-    &lt;<font class="function-name">main-window</font>&gt;
-         &lt;<font class="function-name">joined-properties</font> <font
-class="variable-name">centered-vertically</font>=<font class="string">"true"</font> <font
-class="variable-name">centered-horizontally</font>=<font class="string">"true"</font>
-                            <font class="variable-name">relative-width</font>=<font class="string">"0.8"</font> <font
-class="variable-name">relative-height</font>=<font class="string">"0.8"</font>/&gt;
-    &lt;/<font class="function-name">main-window</font>&gt;
-    <font class="comment">&lt;!-- size of the screen last displayed on --&gt;</font>
-    &lt;<font class="function-name">screen</font> <font class="variable-name">width</font>=<font class="string">"1024"</font> <font class="variable-name">height</font>=<font class="string">"768"</font>/&gt;
-    <font class="comment">&lt;!-- reference to active mode --&gt;</font>
-    &lt;<font class="function-name">active-mode</font> <font class="variable-name">name</font>=<font class="string">"explorer"</font>/&gt;
-    <font class="comment">&lt;!-- reference to maximized mode --&gt;</font>
-    &lt;<font class="function-name">maximized-mode</font> <font class="variable-name">name</font>=<font class="string">"explorer"</font>/&gt;
-    <font class="comment">&lt;!-- reference to toolbar configuration --&gt;</font>
-    &lt;<font class="function-name">toolbar</font> <font class="variable-name">configuration</font>=<font class="string">"Standard"</font>/&gt;
-&lt;/<font class="function-name">windowmanager</font>&gt;
+&lt;?<span class="keyword">xml</span> <span class="variable-name">version</span>=<span class="string">"1.0"</span> <span class="variable-name">encoding</span>=<span class="string">"UTF-8"</span>?&gt;
+&lt;!<span class="keyword">DOCTYPE</span> <span class="type">windowmanager</span> <span class="keyword">PUBLIC</span>
+          <span class="string">"-//NetBeans//DTD Window Manager Properties 2.0//EN"</span>
+          <span class="string">"<a href="http://www.netbeans.org/dtds/windowmanager-properties2_0.dtd">http://www.netbeans.org/dtds/windowmanager-properties2_0.dtd</a>"</span>&gt;
+&lt;<span class="function-name">windowmanager</span> <span class="variable-name">version</span>=<span class="string">"2.0"</span>&gt;
+    <span class="comment">&lt;!-- size and location of the main window --&gt;</span>
+    &lt;<span class="function-name">main-window</span>&gt;
+         &lt;<span class="function-name">joined-properties</span> <span
+class="variable-name">centered-vertically</span>=<span class="string">"true"</span> <span
+class="variable-name">centered-horizontally</span>=<span class="string">"true"</span>
+                            <span class="variable-name">relative-width</span>=<span class="string">"0.8"</span> <span
+class="variable-name">relative-height</span>=<span class="string">"0.8"</span>/&gt;
+    &lt;/<span class="function-name">main-window</span>&gt;
+    <span class="comment">&lt;!-- size of the screen last displayed on --&gt;</span>
+    &lt;<span class="function-name">screen</span> <span class="variable-name">width</span>=<span class="string">"1024"</span> <span class="variable-name">height</span>=<span class="string">"768"</span>/&gt;
+    <span class="comment">&lt;!-- reference to active mode --&gt;</span>
+    &lt;<span class="function-name">active-mode</span> <span class="variable-name">name</span>=<span class="string">"explorer"</span>/&gt;
+    <span class="comment">&lt;!-- reference to maximized mode --&gt;</span>
+    &lt;<span class="function-name">maximized-mode</span> <span class="variable-name">name</span>=<span class="string">"explorer"</span>/&gt;
+    <span class="comment">&lt;!-- reference to toolbar configuration --&gt;</span>
+    &lt;<span class="function-name">toolbar</span> <span class="variable-name">configuration</span>=<span class="string">"Standard"</span>/&gt;
+&lt;/<span class="function-name">windowmanager</span>&gt;
 </pre>
 
 Modules will typically never need to access these global properties, and 
@@ -1171,7 +1171,7 @@ have been.</p>
 
 
 
-<!--<h3><a name="xml-visual">Visual Display</a></h3>
+<!--<h3 id="xml-visual">Visual Display</h3>
 
 <H4>Defining layout for multiple interfaces of the system</H4>
 
@@ -1273,7 +1273,7 @@ honored.</p>
 
 
 <!-- XXX What's this for a strange thing? Is this supposed to be supported?? -->
-<!--<h3><a name="xml-programmatic">Programmatic Manipulation</a></h3>
+<!--<h3 id="xml-programmatic">Programmatic Manipulation</h3>
 
 <div class="nonnormative">
 
@@ -1324,19 +1324,19 @@ an <code>InstanceCookie</code> which will produce the correct
 you might for example retrieve a mode as follows:</p>
 
 <pre>
-<font class="type">FileSystem</font> <font class="variable-name">sfs</font> = Repository.getDefault().getDefaultFileSystem();
-<font class="comment">// Assume these two were known somehow:
-</font><font class="type">String</font> <font class="variable-name">wsName</font> = <font class="string">"Editing"</font>;
-<font class="type">String</font> <font class="variable-name">modeName</font> = <font class="string">"editor"</font>;
-<font class="type">FileObject</font> <font class="variable-name">modeFolder</font> = sfs.findResource(<font class="string">"Windows/WindowManager/"</font> + wsName + <font class="string">"/"</font> + modeName);
-<font class="comment">// deal with null result...
+<span class="type">FileSystem</span> <span class="variable-name">sfs</span> = Repository.getDefault().getDefaultFileSystem();
+<span class="comment">// Assume these two were known somehow:
+</span><span class="type">String</span> <span class="variable-name">wsName</span> = <span class="string">"Editing"</span>;
+<span class="type">String</span> <span class="variable-name">modeName</span> = <span class="string">"editor"</span>;
+<span class="type">FileObject</span> <span class="variable-name">modeFolder</span> = sfs.findResource(<span class="string">"Windows/WindowManager/"</span> + wsName + <span class="string">"/"</span> + modeName);
+<span class="comment">// deal with null result...
 // this would also work with the .wsmode file, but the folder is the primary file so:
-</font><font class="type">DataObject</font> <font class="variable-name">modeObj</font> = DataObject.find(modeFolder);
-<font class="type">InstanceCookie</font> <font class="variable-name">instance</font> = (<font class="type">InstanceCookie</font>)modeObj.getCookie(InstanceCookie.<font class="keyword">class</font>);
-<font class="comment">// instance could be null if .wsmode was missing...
-</font><font class="type">Mode</font> <font class="variable-name">m</font> = (<font class="type">Mode</font>)instance.instanceCreate();
-<font class="comment">// now use it as desired...
-</font></pre>
+</span><span class="type">DataObject</span> <span class="variable-name">modeObj</span> = DataObject.find(modeFolder);
+<span class="type">InstanceCookie</span> <span class="variable-name">instance</span> = (<span class="type">InstanceCookie</span>)modeObj.getCookie(InstanceCookie.<span class="keyword">class</span>);
+<span class="comment">// instance could be null if .wsmode was missing...
+</span><span class="type">Mode</span> <span class="variable-name">m</span> = (<span class="type">Mode</span>)instance.instanceCreate();
+<span class="comment">// now use it as desired...
+</span></pre>
 
 <H4>Writing from the Java-level API</H4>
 
@@ -1350,13 +1350,13 @@ receiving a property change event on the component.</p>
 <code>SaveCookie</code>:</p>
 
 <pre>
-<font class="type">DataObject</font> <font class="variable-name">modeObj</font> = <font class="comment">/* as above */</font>;
-<font class="type">SaveCookie</font> <font class="variable-name">save</font> = (<font class="type">SaveCookie</font>)modeObj.getCookie(SaveCookie.<font class="keyword">class</font>);
-<font class="keyword">if</font> (save != <font class="constant">null</font>) {
+<span class="type">DataObject</span> <span class="variable-name">modeObj</span> = <span class="comment">/* as above */</span>;
+<span class="type">SaveCookie</span> <span class="variable-name">save</span> = (<span class="type">SaveCookie</span>)modeObj.getCookie(SaveCookie.<span class="keyword">class</span>);
+<span class="keyword">if</span> (save != <span class="constant">null</span>) {
     save.save();
-} <font class="keyword">else</font> {
-    <font class="comment">// was already up-to-date on disk
-</font>}
+} <span class="keyword">else</span> {
+    <span class="comment">// was already up-to-date on disk
+</span>}
 </pre>
 
 <p>You could also use calls such as <code>DataObject.delete()</code>
@@ -1401,7 +1401,7 @@ modes using the Java-level API.</p>
 <div class="nonnormative">
 -->
 
-<h3><a name="xml-scenarios">Common Scenarios</a></h3>
+<h3 id="xml-scenarios">Common Scenarios</h3>
 
 <p>Following chapter summarizes procedures that module can do in order to use
 features of XML mode layout. Each procedure is detailed into steps which
@@ -1424,24 +1424,24 @@ Following section shows creation of new mode defined by module.
         components contained in mode yet:
 
 <pre>
-&lt;?<font class="keyword">xml</font> <font class="variable-name">version</font>=<font class="string">"1.0"</font> <font class="variable-name">encoding</font>=<font class="string">"UTF-8"</font>?&gt;
-&lt;!<font class="keyword">DOCTYPE</font> <font class="type">filesystem</font> <font class="keyword">PUBLIC</font>
-          <font class="string">"-//NetBeans//DTD Filesystem 1.0//EN"</font>
-          <font class="string">"http://www.netbeans.org/dtds/filesystem-1_0.dtd"</font>&gt;
-&lt;<font class="function-name">filesystem</font>&gt;
-    &lt;<font class="function-name">folder</font> <font class="variable-name">name</font>=<font
-class="string">"Windows2"</font>&gt;
-        &lt;<font class="function-name">folder</font> <font class="variable-name">name</font>=<font
-class="string">"Modes"</font>&gt;
-            <font class="comment">&lt;!-- configuration file is stored separately --&gt;</font>
-            &lt;<font class="function-name">file</font> <font class="variable-name">name</font>=<font
-class="string">"my_own_mode.wsmode"</font> <font class="variable-name">url</font>=<font
-class="string">"my_own_mode.wsmode"</font>/&gt;
-            &lt;<font class="function-name">folder</font> <font class="variable-name">name</font>=<font
-class="string">"my_own_mode"</font>/&gt;
-        &lt;/<font class="function-name">folder</font>&gt;
-    &lt;/<font class="function-name">folder</font>&gt;
-&lt;/<font class="function-name">filesystem</font>&gt;
+&lt;?<span class="keyword">xml</span> <span class="variable-name">version</span>=<span class="string">"1.0"</span> <span class="variable-name">encoding</span>=<span class="string">"UTF-8"</span>?&gt;
+&lt;!<span class="keyword">DOCTYPE</span> <span class="type">filesystem</span> <span class="keyword">PUBLIC</span>
+          <span class="string">"-//NetBeans//DTD Filesystem 1.0//EN"</span>
+          <span class="string">"http://www.netbeans.org/dtds/filesystem-1_0.dtd"</span>&gt;
+&lt;<span class="function-name">filesystem</span>&gt;
+    &lt;<span class="function-name">folder</span> <span class="variable-name">name</span>=<span
+class="string">"Windows2"</span>&gt;
+        &lt;<span class="function-name">folder</span> <span class="variable-name">name</span>=<span
+class="string">"Modes"</span>&gt;
+            <span class="comment">&lt;!-- configuration file is stored separately --&gt;</span>
+            &lt;<span class="function-name">file</span> <span class="variable-name">name</span>=<span
+class="string">"my_own_mode.wsmode"</span> <span class="variable-name">url</span>=<span
+class="string">"my_own_mode.wsmode"</span>/&gt;
+            &lt;<span class="function-name">folder</span> <span class="variable-name">name</span>=<span
+class="string">"my_own_mode"</span>/&gt;
+        &lt;/<span class="function-name">folder</span>&gt;
+    &lt;/<span class="function-name">folder</span>&gt;
+&lt;/<span class="function-name">filesystem</span>&gt;
 </pre>
 
         <p>What example shows? Creates folder <b>Windows2/Modes/my_own_mode</b>
@@ -1461,24 +1461,24 @@ like this (ser or settings file shower.ser or shower.settings is expected in
 folder Windows/Components):
 
 <pre>
-&lt;?<font class="keyword">xml</font> <font class="variable-name">version</font>=<font class="string">"1.0"</font> <font class="variable-name">encoding</font>=<font class="string">"UTF-8"</font>?&gt;
-&lt;!<font class="keyword">DOCTYPE</font> <font class="type">filesystem</font> <font class="keyword">PUBLIC</font>
-          <font class="string">"-//NetBeans//DTD Filesystem 1.0//EN"</font>
-          <font class="string">"http://www.netbeans.org/dtds/filesystem-1_0.dtd"</font>&gt;
-&lt;<font class="function-name">filesystem</font>&gt;
-    &lt;<font class="function-name">folder</font> <font class="variable-name">name</font>=<font
-class="string">"Windows2"</font>&gt;
-        &lt;<font class="function-name">folder</font> <font class="variable-name">name</font>=<font
-class="string">"Modes"</font>&gt;
-            <font class="comment">&lt;!-- foreign mode, don't specify data file --&gt;</font>
-            &lt;<font class="function-name">folder</font> <font class="variable-name">name</font>=<font
-class="string">"bathroom"</font>&gt;
-                <font class="comment">&lt;!-- configuration file stored separately --&gt;</font>
-                &lt;<font class="function-name">file</font> <font class="variable-name">name</font>=<font class="string">"shower.wstcref"</font> <font class="variable-name">url</font>=<font class="string">"shower.wstcref"</font>&gt;
-            &lt;/<font class="function-name">folder</font>&gt;
-        &lt;/<font class="function-name">folder</font>&gt;
-    &lt;/<font class="function-name">folder</font>&gt;
-&lt;/<font class="function-name">filesystem</font>&gt;
+&lt;?<span class="keyword">xml</span> <span class="variable-name">version</span>=<span class="string">"1.0"</span> <span class="variable-name">encoding</span>=<span class="string">"UTF-8"</span>?&gt;
+&lt;!<span class="keyword">DOCTYPE</span> <span class="type">filesystem</span> <span class="keyword">PUBLIC</span>
+          <span class="string">"-//NetBeans//DTD Filesystem 1.0//EN"</span>
+          <span class="string">"http://www.netbeans.org/dtds/filesystem-1_0.dtd"</span>&gt;
+&lt;<span class="function-name">filesystem</span>&gt;
+    &lt;<span class="function-name">folder</span> <span class="variable-name">name</span>=<span
+class="string">"Windows2"</span>&gt;
+        &lt;<span class="function-name">folder</span> <span class="variable-name">name</span>=<span
+class="string">"Modes"</span>&gt;
+            <span class="comment">&lt;!-- foreign mode, don't specify data file --&gt;</span>
+            &lt;<span class="function-name">folder</span> <span class="variable-name">name</span>=<span
+class="string">"bathroom"</span>&gt;
+                <span class="comment">&lt;!-- configuration file stored separately --&gt;</span>
+                &lt;<span class="function-name">file</span> <span class="variable-name">name</span>=<span class="string">"shower.wstcref"</span> <span class="variable-name">url</span>=<span class="string">"shower.wstcref"</span>&gt;
+            &lt;/<span class="function-name">folder</span>&gt;
+        &lt;/<span class="function-name">folder</span>&gt;
+    &lt;/<span class="function-name">folder</span>&gt;
+&lt;/<span class="function-name">filesystem</span>&gt;
 </pre>
 
 There are several other notes that developer should be aware of:
@@ -1541,18 +1541,15 @@ Module A needs no changes, module B has to assure following:
 Similar procedures can be applied when module needs to override only one top
 component reference entry or hide whole workspace.
 
-</div>
-
-
 <div class="nonnormative">
 
-<h2><a name="diagrams">UML Diagrams</a></h2>
+<h2 id="diagrams">UML Diagrams</h2>
 
-<h3><a name="diagram_basic">Overall structure class diagram</a></h3>
+<h3 id="diagram_basic">Overall structure class diagram</h3>
 
 <img src="windows.gif" alt="general UML">
 
-<h3><a name="diagram_inputoutput">Input-Output class diagram</a></h3>
+<h3 id="diagram_inputoutput">Input-Output class diagram</h3>
 
 <img src="inputoutput.gif" alt="I/O UML">
 

--- a/platform/options.api/arch.xml
+++ b/platform/options.api/arch.xml
@@ -1081,8 +1081,7 @@
    <api name="OptionsExportLayers"
         group="layer"
         type="export"
-        category="devel"
-        url="">
+        category="devel">
         Use OptionsExport/&lt;MyCategory&gt; folder for registration of items for export/import
         of options. Registration in layers looks as follows
  <pre style="background-color: rgb(255, 255, 153);">

--- a/platform/options.api/src/org/netbeans/spi/options/OptionsPanelController.java
+++ b/platform/options.api/src/org/netbeans/spi/options/OptionsPanelController.java
@@ -355,9 +355,9 @@ public abstract class OptionsPanelController {
          * <blockquote><table>
          * <caption>Split examples showing array and keywords</caption>
          * <tr><th>Provided array</th><th>Keywords</th></tr> 
-         * <tr><td align=center>{ "Boo", "fOo" }</td><td><tt>{ "BOO", "FOO" }</tt></td></tr>
-         * <tr><td align=center>{ "boo and", "foo" }</td><td><tt>{ "BOO AND", "FOO" }</tt></td></tr>
-         * <tr><td align=center>{ "boo,and", "foo" }</td><td><tt>{ "BOO", "AND", "FOO" }</tt></td></tr> 
+         * <tr><td>{ "Boo", "fOo" }</td><td><code>{ "BOO", "FOO" }</code></td></tr>
+         * <tr><td>{ "boo and", "foo" }</td><td><code>{ "BOO AND", "FOO" }</code></td></tr>
+         * <tr><td>{ "boo,and", "foo" }</td><td><code>{ "BOO", "AND", "FOO" }</code></td></tr> 
          * </table></blockquote>
          *
          * <p> The user's search-text is split around the space character to form words.
@@ -367,10 +367,10 @@ public abstract class OptionsPanelController {
          * <blockquote><table> 
          * <caption>Search examples showing search-text and results</caption>
          * <tr><th>User's search-text</th><th>Result</th></tr>
-         * <tr><td align=center>"boo"</td><td><tt>keyword found</tt></td></tr>
-         * <tr><td align=center>"nd"</td><td><tt>keyword found</tt></td></tr>
-         * <tr><td align=center>"boo and"</td><td><tt>keyword found</tt></td></tr>
-         * <tr><td align=center>"boo moo"</td><td><tt>keyword NOT found</tt></td></tr>
+         * <tr><td>"boo"</td><td><code>keyword found</code></td></tr>
+         * <tr><td>"nd"</td><td><code>keyword found</code></td></tr>
+         * <tr><td>"boo and"</td><td><code>keyword found</code></td></tr>
+         * <tr><td>"boo moo"</td><td><code>keyword NOT found</code></td></tr>
          * </table></blockquote>
          */
         String[] keywords();

--- a/platform/settings/src/org/netbeans/api/settings/ConvertAsJavaBean.java
+++ b/platform/settings/src/org/netbeans/api/settings/ConvertAsJavaBean.java
@@ -36,10 +36,10 @@ import java.lang.annotation.Target;
  * default constructor:
  * <pre>
  * <code>@</code>ConvertAsJavaBean
- * <font class="type">public class</font> YourObject {
- *   <font class="type">public</font> YourObject() {}
- *   <font class="type">public</font> <font class="type">String</font> <font class="function-name">getName</font>();
- *   <font class="type">public void</font> <font class="function-name">setName</font>(<font class="type">String</font> <font class="variable-name">name</font>);
+ * <span class="type">public class</span> YourObject {
+ *   <span class="type">public</span> YourObject() {}
+ *   <span class="type">public</span> <span class="type">String</span> <span class="function-name">getName</span>();
+ *   <span class="type">public void</span> <span class="function-name">setName</span>(<span class="type">String</span> <span class="variable-name">name</span>);
  * }
  * </pre>
  * If the bean supports {@link PropertyChangeListener} notifications and

--- a/platform/settings/src/org/netbeans/api/settings/ConvertAsProperties.java
+++ b/platform/settings/src/org/netbeans/api/settings/ConvertAsProperties.java
@@ -30,13 +30,13 @@ import java.util.Properties;
  * <a href="../../spi/settings/package-summary.html">is available</a> in separate document,
  * here is the shortest possible howto:
  * <pre>
- * <code>@</code>ConvertAsProperties(dtd="-//Your Org//Your Setting//EN")
- * <font class="type">public class</font> YourObject {
- *   <font class="type">public</font> YourObject() {} // public constructor is a must
- *   <font class="type">void</font> <font class="function-name">readProperties</font>(java.util.<font class="type">Properties</font> <font class="variable-name">p</font>) {
+ * <code>@</code>ConvertAsProperties(dtd="-//Yosur Org//Your Setting//EN")
+ * <span class="type">public class</span> YourObject {
+ *   <span class="type">public</span> YourObject() {} // public constructor is a must
+ *   <span class="type">void</span> <span class="function-name">readProperties</span>(java.util.<span class="type">Properties</span> <span class="variable-name">p</span>) {
  *     // do the read
  *   }
- *   <font class="type">void</font> <font class="function-name">writeProperties</font>(java.util.<font class="type">Properties</font> <font class="variable-name">p</font>) {
+ *   <span class="type">void</span> <span class="function-name">writeProperties</span>(java.util.<span class="type">Properties</span> <span class="variable-name">p</span>) {
  *     // handle the store
  *   }
  * }

--- a/platform/settings/src/org/netbeans/spi/settings/package.html
+++ b/platform/settings/src/org/netbeans/spi/settings/package.html
@@ -26,7 +26,7 @@
 Makes it possible to store settings in a custom human-readable storage format or
 reuse any existing format by using convertors.
 
-<h1>Contents</h1>
+<h2>Contents</h2>
 
 <ul>
 <li><a href="#intro">What are Convertors?</a></li>
@@ -45,10 +45,10 @@ reuse any existing format by using convertors.
 </ul>
 
 
-<h1>Settings API</h1>
+<h2>Settings API</h2>
 
 
-<h2><a name="intro">What are Convertors?</a></h2>
+<h3 id="intro">What are Convertors?</h3>
 
 Convertors are intended, as the name indicates, to convert objects
 from and to its persistent state. They are supposed to facilitate
@@ -57,9 +57,9 @@ and to allow to separate code related information like class names from data
 to prevent to later compatibility issues.
 
 
-<h2><a name="use">Make Own Convertor</a></h2>
+<h3 id="use">Make Own Convertor</h3>
 
-<h3><a name="use-create">Subclass Convertor</a></h3>
+<h4 id="use-create">Subclass Convertor</h4>
 
 <p>Creating a convertor means creating a new class which subclasses
 the abstract <a href="Convertor.html"><code>Convertor</code></a> class.</p>
@@ -77,7 +77,7 @@ E.g. you can incorporate the property change support in your setting object as
 the source of notifications. The <code>Convertor.registerSaver</code>
 will register own listener and filter fired events you want the framework to be notified.
 
-<h3><a name="use-own">Register Convertor</a></h3>
+<h4 id="use-own">Register Convertor</h4>
 If you have already written own convertor class it is necessary to register it.
 <p>
 Each <code>.settings</code> file containing values
@@ -131,7 +131,7 @@ has to contain following attributes
 </pre>
 
 
-<h3><a name="use-memory">Runtime Instances</a></h3>
+<h4 id="use-memory">Runtime Instances</h4>
 Now if you need to create new persistent instances of your setting object in the runtime you have to
 register its class with attribute <code>settings.providerPath</code> under
 <code>xml/memory</code> folder. The attribute has to contain path to the environment provider
@@ -192,7 +192,7 @@ attribute <code>settings.subclasses</code> with boolean value set to true like t
 <p> Please use the attribute <code>settings.subclasses</code> only in case
 you are sure your convertor can handle all subclasses!
 
-<h3><a name="use-composed">Composed Content</a></h3>
+<h4 id="use-composed">Composed Content</h4>
 In order to allow to reuse existing convertors and to put their output together
 into one XML document
 the settings module introduces a <a href="DOMConvertor.html"><code>DOMConvertor</code></a>
@@ -257,7 +257,7 @@ the output and also provides APIs describing the hierarchy of nested
 elements, arbitrary complex.
 </p>
 
-<h2><a name="find">Finding Settings</a></h2>
+<h3 id="find">Finding Settings</h3>
 To find out your setting you can use the <a href="@org-openide-util@/org/openide/util/doc-files/api.html#lookup">
 lookup system</a>. In such case you have to place your .settings file under
 <code>Services</code> folder. This is useful for settings shared among modules.
@@ -273,21 +273,21 @@ Otherwise you can place the file under own folder and use
 </pre>
 
 
-<h2><a name="version">Versioning Settings</a></h2>
+<h3 id="version">Versioning Settings</h3>
 
-<h3>Replacing the setting object class</h3>
+<h4>Replacing the setting object class</h4>
 Update the environment provider registration mainly file attributes
 <code>settings.instanceClass</code> and <code>settings.instanceOf</code>. If an old class
 is referenced inside the format use <code>META-INF/netbeans/translate.names</code> file.
 
-<h3>Replacing the setting format</h3>
+<h4>Replacing the setting format</h4>
 Register an entity for the newly introduced format.
 Register your setting class with proper file attribute <code>settings.providerPath</code>
 as was described in the <a href="#use-memory">section</a> about creating settings in the runtime.
 Do not remove the old registration! The framework will read the file via original
 convertor but changes will be stored via new one.
 
-<h2><a name="xmlprops">Properties Format</a></h2>
+<h3 id="xmlprops">Properties Format</h3>
 For some (and maybe many) modules it is sufficient to store its values as
 name, value string pairs. For them the Settings module provides a special
 convertor that handles content of java.util.Properties. The format definition

--- a/platform/spi.quicksearch/arch.xml
+++ b/platform/spi.quicksearch/arch.xml
@@ -145,20 +145,18 @@
         </question>
 -->
  <answer id="arch-usecases">
-  <p>
-      
    <usecase id="newProvider" name="How To Add New Quick Search Provider" >
       In order to plug in a new Quick Search provider and new category of results,
       module writers need to complete following steps:
 
-      <h5>1. Implement <a href="@TOP@/org/netbeans/spi/quicksearch/SearchProvider.html">SearchProvider</a></h5>
+      <h4>1. Implement <a href="@TOP@/org/netbeans/spi/quicksearch/SearchProvider.html">SearchProvider</a></h4>
         <ul>
             <li>Implement body of <b><code>SearchProvider.evaluate</code></b> method
             like suggested in its <a href="@TOP@/org/netbeans/spi/quicksearch/SearchProvider.html">javadoc</a>.
             </li>
         </ul>
       
-      <h5>2. Register SearchProvider implementation in xml layer</h5>
+      <h4>2. Register SearchProvider implementation in xml layer</h4>
             Register your SearchProvider implementation in your module's xml layer file under
             main <b>"/QuickSearch"</b> folder. Registration xml syntax is following:
             
@@ -216,7 +214,7 @@
           It means that all providers (possibly in different NetBeans modules)
           need to be registered under the same folder, as shown below:</p>
        
-       <h5>Provider 1</h5>   
+       <h4>Provider 1</h4>   
             Provider 1 is category "owner", which defines properties of <code>SharedCategory</code> such as 
             display name, position and command prefix.
             <pre>
@@ -232,7 +230,7 @@
               &lt;/folder&gt;
             </pre>
 
-       <h5>Provider 2</h5>   
+       <h4>Provider 2</h4>   
             Other providers from other modules are sharing category with Provider 1.
             Provider 2 does not define properties of <code>SharedCategory</code>,
             as they were already defined by Provider 1.
@@ -248,7 +246,7 @@
               &lt;/folder&gt;
             </pre>
 
-       <h5>Provider 3</h5>   
+       <h4>Provider 3</h4>   
             The same rules apply like for Provider 2. Note that position attribute
             can be used to control position of provider's results in shared category.
             Results from provider with lowest position will go first and so on.
@@ -290,12 +288,12 @@
         However, if your module wants to disable "Recent Searches" or any other
         category, follow the steps below:
         
-        <h5>Define module dependency</h5>
+        <h4>Define module dependency</h4>
             Your module have to depend on module where provider you want to disable
             is contained. In case of "Recent Searches" provider, it's <code>spi,quicksearch</code>,
             on which you probably already depend.
 
-        <h5>Disable provider using "_hidden"</h5>
+        <h4>Disable provider using "_hidden"</h4>
             For example, to disable "Recent Searches" provider, write into your layer:
             
             <pre>
@@ -315,7 +313,7 @@
         NetBeans platform. To enable Quick Search feature in your application,
         complete following steps:
         
-        <h5>1. Write XML layer registration</h5>
+        <h4>1. Write XML layer registration</h4>
             Add the following lines to XML layer of some of your modules in your
             application suite:
         
@@ -330,7 +328,7 @@
         &lt;/folder&gt;
         </pre>
         
-        <h5>2. Localize Toolbar Name</h5>
+        <h4>2. Localize Toolbar Name</h4>
              Replace <code>com.myapp.mymodule.MyBundle</code> in the xml registration
              above with path to your properties file, in which you'll define
              localized name of Quick Search toolbar:
@@ -377,7 +375,6 @@
         Look&amp;Feel, you can put a <code>Border</code> instance into
         <code>UIManager</code> under key <code>nb.quicksearch.border</code>.
    </usecase>
-  </p>
  </answer>
 
 

--- a/platform/uihandler/arch.xml
+++ b/platform/uihandler/arch.xml
@@ -820,13 +820,13 @@
                 Four common parameters are added always before sending logger info and two error 
                 parameters are added only if an exception rised.
                 
-                <ul title="common parameters">
+                <ul id="common_parameters">
                     <li>Operating system name, version and architecture</li>
                     <li>Virtual machine name and version</li>
                     <li>Application version and build number</li>
                     <li>User name</li>
                 </ul>
-                <ul title="error parameters">
+                <ul id="error_parameters">
                     <li>Error summary</li>
                     <li>User's comment to an error situation</li>
                 </ul>

--- a/platform/uihandler/src/org/netbeans/modules/uihandler/api/doc-files/ui.html
+++ b/platform/uihandler/src/org/netbeans/modules/uihandler/api/doc-files/ui.html
@@ -44,7 +44,7 @@
 
 <h1>Scenarios</h1>
 
-<h3>Scenario: We need returning users</h3>
+<h2>Scenario: We need returning users</h2>
 
 <p>
     Important user actions are recorded and remember in the system
@@ -82,7 +82,7 @@
 </p>
 
 
-<h3>Scenario: We need confident users</h3>
+<h2>Scenario: We need confident users</h2>
 
 <p>
     Not all people like to sign bianco checks. Many of them 
@@ -105,7 +105,7 @@
     server.
 </p>
 
-<h3>Scenario: We need to not scare newcommers</h3>
+<h2>Scenario: We need to not scare newcommers</h2>
 
 <p>
     The submission dialog shall not open too "early". Instead it shall
@@ -124,7 +124,7 @@
     open.
 </p>
 
-<h3>Scenario: We need reliable submissions</h3>
+<h2>Scenario: We need reliable submissions</h2>
 
 <p>
     We are not interested in logs from people who just play with the system
@@ -139,7 +139,7 @@
     they will be of similar level of value for analysis.
 </p>
 
-<h3>Scenario: Easy bug reports</h3>
+<h2>Scenario: Easy bug reports</h2>
 
 <p>
     Easy bug reporting is critical to improving quality of any product.
@@ -156,7 +156,7 @@
 
 <h1>Ascii Art</h1>
 
-<h3>Submittion Button</h3>
+<h2>Submittion Button</h2>
 
 <p>
     This button shall be placed in a status bar and shall encourage user to
@@ -175,7 +175,7 @@
     maximum (currently 1000). 
 </p>
 
-<h3>Submittion Dialog</h3>
+<h2>Submittion Dialog</h2>
 
 <p>
     This dialog appears when the user presses the button in status bar:
@@ -208,7 +208,7 @@
 </pre>
 
 
-<h3>Examination Dialog</h3>
+<h2>Examination Dialog</h2>
 
 <p>
     When the user chooses to see the data about the be transfered to the server,
@@ -247,7 +247,7 @@
 </pre>
 
 
-<h3>Error Dialog</h3>
+<h2>Error Dialog</h2>
 
 <p>
     When an exception is rised, its behaviour remains the same as is usual

--- a/platform/uihandler/src/org/netbeans/modules/uihandler/api/package.html
+++ b/platform/uihandler/src/org/netbeans/modules/uihandler/api/package.html
@@ -22,9 +22,8 @@
     under the License.
 
 -->
-<body>
 Package with interfaces that other modules may implement in order to
 be notified about important lifecycle points during collecting the UI
 Gestures.
-</body></body>
+</body>
 </html>


### PR DESCRIPTION
this PR make the "stable" javadoc html compliant for jdk 23 javadoc.

There is a few modules left for being complete.

With this PR I added the template xslt change, to generate a table and reorder the headings. Some color taken from javadoc 23.


