### PR TITLE
Persist size of git create and switch branch windows

### DIFF
--- a/ide/git/src/org/netbeans/modules/git/ui/branch/CreateBranch.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/branch/CreateBranch.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.git.ui.branch;
 
 import java.awt.Dialog;
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.util.HashSet;
 import java.util.Map;
@@ -38,6 +37,7 @@ import org.openide.DialogDisplayer;
 import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
 import org.netbeans.modules.git.GitModuleConfig;
+import org.netbeans.modules.versioning.util.DialogBoundsPreserver;
 
 /**
  *
@@ -86,16 +86,14 @@ public class CreateBranch implements DocumentListener {
                 new Object[] { okButton, DialogDescriptor.CANCEL_OPTION }, okButton, DialogDescriptor.DEFAULT_ALIGN,
                 new HelpCtx("org.netbeans.modules.git.ui.branch.CreateBranch"), null); //NOI18N
         validate();
-        revisionPicker.addPropertyChangeListener(new PropertyChangeListener() {
-            @Override
-            public void propertyChange (PropertyChangeEvent evt) {
-                if (evt.getPropertyName() == RevisionDialogController.PROP_VALID) {
-                    setRevisionValid(Boolean.TRUE.equals(evt.getNewValue()));
-                }
+        revisionPicker.addPropertyChangeListener(evt -> {
+            if (evt.getPropertyName() == RevisionDialogController.PROP_VALID) {
+                setRevisionValid(Boolean.TRUE.equals(evt.getNewValue()));
             }
         });
         panel.branchNameField.getDocument().addDocumentListener(this);
         Dialog d = DialogDisplayer.getDefault().createDialog(dd);
+        DialogBoundsPreserver.preserveAndRestore(d, GitModuleConfig.getDefault().getPreferences(), this.getClass().getName());
         d.setVisible(true);
         return okButton == dd.getValue();
     }
@@ -174,7 +172,7 @@ public class CreateBranch implements DocumentListener {
     }
 
     private static Set<String> getLocalBranches (Map<String, GitBranch> existingBranches) {
-        Set<String> branchNames = new HashSet<String>();
+        Set<String> branchNames = new HashSet<>();
         for (Map.Entry<String, GitBranch> e : existingBranches.entrySet()) {
             GitBranch branch = e.getValue();
             if (!branch.isRemote() && !GitBranch.NO_BRANCH.equals(branch.getName())) {

--- a/ide/versioning.util/src/org/netbeans/modules/versioning/util/DialogBoundsPreserver.java
+++ b/ide/versioning.util/src/org/netbeans/modules/versioning/util/DialogBoundsPreserver.java
@@ -22,8 +22,9 @@ import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.Rectangle;
+import java.awt.Window;
+import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.awt.event.WindowListener;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.prefs.Preferences;
@@ -36,44 +37,43 @@ import org.openide.util.Utilities;
  * 
  * @author Tomas Stupka
  */
-public class DialogBoundsPreserver implements WindowListener {
+public class DialogBoundsPreserver extends WindowAdapter {
 
     private static final String DELIMITER = "#";        // NOI18N
-    private Preferences preferences;
-    private String key;
+    private final Preferences preferences;
+    private final String key;
 
     public DialogBoundsPreserver(Preferences preferences, String key) {
         this.preferences = preferences;            
         this.key = key;
     }
 
+    /**
+     * Register window before it is opened to restore its bounds the next time it is opened.
+     * Bounds and position are stored on close.
+     */
+    public static void preserveAndRestore(Window window, Preferences preferences, String key) {
+        DialogBoundsPreserver preserver = new DialogBoundsPreserver(preferences, key);
+        window.addWindowListener(preserver);
+        // init bounds from storage before it is made visible
+        preserver.windowOpened(new WindowEvent(window, WindowEvent.WINDOW_OPENED));
+    }
+
+    @Override
     public void windowOpened(WindowEvent evt) {
         Rectangle r = getDialogBounds();        
-        if(r != null && checkBounds(r) ) {         
+        if (r != null && checkBounds(r)) {         
             evt.getWindow().setBounds(r);            
         }                
     }
-    public void windowClosing(WindowEvent evt) {
-        // ignore 
-    }
+
+    @Override
     public void windowClosed(WindowEvent evt) {
         Rectangle r = evt.getWindow().getBounds();
         if(checkBounds(r)) {
             setDialogBounds(r);   
         }   
     }
-    public void windowIconified(WindowEvent arg0) {
-        // ignore
-    }
-    public void windowDeiconified(WindowEvent arg0) {
-        // ignore
-    }
-    public void windowActivated(WindowEvent arg0) {
-        // ignore
-    }
-    public void windowDeactivated(WindowEvent arg0) {
-        // ignore
-    }    
 
     private boolean checkBounds(Rectangle r) {
         Rectangle[] screens = getScreenBounds();
@@ -88,19 +88,15 @@ public class DialogBoundsPreserver implements WindowListener {
     }   
 
     private void setDialogBounds(Rectangle r) {        
-        preferences.put(key, r.getX() + DELIMITER + r.getY() + DELIMITER + r.getWidth() + DELIMITER + r.getHeight());         // NOI18N   
+        preferences.put(key, r.getX() + DELIMITER + r.getY() + DELIMITER + r.getWidth() + DELIMITER + r.getHeight());
     }        
 
     private Rectangle getDialogBounds() {
         String size = preferences.get(key, DELIMITER);        
         if(size != null) {                                    
             String[] dim = size.split(DELIMITER);             
-            if(dim.length != 4 || 
-               dim[0].trim().equals("") ||                                      // NOI18N 
-               dim[1].trim().equals("") ||                                      // NOI18N
-               dim[2].trim().equals("") ||                                      // NOI18N    
-               dim[3].trim().equals("") )                                       // NOI18N
-            {
+            if (dim.length != 4 || dim[0].isBlank() || dim[1].isBlank()
+                                || dim[2].isBlank() || dim[3].isBlank()) {
                 return null;
             }
             Rectangle r = new Rectangle();
@@ -115,12 +111,12 @@ public class DialogBoundsPreserver implements WindowListener {
 
     private Rectangle[] getScreenBounds() {
         GraphicsDevice[] gds = GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices();
-        List<Rectangle> rects = new ArrayList<Rectangle>(gds.length);
+        List<Rectangle> rects = new ArrayList<>(gds.length);
         for (GraphicsDevice gd : gds) {
             GraphicsConfiguration gc = gd.getDefaultConfiguration();
             rects.add(Utilities.getUsableScreenBounds(gc));
         }
-        return rects.toArray(new Rectangle[0]);
+        return rects.toArray(Rectangle[]::new);
     }
     
 }

--- a/ide/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitPanel.java
+++ b/ide/versioning.util/src/org/netbeans/modules/versioning/util/common/VCSCommitPanel.java
@@ -34,7 +34,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import javax.swing.JButton;
 import org.netbeans.modules.versioning.util.DialogBoundsPreserver;
-import org.netbeans.modules.versioning.util.VersioningEvent;
 import org.openide.DialogDescriptor;
 import org.openide.util.HelpCtx;
 import java.awt.EventQueue;
@@ -74,8 +73,6 @@ import org.openide.NotifyDescriptor;
 import static java.awt.Component.CENTER_ALIGNMENT;
 import static java.awt.Component.LEFT_ALIGNMENT;
 import java.awt.event.KeyEvent;
-import java.awt.event.WindowEvent;
-import java.awt.event.WindowListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import javax.swing.Action;
@@ -115,13 +112,13 @@ public abstract class VCSCommitPanel<F extends VCSFileNode> extends AutoResizing
     private final JButton commitButton = new JButton();
     private final JButton cancelButton = new JButton();
         
-    private VCSCommitTable commitTable;
+    private final VCSCommitTable commitTable;
     
     private JTabbedPane tabbedPane;
         
     private final Preferences preferences;
     private final VCSCommitParameters parameters;
-    private final Map<String, VCSCommitFilter> filters = new LinkedHashMap<String, VCSCommitFilter>();
+    private final Map<String, VCSCommitFilter> filters = new LinkedHashMap<>();
     private final VCSCommitDiffProvider diffProvider;
     private final VCSCommitPanelModifier modifier;
     private static final String ERROR_COLOR;
@@ -586,25 +583,16 @@ public abstract class VCSCommitPanel<F extends VCSFileNode> extends AutoResizing
         
         final VCSCommitTable table = getCommitTable();
         computeNodes();
-        addVersioningListener(new VersioningListener() {
-            @Override
-            public void versioningEvent(VersioningEvent event) {
-                valuesChanged();
-            }
+        addVersioningListener(e -> {
+            valuesChanged();
         });
-        table.getTableModel().addTableModelListener(new TableModelListener() {
-            @Override
-            public void tableChanged(TableModelEvent e) {
-                valuesChanged();
-            }
+        table.getTableModel().addTableModelListener(e -> {
+            valuesChanged();
         });
 
-        final Dialog dialog = DialogDisplayer.getDefault().createDialog(dd);
-
-        WindowListener windowListener = new DialogBoundsPreserver(preferences, this.getClass().getName());
-        dialog.addWindowListener(windowListener);
+        Dialog dialog = DialogDisplayer.getDefault().createDialog(dd);
         dialog.pack();
-        windowListener.windowOpened(new WindowEvent(dialog, WindowEvent.WINDOW_OPENED));
+        DialogBoundsPreserver.preserveAndRestore(dialog, preferences, this.getClass().getName());
         dialog.setVisible(true);
         
         if (dd.getValue() == DialogDescriptor.CLOSED_OPTION) {


### PR DESCRIPTION
 - reuses the utility class from the revision selection window which already had that functionality
 - implemented for create and switch branch windows
 - refactored commit window to use the same utility

easiest way to access those windows (commit and create/switch branch) is via the git toolbar. The create-branch window has a select button which leads to the revision picker window. All 4 should persist their size now.