### PR TITLE
Handle null mimepath in DAPBreakpointActionProvider

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/breakpoints/DAPBreakpointActionProvider.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/breakpoints/DAPBreakpointActionProvider.java
@@ -53,6 +53,9 @@ extends ActionsProviderSupport implements PropertyChangeListener {
     private static final Map<String, BreakpointInfo> mimeType2BreakpointInfo = new HashMap<>();
 
     private static boolean hasMimeTypeDAPBreakpoints(String mimeType) {
+        if(mimeType == null) {
+            return false;
+        }
         synchronized (mimeType2BreakpointInfo) {
             return mimeType2BreakpointInfo.computeIfAbsent(mimeType, mt -> {
                 Result<RegisterDAPBreakpoints> result = MimeLookup.getLookup(mimeType).lookupResult(RegisterDAPBreakpoints.class);


### PR DESCRIPTION
It was observed, that there can be situation where DAPBreakpointActionProvider is invoked on a document without mime path in that case an assertion is hit.

Improve handling of that case by indicating, that break points are not supported in that case.

```
java.lang.AssertionError: path cannot be null
                at org.netbeans.api.editor.mimelookup.MimePath.parse(MimePath.java:201)
                at org.netbeans.api.editor.mimelookup.MimeLookup.getLookup(MimeLookup.java:111)
                at org.netbeans.modules.lsp.client.debugger.breakpoints.DAPBreakpointActionProvider.lambda$hasMimeTypeDAPBreakpoints$1(DAPBreakpointActionProvider.java:58)
                at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1228)
                at org.netbeans.modules.lsp.client.debugger.breakpoints.DAPBreakpointActionProvider.hasMimeTypeDAPBreakpoints(DAPBreakpointActionProvider.java:57)
                at org.netbeans.modules.lsp.client.debugger.breakpoints.DAPBreakpointActionProvider.isRelevantFile(DAPBreakpointActionProvider.java:133)
                at org.netbeans.modules.lsp.client.debugger.breakpoints.DAPBreakpointActionProvider.getCurrentLine(DAPBreakpointActionProvider.java:123)
                at org.netbeans.modules.lsp.client.debugger.breakpoints.DAPBreakpointActionProvider.propertyChange(DAPBreakpointActionProvider.java:140)
                at org.openide.util.WeakListenerImpl$PropertyChange.propertyChange(WeakListenerImpl.java:189)
                at java.desktop/java.beans.PropertyChangeSupport.fire(PropertyChangeSupport.java:343)
                at java.desktop/java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:335)
                at org.netbeans.spi.debugger.ui.EditorContextDispatcher.firePropertyChange(EditorContextDispatcher.java:521)
                at org.netbeans.spi.debugger.ui.EditorContextDispatcher.access$2000(EditorContextDispatcher.java:101)
                at org.netbeans.spi.debugger.ui.EditorContextDispatcher$EventFirer.run(EditorContextDispatcher.java:990)
                at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1403)
                at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
                at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
                at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2018)
Caused: org.openide.util.RequestProcessor$SlowItem
                at org.openide.util.RequestProcessor.post(RequestProcessor.java:395)
                at org.netbeans.spi.debugger.ui.EditorContextDispatcher$EditorLookupListener.lookupChanged(EditorContextDispatcher.java:700)
                at org.netbeans.spi.debugger.ui.EditorContextDispatcher$EditorLookupListener.coalescedLookupChanged(EditorContextDispatcher.java:659)
                at org.netbeans.spi.debugger.ui.EditorContextDispatcher$EditorLookupListener.resultChanged(EditorContextDispatcher.java:622)
                at org.openide.util.lookup.SimpleProxyLookup.checkLookup(SimpleProxyLookup.java:89)
                at org.openide.util.lookup.SimpleProxyLookup.lookup(SimpleProxyLookup.java:134)
                at org.netbeans.modules.openide.windows.GlobalActionContextImpl.propertyChange(GlobalActionContextImpl.java:169)
                at java.desktop/java.beans.PropertyChangeSupport.fire(PropertyChangeSupport.java:343)
                at java.desktop/java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:335)
                at java.desktop/java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:268)
                at org.netbeans.core.windows.RegistryImpl.doFirePropertyChange(RegistryImpl.java:304)
                at org.netbeans.core.windows.RegistryImpl.access$100(RegistryImpl.java:44)
                at org.netbeans.core.windows.RegistryImpl$1.run(RegistryImpl.java:145)
                at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
                at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:773)
                at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
                at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
                at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
                at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
                at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
                at org.netbeans.core.TimableEventQueue.dispatchEvent(TimableEventQueue.java:136)
                at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
                at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
                at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
                at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
                at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
[catch] at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```