### PR TITLE
solves #7044, issues with record refactoring inner classes with generics, varargs and implements clauses.

### DIFF
--- a/harness/nbjunit/nbproject/project.properties
+++ b/harness/nbjunit/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/harness/nbjunit/src/org/netbeans/junit/AssertLinesEqualHelpers.java
+++ b/harness/nbjunit/src/org/netbeans/junit/AssertLinesEqualHelpers.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.junit;
+
+import java.io.PrintStream;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.fail;
+import static org.netbeans.junit.AssertLinesEqualHelpers.StringsCompareMode.EXACT;
+
+/**
+ *
+ * @author homberghp
+ */
+public class AssertLinesEqualHelpers {
+
+    public enum StringsCompareMode {
+        EXACT, IGNORE_DUP_SPACES, IGNORE_INDENTATION, IGNORE_WHITESPACE_DIFF
+    }
+    private static StringsCompareMode stringsCompareMode = EXACT;
+    private static Function<String, String> linePreprocessor = s -> s;
+    public static boolean showOutputOnPass = false;
+
+    /**
+     * Sets the string compare mode.
+     * <ul>
+     * <li>EXACT: exact line by line, including empty lines.
+     * <li>IGNORE_DUP_SPACES: ignore duplicate (inner) spacing
+     * </li>INGNORE_INDENTATION ignore difference in leading and trailing white
+     * space
+     * </li>INGNORE_WHITE_SPACE_DIFF ignore difference in any white space
+     * </ul>
+     *
+     * @param mode
+     */
+    public static void setStringCompareMode(StringsCompareMode mode) {
+        stringsCompareMode = mode;
+        linePreprocessor = switch (mode) {
+            case EXACT ->
+                s -> s;
+            case IGNORE_DUP_SPACES ->
+                s -> s.replaceAll("\\s{2,}", " ");
+            case IGNORE_INDENTATION ->
+                s -> s.trim();
+            case IGNORE_WHITESPACE_DIFF ->
+                s -> s.trim().replaceAll("\\s{2,}", " ");
+        };
+
+    }
+
+    /**
+     * Prints a source by splitting on the line breaks and prefixing with name
+     * and line number.
+     *
+     * @param out the stream to print to
+     * @param name the name as prefix to each line
+     * @param source the source code to print to the out stream.
+     */
+    public static void printNumbered(final PrintStream out, final String name, String source) {
+        AtomicInteger c = new AtomicInteger(1);
+        source.trim().lines().forEach(l -> out.println("%s [%4d] %s".formatted(name, c.getAndIncrement(), l)));
+    }
+
+    /**
+     * Compare strings by replacing all multiples of white space([ \t\n\r]) with
+     * a space.
+     *
+     * The test programmer chooses this to make it easier to write the input and
+     * the expected strings.
+     *
+     * @param expected to compare
+     * @param actual to compare
+     */
+    public static void assertLinesEqual1(String name, String expected, String actual) {
+        try {
+            assertEquals(name, expected.replaceAll("[ \t\r\n\n]+", " "), actual.replaceAll("[ \t\r\n\n]+", " "));
+        } catch (Throwable t) {
+            System.err.println("expected:");
+            System.err.println(expected);
+            System.err.println("actual:");
+            System.err.println(actual);
+            throw t;
+        }
+    }
+
+    /**
+     * Compare strings by splitting them into lines, remove empty lines, and
+     * trim white space.Only when any of the lines differ, all lines are printed
+     * with the unequal lines flagged.
+     *
+     * Before the lines are compared, they are trimmed and the white space is
+     * normalized by collapsing multiple white space characters into one. This
+     * should make the tests less brittle.
+     *
+     * If any of the compared lines are unequal, this test fails and the
+     * comparison result is shown on stderr in a simplified diff format.
+     *
+     * @param testName to print before comparison result.
+     * @param fileName to print before each compared line.
+     * @param expected to compare
+     * @param actual to compare
+     */
+    public static void assertLinesEqual2(String testName,String fileName, String expected, String actual) {
+        if (stringsCompareMode != EXACT) {
+            expected = expected.trim().replaceAll("([\t\r\n])\\1+", "$1");
+            actual = actual.trim().replaceAll("([\t\r\n])\\1+", "$1");
+        }
+        String[] linesExpected;
+        String[] linesActual;
+        linesExpected = expected.lines().toArray(String[]::new);
+        linesActual = actual.lines().toArray(String[]::new);
+        int limit = Math.max(linesExpected.length, linesActual.length);
+        StringBuilder sb = new StringBuilder();
+        boolean equals = true;
+        for (int i = 0; i < limit; i++) {
+            String oe = (i < linesExpected.length ? linesExpected[i] : "");
+            String oa = (i < linesActual.length ? linesActual[i] : "");
+            String e = linePreprocessor.apply(oe);
+            String a = linePreprocessor.apply(oa);
+            // somehow my user is inserted, so avoid to test those lines.
+            if (e.contains("@author") && a.contains("@author")) {
+                e = a = "* @author goes here";
+                oa = oe;
+            }
+            boolean same = e.equals(a);
+            String sep = same ? "   " : " | ";
+            equals &= same;
+            sb.append(String.format(fileName + " [%3d] %-80s%s%-80s%n", i, oe, sep, oa));
+        }
+        if (!equals || showOutputOnPass) {
+            System.err.println("test " + testName + (equals ? " PASSED" : " FAILED") + " with compare mode = " + stringsCompareMode);
+            System.err.print(String.format(fileName + "       %-80s%s%-80s%n", "expected", " + ", "actual"));
+            System.err.println(sb.toString());
+            System.err.flush();
+            if (!equals) {
+                fail("lines differ, see stderr for more details.");
+            }
+        }
+    }
+
+}

--- a/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
@@ -164,7 +164,7 @@ public final class GeneratorUtilities {
      * @param sourceRoot a source root under which the new file is created
      * @param path a relative path to file separated by '/'
      * @param kind the kind of Element to use for the template, can be null or
-     * CLASS, INTERFACE, ANNOTATION_TYPE, ENUM, PACKAGE
+     * CLASS, INTERFACE, ANNOTATION_TYPE, ENUM, PACKAGE, RECORD
      * @return new CompilationUnitTree created from a template
      * @throws IOException when an exception occurs while creating the template
      * @since 0.101
@@ -632,7 +632,7 @@ public final class GeneratorUtilities {
             // ignore type
             Tree parent = getCurrentPath().getParentPath().getLeaf();
             Tree.Kind k = parent.getKind();
-            if (k == Tree.Kind.CLASS || k == Tree.Kind.INTERFACE || k == Tree.Kind.ENUM) {
+            if (k == Tree.Kind.CLASS || k == Tree.Kind.INTERFACE || k == Tree.Kind.ENUM || k == Tree.Kind.RECORD) {
                 member = node;
             }
             Object o = scan(node.getInitializer(), p);
@@ -643,7 +643,7 @@ public final class GeneratorUtilities {
         @Override public Object visitBlock(BlockTree node, Object p) { 
             Tree parent = getCurrentPath().getParentPath().getLeaf();
             Tree.Kind k = parent.getKind();
-            if (k == Tree.Kind.CLASS || k == Tree.Kind.INTERFACE || k == Tree.Kind.ENUM) {
+            if (k == Tree.Kind.CLASS || k == Tree.Kind.INTERFACE || k == Tree.Kind.ENUM || k == Tree.Kind.RECORD) {
                 member = node;
                 return super.visitBlock(node, p);
             }
@@ -1453,7 +1453,10 @@ public final class GeneratorUtilities {
                         break;
                     }
                    switch (p2.getLeaf().getKind()) {
-                       case CLASS: case INTERFACE: case ENUM: case RECORD:
+                       case CLASS:
+                       case INTERFACE:
+                       case ENUM:
+                       case RECORD:
                        case METHOD:
                        case BLOCK:
                        case VARIABLE:

--- a/java/java.source.base/src/org/netbeans/api/java/source/RecordUtils.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/RecordUtils.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.api.java.source;
+
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
+import static com.sun.source.tree.Tree.Kind.RECORD;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.tree.JCTree;
+import java.util.LinkedHashSet;
+//import java.util.List;
+//import com.sun.tools.javac.util.List;
+import java.util.List;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import static java.util.stream.Collectors.toCollection;
+import javax.lang.model.element.Modifier;
+import org.netbeans.api.annotations.common.NonNull;
+
+/**
+ * Utilities specific for record types.
+ *
+ * @author homberghp
+ */
+public class RecordUtils {
+
+    public static boolean isConStructor(Tree m) {
+
+        if (m.getKind() != Kind.METHOD) {
+            return false;
+        }
+        MethodTree met = (MethodTree) m;
+        if (met.getModifiers().getFlags().contains(Modifier.STATIC)) {
+            return false;
+        }
+        return met.getReturnType() == null;
+    }
+
+    /**
+     * Count the record components of a record.
+     *
+     * @param record to be counted for its components.
+     * @return the count
+     */
+    public static int countComponents(ClassTree record) {
+        return (int) record.getMembers()
+                .stream()
+                .filter(RecordUtils::isNormalField)
+                .count();
+    }
+
+    public static List<String> componentNames(ClassTree record) {
+        List<String> result = components(record).stream()
+                .map(m -> ((VariableTree) m).getName().toString())
+                .toList();
+        return result;
+    }
+
+    public static List<Tree> components(ClassTree record) {
+
+        List<Tree> result = record.getMembers()
+                .stream()
+                .filter(m -> m.getKind() == Kind.VARIABLE)
+                .map(VariableTree.class::cast)
+                .filter(RecordUtils::isNormalField)
+                .map(Tree.class::cast)
+                .toList();
+        return result;
+    }
+
+    public static Set<String> parameterNames(MethodTree method) {
+        Set<String> result = method.getParameters()
+                .stream()
+                .map(m -> ((VariableTree) m).getName().toString())
+                .collect(Collectors.toSet());
+        return result;
+    }
+
+    public static boolean isNormalField(Tree t) {
+        return t.getKind() == Kind.VARIABLE && !((VariableTree) t).getModifiers().getFlags().contains(Modifier.STATIC);
+    }
+
+    public static boolean emptyMethod(Tree t) {
+        if (t.getKind() != Kind.METHOD) {
+            return false;
+        }
+        MethodTree mt = (MethodTree) t;
+        long count = mt.getBody().getStatements().stream().filter(s -> !s.toString().contains("super();")).count();
+        return count == 0l;//mt.getBody().getStatements().isEmpty();
+    }
+
+    /**
+     * A member is a normal field when not a class, (or enum ...) not a method
+     * and not static. For record that should be a record component then.
+     *
+     * @param t
+     * @return true if fields of the class/record are of same amount, order and
+     * types
+     */
+    public static boolean isRecordComponent(Tree t) {
+        if (t.getKind() == Kind.CLASS) {
+            return false;
+        }
+        if (t.getKind() == Kind.METHOD) {
+            return false;
+        }
+        if (t.getKind() == Kind.VARIABLE && t instanceof VariableTree vt) {
+            return !vt.getModifiers().getFlags().contains(Modifier.STATIC);
+        }
+        return false;
+    }
+
+    public static boolean hasAllParameterNames(MethodTree method, Set<String> names) {
+        Set<String> actualNames = method.getParameters().stream().map(m -> m.getName().toString()).collect(Collectors.toSet());
+        return names.size() == actualNames.size() && names.containsAll(actualNames);
+    }
+
+    /**
+     * Get the canonical parameters of a record.
+     *
+     * Implementation detail: The method scans the tree and looks for a
+     * constructor with a matching signature. returns 0 if not a record or no
+     * constructor found.
+     *
+     * @param record tree presenting the record
+     * @return the list of fields as declared in the record header.
+     */
+    public static List<JCTree.JCVariableDecl> canonicalParameters(JCTree.JCClassDecl record) {
+        if (record.getKind()!= RECORD) return List.of();
+        Set<String> expectedNames = record.getMembers().stream()
+                .filter(m -> RecordUtils.isNormalField(m))
+                .map(m -> ((JCTree.JCVariableDecl) m).getName().toString())
+                .collect(Collectors.toSet());
+        List<JCTree.JCVariableDecl> result = record.getMembers().stream()
+                .filter(m -> RecordUtils.isConStructor(m))
+                .map(JCTree.JCMethodDecl.class::cast)
+                .filter(t -> RecordUtils.hasAllParameterNames(t, expectedNames))
+                .flatMap(m -> ((JCTree.JCMethodDecl) m).getParameters().stream()).toList();
+        return result;
+    }
+
+    /**
+     * Get the canonical parameters of a record.Implementation detail: The
+     * method scans the tree and looks for a constructor with a matching
+     * signature.
+     *
+     * returns 0 if not a record or no constructor found.
+     *
+     * @param aRecord tree presenting the record
+     * @return the list of fields as declared in the record header.
+     */
+    public static List<Tree> canonicalParameters(ClassTree aRecord) {
+        // get the names of the RecordComponents
+        Set<String> expectedNames = aRecord.getMembers().stream()
+                .filter(m -> RecordUtils.isNormalField(m))
+                .map(VariableTree.class::cast)
+                .map(vt -> vt.getName().toString())
+                .collect(toCollection(LinkedHashSet::new));
+
+        // get the constructor that has the expected parameters.
+        var result = aRecord.getMembers().stream()
+                .filter(RecordUtils::isConStructor)
+                .map(MethodTree.class::cast)
+                .filter(mt -> hasAllParameterNames(mt, expectedNames))
+                .flatMap(mt -> mt.getParameters().stream())
+                .map(Tree.class::cast)
+                .toList();
+
+        if (result.isEmpty()) {
+            result = components(aRecord);
+        }
+        return result;
+    }
+
+    /**
+     * For the record get the NON component members, such as static fields, and
+     * methods.
+     *
+     * @param aRecord to process
+     * @return the list of selected members
+     */
+    public static @NonNull
+    List<Tree> nonComponentMembers(ClassTree aRecord) {
+        return aRecord.getMembers().stream()
+                .filter(m -> !RecordUtils.isNormalField(m))
+                .map(Tree.class::cast)
+                .toList();
+    }
+
+    public static boolean isCompactConstructor(Tree rec, Tree met) {
+        if (rec.getKind() != Kind.RECORD) {
+            return false;
+        }
+        ClassTree recTree = (ClassTree) rec;
+        if (met.getKind() != Kind.METHOD) {
+            return false;
+        }
+        MethodTree methodTree= (MethodTree) met;
+
+        var componentNames = Set.copyOf(componentNames(recTree));
+        return hasAllParameterNames(methodTree, componentNames);
+//        return true;
+    }
+}

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeMaker.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeMaker.java
@@ -423,6 +423,28 @@ public final class TreeMaker {
     }
     
     /**
+     * Creates a new ClassTree representing record.
+     *
+     * @param modifiers the modifiers declaration
+     * @param simpleName        the name of the class without its package, such
+     * @param implementsClauses the list of the interfaces this class
+     *                          implements, or an empty list.
+     *                          as "String" for the class "java.lang.String".
+     * @param implementsClauses the list of the interfaces this class
+     *                          implements, or an empty list.
+     * @param memberDecls       the list of fields defined by this class, or an
+     *                          empty list.
+     * @see com.sun.source.tree.ClassTree
+     */
+    public ClassTree Record(ModifiersTree modifiers,
+             CharSequence simpleName,
+             List<? extends TypeParameterTree> typeParameters,
+             List<? extends Tree> implementsClauses,
+             List<? extends Tree> memberDecls) {
+        return delegate.Record(modifiers, simpleName, typeParameters, implementsClauses, memberDecls);
+    }
+
+    /**
      * Creates a new CompilationUnitTree.
      *
      * @param packageName        a tree representing the package name.

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -125,7 +125,7 @@ public final class TreeUtilities {
      */
     @Deprecated
     public boolean isClass(ClassTree tree) {
-        return (((JCTree.JCModifiers)tree.getModifiers()).flags & (Flags.INTERFACE | Flags.ENUM | Flags.ANNOTATION)) == 0;
+        return (((JCTree.JCModifiers)tree.getModifiers()).flags & (Flags.INTERFACE | Flags.ENUM | Flags.RECORD | Flags.ANNOTATION)) == 0;
     }
     
     /**Checks whether the given tree represents an interface.

--- a/java/java.source.base/src/org/netbeans/api/java/source/WorkingCopy.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/WorkingCopy.java
@@ -549,6 +549,7 @@ public class WorkingCopy extends CompilationController {
             case ANNOTATION_TYPE:
             case CLASS:
             case ENUM:
+            case RECORD:
             case INTERFACE:
                 children = ((ClassTree) parentPath.getLeaf()).getMembers(); break;
             case CASE:  children = ((CaseTree) parentPath.getLeaf()).getStatements(); break;
@@ -892,7 +893,6 @@ public class WorkingCopy extends CompilationController {
             final Tree brandNew = itt.translate(path.getLeaf());
 
             //tagging debug
-            //System.err.println("brandNew=" + brandNew);
             new CommentReplicator(presentInResult.keySet()).process(diffContext.origUnit);
             addCommentsToContext(diffContext);
             for (ClassTree ct : classes) {
@@ -1221,6 +1221,7 @@ public class WorkingCopy extends CompilationController {
             case INTERFACE: return "Templates/Classes/Interface.java"; // NOI18N
             case ANNOTATION_TYPE: return "Templates/Classes/AnnotationType.java"; // NOI18N
             case ENUM: return "Templates/Classes/Enum.java"; // NOI18N
+            case RECORD: return "Templates/Classes/Record.java"; // NOI18N
             case PACKAGE: return "Templates/Classes/package-info.java"; // NOI18N
             default:
                 Logger.getLogger(WorkingCopy.class.getName()).log(Level.SEVERE, "Cannot resolve template for {0}", kind);
@@ -1247,6 +1248,9 @@ public class WorkingCopy extends CompilationController {
                     break;
                 case ENUM:
                     kind = ElementKind.ENUM;
+                    break;
+                case RECORD:
+                    kind = ElementKind.RECORD;
                     break;
                 default:
                     Logger.getLogger(WorkingCopy.class.getName()).log(Level.SEVERE, "Cannot resolve template for {0}", cut.getTypeDecls().get(0).getKind());

--- a/java/java.source.base/src/org/netbeans/modules/java/source/builder/TreeFactory.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/builder/TreeFactory.java
@@ -324,6 +324,15 @@ public class TreeFactory {
         return Class(flags, (com.sun.tools.javac.util.List<JCAnnotation>) modifiers.getAnnotations(), simpleName, Collections.<TypeParameterTree>emptyList(), null, implementsClauses, memberDecls);
     }
     
+    public ClassTree Record(ModifiersTree modifiers,
+             CharSequence simpleName,
+             List<? extends TypeParameterTree> typeParameters,
+             List<? extends Tree> implementsClauses,
+             List<? extends Tree> memberDecls) {
+        long flags = getBitFlags(modifiers.getFlags()) | Flags.RECORD;
+        return Class(flags, (com.sun.tools.javac.util.List<JCAnnotation>) modifiers.getAnnotations(), simpleName, typeParameters, null, implementsClauses, memberDecls);
+    }
+
     public CompilationUnitTree CompilationUnit(PackageTree packageDecl,
                                                List<? extends ImportTree> importDecls, 
                                                List<? extends Tree> typeDecls, 

--- a/java/java.source.base/src/org/netbeans/modules/java/source/pretty/WidthEstimator.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/pretty/WidthEstimator.java
@@ -85,7 +85,6 @@ public class WidthEstimator extends JCTree.Visitor {
 	}
     }
     public void visitTree(JCTree tree) {
-System.err.println("Need width calc for "+tree);
 	width = maxwidth;
     }
     public void visitParens(JCParens tree) {

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/RecordUtilsTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/RecordUtilsTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.api.java.source;
+
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCClassDecl;
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+import static org.netbeans.api.java.source.CommentCollectorTest.getJavaSource;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.java.source.usages.IndexUtil;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+/**
+ *
+ * @author homberghp
+ */
+public class RecordUtilsTest extends NbTestCase {
+
+    public RecordUtilsTest(String s) {
+        super(s);
+    }
+    private File work;
+
+    @Override
+    protected void setUp() throws Exception {
+        File wd = getWorkDir();
+        FileObject cache = FileUtil.createFolder(new File(wd, "cache"));
+        IndexUtil.setCacheFolder(FileUtil.toFile(cache));
+        work = new File(wd, "work");
+        work.mkdirs();
+
+        super.setUp();
+    }
+
+    @Test
+    public void testComponentCount() throws Exception {
+
+        File testFile = new File(work, "Test.java");
+        JCClassDecl[] records = prepareJCClassTree(testFile, recordCode);
+        assertEquals(3, RecordUtils.countComponents(records[0]));
+    }
+
+    /**
+     * records[0] = classtree records[1] = methodtree ctor compact (hidden)
+     * records[2] = methodtree ctor with 2 params records[3] = variabletree
+     * static records[4] = methodtree method m
+     */
+    String recordCode
+            = """
+            package test;
+            public record Test<G>(int age, String name, G... grade) implements Serializable {
+               public Test(String name, G... grade){
+                  this(1, name, grade);
+               }
+               public Test{
+                    assert age > 0;
+                    assert !name.isBlank();
+                }
+
+                public static String me = "puk";
+                public int m(){
+                    return age+1;
+                }
+            }
+            """;
+
+    static JCClassDecl[] prepareJCClassTree(File testFile, final String recordCode) throws Exception, IOException {
+        TestUtilities.copyStringToFile(testFile, recordCode);
+        JavaSource src = getJavaSource(testFile);
+        final JCClassDecl[] records = new JCClassDecl[1];
+        Task<WorkingCopy> task = new Task<WorkingCopy>() {
+            public void run(final WorkingCopy workingCopy) throws Exception {
+                workingCopy.toPhase(JavaSource.Phase.PARSED);
+                records[0] = (JCClassDecl) workingCopy.getCompilationUnit().getTypeDecls().get(0);
+            }
+        };
+        src.runModificationTask(task);
+        return records;
+    }
+
+    @Test
+    public void testCanonicalParameters() throws Exception {
+        File testFile = new File(work, "Test.java");
+        JCClassDecl[] records = prepareJCClassTree(testFile, recordCode);
+        List<JCTree.JCVariableDecl> canonicalParameters = RecordUtils.canonicalParameters(records[0]);
+        assertEquals(3, canonicalParameters.size());
+    }
+
+    @Test
+    public void testComponentNames() throws Exception {
+        File testFile = new File(work, "Test.java");
+        JCClassDecl[] records = prepareJCClassTree(testFile, recordCode);
+        List<String> componentNames = RecordUtils.componentNames(records[0]);
+        List<String> expected = List.of("age", "name", "grade");
+        assertEquals(expected, componentNames);
+    }
+
+    @Test
+    public void testGetComponents() throws Exception {
+        File testFile = new File(work, "Test.java");
+        JCClassDecl[] records = prepareJCClassTree(testFile, recordCode);
+
+        List<Tree> recordComponents = RecordUtils.components(records[0]);
+        assertEquals(3, recordComponents.size());
+    }
+
+    @Test
+    public void testHassAllParams() throws Exception {
+        File testFile = new File(work, "Test.java");
+        JCClassDecl[] records = prepareJCClassTree(testFile, recordCode);
+        List<JCTree> members = records[0].getMembers();
+        JCTree.JCMethodDecl cand = (JCTree.JCMethodDecl) members.get(4);
+        Set<String> componentNames = new LinkedHashSet(RecordUtils.componentNames(records[0]));
+        assertTrue(RecordUtils.hasAllParameterNames(cand, componentNames));
+    }
+
+    @Test
+    public void testNonComponentMembers() throws Exception {
+        File testFile = new File(work, "Test.java");
+        JCClassDecl[] records = prepareJCClassTree(testFile, recordCode);
+        List<Tree> members = RecordUtils.nonComponentMembers(records[0]);
+        assertEquals("onon components ", 4, members.size());
+    }
+
+    @Test
+    public void testIsCompact() throws Exception {
+        File testFile = new File(work, "Test.java");
+        JCClassDecl[] records = prepareJCClassTree(testFile, recordCode);
+        List<Tree> members = RecordUtils.nonComponentMembers(records[0]);
+        Tree rec = records[0];
+        Tree candidate =  members.get(1);
+        assertTrue(RecordUtils.isCompactConstructor(rec, candidate));
+    }
+
+    @Test
+    public void testIsNotCompact() throws Exception {
+        File testFile = new File(work, "Test.java");
+        JCClassDecl[] records = prepareJCClassTree(testFile, recordCode);
+        List<Tree> members = RecordUtils.nonComponentMembers(records[0]);
+        Tree rec = records[0];
+        Tree cand= members.get(2);
+        System.err.println("cand = " + cand);
+        assertFalse(RecordUtils.isCompactConstructor(rec, cand));
+    }
+
+
+}

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/JavaPluginUtils.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/JavaPluginUtils.java
@@ -523,8 +523,16 @@ public final class JavaPluginUtils {
     public static CompilationUnitTree createCompilationUnit(FileObject sourceRoot, String relativePath, Tree typeDecl, WorkingCopy workingCopy, TreeMaker make) {
         GeneratorUtilities genUtils = GeneratorUtilities.get(workingCopy);
         CompilationUnitTree newCompilation;
+        Kind requestedKind = typeDecl.getKind();
+        ElementKind templateKind=
+        switch (requestedKind) {
+            case ENUM-> ElementKind.ENUM;
+            case RECORD-> ElementKind.RECORD;
+            default -> ElementKind.CLASS;
+        };
         try {
-            newCompilation = genUtils.createFromTemplate(sourceRoot, relativePath, ElementKind.CLASS);
+//            newCompilation = genUtils.createFromTemplate(sourceRoot, relativePath, ElementKind.CLASS);
+            newCompilation = genUtils.createFromTemplate(sourceRoot, relativePath, templateKind);
             List<? extends Tree> typeDecls = newCompilation.getTypeDecls();
             if (typeDecls.isEmpty()) {
                 newCompilation = make.addCompUnitTypeDecl(newCompilation, typeDecl);
@@ -532,7 +540,7 @@ public final class JavaPluginUtils {
                 List<Tree> typeDeclarations = new LinkedList<Tree>(newCompilation.getTypeDecls());
                 Tree templateClazz = typeDeclarations.remove(0); // TODO: Check for class with correct name, template could start with another type.
                 // mark the template CU as removed; any untransfered comments will be (?) lost.
-                workingCopy.getTreeMaker().asRemoved(templateClazz);
+                Tree asRemoved = workingCopy.getTreeMaker().asRemoved(templateClazz);
                 typeDecl = genUtils.importComments(typeDecl, newCompilation);
                 if (workingCopy.getTreeUtilities().getComments(typeDecl, true).isEmpty()) {
                     genUtils.copyComments(templateClazz, typeDecl, true);

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/UIUtilities.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/UIUtilities.java
@@ -335,6 +335,9 @@ public final class UIUtilities {
                     case ENUM:
                         stringBuilder.append("enum "); // NOI18N
                         break;
+                    case RECORD:
+                        stringBuilder.append("record "); // NOI18N
+                        break;
                     case ANNOTATION_TYPE:
                         stringBuilder.append("@interface "); // NOI18N
                         break;

--- a/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ExtractSuperclassTest.java
+++ b/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ExtractSuperclassTest.java
@@ -81,7 +81,7 @@ public class ExtractSuperclassTest extends RefactoringTestBase {
                 + "    }\n"
                 + "}\n"));
     }
-    
+
     public void test231146() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("extract/ExtractBaseClass.java", "package extract;\n"
@@ -96,7 +96,7 @@ public class ExtractSuperclassTest extends RefactoringTestBase {
                 + "class ExtractSuperClass { }\n"));
         performExtractSuperclass(src.getFileObject("extract/ExtractBaseClass.java"), 1, -1, "ExtractSuperClass", Boolean.FALSE, new Problem(true, "ERR_ClassClash"));
     }
-    
+
     public void test252621() throws Exception { //#252621 - [Extract Superclass] Import for annotation is not added
         writeFilesAndWaitForScan(src,
                 new File("extract/ExtractBaseClass.java", "package extract;\n"
@@ -131,43 +131,59 @@ public class ExtractSuperclassTest extends RefactoringTestBase {
                 + "    }\n"
                 + "}\n"));
     }
-    
-    
-    public void test231639() throws Exception { //#231639 - StackOverflowError at com.sun.tools.javac.code.Type$WildcardType.getExtendsBound 
+
+
+    public void test231639() throws Exception { //#231639 - StackOverflowError at com.sun.tools.javac.code.Type$WildcardType.getExtendsBound
         writeFilesAndWaitForScan(src,
-                new File("extract/ExtractBaseClass.java", "package extract;\n"
-                + "\n"
-                + "import java.io.IOException;\n"
-                + "\n"
-                + "public class ExtractBaseClass<D extends Comparable<? super D>> {\n"
-                + "    public void method(D d) throws IOException {\n"
-                + "        System.out.println(\"Hello\");\n"
-                + "    }\n"
-                + "}"));
+            new File("extract/ExtractBaseClass.java",
+                """
+                package extract;
+
+                import java.io.IOException;
+
+                public class ExtractBaseClass<D extends Comparable<? super D>> {
+                    public void method(D d) throws IOException {
+                        System.out.println("Hello");
+                    }
+                }"""
+            )
+        );
         performExtractSuperclass(src.getFileObject("extract/ExtractBaseClass.java"), 1, -1, "ExtractSuperClass", Boolean.FALSE);
+        sideBySideCompare=true;
+        RETRIES=1;
         verifyContent(src,
-                new File("extract/ExtractBaseClass.java", "package extract;\n"
-                + "\n"
-                + "import java.io.IOException;\n"
-                + "\n"
-                + "public class ExtractBaseClass<D extends Comparable<? super D>> extends ExtractSuperClass<D> {\n"
-                + "    \n"
-                + "}"),
-                new File("extract/ExtractSuperClass.java", "/* * Refactoring License */ package extract;\n"
-                + "\n"
-                + "import java.io.IOException;\n"
-                + "\n"
-                + "/**\n"
-                + " *\n"
-                + " * @author junit\n"
-                + " */\n"
-                + "public class ExtractSuperClass<D extends Comparable<? super D>> {\n"
-                + "    public void method(D d) throws IOException {\n"
-                + "        System.out.println(\"Hello\");\n"
-                + "    }\n"
-                + "}\n"));
+                new File("extract/ExtractBaseClass.java",
+                    """
+                    package extract;
+
+                    import java.io.IOException;
+
+                    public class ExtractBaseClass<D extends Comparable<? super D>> extends ExtractSuperClass<D> {
+                    }"""),
+                new File("extract/ExtractSuperClass.java",
+                    """
+                    /*
+                     * Refactoring License
+                     */
+
+                    package extract;
+
+                    import java.io.IOException;
+
+                    /**
+                     *
+                     * @author junit
+                     */
+                    public class ExtractSuperClass<D extends Comparable<? super D>> {
+
+                        public void method(D d) throws IOException {
+                            System.out.println("Hello");
+                        }
+
+                    }
+                    """));
     }
-    
+
     public void test226518a() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("extract/ExtractBaseClass.java", "package extract;\n"
@@ -202,7 +218,7 @@ public class ExtractSuperclassTest extends RefactoringTestBase {
                 + "    }\n"
                 + "}\n"));
     }
-    
+
     public void test226518b() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("extract/ExtractBaseClass.java", "package extract;\n"
@@ -237,7 +253,7 @@ public class ExtractSuperclassTest extends RefactoringTestBase {
                 + "    }\n"
                 + "}\n"));
     }
-    
+
     public void test226518c() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("extract/ExtractBaseClass.java", "package extract;\n"
@@ -275,7 +291,7 @@ public class ExtractSuperclassTest extends RefactoringTestBase {
                 + "    }\n"
                 + "}\n"));
     }
-    
+
     public void test212624a() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("extract/ExtractBaseClass.java", "package extract;\n"
@@ -306,7 +322,7 @@ public class ExtractSuperclassTest extends RefactoringTestBase {
                 + "    protected String value;\n"
                 + "}\n"));
     }
-     
+
     public void test212624b() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("extract/ExtractBaseClass.java", "package extract;\n"
@@ -370,8 +386,8 @@ public class ExtractSuperclassTest extends RefactoringTestBase {
                 + "    } // Trailing comments\n"
                 + "}\n"));
     }
-    
-    public void test211894b() throws Exception {    
+
+    public void test211894b() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("extract/ExtractBaseClass.java", "package extract;\n"
                 + "\n"
@@ -412,17 +428,17 @@ public class ExtractSuperclassTest extends RefactoringTestBase {
             public void run(CompilationController info) throws Exception {
                 info.toPhase(JavaSource.Phase.RESOLVED);
                 CompilationUnitTree cut = info.getCompilationUnit();
-                
+
                 ClassTree classTree = (ClassTree) cut.getTypeDecls().get(0);
                 if(innerpos >= 0) {
                     classTree = (ClassTree) classTree.getMembers().get(innerpos);
                 }
                 final TreePath classPath = info.getTrees().getPath(cut, classTree);
                 TypeElement classEl = (TypeElement) info.getTrees().getElement(classPath);
-                
+
                 TypeMirror superclass = classEl.getSuperclass();
                 TypeElement superEl = (TypeElement) info.getTypes().asElement(superclass);
-                
+
                 MemberInfo[] members;
                 if(position < 0) {
                     List<? extends Tree> classMembers = classTree.getMembers();
@@ -449,7 +465,7 @@ public class ExtractSuperclassTest extends RefactoringTestBase {
                 r[0].setMembers(members);
             }
         }, true);
-        
+
         RefactoringSession rs = RefactoringSession.create("Session");
         List<Problem> problems = new LinkedList<Problem>();
 

--- a/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InnerOuterRecordTest.java
+++ b/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InnerOuterRecordTest.java
@@ -1,0 +1,886 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.refactoring.java.test;
+
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreePath;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Name;
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+import org.netbeans.api.java.source.CompilationController;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.Task;
+import org.netbeans.api.java.source.TreePathHandle;
+import org.netbeans.junit.AssertLinesEqualHelpers;
+import org.netbeans.modules.refactoring.api.Problem;
+import org.netbeans.modules.refactoring.api.RefactoringSession;
+import org.netbeans.modules.refactoring.java.api.InnerToOuterRefactoring;
+import static org.netbeans.modules.refactoring.java.test.RefactoringTestBase.addAllProblems;
+import static org.netbeans.junit.AssertLinesEqualHelpers.*;
+import org.openide.util.Exceptions;
+
+/**
+ * Test inner to outer refactoring for test.
+ *
+ * In the input files, and the expected outcomes, the indentation does not
+ * really matter as far as the tests are concerned because the indentation is
+ * stripped away before the remaining source lines are compared to the expected
+ * lines.
+ *
+ * @author homberghp {@code <pieter.van.den.hombergh@gmail.com)>}
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class InnerOuterRecordTest extends RefactoringTestBase {
+
+    public InnerOuterRecordTest(String name) {
+        super(name, "16");
+        //ensure we are running on at least 16.
+        try {
+            SourceVersion.valueOf("RELEASE_16"); //NOI18N
+        } catch (IllegalArgumentException ex) {
+            //OK, no RELEASE_16, skip test
+            throw new RuntimeException("need at least Java 16 for record");
+        }
+        sideBySideCompare = true;
+//        showOutputOnPass=true;
+
+//        RETRIES=1;
+    }
+
+    public void test9ApacheNetbeans7044() throws Exception {
+        // initial outer has record with meaningful canonical constructor.
+        // note that Inner class should be in last member for assumptions in the test.
+        String source
+                = """
+                package t;
+
+                import java.time.LocalDate;
+                import java.util.Objects;
+
+                public class A {
+
+                    void useStudent() {
+                        F s = new F(42,"Jan Klaassen", LocalDate.now().minusDays(1));
+                        System.out.println("student = " + s);
+                    }
+                    record F(int id, String name, LocalDate dob) {
+
+                        /**
+                          * Validate stuff.
+                          */
+                        public F {
+                            Objects.requireNonNull(id);
+                            Objects.requireNonNull(name);
+                            Objects.requireNonNull(dob);
+                            assert !name.isEmpty() && !name.isBlank();
+                            assert dob.isAfter(LocalDate.EPOCH);
+                        }
+                    }
+
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+
+                import java.time.LocalDate;
+                import java.util.Objects;
+
+                public class A {
+
+                    void useStudent() {
+                        F s = new F(42,"Jan Klaassen", LocalDate.now().minusDays(1));
+                        System.out.println("student = " + s);
+                    }
+
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.time.LocalDate;
+                import java.util.Objects;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                 record F(int id, String name, LocalDate dob) {
+
+                    /**
+                     * Validate stuff.
+                     */
+                    public F {
+                        Objects.requireNonNull(id);
+                        Objects.requireNonNull(name);
+                        Objects.requireNonNull(dob);
+                        assert !name.isEmpty() && !name.isBlank();
+                        assert dob.isAfter(LocalDate.EPOCH);
+                    }
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    public void test1BasicClassInClass() throws Exception {
+        // initial outer has record with meaningful canonical constructor.
+        String source
+                = """
+            package t;
+            import java.time.LocalDate;
+            import java.util.Objects;
+            public class A {
+                void useStudent() {
+                    F s = new F(42, "Jan Klaassen", LocalDate.now().minusDays(1));
+                    System.out.println("student = " + s);
+                }
+                public static class F {
+                    int id;
+                    String name;
+                    LocalDate dob
+                    public Student(int id, String name, LocalDate dob) {
+                        Objects.requireNonNull(id);
+                        Objects.requireNonNull(name);
+                        Objects.requireNonNull(dob);
+                        assert !name.isEmpty() && !name.isBlank();
+                        assert dob.isAfter(LocalDate.EPOCH);
+                        this.id=id;
+                        this.name=name;
+                        this.dob=dob;
+                    }
+                }
+            }
+            """;
+        String newOuter
+                = """
+                package t;
+                import java.time.LocalDate;
+                import java.util.Objects;
+                public class A {
+                    void useStudent() {
+                        F s = new F(42, "Jan Klaassen", LocalDate.now().minusDays(1));
+                        System.out.println("student = " + s);
+                    }
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.time.LocalDate;
+                import java.util.Objects;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                public class F {
+
+                    int id;
+                    String name;
+                    LocalDate dob;
+
+                    public F(int id, String name, LocalDate dob) {
+                        Objects.requireNonNull(id);
+                        Objects.requireNonNull(name);
+                        Objects.requireNonNull(dob);
+                        assert !name.isEmpty() && !name.isBlank();
+                        assert dob.isAfter(LocalDate.EPOCH);
+                        this.id = id;
+                        this.name = name;
+                        this.dob = dob;
+                    }
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    public void test2BasicRecordInRecord() throws Exception {
+        String source
+                = """
+                package t;
+                import java.time.LocalDate;
+                record A(int id, String name, LocalDate dob) {
+                   static F f;
+                   record F(int x, int y){
+                      /** I should be back. */
+                      static String code = "nix";
+                   }
+                }
+                """;
+        String newOuter
+                =
+                """
+                package t;
+                import java.time.LocalDate;
+                record A(int id, String name, LocalDate dob) {
+                   static F f;
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                /**
+                 *
+                 * @author hom
+                 */
+                 record F(int x, int y) {
+                    /** I should be back. */
+                    static String code = "nix";
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    /**
+     * Test to verify what happens to the compact constructor in the outer
+     * record. It appears to survive the refactoring.
+     *
+     * @throws Exception
+     */
+    public void test3OuterWithCompact() throws Exception {
+        String source
+                = """
+                package t;
+
+                import java.time.LocalDate;
+
+                /** Record with compact ctor. */
+                record A(F f){
+                    public A{
+                        assert f!=null;
+                    }
+                    record F(int id, String name, LocalDate dob){}
+
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+
+                import java.time.LocalDate;
+
+                /** Record with compact ctor. */
+                record A(F f){
+                    public A{
+                        assert f!=null;
+                    }
+
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.time.LocalDate;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                 record F(int id, String name, LocalDate dob) {
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    public void test4InnerWithCompact() throws Exception {
+        String source
+                = """
+                package t;
+                import java.time.LocalDate;
+                record A(F f) {
+                    public A {
+                        assert f != null;
+                    }
+                    record F(int id, String name, LocalDate dob) {
+                        public F {
+                            if (dob.isBefore(LocalDate.EPOCH)) {
+                                throw new IllegalArgumentException("to old " + dob);
+                            }
+                        }
+                    }
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+                import java.time.LocalDate;
+                record A(F f) {
+                    public A {
+                        assert f != null;
+                    }
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.time.LocalDate;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                 record F(int id, String name, LocalDate dob) {
+
+                    public F {
+                        if (dob.isBefore(LocalDate.EPOCH)) {
+                            throw new IllegalArgumentException("to old " + dob);
+                        }
+                    }
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    // outer may have effect
+    public void test5ClassWithInnerRecord() throws Exception {
+        String source
+                = """
+                package t;
+
+                import java.time.LocalDate;
+
+                class A {
+
+                    final F f;
+                    public A(F f) {
+                        assert f != null;
+                        this.f=f;
+                    }
+                    record F(int id, String name, LocalDate dob) {
+                        public F   {
+                            if (dob.isBefore(LocalDate.EPOCH)) {
+                                throw new IllegalArgumentException("to old " + dob);
+                            }
+                        }
+                    }
+
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+
+                import java.time.LocalDate;
+
+                class A {
+
+                    final F f;
+                    public A(F f) {
+                        assert f != null;
+                        this.f=f;
+                    }
+
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.time.LocalDate;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                 record F(int id, String name, LocalDate dob) {
+
+                    public F {
+                        if (dob.isBefore(LocalDate.EPOCH)) {
+                            throw new IllegalArgumentException("to old " + dob);
+                        }
+                    }
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    public void test6InnerWithCompactAndMethodAndExtraCtor() throws Exception {
+        AssertLinesEqualHelpers.setStringCompareMode(StringsCompareMode.IGNORE_WHITESPACE_DIFF);
+        String source
+                = """
+                package t;
+
+                import java.time.LocalDate;
+
+                record A(F f) {
+
+                    enum Suite {
+                        SPADE, CLUB, DIAMOND, HEART;
+                    }
+
+                    public A {
+                        assert f != null;
+                    }
+
+                    record F(int id, String name, LocalDate dob) {
+
+                        public F {
+                            if (dob.isBefore(LocalDate.EPOCH)) {
+                                throw new IllegalArgumentException("to old " + dob);
+                            }
+                        }
+
+                        public F(int id, String name){
+                            this(id,name,LocalDate.now());
+                        }
+
+                        boolean bornBefore(LocalDate someDate) {
+                            return dob.isBefore(someDate);
+                        }
+
+                    }
+
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+
+                import java.time.LocalDate;
+
+                record A(F f) {
+
+                    enum Suite {
+                        SPADE, CLUB, DIAMOND, HEART;
+                    }
+
+                    public A {
+                        assert f != null;
+                    }
+
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.time.LocalDate;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                record F(int id, String name, LocalDate dob) {
+
+                    public F {
+                        if (dob.isBefore(LocalDate.EPOCH)) {
+                            throw new IllegalArgumentException("to old " + dob);
+                        }
+                    }
+
+                    public F(int id, String name) {
+                        this(id, name, LocalDate.now());
+                    }
+
+                    boolean bornBefore(LocalDate someDate) {
+                        return dob.isBefore(someDate);
+                    }
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    public void test7Generic() throws Exception {
+        String source
+                = """
+                package t;
+                record A(F f) {
+                    public A {
+                        assert f != null;
+                    }
+                    record F<P, Q>(P first, Q second) {
+                        public F {
+                            assert null != first;
+                            assert null != second;
+                        }
+                    }
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+                record A(F f) {
+                    public A {
+                        assert f != null;
+                    }
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+                package t;
+                /**
+                 *
+                 * @author junit
+                 */
+                record F<P, Q>(P first, Q second) {
+                    public F {
+                        assert null != first;
+                        assert null != second;
+                    }
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    public void test8Varargs() throws Exception {
+        RETRIES = 0;
+//        debug = true;
+        String source =
+                """
+                package t;
+                record A(F f) {
+                    public A {
+                        assert f != null;
+                    }
+                    record F<P>(P first, String... second) {
+                        public F {
+                            assert null != first;
+                            assert null != second;
+                        }
+                    }
+                }
+                """;
+        String newOuter =
+                """
+                package t;
+                record A(F f) {
+                    public A {
+                        assert f != null;
+                    }
+                }
+                """;
+        String newInner =
+                """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                record F<P>(P first, String... second) {
+
+                    public F {
+                        assert null != first;
+                        assert null != second;
+                    }
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    // show that brace comes too early in inner record.
+    public void test8RecordImplements1() throws Exception {
+//        debug = true;
+        RETRIES = 0;
+        sideBySideCompare = true;
+        String source
+                = """
+                package t;
+                import java.time.LocalDate;
+                import java.io.Serializable;
+                public class A implements Cloneable, Serializable {
+                    static F f;
+                    public record F(int x, int y) implements Cloneable, Serializable {
+                        /** I should be back. */
+                        static String code = "nix";
+                   }
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+                import java.time.LocalDate;
+                import java.io.Serializable;
+                public class A implements Cloneable, Serializable {
+                    static F f;
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.io.Serializable;
+
+                /**
+                 *
+                 * @author hom
+                 */
+                public record F(int x, int y) implements Cloneable, Serializable {
+                    /** I should be back. */
+                    static String code = "nix";
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    // show that outer record survives casual diff.
+    public void test8RecordImplements2() throws Exception {
+//        debug = true;
+        RETRIES = 0;
+        sideBySideCompare = true;
+//        showOutputOnPass=true;
+        String source
+                = """
+                package t;
+                import java.time.LocalDate;
+                import java.io.Serializable;
+                public record A(int a, String b) implements Cloneable, Serializable {
+                    static F f;
+                    enum F {
+                        F1, F2;
+                        /** I should be back. */
+                        static String code = "nix";
+                   }
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+                import java.time.LocalDate;
+                import java.io.Serializable;
+                public record A(int a, String b) implements Cloneable, Serializable {
+                    static F f;
+                }
+                """;
+        String newInner
+                =
+                """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                /**
+                 *
+                 * @author hom
+                 */
+                 enum F {
+
+                    F1, F2;
+                    /** I should be back. */
+                    static String code = "nix";
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    // Test shows that inner enum does not have the too early brace problem.
+    public void test8EnumImplements() throws Exception {
+//        debug = true;
+        RETRIES = 0;
+        sideBySideCompare = true;
+        String source
+                = """
+                package t;
+                import java.time.LocalDate;
+                import java.io.Serializable;
+                public class A implements Cloneable, Serializable {
+                    static F f;
+                    enum F implements Cloneable, Serializable {
+                        F1,F2;
+                        /** I should be back. */
+                        static String code = "nix";
+                   }
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+                import java.time.LocalDate;
+                import java.io.Serializable;
+                public class A implements Cloneable, Serializable {
+                    static F f;
+                }
+                """;
+        String newInner
+                =
+                """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.io.Serializable;
+
+                /**
+                 *
+                 * @author hom
+                 */
+                 enum F implements Cloneable, Serializable {
+
+                    F1, F2;
+                    /** I should be back. */
+                    static String code = "nix";
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    void innerOuterSetupAndTest(String source, String newOuterText, String newInnerText) throws Exception {
+        writeFilesNoIndexing(src, new File("t/A.java", source));
+        performInnerToOuterTest2(null);
+        verifyContent(src, new File("t/A.java", newOuterText), new File("t/F.java", newInnerText));
+    }
+    boolean debug = false;
+
+    // variant for record inner to outer test
+    private void performInnerToOuterTest2(String newOuterName, Problem... expectedProblems) throws Exception {
+        final InnerToOuterRefactoring[] r = new InnerToOuterRefactoring[1];
+        JavaSource.forFileObject(src.getFileObject("t/A.java")).runUserActionTask(new Task<CompilationController>() {
+            @Override
+            public void run(CompilationController parameter) {
+                try {
+                    parameter.toPhase(JavaSource.Phase.RESOLVED);
+                } catch (IOException ex) {
+                    Exceptions.printStackTrace(ex);
+                }
+                CompilationUnitTree cut = parameter.getCompilationUnit();
+                if (debug) {
+                    System.err.println("cut is of type " + cut.getClass().getCanonicalName());
+                }
+                ClassTree outer = (ClassTree) cut.getTypeDecls().get(0);
+                if (debug) {
+                    printNumbered(System.err, "start source " + outer.getKind().toString(), outer.toString());
+                }
+                List<? extends Tree> members = outer.getMembers();
+                int m = 0;
+                if (debug) {
+                    printMembers(members, m);
+                }
+                // selecting the last element assumes that the inner class is the last member in the outer class.
+                Tree lastInnerClass
+                        = outer.getMembers().get(outer.getMembers().size() - 1);
+                if (debug && lastInnerClass instanceof ClassTree lct) {
+//                    String n = "lastInnerClass " + lastInnerClass.getKind().toString();
+//                    printNumbered(System.err, n, lastInnerClass.toString());
+                    printClassTree(lct);
+                }
+                TreePath tp = TreePath.getPath(cut, lastInnerClass);
+                try {
+                    r[0]
+                            = new InnerToOuterRefactoring(TreePathHandle.create(tp, parameter));
+                } catch (Throwable t) {
+                    System.err.println("InnerOuter refatoring failed with exception " + t);
+                    t.printStackTrace(System.out);
+                    throw t;
+                }
+            }
+        }, true);
+        r[0].setClassName("F");
+        if (debug) {
+            printNumbered(System.err, "result ", r[0].toString());
+        }
+        r[0].setReferenceName(newOuterName);
+        RefactoringSession rs = RefactoringSession.create("Session");
+        List<Problem> problems = new LinkedList<Problem>();
+        addAllProblems(problems, r[0].preCheck());
+        addAllProblems(problems, r[0].prepare(rs));
+        addAllProblems(problems, rs.doRefactoring(true));
+        assertProblems(Arrays.asList(expectedProblems), problems);
+    }
+
+    // test helper
+    static void printMembers(List<? extends Tree> members, int m) {
+        printMembers(members, m, "");
+    }
+
+    // test helper
+    static void printMembers(List<? extends Tree> members, int m, String indent) {
+        for (Tree member : members) {
+            printNumbered(System.err, indent + "member %d %15s".formatted(m, member.getKind()), member.toString());
+            String toString = member.toString();
+            if (member instanceof ClassTree ct) {
+                int n = 0;
+                Name simpleName = ct.getSimpleName();
+                List<? extends Tree> members1 = ct.getMembers();
+                printMembers(members1, n, indent + "  " + m + " ");
+            }
+            m++;
+        }
+    }
+
+    // test helper
+    static void printClassTree(ClassTree ct) {
+        printMembers(ct.getMembers(), 0, "class " + ct.getSimpleName() + " type " + ct.getKind() + " ");
+    }
+}

--- a/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RefactoringTestBase.java
+++ b/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RefactoringTestBase.java
@@ -21,7 +21,9 @@ package org.netbeans.modules.refactoring.java.test;
 import java.io.EOFException;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,6 +33,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.event.ChangeListener;
@@ -46,6 +49,7 @@ import org.netbeans.api.project.SourceGroup;
 import org.netbeans.api.project.Sources;
 import org.netbeans.core.startup.Main;
 import org.netbeans.junit.NbTestCase;
+import static org.netbeans.junit.AssertLinesEqualHelpers.*;
 import org.netbeans.modules.java.source.BootClassPathUtil;
 import org.netbeans.modules.java.source.TestUtil;
 import org.netbeans.modules.java.source.indexing.JavaCustomIndexer;
@@ -84,7 +88,38 @@ public class RefactoringTestBase extends NbTestCase {
         this.sourcelevel = sourcelevel;
     }
 
+    static boolean debug = false;
+//    static boolean skipIndexing = false;
+
+    /**
+     * Write given files to sourceRoot and fully re index.
+     *
+     * First the (file) children of sourceRoot are deleted. This method can take
+     * a substantial time of your patience, so use wisely. See the doc in
+     * {@link IndexManager#refreshIndexAndWait}
+     *
+     * @param sourceRoot sic
+     * @param files to save
+     * @throws Exception whenever
+     */
     protected static void writeFilesAndWaitForScan(FileObject sourceRoot, File... files) throws Exception {
+        writeFilesAndWaitForScan(true, sourceRoot, files);
+    }
+
+    /**
+     * Write given files to sourceRoot and possibly reindex.
+     *
+     * First the (file) children of sourceRoot are deleted. This method can take
+     * a substantial time of your patience, so use wisely. See the doc in
+     * {@link IndexManager#refreshIndexAndWait}
+     *
+     * @param fulleIndex fully reindex the type repo
+     * @param sourceRoot sic
+     * @param files to save
+     * @throws Exception whenever
+     */
+    protected static void writeFilesAndWaitForScan(boolean fullIndex, FileObject sourceRoot, File... files) throws Exception {
+        long currentTimeMillis = System.currentTimeMillis();
         for (FileObject c : sourceRoot.getChildren()) {
             c.delete();
         }
@@ -94,9 +129,38 @@ public class RefactoringTestBase extends NbTestCase {
             TestUtilities.copyStringToFile(fo, f.content);
         }
 
-        IndexingManager.getDefault().refreshIndexAndWait(sourceRoot.toURL(), null, true);
+        if (fullIndex) {
+            IndexingManager.getDefault().refreshIndexAndWait(sourceRoot.toURL(), null, true);
+            long currentTimeMillis1 = System.currentTimeMillis();
+            if (debug) {
+                System.err.println("writeFilesAndWaitForScan took " + (currentTimeMillis1 - currentTimeMillis) + " millis");
+            }
+        }
     }
 
+    /**
+     * Save file but do not reindex.
+     *
+     * Deletes the existing files under sourceRoot, then saves the given files.
+     *
+     * Makes tests run faster. In particular single tests.
+     *
+     * @param sourceRoot sic
+     * @param files to save
+     * @throws Exception whenever
+     */
+    protected static void writeFilesNoIndexing(FileObject sourceRoot, File... files) throws Exception {
+        writeFilesAndWaitForScan(false, sourceRoot, files);
+    }
+
+    /**
+     * Verify that the given file(names) are present in the sourceRoot and that
+     * the files in said sourceRoot are equal to the given files.
+     *
+     * @param sourceRoot to contain generated (refactored) files
+     * @param files expected files
+     * @throws Exception well why not?
+     */
     protected void verifyContent(FileObject sourceRoot, File... files) throws Exception {
         List<FileObject> todo = new LinkedList<FileObject>();
 
@@ -109,33 +173,41 @@ public class RefactoringTestBase extends NbTestCase {
         while (!todo.isEmpty()) {
             FileObject file = todo.remove(0);
 
-            if (file.isData()) {
+            if (file.isData()) { // normal file
                 content.put(FileUtil.getRelativePath(sourceRoot, file), copyFileToString(FileUtil.toFile(file)));
-            } else {
+            } else { // it is a folder
                 todo.addAll(Arrays.asList(file.getChildren()));
             }
         }
 
+        List<Throwable> exc = new ArrayList<>();
         for (File f : files) {
-            String fileContent = content.remove(f.filename);
-
-            assertNotNull(f);
-            assertNotNull(f.content);
-            assertNotNull("Cannot find " + f.filename + " in map " + content, fileContent);
+            // take the element from the map filled by sourceRootTraversal.
             try {
-            assertEquals(getName() ,f.content.replaceAll("[ \t\r\n\n]+", " "), fileContent.replaceAll("[ \t\r\n\n]+", " "));
-            } catch (Throwable t) {
-                System.err.println("expected:");
-                System.err.println(f.content);
-                System.err.println("actual:");
-                System.err.println(fileContent);
-                throw t;
+                String fileContent = content.remove(f.filename);
+                assertNotNull(f);
+                assertNotNull(f.content);
+                assertNotNull("Cannot find expected " + f.filename + " in map filled by sourceRoot " + content, fileContent);
+                if (sideBySideCompare) {
+                    assertLinesEqual2(getName(),f.filename, f.content, fileContent);
+                } else { // original tests.
+                    assertLinesEqual1(f.filename, f.content, fileContent);
+                }
+            } catch (AssertionError | Exception t) {
+                exc.add(t);
             }
         }
+        if (exc.size() > 0) {
+            Throwable x = exc.get(0);
+            if (x instanceof AssertionError ae) throw ae;
+            throw (Exception) x;
+        }
 
-        assertTrue(content.toString(), content.isEmpty());
+        assertTrue("not all files processeed", content.isEmpty());
     }
-    
+
+    protected boolean sideBySideCompare = false;
+
     /**
      * Returns a string which contains the contents of a file.
      *
@@ -173,8 +245,8 @@ public class RefactoringTestBase extends NbTestCase {
         boolean goldenHasNext = g.hasNext();
         boolean realHasNext = r.hasNext();
 
-        assertFalse(goldenHasNext?"Expected: " + g.next().getMessage():"", goldenHasNext);
-        assertFalse(realHasNext?"Unexpected: " + r.next().getMessage():"", realHasNext);
+        assertFalse(goldenHasNext ? "Expected: " + g.next().getMessage() : "", goldenHasNext);
+        assertFalse(realHasNext ? "Unexpected: " + r.next().getMessage() : "", realHasNext);
     }
 
     static {
@@ -182,6 +254,7 @@ public class RefactoringTestBase extends NbTestCase {
     }
 
     protected static final class File {
+
         public final String filename;
         public final String content;
 
@@ -202,144 +275,147 @@ public class RefactoringTestBase extends NbTestCase {
         System.setProperty("org.netbeans.modules.java.source.usages.SourceAnalyser.fullIndex", "true");
         Logger.getLogger("").setLevel(Level.SEVERE); //turn off chatty logs
         MimeTypes.setAllMimeTypes(new HashSet<String>());
-        SourceUtilsTestUtil.prepareTest(new String[] {"org/netbeans/modules/openide/loaders/layer.xml",
-                    "org/netbeans/modules/java/source/resources/layer.xml",
-                    "org/netbeans/modules/java/editor/resources/layer.xml",
-            "org/netbeans/modules/refactoring/java/test/resources/layer.xml", "META-INF/generated-layer.xml"}, new Object[] {
-                    new ClassPathProvider() {
-                        @Override
-                        public ClassPath findClassPath(FileObject file, String type) {
-                    if (sourcePath != null && sourcePath.contains(file)){
-                                if (ClassPath.BOOT.equals(type)) {
-                                    return TestUtil.getBootClassPath();
-                                }
-                                if (JavaClassPathConstants.MODULE_BOOT_PATH.equals(type)) {
-                                    return BootClassPathUtil.getModuleBootPath();
-                                }
-                                if (ClassPath.COMPILE.equals(type)) {
-                                    return ClassPathSupport.createClassPath(new FileObject[0]);
-                                }
-                                if (ClassPath.SOURCE.equals(type)) {
-                                    return sourcePath;
-                                }
-                            }
+        SourceUtilsTestUtil.prepareTest(new String[]{"org/netbeans/modules/openide/loaders/layer.xml",
+            "org/netbeans/modules/java/source/resources/layer.xml",
+            "org/netbeans/modules/java/editor/resources/layer.xml",
+            "org/netbeans/modules/refactoring/java/test/resources/layer.xml", "META-INF/generated-layer.xml"}, new Object[]{
+            new ClassPathProvider() {
+                @Override
+                public ClassPath findClassPath(FileObject file, String type) {
+                    if (sourcePath != null && sourcePath.contains(file)) {
+                        if (ClassPath.BOOT.equals(type)) {
+                            return TestUtil.getBootClassPath();
+                        }
+                        if (JavaClassPathConstants.MODULE_BOOT_PATH.equals(type)) {
+                            return BootClassPathUtil.getModuleBootPath();
+                        }
+                        if (ClassPath.COMPILE.equals(type)) {
+                            return ClassPathSupport.createClassPath(new FileObject[0]);
+                        }
+                        if (ClassPath.SOURCE.equals(type)) {
+                            return sourcePath;
+                        }
+                    }
 
-                            return null;
-                        }
-                    },
-                    new ProjectFactory() {
-                        @Override
-                        public boolean isProject(FileObject projectDirectory) {
-                            return src != null && src.getParent() == projectDirectory;
-                        }
-                        @Override
-                        public Project loadProject(final FileObject projectDirectory, ProjectState state) throws IOException {
-                if (!isProject(projectDirectory)) {
                     return null;
                 }
-                            return new Project() {
+            },
+            new ProjectFactory() {
+                @Override
+                public boolean isProject(FileObject projectDirectory) {
+                    return src != null && src.getParent() == projectDirectory;
+                }
+
+                @Override
+                public Project loadProject(final FileObject projectDirectory, ProjectState state) throws IOException {
+                    if (!isProject(projectDirectory)) {
+                        return null;
+                    }
+                    return new Project() {
+                        @Override
+                        public FileObject getProjectDirectory() {
+                            return projectDirectory;
+                        }
+
+                        @Override
+                        public Lookup getLookup() {
+                            final Project p = this;
+                            return Lookups.singleton(new Sources() {
+
                                 @Override
-                                public FileObject getProjectDirectory() {
-                                    return projectDirectory;
+                                public SourceGroup[] getSourceGroups(String type) {
+                                    return new SourceGroup[]{GenericSources.group(p, src.getParent(), "source", "Java Sources", null, null),
+                                        GenericSources.group(p, test, "testsources", "Test Sources", null, null)};
                                 }
+
                                 @Override
-                                public Lookup getLookup() {
-                                    final Project p = this;
-                                    return Lookups.singleton(new Sources() {
-
-                                        @Override
-                                        public SourceGroup[] getSourceGroups(String type) {
-                                return new SourceGroup[] {GenericSources.group(p, src.getParent(), "source", "Java Sources", null, null),
-                                                        GenericSources.group(p, test, "testsources", "Test Sources", null, null)};
-                                        }
-
-                                        @Override
-                                        public void addChangeListener(ChangeListener listener) {
-                                        }
-
-                                        @Override
-                                        public void removeChangeListener(ChangeListener listener) {
-                                        }
-                                    });
+                                public void addChangeListener(ChangeListener listener) {
                                 }
-                            };
+
+                                @Override
+                                public void removeChangeListener(ChangeListener listener) {
+                                }
+                            });
                         }
-                        @Override
-            public void saveProject(Project project) throws IOException, ClassCastException {}
-                    },
-                    new TestLocator() {
+                    };
+                }
 
-                        @Override
-                        public boolean appliesTo(FileObject fo) {
-                            return true;
-                        }
+                @Override
+                public void saveProject(Project project) throws IOException, ClassCastException {
+                }
+            },
+            new TestLocator() {
 
-                        @Override
-                        public boolean asynchronous() {
-                            return false;
-                        }
+                @Override
+                public boolean appliesTo(FileObject fo) {
+                    return true;
+                }
 
-                        @Override
-                        public LocationResult findOpposite(FileObject fo, int caretOffset) {
-                            ClassPath srcCp;
+                @Override
+                public boolean asynchronous() {
+                    return false;
+                }
 
-                            if ((srcCp = ClassPath.getClassPath(fo, ClassPath.SOURCE)) == null) {
-                                return new LocationResult("File not found"); //NOI18N
-                            }
+                @Override
+                public LocationResult findOpposite(FileObject fo, int caretOffset) {
+                    ClassPath srcCp;
 
-                            String baseResName = srcCp.getResourceName(fo, '/', false);
-                            String testResName = getTestResName(baseResName, fo.getExt());
-                            assert testResName != null;
-                            FileObject fileObject = test.getFileObject(testResName);
-                if(fileObject != null) {
-                                return new LocationResult(fileObject, -1);
-                            }
+                    if ((srcCp = ClassPath.getClassPath(fo, ClassPath.SOURCE)) == null) {
+                        return new LocationResult("File not found"); //NOI18N
+                    }
 
-                            return new LocationResult("File not found"); //NOI18N
-                        }
+                    String baseResName = srcCp.getResourceName(fo, '/', false);
+                    String testResName = getTestResName(baseResName, fo.getExt());
+                    assert testResName != null;
+                    FileObject fileObject = test.getFileObject(testResName);
+                    if (fileObject != null) {
+                        return new LocationResult(fileObject, -1);
+                    }
 
-                        @Override
-                        public void findOpposite(FileObject fo, int caretOffset, LocationListener callback) {
-                            throw new UnsupportedOperationException("This should not be called on synchronous locators.");
-                        }
+                    return new LocationResult("File not found"); //NOI18N
+                }
 
-                        @Override
-                        public FileType getFileType(FileObject fo) {
-                if(FileUtil.isParentOf(test, fo)) {
-                                return FileType.TEST;
-                } else if(FileUtil.isParentOf(src, fo)) {
-                                return FileType.TESTED;
-                            }
-                            return FileType.NEITHER;
-                        }
+                @Override
+                public void findOpposite(FileObject fo, int caretOffset, LocationListener callback) {
+                    throw new UnsupportedOperationException("This should not be called on synchronous locators.");
+                }
 
-                        private String getTestResName(String baseResName, String ext) {
-                StringBuilder buf
-                        = new StringBuilder(baseResName.length() + ext.length() + 10);
-                            buf.append(baseResName).append("Test");                         //NOI18N
-                            if (ext.length() != 0) {
-                                buf.append('.').append(ext);
-                            }
-                            return buf.toString();
-                        }
-                    },
-                    new SourceLevelQueryImplementation() {
+                @Override
+                public FileType getFileType(FileObject fo) {
+                    if (FileUtil.isParentOf(test, fo)) {
+                        return FileType.TEST;
+                    } else if (FileUtil.isParentOf(src, fo)) {
+                        return FileType.TESTED;
+                    }
+                    return FileType.NEITHER;
+                }
 
-                        @Override
-                        public String getSourceLevel(FileObject javaFile) {
-                            return sourcelevel;
-                        }
-                    }});
+                private String getTestResName(String baseResName, String ext) {
+                    StringBuilder buf
+                            = new StringBuilder(baseResName.length() + ext.length() + 10);
+                    buf.append(baseResName).append("Test");                         //NOI18N
+                    if (ext.length() != 0) {
+                        buf.append('.').append(ext);
+                    }
+                    return buf.toString();
+                }
+            },
+            new SourceLevelQueryImplementation() {
+
+                @Override
+                public String getSourceLevel(FileObject javaFile) {
+                    return sourcelevel;
+                }
+            }});
         Main.initializeURLFactory();
         org.netbeans.api.project.ui.OpenProjects.getDefault().getOpenProjects();
-        
+
 //        org.netbeans.modules.java.source.TreeLoader.DISABLE_CONFINEMENT_TEST = true;
-        
         prepareTest();
-        org.netbeans.api.project.ui.OpenProjects.getDefault().open(new Project[] {prj = ProjectManager.getDefault().findProject(src.getParent())}, false);
+        org.netbeans.api.project.ui.OpenProjects.getDefault().open(new Project[]{prj = ProjectManager.getDefault().findProject(src.getParent())}, false);
         MimeTypes.setAllMimeTypes(Collections.singleton("text/x-java"));
         sourcePath = ClassPathSupport.createClassPath(src, test);
-        GlobalPathRegistry.getDefault().register(ClassPath.SOURCE, new ClassPath[] {sourcePath});
+        GlobalPathRegistry.getDefault().register(ClassPath.SOURCE, new ClassPath[]{sourcePath});
         RepositoryUpdater.getDefault().start(true);
         super.setUp();
         FileUtil.createData(FileUtil.getConfigRoot(), "Templates/Classes/Empty.java");
@@ -349,8 +425,8 @@ public class RefactoringTestBase extends NbTestCase {
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        GlobalPathRegistry.getDefault().unregister(ClassPath.SOURCE, new ClassPath[] {sourcePath});
-        org.netbeans.api.project.ui.OpenProjects.getDefault().close(new Project[] {prj});
+        GlobalPathRegistry.getDefault().unregister(ClassPath.SOURCE, new ClassPath[]{sourcePath});
+        org.netbeans.api.project.ui.OpenProjects.getDefault().close(new Project[]{prj});
         CountDownLatch cdl = new CountDownLatch(1);
         RepositoryUpdater.getDefault().stop(() -> {
             cdl.countDown();
@@ -366,12 +442,12 @@ public class RefactoringTestBase extends NbTestCase {
         src = FileUtil.createFolder(projectFolder, "src");
         test = FileUtil.createFolder(projectFolder, "test");
 
-            FileObject cache = FileUtil.createFolder(workdir, "cache");
+        FileObject cache = FileUtil.createFolder(workdir, "cache");
 
-            CacheFolder.setCacheFolder(cache);
-        }
+        CacheFolder.setCacheFolder(cache);
+    }
 
-    @ServiceProvider(service=MimeDataProvider.class)
+    @ServiceProvider(service = MimeDataProvider.class)
     public static final class MimeDataProviderImpl implements MimeDataProvider {
 
         private static final Lookup L = Lookups.singleton(new JavaCustomIndexer.Factory());
@@ -384,7 +460,7 @@ public class RefactoringTestBase extends NbTestCase {
 
             return null;
         }
-        
+
     }
 
     protected static boolean problemIsFatal(List<Problem> problems) {
@@ -400,7 +476,7 @@ public class RefactoringTestBase extends NbTestCase {
         return false;
     }
 
-    private static final int RETRIES = 3;
+    protected int RETRIES = 3;
 
     @Override
     protected void runTest() throws Throwable {
@@ -411,10 +487,13 @@ public class RefactoringTestBase extends NbTestCase {
                 super.runTest();
                 return;
             } catch (Throwable t) {
-                if (exc == null) exc = t;
+                if (exc == null) {
+                    exc = t;
+                }
             }
         }
-        throw exc;
+        if (exc != null) {
+            throw exc;
+        }
     }
-
 }


### PR DESCRIPTION
This is my final version of the solution for #7044 

The main problems/changes are  java/java.source/base/... CausualDiff.java

Problems solved are:

* refactor an inner record to top-level no longer drops record features.
* The implements clause is  put before the first curly brace instead of after
* add recordutis + test mainly to properly obtain record components as parameters to the record header
* various places with missing record consideration
* adds TreeMaker of RECORD

Adds a helper class in nbjunit to create formatted output when comparing source code