### PR TITLE
PHP: If a function or method does not have a return operator, the @return void tag is generated when generating a phpDoc

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/typinghooks/PhpCommentGenerator.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/typinghooks/PhpCommentGenerator.java
@@ -114,6 +114,8 @@ public final class PhpCommentGenerator {
 
         if (i.hasReturn) {
             generateDocEntry(doc, toAdd, "@return", indent, null, i.getReturnType()); // NOI18N
+        } else {
+            generateDocEntry(doc, toAdd, "@return", indent, null, Type.VOID); // NOI18N
         }
 
         addVariables(doc, toAdd, "@throws", indent, i.throwsExceptions);

--- a/php/php.editor/test/unit/data/testfiles/bracketCompleter/issue193118_01.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/bracketCompleter/issue193118_01.php.indented
@@ -1,7 +1,8 @@
 <?php
 
 /**
- * ^
+ * 
+ * @return void^
  */
 function f(){
   $r= '/.*/';

--- a/php/php.editor/test/unit/data/testfiles/bracketCompleter/issue193118_02.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/bracketCompleter/issue193118_02.php.indented
@@ -1,7 +1,8 @@
 <?php
 
 /**
- * ^
+ * 
+ * @return void^
  */
 function f(){
   $r= '/./*';

--- a/php/php.editor/test/unit/data/testfiles/bracketCompleter/issue197924_01.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/bracketCompleter/issue197924_01.php.indented
@@ -2,7 +2,8 @@
 
 /**
  * 
- * @param type $alias^
+ * @param type $alias
+ * @return void^
  */
 function func($alias) {
     $blah = "/blee*/";

--- a/php/php.editor/test/unit/data/testfiles/bracketCompleter/issue197924_02.php.indented
+++ b/php/php.editor/test/unit/data/testfiles/bracketCompleter/issue197924_02.php.indented
@@ -2,7 +2,8 @@
 
 /**
  * 
- * @param type $alias^
+ * @param type $alias
+ * @return void^
  */
 function func($alias) {
     $blah = "/blee/*";

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/typinghooks/PhpCommentGeneratorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/typinghooks/PhpCommentGeneratorTest.java
@@ -51,7 +51,8 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                             "<?php\n" +
                             "/**\n" +
                             " * \n" +
-                            " * @param " + PhpCommentGenerator.TYPE_PLACEHOLDER + " $i^\n" +
+                            " * @param " + PhpCommentGenerator.TYPE_PLACEHOLDER + " $i\n" +
+                            " * @return void^\n" +
                             " */\n" +
                             "function foo($i) {\n" +
                             "}\n" +
@@ -70,7 +71,8 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                             "$r = 1;\n" +
                             "/**\n" +
                             " * \n" +
-                            " * @global int $r^\n" +
+                            " * @global int $r\n" +
+                            " * @return void^\n" +
                             " */\n" +
                             "function foo() {\n" +
                             "    global $r;\n" +
@@ -88,7 +90,8 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                             "<?php\n" +
                             "/**\n" +
                             " * \n" +
-                            " * @staticvar " + PhpCommentGenerator.TYPE_PLACEHOLDER + " $r^\n" +
+                            " * @staticvar " + PhpCommentGenerator.TYPE_PLACEHOLDER + " $r\n" +
+                            " * @return void^\n" +
                             " */\n" +
                             "function foo() {\n" +
                             "    static $r;\n" +
@@ -159,7 +162,8 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                             "class foo {\n" +
                             "    /**\n" +
                             "     * \n" +
-                            "     * @param " + PhpCommentGenerator.TYPE_PLACEHOLDER + " $par^\n" +
+                            "     * @param " + PhpCommentGenerator.TYPE_PLACEHOLDER + " $par\n" +
+                            "     * @return void^\n" +
                             "     */\n" +
                             "    function bar($par) {\n" +
                             "    }\n" +
@@ -206,7 +210,8 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                 "?>", "<?php\n" +
                 "class MyCls {\n" +
                 "    /**\n" +
-                "     * ^\n" +
+                "     * \n" +
+                "     * @return void^\n" +
                 "     */\n" +
                 "    public static function beginRequest()\n" +
                 "    {\n" +
@@ -233,7 +238,8 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                 "interface Iface1 {\n" +
                 "    /**\n" +
                 "     * \n" +
-                "     * @param type $param^\n" +
+                "     * @param type $param\n" +
+                "     * @return void^\n" +
                 "     */\n" +
                 "    public function faceFnc($param);\n" +
                 "}\n" +
@@ -254,7 +260,8 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                 "class Test {\n" +
                 "    /**\n" +
                 "     * \n" +
-                "     * @param SomeClass $someClass^\n" +
+                "     * @param SomeClass $someClass\n" +
+                "     * @return void^\n" +
                 "     */\n" +
                 "    public function getSomething(SomeClass $someClass) {}\n" +
                 "}";
@@ -275,7 +282,8 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                 "class Test {\n" +
                 "    /**\n" +
                 "     * \n" +
-                "     * @param SomeClassAlias $someClass^\n" +
+                "     * @param SomeClassAlias $someClass\n" +
+                "     * @return void^\n" +
                 "     */\n" +
                 "    public function getSomething(SomeClassAlias $someClass) {}\n" +
                 "}";
@@ -295,7 +303,8 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                 "<?php\n"
                 + "/**\n"
                 + " * \n"
-                + " * @param " + PhpCommentGenerator.TYPE_PLACEHOLDER + " $i^\n"
+                + " * @param " + PhpCommentGenerator.TYPE_PLACEHOLDER + " $i\n"
+                + " * @return void^\n"
                 + " */\n"
                 + "function foo(...$i) {\n"
                 + "}\n"
@@ -319,7 +328,8 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                 + "class foo {\n"
                 + "    /**\n"
                 + "     * \n"
-                + "     * @param " + PhpCommentGenerator.TYPE_PLACEHOLDER + " $par^\n"
+                + "     * @param " + PhpCommentGenerator.TYPE_PLACEHOLDER + " $par\n"
+                + "     * @return void^\n"
                 + "     */\n"
                 + "    function bar(&...$par) {\n"
                 + "    }\n"
@@ -351,7 +361,8 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                 + "class Bar {\n"
                 + "    /**\n"
                 + "     * \n"
-                + "     * @param callable $callable^\n"
+                + "     * @param callable $callable\n"
+                + "     * @return void^\n"
                 + "     */\n"
                 + "    function callableType(callable $callable) {\n"
                 + "        //...\n"
@@ -384,7 +395,8 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                 + "class Bar {\n"
                 + "    /**\n"
                 + "     * \n"
-                + "     * @param int $int^\n"
+                + "     * @param int $int\n"
+                + "     * @return void^\n"
                 + "     */\n"
                 + "    function intType(int $int) {\n"
                 + "        //...\n"
@@ -417,7 +429,8 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                 + "class Bar {\n"
                 + "    /**\n"
                 + "     * \n"
-                + "     * @param iterable $iterable^\n"
+                + "     * @param iterable $iterable\n"
+                + "     * @return void^\n"
                 + "     */\n"
                 + "    function iterableType(iterable $iterable) {\n"
                 + "        //...\n"


### PR DESCRIPTION
If a function or method does not have a `return` operator, the `@return void` tag is generated when generating a phpDoc.

before:

https://github.com/user-attachments/assets/f14a7c14-53aa-4e77-9678-430e18da882a




after:

https://github.com/user-attachments/assets/ad873709-c2e9-4387-84b2-ed805af0c51f





---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [ ] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [ ] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [ ] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [ ] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>