### PR TITLE
Improving LSP client, not crashing cpplite.editor when ccls/clangd is not specified.

### DIFF
--- a/cpplite/cpplite.editor/nbproject/project.properties
+++ b/cpplite/cpplite.editor/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.release=11
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/BreadcrumbsImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/BreadcrumbsImpl.java
@@ -39,7 +39,9 @@ import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 import javax.swing.text.Position;
 import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.DocumentSymbolOptions;
 import org.eclipse.lsp4j.DocumentSymbolParams;
+import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
@@ -82,6 +84,13 @@ public class BreadcrumbsImpl implements BackgroundTask {
 
     @Override
     public void run(LSPBindings bindings, FileObject file) {
+        ServerCapabilities capa = bindings.getInitResult().getCapabilities();
+        Either<Boolean, DocumentSymbolOptions> documentSymbolProviderOpt = capa != null ? capa.getDocumentSymbolProvider() : null;
+
+        if (documentSymbolProviderOpt == null || (documentSymbolProviderOpt.isLeft() && documentSymbolProviderOpt.getLeft() == Boolean.FALSE)) {
+            return ;
+        }
+
         try {
             //TODO: modified while the query is running?
             List<Either<SymbolInformation, DocumentSymbol>> symbols = bindings.getTextDocumentService().documentSymbol(new DocumentSymbolParams(new TextDocumentIdentifier(Utils.toURI(file)))).get();

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/CompletionProviderImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/CompletionProviderImpl.java
@@ -213,7 +213,11 @@ public class CompletionProviderImpl implements CompletionProvider {
                         String rightLabel;
                         if (i.getLabelDetails() != null) {
                             leftLabel = encode(i.getLabel() + (i.getLabelDetails().getDetail() != null ? i.getLabelDetails().getDetail() : ""));
-                            rightLabel = encode(i.getLabelDetails().getDescription());
+                            if (i.getLabelDetails().getDescription() != null) {
+                                rightLabel = encode(i.getLabelDetails().getDescription());
+                            } else {
+                                rightLabel = null;
+                            }
                         } else {
                             leftLabel = encode(i.getLabel());
                             if (i.getDetail() != null) {
@@ -341,7 +345,7 @@ public class CompletionProviderImpl implements CompletionProvider {
 
                             @Override
                             public void render(Graphics grphcs, Font font, Color color, Color color1, int i, int i1, boolean bln) {
-                                CompletionUtilities.renderHtml(icon, leftLabel, rightLabel, grphcs, font, color, i, i1, bln);
+                                COMPLETION_ITEM_RENDERER.renderCompletionItem(icon, leftLabel, rightLabel, grphcs, font, color, i, i1, bln);
                             }
 
                             @Override
@@ -566,4 +570,17 @@ public class CompletionProviderImpl implements CompletionProvider {
 
         return template.toString();
     }
+
+    //for tests:
+    static IndirectCompletionItemRenderer COMPLETION_ITEM_RENDERER = new IndirectCompletionItemRenderer() {
+        @Override
+        public void renderCompletionItem(ImageIcon icon, String leftLabel, String rightLabel, Graphics grphcs, Font font, Color color, int i, int i1, boolean bln) {
+            CompletionUtilities.renderHtml(icon, leftLabel, rightLabel, grphcs, font, color, i, i1, bln);
+        }
+    };
+
+    interface IndirectCompletionItemRenderer {
+        public void renderCompletionItem(ImageIcon icon, String leftLabel, String rightLabel, Graphics grphcs, Font font, Color color, int i, int i1, boolean bln);
+    }
+
 }


### PR DESCRIPTION
Three smallish improvements here:
- in `cpplite.editor`, when one of `ccls` or `clangd` is not specified in the settings, the path for the given server is `null`, and this `null` is sent to `List.of`, but `List.of` is null averse, and throws an exception, breaking the CPPLite C/C++ support (as even the one server that is specified won't be able to run, as the exception happens too soon). This PR proposes one way to fix that, but there are other ways.
- in `lsp.client`, if the server does not provide document symbol provider, don't use it for breadcrumbs (otherwise it tends to fail with an exception)
- in `lsp.client`, `CompletionItem.getLabelDetails().getDescription()` may be `null` - account for that.