### PR TITLE
Smaller bug fixes in the editor libraries

### DIFF
--- a/ide/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaret.java
+++ b/ide/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaret.java
@@ -1119,8 +1119,13 @@ public final class EditorCaret implements Caret {
                                 break;
 
                             case THIN_LINE_CARET:
-                                int upperX = caretBounds.x;
-                                g.drawLine((int) upperX, caretBounds.y, caretBounds.x, (caretBounds.y + caretBounds.height - 1));
+                                /* "For horizontal or vertical 1-pixel wide line fills, it is generally better to use fillRect
+                                rather than drawLine. The rounding of the drawLine method moves lines by half a device pixel."
+                                The latter has become relevant now that Graphics2D instances may include a HiDPI/Retina scaling
+                                transform. Being off by 0.5 pixel can sometimes cause the caret to leave "droppings", if it is
+                                painted outside the repaint rectangle.
+                                https://web.archive.org/web/20070223151745/http://java.sun.com/products/java-media/2D/reference/faqs/index.html */
+                                g.fillRect(caretBounds.x, caretBounds.y, 1, caretBounds.height - 1);
                                 painted = true;
                                 break;
 

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
@@ -1510,6 +1510,11 @@ public final class DocumentViewOp
         }
        
         JTextComponent textComponent = docView.getTextComponent();
+        if (textComponent == null) {
+            /* May occur in some cases where the editor was closed while scroll events are still
+            coming in from trackpad "momentum" on MacOS. */
+            return;
+        }
         Keymap keymap = textComponent.getKeymap();
         double wheelRotation = evt.getPreciseWheelRotation();
         if (wheelRotation < 0) {

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewBuilder.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/ViewBuilder.java
@@ -1196,7 +1196,9 @@ final class ViewBuilder {
         
         // For accurate span force computation of text layouts
         Rectangle2D.Double docViewRect = docView.getAllocationCopy();
-        if (docView.op.isAccurateSpan()) { // All pViews should already have children
+        /* In the firstReplaceValid case, we need to process firstReplace even if !isAccurateSpan,
+        to get the repaint described further below. */
+        if (docView.op.isAccurateSpan() || firstReplaceValid) { // All pViews should already have children
             int pIndex = docReplace.index;
             int endIndex = docReplace.addEndIndex();
             if (firstReplaceValid) { // Include pView of firstReplace too
@@ -1212,6 +1214,10 @@ final class ViewBuilder {
                     break;
                 }
                 pView.checkLayoutUpdate(pIndex, ViewUtils.shapeAsRect(pAlloc));
+                if (!docView.op.isAccurateSpan()) {
+                    // In this case we just needed the repaint of firstReplace via checkLayoutUpdate.
+                    break;
+                }
             }
         }
         

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/WrapInfoUpdater.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/WrapInfoUpdater.java
@@ -27,6 +27,7 @@ import java.util.logging.Logger;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.View;
 import org.netbeans.lib.editor.util.swing.DocumentUtilities;
+import org.netbeans.modules.editor.lib2.EditorPreferencesDefaults;
 
 
 /**
@@ -104,9 +105,11 @@ final class WrapInfoUpdater {
         TextLayout lineContinuationTextLayout = docView.op.getLineContinuationCharTextLayout();
         final float lineContTextLayoutAdvance =
             lineContinuationTextLayout == null ? 0f : lineContinuationTextLayout.getAdvance();
-        // Make reasonable minimum width so that the number of visual lines does not double suddenly
-        // when user would minimize the width too much. Also have enough space for line continuation mark
-        availableWidth = Math.max(visibleWidth - lineContTextLayoutAdvance,
+        /* Keep a reasonable minimum width so that the number of visual lines does not double suddenly
+        if the user reduces the width too much. Also have enough space for a line continuation mark, and
+        enough to avoid the caret disappearing entirely off the paintable edge at the end of a line. */
+        availableWidth = Math.max(visibleWidth - lineContTextLayoutAdvance
+                - EditorPreferencesDefaults.defaultThickCaretWidth,
                 docView.op.getDefaultCharWidth() * 4);
         logMsgBuilder = LOG.isLoggable(Level.FINE) ? new StringBuilder(100) : null;
         if (logMsgBuilder != null) {


### PR DESCRIPTION
Here are a few smaller bug fixes in the ide/editor.lib2 module, each in a separate commit (since they are independent of each other).

* For platform apps that use the THIN_LINE_CARET option, on HiDPI monitors, fix a paint bug where a pixel-thick line from the caret may remain outside the repaint area, leaving "cursor droppings" behind as the user types.
* Avoid a NullPointerException that could occur if an editor is closed while MacOS trackpad scrolling events are still coming in.
* Fix an editor repaint bug which could leave lines appearing duplicated. Easy to reproduce on plain text files; see the commit for reproduction steps.

  <img width="1035" alt="image" src="https://github.com/user-attachments/assets/b203d8cb-04b1-449f-a39c-c153131eeb98" />
 
  The cause was clear: An existing comment in o.n.modules.editor.lib2.view.ViewBuilder explains that "For valid firstReplace the current impl repaints whole line", but that repaint was in a block of code that was being skipped as an optimization (the "accurate span" calculation). The fix is to check for the "firstReplace" case and ensure that repaint() will be called regardless (via the checkLayoutUpdate method).
* When line wrapping is enabled, adjust the wrap line length so that the text caret can't end up completely outside the scroll viewport (making it invisible).