### PR TITLE
Icon fix: Interface and Abstract class are not distinguished

### DIFF
--- a/java/java.source/src/org/netbeans/modules/java/JavaNode.java
+++ b/java/java.source/src/org/netbeans/modules/java/JavaNode.java
@@ -101,7 +101,9 @@ public final class JavaNode extends DataNode implements ChangeListener {
     private static final long serialVersionUID = -7396485743899766258L;
 
     private static final String JAVA_ICON_BASE = "org/netbeans/modules/java/resources/class.png"; // NOI18N
+    private static final String JAVA_ICON_BASE_SVG = "org/netbeans/modules/java/resources/class.svg"; // NOI18N
     private static final String CLASS_ICON_BASE = "org/netbeans/modules/java/resources/clazz.gif"; // NOI18N
+    private static final String CLASS_ICON_BASE_SVG = "org/netbeans/modules/java/resources/clazz.svg"; // NOI18N
     private static final String ABSTRACT_CLASS_ICON_BASE = "org/netbeans/modules/java/resources/abstract_class_file.png"; //NOI18N
     private static final String INTERFACE_ICON_BASE = "org/netbeans/modules/java/resources/interface_file.png"; //NOI18N
     private static final String ENUM_ICON_BASE = "org/netbeans/modules/java/resources/enum_file.png";   //NOI18N
@@ -566,7 +568,9 @@ public final class JavaNode extends DataNode implements ChangeListener {
             final Object attrValue = parent.getProperty("url", null);   //NOI18N
             if (attrValue instanceof URL) {
                 final String url = attrValue.toString();
-                if (!(isJavaSource ? url.endsWith(JAVA_ICON_BASE) : url.endsWith(CLASS_ICON_BASE))) {
+                if (!(url.endsWith(isJavaSource ? JAVA_ICON_BASE : CLASS_ICON_BASE) ||
+                    url.endsWith(isJavaSource ? JAVA_ICON_BASE_SVG : CLASS_ICON_BASE_SVG)))
+                {
                     return parent;
                 }
             }


### PR DESCRIPTION
As reported at https://github.com/apache/netbeans/issues/8358 , the icons for abstract classes and interfaces had regressed to becoming the regular class icon. This was caused by the introduction of SVG icons for these and many others in https://github.com/apache/netbeans/pull/8083 .

The bug was due to a special piece of logic in JavaNode that actually checked for the file name of the icon. Since the file name now ends with ".svg", the behavior changed.

I could not immediately find any other similar cases.