### PR TITLE
CI: build javadoc on JDK 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -438,16 +438,18 @@ jobs:
         run: ant -quiet -Dcluster.config=$CLUSTER_CONFIG test -Dtest.includes=NoTestsJustBuild
 
       # 13-14 min for javadoc; JDK version must be synced with nb-javac
-      - name: Set up JDK 23 for javadoc
+      - name: Set up JDK 24 for javadoc
         if: env.test_javadoc == 'true' && success()
         uses: actions/setup-java@v4
         with:
-          java-version: 23 
+          java-version: 24
           distribution: ${{ env.DEFAULT_JAVA_DISTRIBUTION }}
 
       - name: Build javadoc
         if: env.test_javadoc == 'true' && success()
-        run: ant $OPTS build-javadoc
+        run: |
+          export ANT_OPTS=-Djdk.xml.totalEntitySizeLimit=200000
+          ant $OPTS build-javadoc
 
       - name: Create Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4


### PR DESCRIPTION
JDK 24 reduces the jaxp entity size limit from 500k to 100k, which is not sufficient for the javadoc target.


```
/home/mbien/NetBeansProjects/netbeans/nbbuild/javadoctools/links.xml:227: JAXP00010004: The accumulated size of entities is "100,003" that exceeded the "100,000" limit set by "jdk.xml.totalEntitySizeLimit".
```
