### PR TITLE
[GH 8334] PHP do not display override hint for constructors

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/AddOverrideAttributeHint.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/AddOverrideAttributeHint.java
@@ -159,6 +159,10 @@ public class AddOverrideAttributeHint extends HintRule {
             if (CancelSupport.getDefault().isCancelled()) {
                 return;
             }
+            if (CodeUtils.isConstructor(method)) {
+                // Override on constructor results in compile Error (checked in PHP 8.4)
+                return;
+            }
             Identifier methodName = method.getFunction().getFunctionName();
             AddOverrideFix fix = new AddOverrideFix(document, method, ts);
             hints.add(new Hint(AddOverrideAttributeHint.this,

--- a/php/php.editor/test/unit/data/testfiles/verification/AddOverrideAttributeHint/testNoOverrideHintOnConstructor_01.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/AddOverrideAttributeHint/testNoOverrideHintOnConstructor_01.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class newPHPClass {
+
+    public function __construct() {
+
+    }
+}
+
+class newPHPClass1 extends newPHPClass {
+
+    public function __construct() {
+        parent::__construct();
+    }
+}
+
+$anon = new class extends newPHPClass {
+
+    public function __construct() {
+        parent::__construct();
+    }
+};

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/AddOverrideAttributeHintTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/AddOverrideAttributeHintTest.java
@@ -507,6 +507,10 @@ public class AddOverrideAttributeHintTest extends PHPHintsTestBase {
         applyHint("testRemoveOverrideAbstractClass_01.php", "    #[\\Overr^ide] // test", "Remove \"#[\\Override]\" Attribute");
     }
 
+    public void testNoOverrideHintOnConstructor_01() throws Exception{
+        checkHints("testNoOverrideHintOnConstructor_01.php");
+    }
+
     private void checkHints(String fileName, PhpVersion phpVersion) throws Exception {
         checkHints(new AddOverrideAttributeHintStub(phpVersion), fileName);
     }


### PR DESCRIPTION
The following leads to a compile error in PHP - so we should not display the Add Override hint for constructors.
```php
<?php
class newPHPClass {

    public function __construct() {

    }
}

class newPHPClass1 extends newPHPClass {
    #[\Override]
    public function __construct() {
        parent::__construct();
    }
}

$anon = new class extends newPHPClass {
    #[\Override]
    public function __construct() {
        parent::__construct();
    }
};

```

Before:
![00_before](https://github.com/user-attachments/assets/0e1bae7a-44b5-4787-af1e-b7968efb0402)

After:
![00_after](https://github.com/user-attachments/assets/76f69a84-78f8-458b-b63f-2f64b3d361e0)


---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>