### PR TITLE
Update guava from 33.2.1-jre to 33.4.6-jre

### DIFF
--- a/ide/c.google.guava.failureaccess/external/binaries-list
+++ b/ide/c.google.guava.failureaccess/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-C4A06A64E650562F30B7BF9AAEC1BFED43ACA12B com.google.guava:failureaccess:1.0.2
+AEAFFD00D57023A2C947393ED251F0354F0985FC com.google.guava:failureaccess:1.0.3

--- a/ide/c.google.guava.failureaccess/external/failureaccess-1.0.3-license.txt
+++ b/ide/c.google.guava.failureaccess/external/failureaccess-1.0.3-license.txt
@@ -1,8 +1,8 @@
-Name: Guava
-Version: 33.2.1
+Name: Guava - Failure Access Library
+Version: 1.0.3
 License: Apache-2.0
 Origin: https://github.com/google/guava
-Description: Guava is a set of core libraries that includes new collection types (such as multimap and multiset), immutable collections, a graph library, and utilities for concurrency, I/O, hashing, primitives, strings, and more.
+Description: A Guava subproject
 
 
                                  Apache License

--- a/ide/c.google.guava.failureaccess/nbproject/project.properties
+++ b/ide/c.google.guava.failureaccess/nbproject/project.properties
@@ -17,6 +17,6 @@
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 spec.version.base=1.6.0
-release.external/failureaccess-1.0.2.jar=modules/com-google-guava-failureaccess.jar
+release.external/failureaccess-1.0.3.jar=modules/com-google-guava-failureaccess.jar
 is.autoload=true
 nbm.module.author=Tomas Stupka

--- a/ide/c.google.guava.failureaccess/nbproject/project.xml
+++ b/ide/c.google.guava.failureaccess/nbproject/project.xml
@@ -28,7 +28,7 @@
            <public-packages/>
            <class-path-extension>
                <runtime-relative-path>com-google-guava-failureaccess.jar</runtime-relative-path>
-               <binary-origin>external/failureaccess-1.0.2.jar</binary-origin>
+               <binary-origin>external/failureaccess-1.0.3.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/c.google.guava/external/binaries-list
+++ b/ide/c.google.guava/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-818E780DA2C66C63BBB6480FEF1F3855EEAFA3E4 com.google.guava:guava:33.2.1-jre
+4437FB72C3CC5D29554B588D9A97BEA12D6A42E1 com.google.guava:guava:33.4.6-jre

--- a/ide/c.google.guava/external/guava-33.4.6-jre-license.txt
+++ b/ide/c.google.guava/external/guava-33.4.6-jre-license.txt
@@ -1,8 +1,8 @@
-Name: Guava - Failure Access Library
-Version: 1.0.2
+Name: Guava
+Version: 33.4.6
 License: Apache-2.0
 Origin: https://github.com/google/guava
-Description: A Guava subproject
+Description: Guava is a set of core libraries that includes new collection types (such as multimap and multiset), immutable collections, a graph library, and utilities for concurrency, I/O, hashing, primitives, strings, and more.
 
 
                                  Apache License

--- a/ide/c.google.guava/nbproject/project.properties
+++ b/ide/c.google.guava/nbproject/project.properties
@@ -17,6 +17,6 @@
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 spec.version.base=27.21.0
-release.external/guava-33.2.1-jre.jar=modules/com-google-guava.jar
+release.external/guava-33.4.6-jre.jar=modules/com-google-guava.jar
 is.autoload=true
 nbm.module.author=Tomas Stupka

--- a/ide/c.google.guava/nbproject/project.xml
+++ b/ide/c.google.guava/nbproject/project.xml
@@ -28,7 +28,7 @@
            <public-packages/>
            <class-path-extension>
                <runtime-relative-path>com-google-guava.jar</runtime-relative-path>
-               <binary-origin>external/guava-33.2.1-jre.jar</binary-origin>
+               <binary-origin>external/guava-33.4.6-jre.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -25,8 +25,8 @@ ide/db.sql.visualeditor/external/javacc-7.0.10.jar java/performance/external/jav
 # bundled maven conflicts with other libraries
 java/maven.embedder/external/apache-maven-3.9.9-bin.zip ide/slf4j.api/external/slf4j-api-1.7.36.jar
 java/maven.embedder/external/apache-maven-3.9.9-bin.zip platform/o.apache.commons.codec/external/commons-codec-1.17.1.jar
-java/maven.embedder/external/apache-maven-3.9.9-bin.zip ide/c.google.guava.failureaccess/external/failureaccess-1.0.2.jar
-java/maven.embedder/external/apache-maven-3.9.9-bin.zip ide/c.google.guava/external/guava-33.2.1-jre.jar
+java/maven.embedder/external/apache-maven-3.9.9-bin.zip ide/c.google.guava.failureaccess/external/failureaccess-1.0.3.jar
+java/maven.embedder/external/apache-maven-3.9.9-bin.zip ide/c.google.guava/external/guava-33.4.6-jre.jar
 java/maven.embedder/external/apache-maven-3.9.9-bin.zip java/maven.indexer/external/javax.annotation-api-1.3.2.jar
 
 # Used to parse data during build, but need to as a lib for ide cluster
@@ -52,7 +52,7 @@ enterprise/websvc.restlib/external/osgi.core-8.0.0.jar platform/libs.osgi/extern
 
 # gradle is used at build-time, so we can ignore the duplicates
 extide/gradle/external/gradle-7.4-bin.zip enterprise/libs.amazon/external/ion-java-1.0.2.jar
-extide/gradle/external/gradle-7.4-bin.zip ide/c.google.guava.failureaccess/external/failureaccess-1.0.2.jar
+extide/gradle/external/gradle-7.4-bin.zip ide/c.google.guava.failureaccess/external/failureaccess-1.0.3.jar
 extide/gradle/external/gradle-7.4-bin.zip ide/c.jcraft.jzlib/external/jzlib-1.1.3.jar
 extide/gradle/external/gradle-7.4-bin.zip ide/libs.commons_compress/external/commons-compress-1.26.2.jar
 extide/gradle/external/gradle-7.4-bin.zip ide/o.apache.commons.lang/external/commons-lang-2.6.jar


### PR DESCRIPTION
 - includes failureaccess update from 1.0.2 to 1.0.3
 - fixes some for-removal deprecation startup warnings (Unsafe API)

the lsp modules are the only direct guava users atm ([search](https://github.com/search?q=repo%3Aapache%2Fnetbeans+%3Ccode-name-base%3Ecom.google.guava%3C%2Fcode-name-base%3E&type=code)), enabling all tests

part of https://github.com/apache/netbeans/issues/8259