### PR TITLE
Register icons for git stash and nb shelve actions

### DIFF
--- a/ide/git/nbproject/project.xml
+++ b/ide/git/nbproject/project.xml
@@ -31,6 +31,15 @@
                     <run-dependency/>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.api.annotations.common</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.56</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.api.progress</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>


### PR DESCRIPTION
So that they can be added to the tool bar.

![image](https://github.com/user-attachments/assets/6d0005da-ef47-4728-b33d-41e0cfc40c16)

The action registration in the context menu is a bit of a mess right now. Git stash via jgit does also only support repo wide "stash push", while shelve works on the selection. This isn't communicated anywhere in the UI though, so I updated the text for the shelve action to "Shelve selected Changes".

The way to get to the shelve action is via the stash window - which is super weird (one is global the other is selection based). Custom toolbar makes this easier.