### PR TITLE
apidoc rewrite to jdk 23 layout (minimal)

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/Arch.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/Arch.java
@@ -115,6 +115,14 @@ public class Arch extends Task implements ErrorHandler, EntityResolver, URIResol
     public void setFooter(String s) {
         footer = s;
     }
+    private String header="";
+    public void setHeader(String s) {
+        header = s;
+    }
+    private boolean deprecatedmenu=false;
+    public void setDeprecatedMenu(boolean b) {
+        deprecatedmenu = b;
+    }
     private File xsl = null;
     public void setXSL (File xsl) {
         this.xsl = xsl;
@@ -480,6 +488,8 @@ public class Arch extends Task implements ErrorHandler, EntityResolver, URIResol
                 if (footer != null) {
                     t.setParameter("arch.footer", footer);
                 }
+                t.setParameter("javadoc-header", header);
+                t.setParameter("deprecated", deprecatedmenu);
                 t.setParameter("arch.answers.date", DateFormat.getDateInstance().format(new Date(questionsFile.lastModified())));
                 
                 String archTarget = output.toString();

--- a/nbbuild/antsrc/org/netbeans/nbbuild/Arch.xsl
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/Arch.xsl
@@ -33,7 +33,8 @@
     <xsl:param name="arch.footer"/>
     <xsl:param name="arch.answers.date"/>
     <xsl:param name="arch.when"/>
-
+    <xsl:param name="javadoc-header" />
+    <xsl:param name="deprecated" />
     <xsl:template match="/">
         <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;</xsl:text>
         <html lang="en">
@@ -43,86 +44,99 @@
                 <xsl:if test="$arch.stylesheet">
                     <link rel="stylesheet" type="text/css" href="{$arch.stylesheet}"/>
                 </xsl:if>
+                <xsl:if test="$javadoc-header">
+                 <link rel="stylesheet" type="text/css" href="resource-files/javadoc.css" title="Style"/>
+                 <script type="text/javascript" src="script-files/script.js"></script>
+                 <script type="text/javascript" src="script-files/jquery-3.7.1.min.js"></script>
+                 <script type="text/javascript" src="script-files/jquery-ui.min.js"></script>
+                </xsl:if>
             </head>
             <body>
+             <script type="text/javascript">var pathtoroot = "./";
+              loadScripts(document, 'script');</script>
+             <noscript>
+              <div>JavaScript is disabled on your browser.</div>
+             </noscript>
+              <header role="banner">
+               <nav role="navigation">
                 <!-- ========= START OF TOP NAVBAR ======= -->
-                <div class="topNav">
-                    <a name="navbar.top">
-                        <!--   -->
-                    </a>
-                    <div class="skipNav">
-                        <a href="#skip.navbar.top" title="Skip navigation links">Skip navigation links</a>
-                    </div>
-                    <a name="navbar.top.firstrow">
-                        <!--   -->
-                    </a>
-                    <ul class="navList noreplace" title="Navigation">
-                        <li>
-                            <a href="apichanges.html">API Changes</a>
-                        </li>
-                        <li class="navBarCell1Rev">Architecture Summary</li>
-                        <li><a href="overview-summary.html">Overview</a></li>
-                        <li>Package</li>
-                        <li>Class</li>
-                        <li>Use</li>
-                        <li>Tree</li>
-                        <li>
-                            <a href="deprecated-list.html">Deprecated</a>
-                        </li>
-                        <li>Index</li>
-                        <li>
-                            <a href="help-doc.html">Help</a>
-                        </li>
-                    </ul>
-                    <div class="aboutLanguage"> </div>
+                <div class="top-nav" id="navbar-top">
+                 <div class="nav-content">
+                  <div class="nav-menu-button">
+                   <button id="navbar-toggle-button" aria-controls="navbar-top" aria-expanded="false" aria-label="Toggle navigation links">
+                    <span class="nav-bar-toggle-icon">
+                     <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
+                    </span>
+                    <span class="nav-bar-toggle-icon">
+                     <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
+                    </span>
+                    <span class="nav-bar-toggle-icon">
+                     <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
+                    </span>
+                   </button>
+                  </div>
+                  <div class="skip-nav">
+                   <a href="#skip-navbar-top" title="Skip navigation links">Skip navigation links</a>
+                  </div>
+
+                  <ul id="navbar-top-firstrow" class="nav-list" title="Navigation">
+                   <li>
+                    <a href="apichanges.html">API Changes</a>
+                   </li>
+                   <li class="nav-bar-cell1-rev">Architecture Summary
+                   </li>
+                   <li>
+                    <a href="index.html">Overview</a>
+                   </li>
+                   <li>
+                    <a href="overview-tree.html">Tree</a>
+                   </li>
+                   <xsl:if test="$deprecated='true'">
+                       <li>
+                           <a href="deprecated-list.html">Deprecated</a>
+                       </li>   
+                   </xsl:if>
+                   <li>
+                    <a href="index-files/index-1.html">Index</a>
+                   </li>
+                   <li><a href="search.html">Search</a></li>
+                   <li>
+                    <a href="help-doc.html#overview">Help</a>
+                   </li>
+                  </ul>
+
+                  <div class="about-language">
+                   <xsl:value-of select="$javadoc-header"/>
+                  </div>
+                 </div>
                 </div>
-                <div class="subNav">
-                    <ul class="navList">
-                        <li>
-                            <a href="index.html?overview-summary.html" target="_top">Frames</a>
-                        </li>
-                        <li>
-                            <a href="overview-summary.html" target="_top">No Frames</a>
-                        </li>
-                    </ul>
-                    <ul class="navList" id="allclasses_navbar_top">
-                        <li>
-                            <a href="allclasses-noframe.html">All Classes</a>
-                        </li>
-                    </ul>
-                    <div>
-                        <script type="text/javascript"><!--
-  allClassesLink = document.getElementById("allclasses_navbar_top");
-  if(window==top) {
-    allClassesLink.style.display = "block";
-  }
-  else {
-    allClassesLink.style.display = "none";
-  }
-  //-->
-                        </script>
-                    </div>
-                    <a name="skip.navbar.top">
-                        <!--   -->
-                    </a>
+                <div class="sub-nav">
+                 <div class="nav-content">
+                  <ol class="sub-nav-list"></ol>
+                  <div class="nav-list-search">
+                   <input type="text" id="search-input" disabled="disabled" placeholder="Search" aria-label="Search in documentation" autocomplete="off"/>
+                   <input type="reset" id="reset-search" disabled="disabled" value="Reset"/>
+                  </div>
+                 </div>
                 </div>
                 <!-- ========= END OF TOP NAVBAR ========= -->
-                <!--<xsl:if test="$arch.overviewlink">
-                    <p class="overviewlink"><a href="{$arch.overviewlink}">Overview</a></p>
-                </xsl:if>
-            -->
+                <span class="skip-nav" id="skip-navbar-top"></span>
+               </nav>
+              </header>
+              <div class="main-grid">
+               <main role="main">
                 <h1>NetBeans Architecture Answers for <xsl:value-of select="api-answers/@module" /><xsl:text> module</xsl:text></h1>
-                
+
                 <xsl:variable name="qver" select="api-answers/api-questions/@version"/>
                 <xsl:variable name="afor" select="api-answers/@question-version" />
-                
+
                 <ul>
                 <li><b>Author:</b><xsl:text> </xsl:text><xsl:value-of select="api-answers/@author" /></li>
                 <li><b>Answers as of:</b><xsl:text> </xsl:text><xsl:value-of select="$arch.answers.date"/></li>
                 <li><b>Answers for questions version:</b><xsl:text> </xsl:text><xsl:value-of select="$afor" /></li>
                 <li><b>Latest available version of questions:</b><xsl:text> </xsl:text><xsl:value-of select="$qver" /></li>
                 </ul>
-                
+
                 <xsl:if test="not($qver=$afor)">
                     <strong>
                         WARNING: answering questions version <xsl:value-of select="$afor"/>
@@ -130,29 +144,31 @@
                     </strong>
                 </xsl:if>
 
-                <hr/>            
+                <hr/>
                 <h2>Interfaces table</h2>
 
                 <xsl:call-template name="generate-api-table">
                     <xsl:with-param name="target" >api-group</xsl:with-param>
                 </xsl:call-template>
-                
-                
+
+
                 <xsl:variable name="all_interfaces" select="//api" />
                 <xsl:if test="not($all_interfaces)" >
                     <b> WARNING: No imported or exported interfaces! </b>
                 </xsl:if>
 
-                <xsl:apply-templates />    
-                
+                <xsl:apply-templates />
+
                 <xsl:if test="$arch.footer">
                     <hr/>
                     <p><xsl:value-of select="$arch.footer"/></p>
                 </xsl:if>
+               </main>
+              </div>
             </body>
         </html>
     </xsl:template>
-    
+
     <xsl:template match="category">
         <hr/>
         <h2>
@@ -164,17 +180,17 @@
             </xsl:for-each>
         </ul>
     </xsl:template>
-    
+
 
     <xsl:template name="answer">
         <xsl:variable name="value" select="@id" />
-    
+
         <p/>
         <font color="gray" >
         <b><a name="answer-{@id}">Question (<xsl:value-of select="@id"/>)</a>:</b> <em><xsl:apply-templates select="./node()" /></em>
         </font>
         <p/>
-        
+
         <xsl:choose>
             <xsl:when test="count(//answer[@id=$value])" >
                 <b>Answer:</b> <!-- <xsl:value-of select="//answer[@id=$value]" /> -->
@@ -183,7 +199,7 @@
             <xsl:when test="string-length($arch.when)=0 or contains($arch.when,@when)" >
                 <b>WARNING:</b>
                 <xsl:text> Question with id="</xsl:text>
-                <i> 
+                <i>
                 <xsl:value-of select="@id" />
                 </i>
                 <xsl:text>" has not been answered!</xsl:text>
@@ -198,7 +214,7 @@
         <!-- generates link to given API -->
         <xsl:variable name="name" select="@name" />
         <xsl:variable name="group" select="@group" />
-        
+
         <a>
             <xsl:attribute name="href" >
                 <xsl:text>#</xsl:text><xsl:value-of select="$group" /><xsl:text>-</xsl:text><xsl:value-of select="$name" />
@@ -215,23 +231,23 @@
         <h4><xsl:value-of select="@name" /></h4>
         <xsl:apply-templates select="./node()" />
     </xsl:template>
-    
+
     <!-- Format random HTML elements as is: -->
     <xsl:template match="@*|node()">
         <xsl:copy>
             <xsl:apply-templates select="@*|node()"/>
         </xsl:copy>
     </xsl:template>
-  
-  
+
+
     <xsl:template match="answer">
         <!-- ignore direct answers -->
     </xsl:template>
     <xsl:template match="hint">
         <!-- ignore direct answers -->
     </xsl:template>
-    
-    <!-- enumerates all groups of APIs and calls given template 
+
+    <!-- enumerates all groups of APIs and calls given template
       on each of them
     -->
     <xsl:template name="generate-api-table" >
@@ -239,7 +255,7 @@
         <xsl:param name="generate-export" select="'true'" />
         <xsl:param name="generate-import" select="'true'" />
         <xsl:param name="generate-group" select="''" />
-    
+
         <xsl:for-each select="//api[
             generate-id() = generate-id(key('apiGroups', @group))
             and
@@ -253,13 +269,13 @@
             </xsl:call-template>
         </xsl:for-each>
 
-    </xsl:template>    
+    </xsl:template>
     <xsl:template name="jump-to-target" >
         <xsl:param name="target" />
         <xsl:param name="group" />
         <xsl:param name="generate-export" />
         <xsl:param name="generate-import" />
-        
+
         <xsl:choose>
             <xsl:when test="$target='api-group'" >
                 <xsl:call-template name="api-group">
@@ -275,32 +291,32 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    
+
 
     <!-- displays group of APIs -->
-    
+
     <xsl:template name="api-group" >
         <xsl:param name="group" />
         <xsl:param name="generate-export" />
         <xsl:param name="generate-import" />
-        
+
         <xsl:element name="h3">
             <xsl:attribute name="id" >
                 <xsl:text>group-</xsl:text><xsl:value-of select="$group" />
             </xsl:attribute>
             Group of <xsl:value-of select="$group"/> interfaces
-        </xsl:element>       
-        
-        <xsl:variable 
-            name="all_interfaces" 
-            select="//api[@group=$group and 
+        </xsl:element>
+
+        <xsl:variable
+            name="all_interfaces"
+            select="//api[@group=$group and
                           generate-id() = generate-id(key('apiNames', @name)) and
                           (
-                            ($generate-export = 'true' and @type = 'export') 
+                            ($generate-export = 'true' and @type = 'export')
                             or
-                            ($generate-import = 'true' and @type = 'import') 
+                            ($generate-import = 'true' and @type = 'import')
                           )
-                  ]" 
+                  ]"
         />
         <!--<table class="tablebg"><tr><td>-->
         <table class="tableapigroup">
@@ -326,10 +342,10 @@
             </xsl:for-each>
             </tbody>
           </table>
-        <!--</td></tr></table>-->        
-    </xsl:template>    
-    
-    <!-- the template to convert an instances of API into an HTML line in a table 
+        <!--</td></tr></table>-->
+    </xsl:template>
+
+    <!-- the template to convert an instances of API into an HTML line in a table
       describing the API -->
 
     <xsl:template name="api-group-name" >
@@ -337,12 +353,12 @@
        <xsl:param name="group" />
        <xsl:param name="category" />
        <xsl:param name="type" />
-       
+
         <tr class="tabler">
             <td>
                 <xsl:value-of select="$name"/>
             </td>
-            <xsl:if test="$type" > 
+            <xsl:if test="$type" >
                 <td> <!-- imported/exported -->
                     <xsl:choose>
                         <xsl:when test="$type='import'">Imported</xsl:when>
@@ -390,9 +406,9 @@
                             </xsl:message>
                         </xsl:otherwise>
                     </xsl:choose>
-                </a>  
+                </a>
             </td>
-            
+
             <td> <!-- description -->
                 <!-- Put anchor here, since name is centered, and we want hyperlinks to scroll to top of table row: -->
                 <a>
@@ -404,10 +420,10 @@
                         <xsl:with-param name="name" select="$name"/>
                         <xsl:with-param name="group" select="$group"/>
                     </xsl:call-template>
-                
+
             </td>
         </tr>
-    </xsl:template>  
+    </xsl:template>
     <xsl:template name="describe">
        <xsl:param name="name" />
        <xsl:param name="group" />
@@ -417,7 +433,7 @@
             <xsl:variable name="describe.node" select="./node()" />
 
             <xsl:variable name="before-hash-sign" select="substring-before(@url,'#')" />
-            
+
             <xsl:if test="@url" >
                 <a>
                     <xsl:attribute name="href" >
@@ -430,7 +446,7 @@
                         <xsl:when test="$before-hash-sign" >
                             <xsl:value-of select="$before-hash-sign" />
                         </xsl:when>
-                        
+
                         <xsl:when test="string-length(@url) > 40">
                             .../<xsl:value-of select="substring-after(substring(@url, string-length(@url) - 40),'/')" />
                         </xsl:when>
@@ -438,14 +454,14 @@
                             <xsl:value-of select="@url" />
                         </xsl:otherwise>
                     </xsl:choose>
-                    
-                </a>                
+
+                </a>
             </xsl:if>
-            
+
             <xsl:if test="$describe.node" >
                 <xsl:apply-templates select="$describe.node" />
             </xsl:if>
        </xsl:for-each>
     </xsl:template>
-        
-</xsl:stylesheet> 
+
+</xsl:stylesheet>

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
@@ -144,7 +144,7 @@ public class CheckLinks extends MatchingTask {
         JUnitReportWriter.writeReport(this, null, report, Collections.singletonMap("testBrokenLinks", testMessage));
     }
     
-    private static Pattern hrefOrAnchor = Pattern.compile("<(a|img|link|h1|h2|h3|h4|li|span)(\\s+shape=\"rect\")?(?:\\s+rel=\"stylesheet\")?\\s+(href|name|id|src)=\"([^\"#]*)(#[^\"$]+)?\"(\\s+shape=\"rect\")?(?:\\s+type=\"text/css\")?\\s*/?>", Pattern.CASE_INSENSITIVE);
+    private static Pattern hrefOrAnchor = Pattern.compile("<(a|code|div|img|link|h1|h2|h3|h4|li|section|span)(\\s+class=\"[\\w\\-]*\")?(\\s+shape=\"rect\")?(?:\\s+rel=\"stylesheet\")?\\s+(href|name|id|src)=\"([^\"#]*)(#[^\"$]+)?\"(\\s+shape=\"rect\")?(?:\\s+type=\"text/css\")?(\\s+class=\"[\\w\\-]*\")?\\s*/?>", Pattern.CASE_INSENSITIVE);
     private static Pattern lineBreak = Pattern.compile("^", Pattern.MULTILINE);
     
     /**
@@ -470,15 +470,15 @@ public class CheckLinks extends MatchingTask {
             Set<String> names = new HashSet<>(100); // Set<String>
             while (m.find()) {
                 // Get the stuff involved:
-                String type = m.group(3);
-                if (type.equalsIgnoreCase("name") || (type.equalsIgnoreCase("id") && !unescape(m.group(4)).startsWith("#"))) {
+                String type = m.group(4);
+                if (type.equalsIgnoreCase("name") || (type.equalsIgnoreCase("id") && !unescape(m.group(5)).startsWith("#"))) {
                     // We have an anchor, therefore refs to it are valid.
-                    String name = unescape(m.group(4));
+                    String name = unescape(m.group(5));
                     if (names.add(name)) {
                         try {
                             //URI does not handle jar:file: protocol
                             //okurls.add(new URI(base.getScheme(), base.getUserInfo(), base.getHost(), base.getPort(), base.getPath(), base.getQuery(), /*fragment*/name));
-                            okurls.add(new URI(base + "#" + name.replaceAll(" ", "%20")));
+                            okurls.add(new URI(base + "#" + name.replace(" ", "%20").replace("<", "%3C").replace(">", "%3E").replace("[", "%5B").replace("]", "%5D")));
                         } catch (URISyntaxException e) {
                             errors.add(normalize(basepath, mappers) + findLocation(content, m.start(4)) + ": bad anchor name: " + e.getMessage());
                         }
@@ -498,10 +498,10 @@ public class CheckLinks extends MatchingTask {
                     }
 
                     if (others != null && !commentedOut) {
-                        String otherbase = unescape(m.group(4));
-                        String otheranchor = unescape(m.group(5));
+                        String otherbase = unescape(m.group(5));
+                        String otheranchor = unescape(m.group(6));
                         String uri = (otheranchor == null) ? otherbase : otherbase + otheranchor;
-                        String location = findLocation(content, m.start(4));
+                        String location = findLocation(content, m.start(5));
                         String fixedUri;
                         if (uri.indexOf(' ') != -1) {
                             fixedUri = uri.replaceAll(" ", "%20");

--- a/nbbuild/javadoctools/apichanges.xsl
+++ b/nbbuild/javadoctools/apichanges.xsl
@@ -68,7 +68,8 @@ committed to the repository for legal reasons. You need to download it:
     <xsl:param name="issue-url-base" select="'https://bz.apache.org/netbeans/show_bug.cgi?id='"/>
     <xsl:param name="apache-issue-url-base" select="'https://issues.apache.org/jira/browse/'"/>
     <xsl:param name="javadoc-url-base" select="'???'"/>
-
+    <xsl:param name="javadoc-header" />
+    <xsl:param name="deprecated" />
     <!-- Main document structure: -->
     <xsl:template match="/">
         <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;</xsl:text>
@@ -76,73 +77,86 @@ committed to the repository for legal reasons. You need to download it:
             <head>
                 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
                 <xsl:apply-templates select="apichanges/htmlcontents/head/title"/>
-                <link rel="stylesheet" type="text/css" href="javadoc.css" title="Style"/>
-                <script type="text/javascript" src="script.js"></script>
+                <link rel="stylesheet" type="text/css" href="resource-files/javadoc.css" title="Style"/>
+                <script type="text/javascript" src="script-files/script.js"></script>
+                <script type="text/javascript" src="script-files/jquery-3.7.1.min.js"></script>
+                <script type="text/javascript" src="script-files/jquery-ui.min.js"></script>
             </head>
             <body>
-                <!-- ========= START OF TOP NAVBAR ======= -->
-                <div class="topNav">
-                    <a name="navbar.top">
-                        <!--   -->
-                    </a>
-                    <div class="skipNav">
-                        <a href="#skip.navbar.top" title="Skip navigation links">Skip navigation links</a>
+                <script type="text/javascript">var pathtoroot = "./";
+                 loadScripts(document, 'script');</script>
+                <noscript>
+                 <div>JavaScript is disabled on your browser.</div>
+                </noscript>
+                 <header role="banner">
+                  <nav role="navigation">
+                   <!-- ========= START OF TOP NAVBAR ======= -->
+                   <div class="top-nav" id="navbar-top">
+                    <div class="nav-content">
+                     <div class="nav-menu-button">
+                      <button id="navbar-toggle-button" aria-controls="navbar-top" aria-expanded="false" aria-label="Toggle navigation links">
+                       <span class="nav-bar-toggle-icon">
+                        <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
+                       </span>
+                       <span class="nav-bar-toggle-icon">
+                        <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
+                       </span>
+                       <span class="nav-bar-toggle-icon">
+                        <xsl:text disable-output-escaping="yes">&amp;nbsp;</xsl:text>
+                       </span>
+                      </button>
+                     </div>
+                     <div class="skip-nav">
+                      <a href="#skip-navbar-top" title="Skip navigation links">Skip navigation links</a>
+                     </div>
+                     <ul id="navbar-top-firstrow" class="nav-list" title="Navigation">
+                      <li class="nav-bar-cell1-rev">API Changes</li>
+                      <li>
+                       <a href="architecture-summary.html">Architecture Summary</a>
+                      </li>
+                      <li>
+                       <a href="index.html">Overview</a>
+                      </li>
+                      <li>
+                       <a href="overview-tree.html">Tree</a>
+                      </li>
+                      <xsl:if test="$deprecated='true'">
+                          <li>
+                              <a href="deprecated-list.html">Deprecated</a>
+                          </li>   
+                      </xsl:if>
+                      <li>
+                       <a href="index-files/index-1.html">Index</a>
+                      </li>
+                      <li><a href="search.html">Search</a></li>
+                      <li>
+                       <a href="help-doc.html#overview">Help</a>
+                      </li>
+                     </ul>
+                
+                     <div class="about-language">
+                      <xsl:value-of select="$javadoc-header"/>
+                     </div>
+                    </div>  
+                   </div>
+                   <div class="sub-nav">
+                    <div class="nav-content">
+                     <ol class="sub-nav-list"></ol>
+                     <div class="nav-list-search">
+                      <input type="text" id="search-input" disabled="disabled" placeholder="Search" aria-label="Search in documentation" autocomplete="off"/>
+                      <input type="reset" id="reset-search" disabled="disabled" value="Reset"/>
+                     </div>
                     </div>
-                    <a name="navbar.top.firstrow">
-                        <!--   -->
-                    </a>
-                    <ul class="navList noreplace" title="Navigation">
-                        <li class="navBarCell1Rev">
-                            API Changes
-                        </li>
-                        <li><a href="architecture-summary.html">Architecture Summary</a></li>
-                        <li><a href="overview-summary.html">Overview</a></li>
-                        <li>Package</li>
-                        <li>Class</li>
-                        <li>Use</li>
-                        <li>Tree</li>
-                        <li>
-                            <a href="deprecated-list.html">Deprecated</a>
-                        </li>
-                        <li>Index</li>
-                        <li>
-                            <a href="help-doc.html">Help</a>
-                        </li>
-                    </ul>
-                    <div class="aboutLanguage"> </div>
-                </div>
-                <div class="subNav">
-                    <ul class="navList">
-                        <li>
-                            <a href="index.html?overview-summary.html" target="_top">Frames</a>
-                        </li>
-                        <li>
-                            <a href="overview-summary.html" target="_top">No Frames</a>
-                        </li>
-                    </ul>
-                    <ul class="navList" id="allclasses_navbar_top">
-                        <li>
-                            <a href="allclasses-noframe.html">All Classes</a>
-                        </li>
-                    </ul>
-                    <div>
-                        <script type="text/javascript"><!--
-  allClassesLink = document.getElementById("allclasses_navbar_top");
-  if(window==top) {
-    allClassesLink.style.display = "block";
-  }
-  else {
-    allClassesLink.style.display = "none";
-  }
-  //-->
-                        </script>
-                    </div>
-                    <a name="skip.navbar.top">
-                        <!--   -->
-                    </a>
-                </div>
-                <!-- ========= END OF TOP NAVBAR ========= -->
+                   </div>
+                   <!-- ========= END OF TOP NAVBAR ========= -->
+                   <span class="skip-nav" id="skip-navbar-top"></span>
+                  </nav>
+                 </header>
+                 <div class="main-grid">
+                  <main role="main">
                 <xsl:apply-templates select="apichanges/htmlcontents/body/node()[not(contains(@class, 'overviewlink'))]"/>
+                  </main>
+                 </div>
             </body>
         </html>
     </xsl:template>
@@ -442,9 +456,9 @@ committed to the repository for legal reasons. You need to download it:
             Unrecognized changelist style: <xsl:value-of select="@style"/>
         </xsl:message>
     </xsl:template>
-    
+
     <!-- Show all change lists usually needed: -->
-    
+
     <xsl:template match="standard-changelists">
       <h1><a name="list-all-apis">Index of APIs</a></h1>
       <xsl:call-template name="changelist-list-all-apis"/>
@@ -452,9 +466,11 @@ committed to the repository for legal reasons. You need to download it:
       <h1><a name="incompat-by-date">Incompatible changes by date</a></h1>
       <p>Fuller descriptions of all changes can be found below (follow links).</p>
       <p>Not all deprecations are listed here, assuming that the deprecated
-        APIs continue to essentially work. For a full deprecation list, please
-        consult the
-        <a href="deprecated-list.html">Javadoc</a>.</p>
+          APIs continue to essentially work.</p>
+      <xsl:if test="$deprecated='true'">   
+          <p>For a full deprecation list, please consult the
+              <a href="deprecated-list.html">Javadoc</a>.</p>
+      </xsl:if>
       <xsl:call-template name="changelist-incompat-by-date"/>
 
       <h1><a name="all-by-date">All changes by date</a></h1>
@@ -499,7 +515,7 @@ committed to the repository for legal reasons. You need to download it:
     <xsl:template match="version" >
         <xsl:apply-templates mode="print-version" select="." />
     </xsl:template>
-    
+
     <xsl:template match="version" mode="print-version" >
         <xsl:value-of select="@major"/>.<xsl:value-of select="@minor"/>
         <xsl:if test="@subminor">.<xsl:value-of select="@subminor"/></xsl:if>
@@ -621,11 +637,11 @@ committed to the repository for legal reasons. You need to download it:
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    
+
     <xsl:template name="print-hash" >
         <xsl:param name="text" />
         <xsl:param name="hash" />
-        
+
         <xsl:variable name="first-char" select="substring($text,1,1)" />
         <xsl:choose>
             <xsl:when test="$text and number($first-char) >= 0">

--- a/nbbuild/javadoctools/build.xml
+++ b/nbbuild/javadoctools/build.xml
@@ -121,7 +121,7 @@
         </taskdef>
         <javadoc-index target="${netbeans.javadoc.dir}/allclasses.xml">
             <packageslist dir="${netbeans.javadoc.dir}">
-                <include name="**/allclasses-noframe.html"/>
+                <include name="**/allclasses-index.html"/>
             </packageslist>
         </javadoc-index>
 
@@ -186,7 +186,7 @@
             </fileset>
         </copy>
         <condition property="javadoc.style.sheet.exists">
-            <available file="${netbeans.javadoc.dir}/org-openide-util/javadoc.css"/>
+            <available file="${netbeans.javadoc.dir}/org-openide-util/resource-files/javadoc.css"/>
         </condition>
 
         <fail unless="javadoc.style.sheet.exists">

--- a/nbbuild/javadoctools/disallowed-links.xml
+++ b/nbbuild/javadoctools/disallowed-links.xml
@@ -51,6 +51,7 @@
     
     <!-- project site we use -->
     <filter pattern="https://bits\.netbeans\.org/html\+java/dev.*" accept="true" />
+    <filter pattern="https://bits\.netbeans\.org/.*" accept="true" />
     <filter pattern="https://graalvm\.org" accept="true" />
     <filter pattern="https://freemarker\.apache\.org" accept="true" />
     <filter pattern="https://felix\.apache\.org" accept="true" />

--- a/nbbuild/javadoctools/export2allmodules.xsl
+++ b/nbbuild/javadoctools/export2allmodules.xsl
@@ -47,7 +47,7 @@
         <span class="modules">
             <xsl:value-of select="@name" />
         </span>
-        (<a><xsl:attribute name="href"><xsl:value-of select="substring-before(@target,'/')" />/overview-summary.html</xsl:attribute>javadoc</a>)
+        (<a><xsl:attribute name="href"><xsl:value-of select="substring-before(@target,'/')" />/index.html</xsl:attribute>javadoc</a>)
         <ul class="modulesclasslist">
             <xsl:variable name="modulename" select="substring-before(@target,'/')" />
             <xsl:for-each select="//class[($modulename = substring-before(@url,'/'))]" >
@@ -87,7 +87,7 @@
             </a>
             (<a>
                 <xsl:attribute name="href">
-                    <xsl:value-of select="substring-before(@target,'/')" />/overview-summary.html</xsl:attribute>
+                    <xsl:value-of select="substring-before(@target,'/')" />/index.html</xsl:attribute>
                 <xsl:attribute name="target">classFrame</xsl:attribute>javadoc</a>)
         </span>
         <br/>

--- a/nbbuild/javadoctools/export2html.xsl
+++ b/nbbuild/javadoctools/export2html.xsl
@@ -272,7 +272,7 @@
                                 </xsl:attribute>
                                 <a>
                                     <xsl:attribute name="href">
-                                        <xsl:value-of select="substring-before(@target,'/')" />/overview-summary.html</xsl:attribute>
+                                        <xsl:value-of select="substring-before(@target,'/')" />/index.html</xsl:attribute>
                                     <xsl:attribute name="target">classFrame</xsl:attribute>
                                     <xsl:value-of select="@name"/>
                                 </a> -
@@ -305,7 +305,7 @@
                         <li>
                             <xsl:variable name="where" select="substring-before(@target, '/')"/>
                             <b>
-                                <a href="{$where}/overview-summary.html">
+                                <a href="{$where}/index.html">
                                     <xsl:value-of select="$where"/>
                                 </a>
                             </b>

--- a/nbbuild/javadoctools/export2index.xsl
+++ b/nbbuild/javadoctools/export2index.xsl
@@ -145,7 +145,7 @@
                                 </xsl:attribute>
                                 <a>
                                     <xsl:attribute name="href">
-                                        <xsl:value-of select="substring-before(@target,'/')" />/overview-summary.html</xsl:attribute>
+                                        <xsl:value-of select="substring-before(@target,'/')" />/index.html</xsl:attribute>
                                     <xsl:value-of select="@name"/>
                                 </a> -
                                 <!-- XXX the following is crap; e.g. messes up descs of Dialogs API, I/O API, ... -->
@@ -177,7 +177,7 @@
                         <li>
                             <xsl:variable name="where" select="substring-before(@target, '/')"/>
                             <b>
-                                <a href="{$where}/overview-summary.html">
+                                <a href="{$where}/index.html">
                                     <xsl:value-of select="$where"/>
                                 </a>
                             </b>
@@ -201,7 +201,7 @@
             <div>
             <xsl:element name="h3">
                 <xsl:attribute name="id">
-                    <xsl:text>def-api-</xsl:text><xsl:value-of select="$module.name"/>
+                    <xsl:text>def-api-</xsl:text><xsl:value-of select="translate($module.name,' ','-')"/>
                 </xsl:attribute>
                 <xsl:value-of select="$module.name"/>
             </xsl:element>            
@@ -210,7 +210,7 @@
                     <xsl:call-template name="filedirapi" >
                         <xsl:with-param name="arch.target" select="$arch.target" />
                     </xsl:call-template>
-                    <xsl:text>/overview-summary.html</xsl:text>
+                    <xsl:text>/index.html</xsl:text>
                 </xsl:attribute>
                 <xsl:text>javadoc</xsl:text>
             </a>
@@ -234,7 +234,7 @@
                 | <a>
                     <xsl:attribute name="href">
                         <xsl:text>usecases.html#usecase-</xsl:text>
-                        <xsl:value-of select="$module.name" />
+                        <xsl:value-of select="translate($module.name,' ','-')" />
                     </xsl:attribute>
                     <xsl:text>usecases</xsl:text>
                 </a>

--- a/nbbuild/javadoctools/export2layer.xsl
+++ b/nbbuild/javadoctools/export2layer.xsl
@@ -94,9 +94,7 @@
                                             <xsl:value-of select="ancestor::module/@name"/>
                                         </a>
                                     </b>
-                                    <p>
-                                        <xsl:apply-templates select="." />
-                                    </p>
+                                    <xsl:apply-templates select="." />
                                 </li>
                             </xsl:for-each>
                         </ul>
@@ -193,7 +191,15 @@
             <xsl:apply-templates select="@*|node()"/>
         </xsl:copy>
     </xsl:template>
-        
+    
+    <xsl:template match="api">
+        <div class="apibloc">
+            <xsl:apply-templates />
+        </div>
+    </xsl:template>
+    <!-- special html 5 rewrite -->
+    <xsl:template match="a/@shape" />
+    <xsl:template match="pre/@space" />
 </xsl:stylesheet>
 
 

--- a/nbbuild/javadoctools/export2property.xsl
+++ b/nbbuild/javadoctools/export2property.xsl
@@ -97,9 +97,7 @@
                                             <xsl:value-of select="ancestor::module/@name"/>
                                         </a>
                                     </b>
-                                    <p>
-                                        <xsl:apply-templates select="." />
-                                    </p>
+                                    <xsl:apply-templates select="." />
                                 </li>
                             </xsl:for-each>
                         </ul>
@@ -198,7 +196,14 @@
             <xsl:apply-templates select="@*|node()"/>
         </xsl:copy>
     </xsl:template>
-        
+    <xsl:template match="api">
+     <div class="apibloc">
+       <xsl:apply-templates />
+     </div>
+    </xsl:template>
+    <!-- special html 5 rewrite -->
+    <xsl:template match="a/@shape" />
+    <xsl:template match="pre/@space" />
 </xsl:stylesheet>
 
 

--- a/nbbuild/javadoctools/export2usecases.xsl
+++ b/nbbuild/javadoctools/export2usecases.xsl
@@ -20,8 +20,8 @@
 
 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-    <xsl:import href="jsonhelp.xsl" />  
-    <xsl:import href="export2allmodules.xsl" />  
+    <xsl:import href="jsonhelp.xsl" />
+    <xsl:import href="export2allmodules.xsl" />
     <xsl:output method="html"/>
     <xsl:param name="date" />
     <xsl:param name="maturity" />
@@ -40,7 +40,7 @@
                 <xsl:call-template name="htmlmainmenu" >
                     <xsl:with-param name="title" >APIs Usecases list</xsl:with-param>
                     <xsl:with-param name="maturity" select="$maturity" />
-                    <xsl:with-param name="version" select="$version"/> 
+                    <xsl:with-param name="version" select="$version"/>
                     <xsl:with-param name="releaseinfo" select="$releaseinfo"/>
                     <xsl:with-param name="menukey" >usecases</xsl:with-param>
                 </xsl:call-template>
@@ -49,37 +49,38 @@
                         <xsl:with-param name="menukey" >usecases</xsl:with-param>
                         <xsl:with-param name="date" select="$date"/>
                     </xsl:call-template>
-                
+
                     <div class="innercontent">
                         <div class="abstract">
                             This page contains extracted usecases for some of the NetBeans modules
-                            that <a href="index.html">offer an API</a>. 
+                            that <a href="index.html">offer an API</a>.
                         </div>
 
                         <xsl:for-each select="//module/arch-usecases[not(../@name='_no module_') and not(.='No answer')]" >
                             <hr/>
                             <h2>
-                                <a>
-                                    <xsl:attribute name="id">
+                                <xsl:variable name="idreplaced" select="../@name"/>
+                                <xsl:attribute name="id">
                                         <xsl:text>usecase-</xsl:text>
-                                        <xsl:value-of select="../@name"/>
-                                    </xsl:attribute>
-                                    <xsl:text>How to use </xsl:text>
-                                </a>
+                                        <xsl:value-of select="translate($idreplaced,' ','-')"/>
+                                </xsl:attribute>
+                                <xsl:text>How to use </xsl:text>
                                 <a>
                                     <xsl:attribute name="href" >
                                         <xsl:text>index.html#def-api-</xsl:text>
-                                        <xsl:value-of select="../@name"/>
+                                        <xsl:value-of select="translate($idreplaced,' ','-')"/>
                                     </xsl:attribute>
                                     <xsl:value-of select="../@name"/>
                                 ?</a>
                             </h2>
-                            <xsl:apply-templates select="../description" />
+                            <p>
+                            <xsl:apply-templates select="../description/node()" />
+                            </p>
                             <p/>
                             <xsl:apply-templates />
                         </xsl:for-each>
                     </div>
-                
+
                 </div>
                 <div class="apidocleft">
                     <xsl:call-template name="listallmodules" />
@@ -88,7 +89,7 @@
             </body>
         </html>
     </xsl:template>
-    
+
     <xsl:template match="api-ref">
         <!-- simply bold the name, it link will likely be visible bellow -->
         <b>
@@ -105,19 +106,19 @@
     <xsl:template match="a[@href]">
         <xsl:variable name="target" select="ancestor::module/@target"/>
         <xsl:variable name="top" select="substring-before($target,'/')" />
-        
+
               <xsl:call-template name="print-url" >
                 <xsl:with-param name="url" select="@href" />
                 <xsl:with-param name="base" select="$target" />
                 <xsl:with-param name="top" select="$top" />
               </xsl:call-template>
         </xsl:template>
-    -->    
+    -->
     <xsl:template name="print-url" >
         <xsl:param name="url" />
         <xsl:param name="base" />
         <xsl:param name="top" />
-        
+
         <xsl:choose>
             <xsl:when  test="contains(@href,'@TOP@')" >
                 <xsl:comment>URL contains @TOP@</xsl:comment>
@@ -132,7 +133,7 @@
             </xsl:when>
             <xsl:when test="contains($url,'//')" >
                 <xsl:comment>This is very likely URL with protocol, if not see nbbuild/javadoctools/export2usecases.xsl</xsl:comment>
-                <a> 
+                <a>
                     <xsl:attribute name="href">
                         <xsl:value-of select="$url" />
                     </xsl:attribute>
@@ -158,13 +159,41 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-            
+
     <xsl:template match="@*|node()">
         <xsl:copy  >
             <xsl:apply-templates select="@*|node()"/>
         </xsl:copy>
     </xsl:template>
-        
+    
+    <xsl:template match="api">
+     <xsl:param name="group" />
+     <xsl:param name="type" />
+    
+     <xsl:variable name="name" select="@name" />
+     <xsl:variable name="category" select="@category" />
+     <xsl:variable name="url" select="@url" />
+
+     <xsl:choose> 
+      <xsl:when test="string-length($url)>0">
+       <a>
+        <xsl:attribute name="href">
+         <xsl:value-of select="$url" />
+        </xsl:attribute>
+        <xsl:value-of select="$name" />
+       </a>
+      </xsl:when>
+      <xsl:otherwise>
+       <xsl:value-of select="$name" />
+      </xsl:otherwise>
+     </xsl:choose>
+
+     <xsl:apply-templates />
+    </xsl:template>
+    <!-- special html 5 rewrite -->
+    <xsl:template match="a/@shape" />
+    <xsl:template match="pre/@space" />
+    <xsl:template match="pre/@xml:space" />
 </xsl:stylesheet>
 
 

--- a/nbbuild/javadoctools/exportInterfaces.xsl
+++ b/nbbuild/javadoctools/exportInterfaces.xsl
@@ -94,5 +94,4 @@
           <xsl:apply-templates select="@*|node()"/>
        </xsl:copy>
     </xsl:template>
-  
 </xsl:stylesheet> 

--- a/nbbuild/javadoctools/exportOverview.xsl
+++ b/nbbuild/javadoctools/exportOverview.xsl
@@ -37,6 +37,7 @@
           <title>Overview</title><!-- note this is ignored -->
          </head>
          <body>
+          <main>
           <h1>Overview of <xsl:value-of select="api-answers/@module" /><xsl:text> module</xsl:text></h1>
           <xsl:apply-templates select="api-answers/answer[@id='arch-overall']/node()" mode="description"/>
           
@@ -93,6 +94,7 @@
                     <xsl:with-param name="generate-group" select="'java'" />
                 </xsl:call-template>
             -->
+          </main>
          </body>
         </html>
          

--- a/nbbuild/javadoctools/javadoc-generic.css
+++ b/nbbuild/javadoctools/javadoc-generic.css
@@ -16,577 +16,1456 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/* Javadoc style sheet */
+/*
+ * Javadoc style sheet
+ */
 
-/* Define colors, fonts and other style attributes here to override the defaults */
-
-/* Page background color */
-body { background-color: #FFFFFF }
-
+@import url('fonts/dejavu.css');
+/*
+ * These CSS custom properties (variables) define the core color and font
+ * properties used in this stylesheet.
+ */
+:root {
+    /* body, block and code fonts */
+    --body-font-family: 'DejaVu Sans', Arial, Helvetica, sans-serif;
+    --block-font-family: 'DejaVu Serif', Georgia, "Times New Roman", Times, serif;
+    --code-font-family: 'DejaVu Sans Mono', monospace;
+    /* Base font sizes for body and code elements */
+    --body-font-size: 14px;
+    --block-font-size: 14px;
+    --code-font-size: 14px;
+    --nav-font-size: 13.2px;
+    /* Line height for continuous text blocks */
+    --block-line-height: 1.4em;
+    /* Text colors for body and block elements */
+    --body-text-color: #353833;
+    --block-text-color: #474747;
+    /* Background colors for various structural elements */
+    --body-background-color: #ffffff;
+    --section-background-color: #f8f8f8;
+    --detail-background-color: #ffffff;
+    /* Colors for navigation bar and table captions */
+    --navbar-background-color: #4D7A97;
+    --navbar-text-color: #ffffff;
+    /* Background color for subnavigation and various headers */
+    --subnav-background-color: #dee3e9;
+    /* Background and text colors for selected tabs and navigation items */
+    --selected-background-color: #f8981d;
+    --selected-text-color: #253441;
+    --selected-link-color: #1f389c;
+    /* Background colors for generated tables */
+    --even-row-color: #ffffff;
+    --odd-row-color: #eeeeef;
+    /* Text color for page title */
+    --title-color: #2c4557;
+    /* Text colors for links */
+    --link-color: #4A6782;
+    --link-color-active: #bb7a2a;
+    /* Snippet colors */
+    --snippet-background-color: #ebecee;
+    --snippet-text-color: var(--block-text-color);
+    --snippet-highlight-color: #f7c590;
+    /* Border colors for structural elements and user defined tables */
+    --border-color: #ededed;
+    --table-border-color: #000000;
+    /* Search input colors */
+    --search-input-background-color: #ffffff;
+    --search-input-text-color: #000000;
+    --search-input-placeholder-color: #909090;
+    /* Highlight color for active search tag target */
+    --search-tag-highlight-color: #ffff00;
+    /* Adjustments for icon and active background colors of copy-to-clipboard buttons */
+    --copy-icon-brightness: 100%;
+    --copy-button-background-color-active: rgba(168, 168, 176, 0.3);
+    /* Colors for invalid tag notifications */
+    --invalid-tag-background-color: #ffe6e6;
+    --invalid-tag-text-color: #000000;
+    /* Navigation bar dimensions */
+    --top-nav-height: 44px;
+    --sub-nav-height: 34px;
+    --nav-height: calc(var(--top-nav-height) + var(--sub-nav-height));
+    scroll-behavior: smooth;
+}
+/*
+ * Styles for individual HTML elements.
+ *
+ * These are styles that are specific to individual HTML elements. Changing them affects the style of a particular
+ * HTML element throughout the page.
+ */
 body {
-    background-color:#ffffff;
-    color:#353833;
-    font-family:'DejaVu Sans', Arial, Helvetica, sans-serif;
-    font-size:14px;
+    background-color:var(--body-background-color);
+    color:var(--body-text-color);
+    font-family:var(--body-font-family);
+    font-size:var(--body-font-size);
     margin:0;
+    padding:0;
+    height:100%;
+    width:100%;
+}
+main [id] {
+    scroll-margin-top: calc(var(--nav-height) + 6px);
 }
 a:link, a:visited {
     text-decoration:none;
-    color:#4A6782;
+    color:var(--link-color);
 }
-a:hover, a:focus {
+a[href]:hover, a[href]:active {
     text-decoration:none;
-    color:#bb7a2a;
-}
-a:active {
-    text-decoration:none;
-    color:#4A6782;
-}
-a[name] {
-    color:#353833;
-}
-a[name]:hover {
-    text-decoration:none;
-    color:#353833;
+    color:var(--link-color-active);
 }
 pre {
-    font-family:'DejaVu Sans Mono', monospace;
-    font-size:14px;
+    font-family:var(--code-font-family);
+    font-size:var(--code-font-size);
 }
 h1 {
-    font-size:20px;
+    font-size:1.428em;
 }
 h2 {
-    font-size:18px;
+    font-size:1.285em;
 }
 h3 {
-    font-size:16px;
-    font-style:italic;
+    font-size:1.14em;
 }
 h4 {
-    font-size:13px;
+    font-size:1.072em;
 }
 h5 {
-    font-size:12px;
+    font-size:1.001em;
 }
 h6 {
-    font-size:11px;
+    font-size:0.93em;
+}
+/* Disable font boosting for selected elements */
+h1, h2, h3, h4, h5, h6, div.member-signature {
+    max-height: 1000em;
 }
 ul {
     list-style-type:disc;
 }
 code, tt {
-    font-family:'DejaVu Sans Mono', monospace;
-    font-size:14px;
-    padding-top:4px;
-    margin-top:8px;
+    font-family:var(--code-font-family);
+}
+:not(h1, h2, h3, h4, h5, h6) > code,
+:not(h1, h2, h3, h4, h5, h6) > tt {
+    font-size:var(--code-font-size);
     line-height:1.4em;
 }
 dt code {
-    font-family:'DejaVu Sans Mono', monospace;
-    font-size:14px;
+    font-family:var(--code-font-family);
+    font-size:1em;
     padding-top:4px;
 }
-table tr td dt code {
-    font-family:'DejaVu Sans Mono', monospace;
-    font-size:14px;
+.summary-table dt code {
+    font-family:var(--code-font-family);
+    font-size:1em;
     vertical-align:top;
     padding-top:4px;
 }
 sup {
     font-size:8px;
 }
-/*
-Document title and Copyright styles
-*/
-.clear {
-    clear:both;
-    height:0px;
-    overflow:hidden;
+button {
+    font-family: var(--body-font-family);
+    font-size: 1em;
 }
-.aboutLanguage {
-    float:right;
-    padding:0px 21px;
-    font-size:11px;
-    z-index:200;
-    margin-top:-9px;
-}
-.legalCopy {
-    margin-left:.5em;
-}
-.bar a, .bar a:link, .bar a:visited, .bar a:active {
-    color:#FFFFFF;
-    text-decoration:none;
-}
-.bar a:hover, .bar a:focus {
-    color:#bb7a2a;
-}
-.tab {
-    background-color:#0066FF;
-    color:#ffffff;
-    padding:8px;
-    width:5em;
-    font-weight:bold;
+hr {
+    border-color: #aaa;
 }
 /*
-Navigation bar styles
-*/
-.bar {
-    background-color:#4D7A97;
-    color:#FFFFFF;
-    padding:.8em .5em .4em .8em;
-    height:auto;/*height:1.8em;*/
-    font-size:11px;
+ * Styles for HTML generated by javadoc.
+ *
+ * These are style classes that are used by the standard doclet to generate HTML documentation.
+ */
+
+/*
+ * Styles for document title and copyright.
+ */
+.about-language {
+    flex: 0 0 auto;
+    padding:0 20px;
     margin:0;
+    font-size:0.915em;
+    max-width: 50%;
+    white-space: nowrap;
 }
-.topNav {
-    background-color:#4D7A97;
-    color:#FFFFFF;
-    float:left;
-    padding:0;
+.legal-copy {
+}
+/*
+ * Styles for navigation bar.
+ */
+@media screen {
+    header {
+        position:sticky;
+        top:0;
+        z-index:2;
+        background: var(--body-background-color);
+    }
+}
+.nav-content {
+    display:flex;
+    flex-direction: row;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+}
+.top-nav {
+    background-color:var(--navbar-background-color);
+    color:var(--navbar-text-color);
     width:100%;
-    clear:right;
-    height:2.8em;
-    padding-top:10px;
-    overflow:hidden;
-    font-size:12px; 
+    height:var(--top-nav-height);
+    overflow:visible;
+    font-size:0.857em;
+    position:relative;
 }
-.bottomNav {
-    margin-top:10px;
-    background-color:#4D7A97;
-    color:#FFFFFF;
-    float:left;
-    padding:0;
-    width:100%;
-    clear:right;
-    height:2.8em;
-    padding-top:10px;
-    overflow:hidden;
-    font-size:12px;
+.top-nav nav.toc {
+    display: none;
+    flex-direction: column;
 }
-.subNav {
-    background-color:#dee3e9;
-    float:left;
-    width:100%;
-    overflow:hidden;
-    font-size:12px;
+.top-nav nav.toc button.show-sidebar,
+.top-nav nav.toc button.hide-sidebar {
+    display: none;
 }
-.subNav div {
-    clear:left;
-    float:left;
-    padding:0 0 5px 6px;
-    text-transform:uppercase;
+button#navbar-toggle-button {
+    display:none;
 }
-ul.navList, ul.subNavList {
-    float:left;
-    margin:0 25px 0 0;
-    padding:0;
+ul.nav-list {
+    display:inline-flex;
+    margin:0;
+    padding-left:4px;
+    flex: 1 1 auto;
+    white-space: nowrap;
 }
-ul.navList li{
+ul.nav-list li {
     list-style:none;
-    float:left;
     padding: 5px 6px;
     text-transform:uppercase;
+    height: 1.2em;
 }
-ul.subNavList li{
+div.sub-nav {
+    background-color:var(--subnav-background-color);
+    width:100%;
+    overflow:hidden;
+    font-size:var(--nav-font-size);
+    height: var(--sub-nav-height);
+}
+ol.sub-nav-list {
+    flex: 1 1 90%;
+    line-height: 1.8em;
+    display: inline-flex;
+    overflow: auto;
+    scroll-snap-type: x mandatory;
+    scroll-padding-left: 13px;
+    scrollbar-width: none;
+    padding-left:6px;
+    white-space: nowrap;
+    margin:0;
+}
+ol.sub-nav-list::-webkit-scrollbar {
+    display: none;
+}
+ol.sub-nav-list li {
     list-style:none;
-    float:left;
+    scroll-snap-align: start;
 }
-.topNav a:link, .topNav a:active, .topNav a:visited, .bottomNav a:link, .bottomNav a:active, .bottomNav a:visited {
-    color:#FFFFFF;
+ol.sub-nav-list li:not(:first-child) {
+    list-style-type: " > ";
+    margin-left: 20px;
+}
+ol.sub-nav-list a {
+    padding: 3px;
+}
+ol.sub-nav-list a.current-selection {
+    background-color: var(--section-background-color);
+    border-radius: 4px;
+}
+.sub-nav .nav-list-search {
+    flex: 1 1 10%;
+    margin:0;
+    padding:6px;
+    position:relative;
+    white-space: nowrap;
+}
+.top-nav .nav-list a:link, .top-nav .nav-list a:active, .top-nav .nav-list a:visited {
+    color:var(--navbar-text-color);
     text-decoration:none;
     text-transform:uppercase;
 }
-.topNav a:hover, .bottomNav a:hover {
-    text-decoration:none;
-    color:#bb7a2a;
-    text-transform:uppercase;
+.top-nav .nav-list a:hover {
+    color:var(--link-color-active);
 }
-.navBarCell1Rev {
-    background-color:#F8981D;
-    color:#253441;
-    margin: auto 5px;
+.nav-bar-cell1-rev {
+    background-color:var(--selected-background-color);
+    color:var(--selected-text-color);
+    margin: 0 5px;
 }
-.skipNav {
+.skip-nav {
     position:absolute;
     top:auto;
     left:-9999px;
     overflow:hidden;
 }
 /*
-Page header and footer styles
-*/
-.header, .footer {
-    clear:both;
-    margin:0 20px;
-    padding:5px 0 0 0;
+ * Hide navigation links and search box in print layout
+ */
+@media print {
+    ul.nav-list, div.sub-nav  {
+        display:none;
+    }
 }
-.indexHeader {
-    margin:10px;
-    position:relative;
-}
-.indexHeader span{
-    margin-right:15px;
-}
-.indexHeader h1 {
-    font-size:13px;
-}
+/*
+ * Styles for page header.
+ */
 .title {
-    color:#2c4557;
+    color:var(--title-color);
     margin:10px 0;
 }
-.subTitle {
+.sub-title {
     margin:5px 0 0 0;
 }
-.header ul {
-    margin:0 0 15px 0;
-    padding:0;
+ul.contents-list {
+    margin: 0 0 15px 0;
+    padding: 0;
+    list-style: none;
 }
-.footer ul {
-    margin:20px 0 5px 0;
-}
-.header ul li, .footer ul li {
-    list-style:none;
-    font-size:13px;
+ul.contents-list li {
+    font-size:0.93em;
 }
 /*
-Heading styles
-*/
-div.details ul.blockList ul.blockList ul.blockList li.blockList h4, div.details ul.blockList ul.blockList ul.blockListLast li.blockList h4 {
-    background-color:#dee3e9;
-    border:1px solid #d0d9e0;
-    margin:0 0 6px -8px;
-    padding:7px 5px;
-}
-ul.blockList ul.blockList ul.blockList li.blockList h3 {
-    background-color:#dee3e9;
-    border:1px solid #d0d9e0;
-    margin:0 0 6px -8px;
-    padding:7px 5px;
-}
-ul.blockList ul.blockList li.blockList h3 {
+ * Styles for headings.
+ */
+body.class-declaration-page .summary h2,
+body.class-declaration-page .details h2,
+body.class-use-page h2,
+body.module-declaration-page .block-list h2 {
+    font-style: italic;
     padding:0;
     margin:15px 0;
+    overflow-x:auto;
 }
-ul.blockList li.blockList h2 {
-    padding:0px 0 20px 0;
+body.class-declaration-page .summary h3,
+body.class-declaration-page .details h3 {
+    background-color:var(--subnav-background-color);
+    border:1px solid var(--border-color);
+    margin:0 0 6px -8px;
+    padding:7px 5px;
+    overflow-x:auto;
 }
 /*
-Page layout container styles
-*/
-.contentContainer, .sourceContainer, .classUseContainer, .serializedFormContainer, .constantValuesContainer {
+ * Styles for page layout containers.
+ */
+.main-grid {
+    display: flex;
+    flex-direction: row;
+}
+.main-grid main {
+    flex: 2.6 1 0;
+    min-width: 240px
+}
+.main-grid nav.toc {
+    flex: 1 1 0;
+    min-width: 240px;
+}
+main {
     clear:both;
     padding:10px 20px;
     position:relative;
 }
-.indexContainer {
-    margin:10px;
-    position:relative;
-    font-size:12px;
+section[id$=-description] :is(dl, ol, ul, p, div, blockquote, pre):last-child,
+section[id$=-description] :is(dl, ol, ul):last-child > :is(li, dd):last-child {
+    margin-bottom:4px;
 }
-.indexContainer h2 {
-    font-size:13px;
-    padding:0 0 3px 0;
-}
-.indexContainer ul {
-    margin:0;
-    padding:0;
-}
-.indexContainer ul li {
-    list-style:none;
-    padding-top:2px;
-}
-.contentContainer .description dl dt, .contentContainer .details dl dt, .serializedFormContainer dl dt {
-    font-size:12px;
+dl.notes > dt {
+    font-family: var(--body-font-family);
+    font-size:0.856em;
     font-weight:bold;
     margin:10px 0 0 0;
-    color:#4E4E4E;
+    color:var(--body-text-color);
 }
-.contentContainer .description dl dd, .contentContainer .details dl dd, .serializedFormContainer dl dd {
-    margin:5px 0 10px 0px;
-    font-size:14px;
-    font-family:'DejaVu Sans Mono',monospace;
+dl.notes > dd {
+    margin:5px 10px 10px 15px;
+    font-size:var(--block-font-size);
+    font-family:var(--block-font-family);
 }
-.serializedFormContainer dl.nameValue dt {
+dl.notes > dd > ul, dl.notes > dd > ol {
+    margin-bottom: 1em;
+    margin-top: 1em;
+}
+dl.name-value > dt {
     margin-left:1px;
     font-size:1.1em;
     display:inline;
     font-weight:bold;
 }
-.serializedFormContainer dl.nameValue dd {
+dl.name-value > dd {
     margin:0 0 0 1px;
     font-size:1.1em;
     display:inline;
 }
 /*
-List styles
-*/
+ * Styles for table of contents.
+ */
+.main-grid nav.toc {
+    background-color: var(--section-background-color);
+    border-right: 1px solid var(--border-color);
+    position: sticky;
+    top: calc(var(--nav-height));
+    max-height: calc(100vh - var(--nav-height));
+    display: flex;
+    flex-direction: column;
+    font-family: var(--body-font-family);
+    z-index: 1;
+}
+.main-grid nav.toc div.toc-header {
+    background-color: var(--section-background-color);
+    border-right: 1px solid var(--border-color);
+    top: var(--nav-height);
+    z-index: 1;
+    padding: 15px 20px;
+}
+.main-grid nav.toc > ol.toc-list {
+    max-height: calc(100vh - var(--nav-height) - 100px);
+    padding-left: 12px;
+}
+.main-grid nav.toc button {
+    position: absolute;
+    bottom: 16px;
+    z-index: 3;
+    background-color: var(--section-background-color);
+    color: #666666;
+    font-size: 0.76rem;
+    border: none;
+    cursor: pointer;
+    padding: 6px 10px;
+    white-space: nowrap;
+}
+.main-grid nav.toc button.hide-sidebar {
+    right: 0;
+}
+.main-grid nav.toc button.show-sidebar {
+    left: 0;
+    display: none;
+}
+.main-grid nav.toc button span {
+    display: none;
+}
+.main-grid nav.toc button:hover {
+    color: var(--body-text-color);
+    border: 1px solid var(--subnav-background-color);
+}
+.main-grid nav.toc button:active {
+    background-color: var(--subnav-background-color);
+    color: var(--link-color-active);
+}
+.main-grid nav.toc button:hover span,
+.main-grid nav.toc button:active span  {
+    display: inline;
+}
+.main-grid nav.toc button:hover {
+    box-shadow: 1px 1px 5px rgba(0,0,0,0.2);
+}
+.main-grid nav.toc.hide-sidebar {
+    min-width: revert;
+    max-width: 28px;
+}
+.main-grid nav.toc.hide-sidebar div.toc-header,
+.main-grid nav.toc.hide-sidebar ol.toc-list,
+.main-grid nav.toc.hide-sidebar button.hide-sidebar {
+    display: none;
+}
+.main-grid nav.toc.hide-sidebar button.show-sidebar {
+    display: inline;
+}
+nav.toc div.toc-header {
+    padding: 15px;
+    display: inline-flex;
+    align-items: center;
+    color: var(--body-text-color);
+    background-color: var(--body-background-color);
+    font-size: 0.856em;
+    font-weight: bold;
+    white-space: nowrap;
+    overflow-x: hidden;
+    position: sticky;
+    min-height: 20px;
+}
+nav.toc > ol.toc-list {
+    overflow: hidden auto;
+    overscroll-behavior: contain;
+}
+nav.toc ol.toc-list {
+    list-style: none;
+    padding-left: 8px;
+    margin: 0;
+}
+nav.toc ol.toc-list ol.toc-list {
+    margin-left: 8px;
+}
+nav.toc ol.toc-list li {
+    margin: 0;
+    font-size: var(--nav-font-size);
+    overflow-x: hidden;
+}
+a.current-selection {
+    font-weight: bold;
+}
+nav.toc a {
+    display: block;
+    padding: 8px;
+}
+nav.toc a.current-selection {
+    background-color: var(--subnav-background-color);
+}
+/*
+ * Styles for lists.
+ */
+li.circle {
+    list-style:circle;
+}
 ul.horizontal li {
     display:inline;
     font-size:0.9em;
 }
-ul.inheritance {
+div.inheritance {
     margin:0;
     padding:0;
 }
-ul.inheritance li {
-    display:inline;
-    list-style:none;
+div.inheritance div.inheritance {
+    margin-left:2em;
 }
-ul.inheritance li ul.inheritance {
-    margin-left:15px;
-    padding-left:15px;
-    padding-top:1px;
+main > div.inheritance {
+    overflow-x:auto;
 }
-ul.blockList, ul.blockListLast {
-    margin:10px 0 10px 0;
+ul.block-list,
+ul.details-list,
+ul.member-list,
+ul.summary-list {
+    margin:4px 0 10px 0;
     padding:0;
 }
-ul.blockList li.blockList, ul.blockListLast li.blockList {
+ul.block-list > li,
+ul.details-list > li,
+ul.member-list > li,
+ul.summary-list > li {
     list-style:none;
     margin-bottom:15px;
     line-height:1.4;
 }
-ul.blockList ul.blockList li.blockList, ul.blockList ul.blockListLast li.blockList {
-    padding:0px 20px 5px 10px;
-    border:1px solid #ededed; 
-    background-color:#f8f8f8;
+ul.ref-list {
+  padding:0;
+  margin:0;
 }
-ul.blockList ul.blockList ul.blockList li.blockList, ul.blockList ul.blockList ul.blockListLast li.blockList {
-    padding:0 0 5px 8px;
-    background-color:#ffffff;
-    border:none;
-}
-ul.blockList ul.blockList ul.blockList ul.blockList li.blockList {
-    margin-left:0;
-    padding-left:0;
-    padding-bottom:15px;
-    border:none;
-}
-ul.blockList ul.blockList ul.blockList ul.blockList li.blockListLast {
+ul.ref-list > li {
     list-style:none;
-    border-bottom:none;
-    padding-bottom:0;
 }
-table tr td dl, table tr td dl dt, table tr td dl dd {
+.summary-table dl, .summary-table dl dt, .summary-table dl dd {
     margin-top:0;
     margin-bottom:1px;
 }
+dl.notes > dd > ul.tag-list, dl.notes > dd > ul.tag-list-long {
+    padding-left: 0;
+    margin: 0;
+    list-style: none;
+}
+ul.tag-list li {
+    display: inline;
+}
+ul.tag-list li:not(:last-child):after,
+ul.tag-list-long li:not(:last-child):after
+{
+    content: ", ";
+    white-space: pre-wrap;
+}
+ul.preview-feature-list {
+    list-style: none;
+    margin:0;
+    padding:0.1em;
+    line-height: 1.6em;
+}
 /*
-Table styles
-*/
-.overviewSummary, .memberSummary, .typeSummary, .useSummary, .constantsSummary, .deprecatedSummary {
+ * Styles for tables.
+ */
+.summary-table, .details-table {
     width:100%;
-    border-left:1px solid #EEE; 
-    border-right:1px solid #EEE; 
-    border-bottom:1px solid #EEE; 
+    border-spacing:0;
+    border:1px solid var(--border-color);
+    border-top:0;
+    padding:0;
 }
-.overviewSummary, .memberSummary  {
-    padding:0px;
-}
-.overviewSummary caption, .memberSummary caption, .typeSummary caption,
-.useSummary caption, .constantsSummary caption, .deprecatedSummary caption {
+.caption {
     position:relative;
     text-align:left;
     background-repeat:no-repeat;
-    color:#253441;
-    font-weight:bold;
+    color:var(--selected-text-color);
     clear:none;
     overflow:hidden;
-    padding:0px;
-    padding-top:10px;
-    padding-left:1px;
-    margin:0px;
-    white-space:pre;
+    padding: 10px 0 0 1px;
+    margin:0;
 }
-.overviewSummary caption a:link, .memberSummary caption a:link, .typeSummary caption a:link,
-.useSummary caption a:link, .constantsSummary caption a:link, .deprecatedSummary caption a:link,
-.overviewSummary caption a:hover, .memberSummary caption a:hover, .typeSummary caption a:hover,
-.useSummary caption a:hover, .constantsSummary caption a:hover, .deprecatedSummary caption a:hover,
-.overviewSummary caption a:active, .memberSummary caption a:active, .typeSummary caption a:active,
-.useSummary caption a:active, .constantsSummary caption a:active, .deprecatedSummary caption a:active,
-.overviewSummary caption a:visited, .memberSummary caption a:visited, .typeSummary caption a:visited,
-.useSummary caption a:visited, .constantsSummary caption a:visited, .deprecatedSummary caption a:visited {
-    color:#FFFFFF;
+.caption a:link, .caption a:visited {
+    color:var(--selected-link-color);
 }
-.overviewSummary caption span, .memberSummary caption span, .typeSummary caption span,
-.useSummary caption span, .constantsSummary caption span, .deprecatedSummary caption span {
+.caption a:hover,
+.caption a:active {
+    color:var(--navbar-text-color);
+}
+.caption span {
+    font-weight:bold;
     white-space:nowrap;
-    padding-top:5px;
-    padding-left:12px;
-    padding-right:12px;
-    padding-bottom:7px;
+    padding:5px 12px 7px 12px;
     display:inline-block;
     float:left;
-    background-color:#F8981D;
+    background-color:var(--selected-background-color);
     border: none;
     height:16px;
 }
-.memberSummary caption span.activeTableTab span {
-    white-space:nowrap;
-    padding-top:5px;
-    padding-left:12px;
-    padding-right:12px;
-    margin-right:3px;
-    display:inline-block;
-    float:left;
-    background-color:#F8981D;
-    height:16px;
+div.table-tabs {
+    padding: 10px 0 0 1px;
+    margin: 0;
 }
-.memberSummary caption span.tableTab span {
-    white-space:nowrap;
-    padding-top:5px;
-    padding-left:12px;
-    padding-right:12px;
-    margin-right:3px;
-    display:inline-block;
-    float:left;
-    background-color:#4D7A97;
-    height:16px;
+div.table-tabs > button {
+    border: none;
+    cursor: pointer;
+    padding: 5px 12px 7px 12px;
+    font-weight: bold;
+    margin-right: 8px;
 }
-.memberSummary caption span.tableTab, .memberSummary caption span.activeTableTab {
-    padding-top:0px;
-    padding-left:0px;
-    padding-right:0px;
-    background-image:none;
-    float:none;
-    display:inline;
+div.table-tabs > .active-table-tab {
+    background: var(--selected-background-color);
+    color: var(--selected-text-color);
 }
-.overviewSummary .tabEnd, .memberSummary .tabEnd, .typeSummary .tabEnd,
-.useSummary .tabEnd, .constantsSummary .tabEnd, .deprecatedSummary .tabEnd {
-    display:none;
-    width:5px;
-    position:relative;
-    float:left;
-    background-color:#F8981D;
+div.table-tabs > button.table-tab {
+    background: var(--navbar-background-color);
+    color: var(--navbar-text-color);
 }
-.memberSummary .activeTableTab .tabEnd {
-    display:none;
-    width:5px;
-    margin-right:3px;
-    position:relative; 
-    float:left;
-    background-color:#F8981D;
+.two-column-search-results {
+    display: grid;
+    grid-template-columns: minmax(400px, max-content) minmax(400px, auto);
 }
-.memberSummary .tableTab .tabEnd {
-    display:none;
-    width:5px;
-    margin-right:3px;
-    position:relative;
-    background-color:#4D7A97;
-    float:left;
-
+div.checkboxes {
+    line-height: 2em;
 }
-.overviewSummary td, .memberSummary td, .typeSummary td,
-.useSummary td, .constantsSummary td, .deprecatedSummary td {
+div.checkboxes > span {
+    margin-left: 10px;
+}
+div.checkboxes > label {
+    margin-left: 8px;
+    white-space: nowrap;
+}
+div.checkboxes > label > input {
+    margin: 0 2px;
+}
+.two-column-summary {
+    display: grid;
+    grid-template-columns: minmax(25%, max-content) minmax(25%, auto);
+}
+.three-column-summary {
+    display: grid;
+    grid-template-columns: minmax(15%, max-content) minmax(20%, max-content) minmax(20%, auto);
+}
+.three-column-release-summary {
+    display: grid;
+    grid-template-columns: minmax(40%, max-content) minmax(10%, max-content) minmax(40%, auto);
+}
+.four-column-summary {
+    display: grid;
+    grid-template-columns: minmax(10%, max-content) minmax(15%, max-content) minmax(15%, max-content) minmax(15%, auto);
+}
+@media screen and (max-width: 1000px) {
+    .four-column-summary {
+        display: grid;
+        grid-template-columns: minmax(15%, max-content) minmax(15%, auto);
+    }
+}
+@media screen and (max-width: 800px) {
+    .two-column-search-results {
+        display: grid;
+        grid-template-columns: minmax(40%, max-content) minmax(40%, auto);
+    }
+    .three-column-summary {
+        display: grid;
+        grid-template-columns: minmax(10%, max-content) minmax(25%, auto);
+    }
+    .three-column-release-summary {
+        display: grid;
+        grid-template-columns: minmax(70%, max-content) minmax(30%, max-content)
+    }
+    .three-column-summary .col-last,
+    .three-column-release-summary .col-last{
+        grid-column-end: span 2;
+    }
+}
+@media screen and (max-width: 600px) {
+    .two-column-summary {
+        display: grid;
+        grid-template-columns: 1fr;
+    }
+}
+.summary-table > div, .details-table > div {
     text-align:left;
-    padding:0px 0px 12px 10px;
+    padding: 8px 3px 3px 7px;
+    overflow: auto hidden;
+    scrollbar-width: thin;
 }
-th.colOne, th.colFirst, th.colLast, .useSummary th, .constantsSummary th,
-td.colOne, td.colFirst, td.colLast, .useSummary td, .constantsSummary td{
+.col-first, .col-second, .col-last, .col-constructor-name, .col-summary-item-name {
     vertical-align:top;
-    padding-right:0px;
+    padding-right:0;
     padding-top:8px;
     padding-bottom:3px;
 }
-th.colFirst, th.colLast, th.colOne, .constantsSummary th {
-    background:#dee3e9;
-    text-align:left;
-    padding:8px 3px 3px 7px;
+.table-header {
+    background:var(--subnav-background-color);
+    font-weight: bold;
 }
-td.colFirst, th.colFirst {
-    white-space:nowrap;
-    font-size:13px;
+/* Sortable table columns */
+.table-header[onclick] {
+    cursor: pointer;
 }
-td.colLast, th.colLast {
-    font-size:13px;
+.table-header[onclick]::after {
+    content:"";
+    display:inline-block;
+    background-image:url('data:image/svg+xml; utf8, \
+    <svg xmlns="http://www.w3.org/2000/svg" width="125" height="170"> \
+    <path d="M10.101 57.059L63.019 4.142l52.917 52.917M10.101 86.392l52.917 52.917 52.917-52.917" style="opacity:.35;"/></svg>');
+    background-size:100% 100%;
+    width:9px;
+    height:14px;
+    margin-left:4px;
+    margin-bottom:-3px;
 }
-td.colOne, th.colOne {
-    font-size:13px;
+.table-header[onclick].sort-asc::after {
+    background-image:url('data:image/svg+xml; utf8, \
+    <svg xmlns="http://www.w3.org/2000/svg" width="125" height="170"> \
+    <path d="M10.101 57.059L63.019 4.142l52.917 52.917" style="opacity:.75;"/> \
+    <path d="M10.101 86.392l52.917 52.917 52.917-52.917" style="opacity:.35;"/></svg>');
+
 }
-.overviewSummary td.colFirst, .overviewSummary th.colFirst,
-.useSummary td.colFirst, .useSummary th.colFirst,
-.overviewSummary td.colOne, .overviewSummary th.colOne,
-.memberSummary td.colFirst, .memberSummary th.colFirst,
-.memberSummary td.colOne, .memberSummary th.colOne,
-.typeSummary td.colFirst{
-    width:25%;
+.table-header[onclick].sort-desc::after {
+    background-image:url('data:image/svg+xml; utf8, \
+    <svg xmlns="http://www.w3.org/2000/svg" width="125" height="170"> \
+    <path d="M10.101 57.059L63.019 4.142l52.917 52.917" style="opacity:.35;"/> \
+    <path d="M10.101 86.392l52.917 52.917 52.917-52.917" style="opacity:.75;"/></svg>');
+}
+.col-first, .col-first {
+    font-size:0.93em;
+}
+.col-second, .col-second, .col-last, .col-constructor-name, .col-summary-item-name, .col-last {
+    font-size:0.93em;
+}
+.col-first, .col-second, .col-constructor-name {
     vertical-align:top;
+    overflow: auto;
 }
-td.colOne a:link, td.colOne a:active, td.colOne a:visited, td.colOne a:hover, td.colFirst a:link, td.colFirst a:active, td.colFirst a:visited, td.colFirst a:hover, td.colLast a:link, td.colLast a:active, td.colLast a:visited, td.colLast a:hover, .constantValuesContainer td a:link, .constantValuesContainer td a:active, .constantValuesContainer td a:visited, .constantValuesContainer td a:hover {
+.col-last {
+    white-space:normal;
+}
+.col-first a:link, .col-first a:visited,
+.col-second a:link, .col-second a:visited,
+.col-first a:link, .col-first a:visited,
+.col-second a:link, .col-second a:visited,
+.col-constructor-name a:link, .col-constructor-name a:visited,
+.col-summary-item-name a:link, .col-summary-item-name a:visited {
     font-weight:bold;
 }
-.tableSubHeadingColor {
-    background-color:#EEEEFF;
+.even-row-color, .even-row-color .table-header {
+    background-color:var(--even-row-color);
 }
-.altColor {
-    background-color:#FFFFFF;
-}
-.rowColor {
-    background-color:#EEEEEF;
+.odd-row-color, .odd-row-color .table-header {
+    background-color:var(--odd-row-color);
 }
 /*
-Content styles
-*/
-.description pre {
-    margin-top:0;
-}
-.deprecatedContent {
-    margin:0;
-    padding:10px 0;
-}
-.docSummary {
-    padding:0;
-}
-
-ul.blockList ul.blockList ul.blockList li.blockList h3 {
-    font-style:normal;
-}
-
+ * Styles for contents.
+ */
 div.block {
-    font-size:14px;
-    font-family:'DejaVu Serif', Georgia, "Times New Roman", Times, serif;
+    font-size:var(--block-font-size);
+    font-family:var(--block-font-family);
+    line-height:var(--block-line-height);
 }
-
-td.colLast div {
-    padding-top:0px;
+.col-last div {
+    padding-top:0;
 }
-
-
-td.colLast a {
+.col-last a {
     padding-bottom:3px;
 }
-/*
-Formatting effect styles
-*/
-.sourceLineNo {
-    color:green;
-    padding:0 30px 0 0;
+.module-signature,
+.package-signature,
+.type-signature,
+.member-signature {
+    font-family:var(--code-font-family);
+    font-size:1em;
+    margin:8px 0 14px 0;
+    white-space: pre-wrap;
 }
-h1.hidden {
-    visibility:hidden;
-    overflow:hidden;
-    font-size:10px;
+.module-signature,
+.package-signature,
+.type-signature {
+    margin-top: 0;
+}
+.member-signature .type-parameters-long,
+.member-signature .parameters,
+.member-signature .exceptions {
+    display: inline-block;
+    vertical-align: top;
+    white-space: pre;
+}
+.member-signature .type-parameters {
+    white-space: normal;
+}
+/*
+ * Styles for formatting effect.
+ */
+.source-line-no {
+    /* Color of line numbers in source pages can be set via custom property below */
+    color:var(--source-linenumber-color, green);
+    padding:0 30px 0 0;
 }
 .block {
     display:block;
-    margin:3px 10px 2px 0px;
-    color:#474747;
+    margin:0 10px 5px 0;
+    color:var(--block-text-color);
 }
-.deprecatedLabel, .descfrmTypeLabel, .memberNameLabel, .memberNameLink,
-.overrideSpecifyLabel, .packageHierarchyLabel, .paramLabel, .returnLabel,
-.seeLabel, .simpleTagLabel, .throwsLabel, .typeNameLabel, .typeNameLink {
+.deprecated-label, .description-from-type-label, .implementation-label, .member-name-link,
+.package-hierarchy-label, .type-name-label, .type-name-link, .search-tag-link, .preview-label, .restricted-label {
     font-weight:bold;
 }
-.deprecationComment, .emphasizedPhrase, .interfaceName {
+.deprecation-comment, .help-footnote, .preview-comment, .restricted-comment {
     font-style:italic;
 }
-
-div.block div.block span.deprecationComment, div.block div.block span.emphasizedPhrase,
-div.block div.block span.interfaceName {
+.deprecation-block, .preview-block, .restricted-block {
+    font-size:1em;
+    font-family:var(--block-font-family);
+    border-style:solid;
+    border-width:thin;
+    border-radius:10px;
+    padding:10px;
+    margin-bottom:10px;
+    margin-right:10px;
+    display:inline-block;
+}
+div.block div.deprecation-comment {
     font-style:normal;
 }
+details.invalid-tag, span.invalid-tag {
+    font-size:1em;
+    font-family:var(--block-font-family);
+    color: var(--invalid-tag-text-color);
+    background: var(--invalid-tag-background-color);
+    border: thin solid var(--table-border-color);
+    border-radius:2px;
+    padding: 2px 4px;
+    display:inline-block;
+}
+details summary {
+    cursor: pointer;
+}
+/*
+ * Styles specific to HTML5 elements.
+ */
+main, nav, header, footer, section {
+    display:block;
+}
+/*
+ * Styles for javadoc search.
+ */
+.ui-menu .ui-state-active {
+    /* Overrides the color of selection used in jQuery UI */
+    background: var(--selected-background-color);
+    color: var(--selected-text-color);
+    /* Workaround for browser bug, see JDK-8275889 */
+    margin: -1px 0;
+    border-top: 1px solid var(--selected-background-color);
+    border-bottom: 1px solid var(--selected-background-color);
+}
+.ui-autocomplete-category {
+    font-weight:bold;
+    font-size:15px;
+    padding:7px 0 7px 3px;
+    background-color:var(--navbar-background-color);
+    color:var(--navbar-text-color);
+    box-sizing: border-box;
+}
+.ui-autocomplete {
+    max-height:85%;
+    max-width:65%;
+    overflow:auto;
+    white-space:nowrap;
+    box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+    overscroll-behavior: contain;
+}
+ul.ui-autocomplete {
+    position:fixed;
+    z-index:10;
+    background-color: var(--body-background-color);
+}
+ul.ui-autocomplete li {
+    float:left;
+    clear:both;
+    min-width:100%;
+    box-sizing: border-box;
+}
+ul.ui-autocomplete li.ui-static-link {
+    position:sticky;
+    bottom:0;
+    left:0;
+    background: var(--subnav-background-color);
+    padding: 5px 0;
+    font-family: var(--body-font-family);
+    font-size: 0.93em;
+    font-weight: bolder;
+    z-index: 10;
+}
+li.ui-static-link a, li.ui-static-link a:visited {
+    text-decoration:none;
+    color:var(--link-color);
+    float:right;
+    margin-right:20px;
+}
+.ui-autocomplete .result-item {
+    font-size: inherit;
+}
+.ui-autocomplete .result-highlight {
+    font-weight:bold;
+}
+.ui-menu .ui-menu-item-wrapper {
+    padding-top: 0.4em;
+    padding-bottom: 0.4em;
+}
+.ui-menu .ui-menu-item-wrapper {
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+input[type="text"] {
+    background-image:url('glass.png');
+    background-size:13px;
+    background-repeat:no-repeat;
+    background-position:2px 3px;
+    background-color: var(--search-input-background-color);
+    color: var(--search-input-text-color);
+    border-color: var(--border-color);
+    border-radius: 4px;
+    padding-left:20px;
+    font-size: var(--nav-font-size);
+    height: 17px;
+}
+input#search-input, input#page-search-input {
+    width: calc(180px + 10vw);
+    margin: 0;
+}
+input#search-input {
+    margin: 0 4px;
+    padding-right: 18px;
+    max-width: 340px;
+}
+input.filter-input {
+    width: 40%;
+    max-width: 140px;
+    margin: 0 4px;
+    padding-right: 18px;
+}
+input#reset-search, input.reset-filter {
+    background-color: transparent;
+    background-image:url('x.png');
+    background-repeat:no-repeat;
+    background-size:contain;
+    border:0;
+    border-radius:0;
+    width:12px;
+    height:12px;
+    font-size:0;
+    display:none;
+}
+input#reset-search {
+    position:absolute;
+    right:15px;
+    top:11px;
+}
+input.reset-filter {
+    position: relative;
+    right: 20px;
+    top: 0;
+}
+input::placeholder {
+    color:var(--search-input-placeholder-color);
+    opacity: 1;
+}
+.search-tag-desc-result {
+    font-style:italic;
+    font-size:11px;
+}
+.search-tag-holder-result {
+    font-style:italic;
+    font-size:12px;
+}
+.search-tag-result:target {
+    background-color:var(--search-tag-highlight-color);
+}
+details.page-search-details {
+    display: inline-block;
+}
+div#result-container {
+    font-size: 1em;
+}
+div#result-container a.search-result-link {
+    padding: 0;
+    margin: 4px 0;
+    width: 100%;
+}
+#result-container .result-highlight {
+    font-weight:bolder;
+}
+.page-search-info {
+    background-color: var(--subnav-background-color);
+    border-radius: 3px;
+    border: 0 solid var(--border-color);
+    padding: 0 8px;
+    overflow: hidden;
+    height: 0;
+    transition: all 0.2s ease;
+}
+div.table-tabs > button.table-tab {
+    background: var(--navbar-background-color);
+    color: var(--navbar-text-color);
+}
+.page-search-header {
+    padding: 5px 12px 7px 12px;
+    font-weight: bold;
+    margin-right: 3px;
+    background-color:var(--navbar-background-color);
+    color:var(--navbar-text-color);
+    display: inline-block;
+}
+button.page-search-header {
+    border: none;
+    cursor: pointer;
+}
+span#page-search-link {
+    text-decoration: underline;
+}
+.module-graph span, .sealed-graph span {
+    display:none;
+    position:absolute;
+}
+.module-graph:hover span, .sealed-graph:hover span {
+    display:block;
+    margin: -100px 0 0 100px;
+    z-index: 5;
+}
+.inherited-list {
+    margin: 10px 0 10px 0;
+}
+.horizontal-scroll {
+    overflow: auto hidden;
+}
+section.class-description {
+    line-height: 1.4;
+}
+.summary section[class$="-summary"], .details section[class$="-details"],
+.class-uses .detail, .serialized-class-details {
+    padding: 0 20px 5px 10px;
+    border: 1px solid var(--border-color);
+    background-color: var(--section-background-color);
+}
+.inherited-list, section[class$="-details"] .detail {
+    padding:0 0 5px 8px;
+    background-color:var(--detail-background-color);
+    border:none;
+}
+.vertical-separator {
+    padding: 0 5px;
+}
+.help-section {
+    font-size: var(--block-font-size);
+    line-height: var(--block-line-height);
+}
+ul.help-section-list {
+    margin: 0;
+}
+ul.help-subtoc > li {
+  display: inline-block;
+  padding-right: 5px;
+  font-size: smaller;
+}
+ul.help-subtoc > li::before {
+  content: "\2022" ;
+  padding-right:2px;
+}
+.help-note {
+    font-style: italic;
+}
+/*
+ * Indicator icon for external links.
+ */
+main a[href*="://"]::after {
+    content:"";
+    display:inline-block;
+    background-image:url('data:image/svg+xml; utf8, \
+      <svg xmlns="http://www.w3.org/2000/svg" width="768" height="768">\
+        <path d="M584 664H104V184h216V80H0v688h688V448H584zM384 0l132 \
+        132-240 240 120 120 240-240 132 132V0z" fill="%234a6782"/>\
+      </svg>');
+    background-size:100% 100%;
+    width:7px;
+    height:7px;
+    margin-left:2px;
+    margin-bottom:4px;
+}
+main a[href*="://"]:hover::after,
+main a[href*="://"]:focus::after {
+    background-image:url('data:image/svg+xml; utf8, \
+      <svg xmlns="http://www.w3.org/2000/svg" width="768" height="768">\
+        <path d="M584 664H104V184h216V80H0v688h688V448H584zM384 0l132 \
+        132-240 240 120 120 240-240 132 132V0z" fill="%23bb7a2a"/>\
+      </svg>');
+}
+/*
+ * Styles for header/section anchor links
+ */
+a.anchor-link {
+    opacity: 0;
+    transition: opacity 0.1s;
+}
+:hover > a.anchor-link {
+    opacity: 80%;
+}
+a.anchor-link:hover,
+a.anchor-link:focus-visible,
+a.anchor-link.visible {
+    opacity: 100%;
+}
+a.anchor-link > img {
+    width: 0.9em;
+    height: 0.9em;
+}
+/*
+ * Styles for copy-to-clipboard buttons
+ */
+button.copy {
+    opacity: 70%;
+    border: none;
+    border-radius: 3px;
+    position: relative;
+    background:none;
+    transition: opacity 0.3s;
+    cursor: pointer;
+}
+:hover > button.copy {
+    opacity: 80%;
+}
+button.copy:hover,
+button.copy:active,
+button.copy:focus-visible,
+button.copy.visible {
+    opacity: 100%;
+}
+button.copy img {
+    position: relative;
+    background: none;
+    filter: brightness(var(--copy-icon-brightness));
+}
+button.copy:active {
+    background-color: var(--copy-button-background-color-active);
+}
+button.copy span {
+    color: var(--body-text-color);
+    position: relative;
+    top: -0.1em;
+    transition: all 0.1s;
+    font-size: 0.76rem;
+    line-height: 1.2em;
+    opacity: 0;
+}
+button.copy:hover span,
+button.copy:focus-visible span,
+button.copy.visible span {
+    opacity: 100%;
+}
+/* search page copy button */
+button#page-search-copy {
+    margin-left: 0.4em;
+    padding:0.3em;
+    top:0.13em;
+}
+button#page-search-copy img {
+    width: 1.2em;
+    height: 1.2em;
+    padding: 0.01em 0;
+    top: 0.15em;
+}
+button#page-search-copy span {
+    color: var(--body-text-color);
+    line-height: 1.2em;
+    padding: 0.2em;
+    top: -0.18em;
+}
+div.page-search-info:hover button#page-search-copy span {
+    opacity: 100%;
+}
+/* snippet copy button */
+button.snippet-copy {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    height: 1.7em;
+    padding: 2px;
+}
+button.snippet-copy img {
+    width: 18px;
+    height: 18px;
+    padding: 0.05em 0;
+}
+button.snippet-copy span {
+    line-height: 1.2em;
+    padding: 0.2em;
+    position: relative;
+    top: -0.5em;
+}
+div.snippet-container:hover button.snippet-copy span {
+    opacity: 100%;
+}
+/*
+ * Styles for user-provided tables.
+ *
+ * borderless:
+ *      No borders, vertical margins, styled caption.
+ *      This style is provided for use with existing doc comments.
+ *      In general, borderless tables should not be used for layout purposes.
+ *
+ * plain:
+ *      Plain borders around table and cells, vertical margins, styled caption.
+ *      Best for small tables or for complex tables for tables with cells that span
+ *      rows and columns, when the "striped" style does not work well.
+ *
+ * striped:
+ *      Borders around the table and vertical borders between cells, striped rows,
+ *      vertical margins, styled caption.
+ *      Best for tables that have a header row, and a body containing a series of simple rows.
+ */
 
-div.contentContainer ul.blockList li.blockList h2{
-    padding-bottom:0px;
+table.borderless,
+table.plain,
+table.striped {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
+table.borderless > caption,
+table.plain > caption,
+table.striped > caption {
+    font-weight: bold;
+    font-size: smaller;
+}
+table.borderless th, table.borderless td,
+table.plain th, table.plain td,
+table.striped th, table.striped td {
+    padding: 2px 5px;
+}
+table.borderless,
+table.borderless > thead > tr > th, table.borderless > tbody > tr > th, table.borderless > tr > th,
+table.borderless > thead > tr > td, table.borderless > tbody > tr > td, table.borderless > tr > td {
+    border: none;
+}
+table.borderless > thead > tr, table.borderless > tbody > tr, table.borderless > tr {
+    background-color: transparent;
+}
+table.plain {
+    border-collapse: collapse;
+    border: 1px solid var(--table-border-color);
+}
+table.plain > thead > tr, table.plain > tbody tr, table.plain > tr {
+    background-color: transparent;
+}
+table.plain > thead > tr > th, table.plain > tbody > tr > th, table.plain > tr > th,
+table.plain > thead > tr > td, table.plain > tbody > tr > td, table.plain > tr > td {
+    border: 1px solid var(--table-border-color);
+}
+table.striped {
+    border-collapse: collapse;
+    border: 1px solid var(--table-border-color);
+}
+table.striped > thead {
+    background-color: var(--subnav-background-color);
+}
+table.striped > thead > tr > th, table.striped > thead > tr > td {
+    border: 1px solid var(--table-border-color);
+}
+table.striped > tbody > tr:nth-child(even) {
+    background-color: var(--odd-row-color)
+}
+table.striped > tbody > tr:nth-child(odd) {
+    background-color: var(--even-row-color)
+}
+table.striped > tbody > tr > th, table.striped > tbody > tr > td {
+    border-left: 1px solid var(--table-border-color);
+    border-right: 1px solid var(--table-border-color);
+}
+table.striped > tbody > tr > th {
+    font-weight: normal;
+}
+/**
+ * Tweak style for small screens.
+ */
+@media screen and (max-width: 1050px) {
+    .summary section[class$="-summary"], .details section[class$="-details"],
+    .class-uses .detail, .serialized-class-details {
+        padding: 0 10px 5px 8px;
+    }
+    input#search-input {
+        width: 22vw;
+    }
+}
+@media screen and (max-width: 920px) {
+    .main-grid nav.toc {
+        display: none;
+    }
+    .top-nav nav.toc {
+        display: none;
+        position: absolute;
+        top: var(--top-nav-height);
+        left: 40vw;
+        width: 60vw;
+        z-index: 7;
+        background-color: var(--section-background-color);
+        box-sizing: border-box;
+    }
+    .top-nav nav.toc div.toc-header {
+        padding: 6px 15px;
+        font-size: 0.94em;
+        background-color: var(--section-background-color);
+        top: calc(var(--top-nav-height) + 10px);
+    }
+    .top-nav nav.toc ol.toc-list li {
+        font-size: 1.04em;
+    }
+    nav.toc a:link, nav.toc a:visited {
+        text-decoration:none;
+        color:var(--link-color);
+    }
+    nav.toc a[href]:hover, nav.toc a[href]:focus {
+        text-decoration:none;
+        color:var(--link-color-active);
+    }
+    :root {
+        scroll-behavior: auto;
+    }
+    header {
+        max-height: 100vh;
+        overflow-y: visible;
+        overscroll-behavior: contain;
+    }
+    nav {
+        overflow: visible;
+    }
+    ul.nav-list {
+        display: none;
+        position: absolute;
+        top: var(--top-nav-height);
+        overflow: auto;
+        z-index: 7;
+        background-color: var(--navbar-background-color);
+        width: 40%;
+        padding: 0;
+        box-sizing: border-box;
+    }
+    ul.nav-list li {
+        float: none;
+        padding: 6px;
+        margin-left: 10px;
+        margin-top: 2px;
+    }
+    .top-nav a:link, .top-nav a:active, .top-nav a:visited {
+        display: block;
+    }
+    .top-nav div.nav-menu-button {
+        flex: 1 1 auto;
+    }
+    .sub-nav ol.sub-nav-list {
+        margin-left: 4px;
+        padding-left: 4px;
+    }
+    button#navbar-toggle-button {
+        width: 3.4em;
+        height: 2.8em;
+        background-color: transparent;
+        display: block;
+        border: 0;
+        margin: 0 10px;
+        cursor: pointer;
+        font-size: 10px;
+    }
+    button#navbar-toggle-button .nav-bar-toggle-icon {
+        display: block;
+        width: 24px;
+        height: 3px;
+        margin: 4px 0;
+        border-radius: 2px;
+        background-color: var(--navbar-text-color);
+    }
+    button#navbar-toggle-button.expanded span.nav-bar-toggle-icon:nth-child(1) {
+        transform: rotate(45deg);
+        transform-origin: 10% 10%;
+        width: 26px;
+    }
+    button#navbar-toggle-button.expanded span.nav-bar-toggle-icon:nth-child(2) {
+        opacity: 0;
+    }
+    button#navbar-toggle-button.expanded span.nav-bar-toggle-icon:nth-child(3) {
+        transform: rotate(-45deg);
+        transform-origin: 10% 90%;
+        width: 26px;
+    }
+}
+@media screen and (max-width: 800px) {
+    .about-language {
+        padding-right: 16px;
+        max-width: 90%;
+    }
+    ul.nav-list li {
+        margin-left: 5px;
+    }
+    main {
+        padding: 10px 12px;
+    }
+    body {
+        -webkit-text-size-adjust: none;
+    }
+}
+@media screen and (max-width: 600px) {
+    .nav-list-search > a {
+        display: none;
+    }
+    input#search-input {
+        width: 18vw;
+    }
+    .summary section[class$="-summary"], .details section[class$="-details"],
+    .class-uses .detail, .serialized-class-details {
+        padding: 0;
+    }
+}
+pre.snippet {
+    background-color: var(--snippet-background-color);
+    color: var(--snippet-text-color);
+    padding: 10px;
+    margin: 12px 0;
+    overflow: auto;
+    white-space: pre;
+}
+div.snippet-container {
+    position: relative;
+}
+@media screen and (max-width: 800px) {
+    pre.snippet {
+        padding-top: 26px;
+    }
+    button.snippet-copy {
+        top: 4px;
+        right: 4px;
+    }
+}
+pre.snippet .italic {
+    font-style: italic;
+}
+pre.snippet .bold {
+    font-weight: bold;
+}
+pre.snippet .highlighted {
+    background-color: var(--snippet-highlight-color);
+    border-radius: 10%;
 }

--- a/nbbuild/javadoctools/javadoc.css
+++ b/nbbuild/javadoctools/javadoc.css
@@ -25,5 +25,14 @@
 /* The rest is the default stylesheet produced by Javadoc 1.4.2: */
 @import "javadoc-generic.css";
 /* Timestamp information for all HTML files in the footer */
+
+/* color from Apache NetBeans Webpage */ 
+:root {
+    --navbar-background-color: #a1c535;
+    --selected-background-color: #1b6ac6;
+    --selected-text-color: #ffffff;
+}
+
+
 .footnote:before { content: "@CSS_TIMESTAMP@"; }
 

--- a/nbbuild/javadoctools/template.xml
+++ b/nbbuild/javadoctools/template.xml
@@ -255,7 +255,8 @@ cause it to fail.
     </target>
 
     <target name="javadoc-make-hyperlinked-title" if="javadoc.main.page">
-        <property name="javadoc.hyperlinked.title" value='&lt;a href="@TOP@${javadoc.main.page}"&gt;${javadoc.title}&lt;/a&gt;'/>
+        <!-- <property name="javadoc.hyperlinked.title" value='&lt;a href="@TOP@${javadoc.main.page}"&gt;${javadoc.title}&lt;/a&gt;'/> -->
+        <property name="javadoc.hyperlinked.title" value="${javadoc.title}"/>
     </target>
 
     <target name="javadoc-stage-alternative" depends="javadoc-init,javadoc-check-timestamps" if="javadoc.should.not.be.generated" unless="javadoc.up.to.date" >
@@ -267,17 +268,22 @@ cause it to fail.
         <tstamp>
             <format property="YEAR" pattern="yyyy"/>
         </tstamp>
-        <copy todir="${javadoc.out.dir}">
+        <copy todir="${javadoc.out.dir}/resource-files">
             <fileset refid="javadoc.css.files"/>
         </copy>
+        
         <replace dir="${javadoc.out.dir}" >
-            <include name="javadoc*.css"/>
+            <include name="**/javadoc*.css"/>
             <include name="nb-docs-stability.css"/>
             <replacefilter token="@CSS_TIMESTAMP@" value="Built on ${TODAY}. Copyright 2017-${YEAR} The Apache Software Foundation. All Rights Reserved." />
             <replacefilter token="@nb-docs-css@" value="${nb-docs.css}"/>
             <replacefilter token="@api-stability-image@" value="${stability.image}"/>
         </replace>
         <mkdir dir="${javadoc.out.dir}/resources"/>
+        <mkdir dir="${javadoc.out.dir}/resource-files/resources"/>
+        <copy file="${javadoc.out.dir}/resource-files/glass.png" todir="${javadoc.out.dir}/resource-files/resources" />
+        <copy file="${javadoc.out.dir}/resource-files/x.png" todir="${javadoc.out.dir}/resource-files/resources" />
+          
         <copy todir="${javadoc.out.dir}/resources">
             <fileset refid="javadoc.resources.files"/>
         </copy>
@@ -307,22 +313,22 @@ cause it to fail.
     </condition>
 
     <target name="javadoc-exec-packages" depends="javadoc-init,javadoc-generate-references,javadoc-generate-overview,javadoc-exec-condition,javadoc-check-timestamps,javadoc-make-plain-title,javadoc-make-hyperlinked-title,javadoc-exec-condition,-javadoc-set-footer" unless="javadoc.exec.packages">
-        <!-- -->
         <javadoc source="${javac.sourcerelease}" failonerror="${apidoc.check}" failonwarning="false" author="false" destdir="${javadoc.out.dir}" packagenames="${javadoc.packages}" stylesheetfile="${javadoc.css.main}" windowtitle="${javadoc.title}" overview="${javadoc.overview}" splitindex="true" use="true" version="false" useexternalfile="true" encoding="UTF-8">
             <sourcepath>
                 <pathelement location="${javadoc.docfiles}"/>
                 <pathelement location="${javadoc.src}"/>
                 <pathelement location="${javadoc.src}/../build/classes-generated"/>
-            </sourcepath>
+            </sourcepath><!--
             <doclet
                 name="org.apidesign.javadoc.codesnippet.Doclet"
                 path="${nb_all}/nbbuild/external/codesnippet-doclet-1.0.jar"
             >
                 <param name="-snippetpath" value="${javadoc.base}/src"/>
                 <param name="-snippetpath" value="${javadoc.base}/test/unit/src"/>
-                <param name="-maxLineLength" value="240"/> <!-- 120 was too short -->
+                <param name="-maxLineLength" value="240"/> <!- - 120 was too short - ->
                 <param name="-snippetmode" value="jep413"/>
             </doclet>
+            -->
             <classpath path="${javadoc.classpath}"/>
             <!-- XXX note, this does not support more than one group -->
             <group packages="${javadoc.packages}">
@@ -344,6 +350,9 @@ cause it to fail.
             <arg value="--disable-line-doc-comments" if:true="${javadoc23.or.later}" />
             <arg value="-Xdoclint:all" />
             <arg value="-Xdoclint:-missing" />
+            <arg value="--allow-script-in-comments" if:true="${javadoc23.or.later}" />
+            <arg value="--snippet-path ${javadoc.base}/test/unit/src:${javadoc.base}/src" if:true="${javadoc23.or.later}" />
+            <arg value="--no-fonts" if:true="${javadoc23.or.later}" />
         </javadoc>
     </target>
 
@@ -379,9 +388,12 @@ cause it to fail.
     </target>
 
     <target name="javadoc-stage-apichanges" depends="javadoc-init,javadoc-check-timestamps,javadoc-stage-export-apichanges" unless="javadoc.up.to.date">
+        <available file="${javadoc.out.dir}/deprecated-list.html" property="hasdeprecated"/>
         <xslt in="${javadoc.apichanges}" out="${javadoc.out.dir}/apichanges.html" style="apichanges.xsl">
             <xmlcatalog refid="nbantextcatalog" />
             <param name="javadoc-url-base" expression="."/>
+            <param name="javadoc-header" expression="${javadoc.header}" />
+            <param name="deprecated" expression="${hasdeprecated}" />
         </xslt>
     </target>
 
@@ -413,12 +425,15 @@ cause it to fail.
         </taskdef>
         <!-- Warn about incorrect question version, but do not make build fail: -->
         <property name="arch.warn" value="true"/>
+        <available file="${javadoc.out.dir}/deprecated-list.html" property="hasdeprecated"/>
         <arch answers="${javadoc.arch}"
               output="${javadoc.out.dir}/architecture-summary.html"
               stylesheet="prose.css"
               overviewlink="overview-summary.html"
               footer="@FOOTER@"
               project="${javadoc.project}"
+              header="${javadoc.header}"
+              deprecatedmenu="${hasdeprecated}"
         />
     </target>
 
@@ -498,10 +513,11 @@ cause it to fail.
 
 
         <replace dir="${javadoc.out.dir}">
-            <replacetoken><![CDATA[<ul class="navList" title="Navigation">]]></replacetoken>
-            <replacevalue><![CDATA[<ul class="navList" title="Navigation"><li><a href="@TOP@apichanges.html">API Changes</a></li><li><a href="@TOP@architecture-summary.html">Architecture Summary</a></li>]]></replacevalue>
+            <replacetoken><![CDATA[<ul id="navbar-top-firstrow" class="nav-list" title="Navigation">]]></replacetoken>
+            <replacevalue><![CDATA[<ul id="navbar-top-firstrow" class="nav-list" title="Navigation"><li><a href="@TOP@apichanges.html">API Changes</a></li><li><a href="@TOP@architecture-summary.html">Architecture Summary</a></li>]]></replacevalue>
             <include name="**/*.html"/>
-            <exclude name="**/**/architecture-summary.html,**/**/apichanges.html"/>
+            <exclude name="**/**/architecture-summary.html"/>
+            <exclude name="**/**/apichanges.html"/>
         </replace>
         <replace dir="${javadoc.out.dir}" token="@TOP@" value="">
             <include name="*.html"/>


### PR DESCRIPTION
This is a proposal to have a bit more modern apidoc. Using css/html from new layout javadoc tool 23.

In order to work, bootstrap ant task 

-   linkchecker need upgrade to scan more element, and allow other ordering of attribute to find href/name/id.
-   javadocindex need to parse new div based navigation file.
-   arch.java needs new parameters to render optional element

  

Inject into arch/apichanges pages 

-  new menu + header that looks like normal apidoc page
-  deprecated menu if deprecated.html present.

 
 correct some top level page to not swallow api so we have correct text instead blank text.
 
 css altered to get green header with green taken from APache NetBeans website to make difference when you look at jdk apidoc.
 
 
 This PR will lead to many checklink errors because ` ( ) , ` should be back to the href as before they were replaced by `-`

Example:
` @org-openide-util@/org/openide/util/BaseUtilities.html#isWindows--` needs to be replaced by `@org-openide-util@/org/openide/util/BaseUtilities.html#isWindows()`
 
 tested on jdk 23 and 24. 
 
