### PR TITLE
JShell Integration: Improve handling of "var" support

### DIFF
--- a/ide/lexer/src/org/netbeans/lib/lexer/token/JoinToken.java
+++ b/ide/lexer/src/org/netbeans/lib/lexer/token/JoinToken.java
@@ -126,4 +126,8 @@ public final class JoinToken<T extends TokenId> extends PropertyToken<T> {
         return "JoiT"; // NOI18N
     }
 
+    @Override
+    public String toString() {
+        return "JoinToken{" + "joinedParts=" + joinedParts + ", completeLength=" + completeLength + ", extraTokenListSpanCount=" + extraTokenListSpanCount + '}';
+    }
 }

--- a/ide/lexer/src/org/netbeans/lib/lexer/token/PartToken.java
+++ b/ide/lexer/src/org/netbeans/lib/lexer/token/PartToken.java
@@ -83,4 +83,9 @@ public final class PartToken<T extends TokenId> extends PropertyToken<T> {
         return "ParT[" + (partTokenIndex+1) + "/" + joinToken().joinedParts().size() + "]"; // NOI18N
     }
 
+    @Override
+    public String toString() {
+        return dumpInfoTokenType();
+    }
+
 }

--- a/ide/lexer/test/unit/src/org/netbeans/lib/lexer/test/join/JoinRandomTest.java
+++ b/ide/lexer/test/unit/src/org/netbeans/lib/lexer/test/join/JoinRandomTest.java
@@ -56,7 +56,8 @@ public class JoinRandomTest extends NbTestCase {
 
     public void testRandom() throws Exception {
         test(1214497020179L);
-//        test(1212495582649L);
+        test(1212495582649L);
+        test(1740600568165L);
 //        test(0L);
     }
     

--- a/java/jshell.support/src/org/netbeans/modules/jshell/resources/layer.xml
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/resources/layer.xml
@@ -123,6 +123,7 @@
                         <attr name="inherit.rules" boolvalue="true"/>
                         <file name="org-netbeans-modules-jshell-support-LocationSuppressRule.instance"/>
                         <file name="org-netbeans-modules-jshell-support-SemicolonMissingRule.instance"/>
+                        <file name="org-netbeans-modules-jshell-support-VarNotAllowedHereRule.instance"/>
                     </folder>
                 </folder>
             </folder>

--- a/java/jshell.support/test/unit/src/org/netbeans/modules/jshell/parsing/LexerTest.java
+++ b/java/jshell.support/test/unit/src/org/netbeans/modules/jshell/parsing/LexerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.jshell.parsing;
+
+import org.junit.Test;
+import org.netbeans.api.lexer.Token;
+import org.netbeans.api.lexer.TokenHierarchy;
+import org.netbeans.api.lexer.TokenSequence;
+import org.netbeans.modules.jshell.model.JShellToken;
+
+public class LexerTest {
+
+    @Test
+    public void testVarLexing() {
+        TokenHierarchy<?> hi = TokenHierarchy.create("[1]-> var ", JShellToken.language());
+        enumerateTokenSequence(hi.tokenSequence(), "", false);
+    }
+
+    @Test
+    public void testVarLexing2() {
+        TokenHierarchy<?> hi = TokenHierarchy.create("[1]-> var String = \"Hallo Welt\"", JShellToken.language());
+        enumerateTokenSequence(hi.tokenSequence(), "", false);
+    }
+
+    private void enumerateTokenSequence(TokenSequence<?> ts, String indent, boolean debug) {
+        ts.moveStart();
+        while (ts.moveNext()) {
+            Token t = ts.token();
+            if (debug) {
+                System.out.printf("%s%s/%s%n", indent, t.id().primaryCategory(), t.id().name());
+            }
+            if (t != null) {
+                TokenSequence embeddedTs = ts.embedded();
+                if (embeddedTs != null) {
+                    enumerateTokenSequence(embeddedTs, indent + "  ", debug);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Part 1: Lexer: Improve handling of grammars using a lexer with backtracking

Entering:

```
var x = "Test"<Enter>
```

into a java platform shell yields exceptions. Checking the java lexer
showed, that the java lexer at that point does backtracking and this
indicates a problem in the lexer infrastructure.  The problem seems
to be caused by the generic lexer infrastructure, which has special
handling for languages embedded into other languages. In the case of
the jshell lexer, this is java code inside the shells code. In combination
with a backtracking lexer this seems to break lexing.

# Part 2:  Improve handling of `var` Statement

- parser falsely reports that var is not supported
- parser reports missing semikolon

The first condition needs to be newly caught, the second condition was
partially caught in `SemicolonMissingRule`, but failed because there is an
potential off-by-one issue.