### PR TITLE
Update jgit from 7.0.0 to 7.2.0

### DIFF
--- a/ide/c.google.gson/external/binaries-list
+++ b/ide/c.google.gson/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-527175CA6D81050B53BDD4C457A6D6E017626B0E com.google.code.gson:gson:2.11.0
+4E773A317740B83B43CFC3D652962856041697CB com.google.code.gson:gson:2.12.1

--- a/ide/c.google.gson/external/gson-2.12.1-license.txt
+++ b/ide/c.google.gson/external/gson-2.12.1-license.txt
@@ -1,7 +1,7 @@
 Name: GSon
 Description: JSon serialization/deserialization library
 Origin: GitHub
-Version: 2.11.0
+Version: 2.12.1
 License: Apache-2.0
 
                                  Apache License

--- a/ide/c.google.gson/nbproject/project.properties
+++ b/ide/c.google.gson/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/gson-2.11.0.jar=modules/com-google-gson.jar
+release.external/gson-2.12.1.jar=modules/com-google-gson.jar
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8

--- a/ide/c.google.gson/nbproject/project.xml
+++ b/ide/c.google.gson/nbproject/project.xml
@@ -28,7 +28,7 @@
            <public-packages/>
            <class-path-extension>
                <runtime-relative-path>com-google-gson.jar</runtime-relative-path>
-               <binary-origin>external/gson-2.11.0.jar</binary-origin>
+               <binary-origin>external/gson-2.12.1.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/libs.git/src/org/netbeans/libs/git/GitRevisionInfo.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/GitRevisionInfo.java
@@ -114,7 +114,7 @@ public final class GitRevisionInfo {
         if (author == null) {
             return (long) revCommit.getCommitTime() * 1000;
         } else {
-            return author.getWhen().getTime();
+            return author.getWhenAsInstant().toEpochMilli();
         }
     }
 

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/CommitCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/CommitCommand.java
@@ -170,9 +170,9 @@ public class CommitCommand extends GitCommand {
         PersonIdent lastAuthor = lastCommit.getAuthorIdent();
         if (lastAuthor != null) {
             PersonIdent author = commit.getAuthor();
-            commit.setAuthor(lastAuthor.getTimeZone() == null
-                    ? new PersonIdent(author, lastAuthor.getWhen())
-                    : new PersonIdent(author, lastAuthor.getWhen(), lastAuthor.getTimeZone()));
+            commit.setAuthor(lastAuthor.getZoneId() == null
+                    ? new PersonIdent(author, lastAuthor.getWhenAsInstant())
+                    : new PersonIdent(author, lastAuthor.getWhenAsInstant(), lastAuthor.getZoneId()));
         }
     }
 
@@ -197,7 +197,7 @@ public class CommitCommand extends GitCommand {
                 treeWalk.addTree(new DirCacheIterator(cache));
                 final int T_HEAD = 0;
                 final int T_INDEX = 1;
-                List<DirCacheEntry> toAdd = new LinkedList<DirCacheEntry>();
+                List<DirCacheEntry> toAdd = new LinkedList<>();
                 while (treeWalk.next() && !monitor.isCanceled()) {
                     String path = treeWalk.getPathString();
                     int mHead = treeWalk.getRawMode(T_HEAD);

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/LogCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/LogCommand.java
@@ -310,11 +310,11 @@ public class LogCommand extends GitCommand {
         Date from  = criteria.getFrom();
         Date to  = criteria.getTo();
         if (from != null && to != null) {
-            filter = AndRevFilter.create(filter, CommitTimeRevFilter.between(from, to));
+            filter = AndRevFilter.create(filter, CommitTimeRevFilter.between(from.toInstant(), to.toInstant()));
         } else if (from != null) {
-            filter = AndRevFilter.create(filter, CommitTimeRevFilter.after(from));
+            filter = AndRevFilter.create(filter, CommitTimeRevFilter.after(from.toInstant()));
         } else if (to != null) {
-            filter = AndRevFilter.create(filter, CommitTimeRevFilter.before(to));
+            filter = AndRevFilter.create(filter, CommitTimeRevFilter.before(to.toInstant()));
         }
         // this must be at the end, limit filter must apply as the last
         if (criteria.getLimit() != -1) {

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/TransportCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/TransportCommand.java
@@ -29,16 +29,13 @@ import java.util.logging.Logger;
 import org.eclipse.jgit.errors.NotSupportedException;
 import org.eclipse.jgit.errors.TransportException;
 import org.eclipse.jgit.errors.UnsupportedCredentialItem;
-import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.storage.file.FileBasedConfig;
 import org.eclipse.jgit.transport.CredentialItem;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.Transport;
 import org.eclipse.jgit.transport.TransportProtocol;
 import org.eclipse.jgit.transport.URIish;
-import org.eclipse.jgit.util.FS;
 import org.eclipse.jgit.util.SystemReader;
 import org.netbeans.libs.git.GitException;
 import org.netbeans.libs.git.jgit.GitClassFactory;
@@ -81,17 +78,17 @@ abstract class TransportCommand extends GitCommand {
                 password = "";
             }
             for (CredentialItem i : items) {
-                if (i instanceof CredentialItem.Username) {
-                    ((CredentialItem.Username) i).setValue(user);
+                if (i instanceof CredentialItem.Username un) {
+                    un.setValue(user);
                     continue;
                 }
-                if (i instanceof CredentialItem.Password) {
-                    ((CredentialItem.Password) i).setValue(password.toCharArray());
+                if (i instanceof CredentialItem.Password pw) {
+                    pw.setValue(password.toCharArray());
                     continue;
                 }
-                if (i instanceof CredentialItem.StringType) {
+                if (i instanceof CredentialItem.StringType st) {
                     if (i.getPromptText().equals("Password: ")) { //NOI18N
-                        ((CredentialItem.StringType) i).setValue(password);
+                        st.setValue(password);
                         continue;
                     }
                 }
@@ -241,16 +238,13 @@ abstract class TransportCommand extends GitCommand {
 
     protected abstract void runTransportCommand () throws GitException;
     
-    private static class DelegatingSystemReader extends SystemReader {
+    private static class DelegatingSystemReader extends SystemReader.Delegate {
+
         private final SystemReader instance;
 
         public DelegatingSystemReader (SystemReader sr) {
+            super(sr);
             this.instance = sr;
-        }
-
-        @Override
-        public String getHostname () {
-            return instance.getHostname();
         }
 
         @Override
@@ -260,35 +254,6 @@ abstract class TransportCommand extends GitCommand {
             }
             return instance.getenv(string);
         }
-
-        @Override
-        public String getProperty (String string) {
-            return instance.getProperty(string);
-        }
-
-        @Override
-        public FileBasedConfig openUserConfig (Config config, FS fs) {
-            return instance.openUserConfig(config, fs);
-        }
-
-        @Override
-        public FileBasedConfig openSystemConfig (Config config, FS fs) {
-            return instance.openSystemConfig(config, fs);
-        }
-
-        @Override
-        public long getCurrentTime () {
-            return instance.getCurrentTime();
-        }
-
-        @Override
-        public int getTimezone (long l) {
-            return instance.getTimezone(l);
-        }
-
-        @Override
-        public FileBasedConfig openJGitConfig(Config config, FS fs) {
-            return instance.openJGitConfig(config, fs);
-        }
+        
     }
 }

--- a/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/ConnectionTest.java
+++ b/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/ConnectionTest.java
@@ -24,10 +24,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.storage.file.FileBasedConfig;
-import org.eclipse.jgit.util.FS;
 import org.eclipse.jgit.util.SystemReader;
 import org.netbeans.junit.Filter;
 import org.netbeans.libs.git.GitClient;
@@ -284,7 +281,7 @@ public class ConnectionTest extends AbstractGitTestCase {
     
     public void testSshConnectionGITSSH_Issue213394 () throws Exception {
         SystemReader sr = SystemReader.getInstance();
-        SystemReader.setInstance(new DelegatingSystemReader(sr) {
+        SystemReader.setInstance(new SystemReader.Delegate(sr) {
 
             @Override
             public String getenv (String string) {
@@ -404,51 +401,4 @@ public class ConnectionTest extends AbstractGitTestCase {
         
     }
 
-    private static class DelegatingSystemReader extends SystemReader {
-        private final SystemReader instance;
-
-        public DelegatingSystemReader (SystemReader sr) {
-            this.instance = sr;
-        }
-
-        @Override
-        public String getHostname () {
-            return instance.getHostname();
-        }
-
-        @Override
-        public String getenv (String string) {
-            return instance.getenv(string);
-        }
-
-        @Override
-        public String getProperty (String string) {
-            return instance.getProperty(string);
-        }
-
-        @Override
-        public FileBasedConfig openUserConfig (Config config, FS fs) {
-            return instance.openUserConfig(config, fs);
-        }
-
-        @Override
-        public FileBasedConfig openSystemConfig (Config config, FS fs) {
-            return instance.openSystemConfig(config, fs);
-        }
-
-        @Override
-        public long getCurrentTime () {
-            return instance.getCurrentTime();
-        }
-
-        @Override
-        public int getTimezone (long l) {
-            return instance.getTimezone(l);
-        }
-
-        @Override
-        public FileBasedConfig openJGitConfig(Config config, FS fs) {
-            return instance.openJGitConfig(config, fs);
-        }
-    }
 }

--- a/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CommitTest.java
+++ b/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/CommitTest.java
@@ -643,9 +643,9 @@ public class CommitTest extends AbstractGitTestCase {
                 new GitUser("user2", "user2.email"), new GitUser("committer2", "committer2.email"), true, NULL_PROGRESS_MONITOR);
         RevCommit amendedCommit = walk.parseCommit(repository.resolve(lastCommit.getRevision()));
         assertEquals("Commit time should not change after amend", time, lastCommit.getCommitTime());
-        assertEquals(originalCommit.getAuthorIdent().getWhen(), amendedCommit.getAuthorIdent().getWhen());
+        assertEquals(originalCommit.getAuthorIdent().getWhenAsInstant(), amendedCommit.getAuthorIdent().getWhenAsInstant());
         // commit time should not equal.
-        assertFalse(originalCommit.getCommitterIdent().getWhen().equals(amendedCommit.getCommitterIdent().getWhen()));
+        assertFalse(originalCommit.getCommitterIdent().getWhenAsInstant().equals(amendedCommit.getCommitterIdent().getWhenAsInstant()));
         statuses = client.getStatus(new File[] { workDir }, NULL_PROGRESS_MONITOR);
         assertStatus(statuses, workDir, newOne, true, GitStatus.Status.STATUS_NORMAL, GitStatus.Status.STATUS_NORMAL, GitStatus.Status.STATUS_NORMAL, false);
         assertStatus(statuses, workDir, another, true, GitStatus.Status.STATUS_NORMAL, GitStatus.Status.STATUS_NORMAL, GitStatus.Status.STATUS_NORMAL, false);
@@ -693,7 +693,9 @@ public class CommitTest extends AbstractGitTestCase {
         GitRevisionInfo commit = client.commit(new File[0], info.getFullMessage(), null, null, NULL_PROGRESS_MONITOR);
         assertEquals(info.getAuthor(), commit.getAuthor());
         assertEquals(info.getCommitTime(), commit.getCommitTime());
-        assertEquals(Utils.findCommit(repository, info.getRevision()).getAuthorIdent().getWhen(),
-                Utils.findCommit(repository, commit.getRevision()).getAuthorIdent().getWhen());
+        assertEquals(
+            Utils.findCommit(repository, info.getRevision()).getAuthorIdent().getWhenAsInstant(),
+            Utils.findCommit(repository, commit.getRevision()).getAuthorIdent().getWhenAsInstant()
+        );
     }
 }

--- a/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/UpdateRefTest.java
+++ b/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/UpdateRefTest.java
@@ -21,6 +21,7 @@ package org.netbeans.libs.git.jgit.commands;
 
 import java.io.File;
 import java.io.IOException;
+import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.ReflogReader;
 import org.eclipse.jgit.lib.Repository;
 import org.netbeans.libs.git.GitClient;
@@ -83,7 +84,9 @@ public class UpdateRefTest extends AbstractGitTestCase {
         
         GitRefUpdateResult res = client.updateReference("master", info.getRevision(), NULL_PROGRESS_MONITOR);
         assertEquals(GitRefUpdateResult.FAST_FORWARD, res);
-        ReflogReader reflogReader = repository.getReflogReader("master");
+        Ref ref = repository.findRef("master");
+        assertNotNull(ref);
+        ReflogReader reflogReader = repository.getRefDatabase().getReflogReader(ref);
         assertEquals("merge " + info.getRevision() + ": Fast-forward", reflogReader.getLastEntry().getComment());
     }
 
@@ -104,7 +107,9 @@ public class UpdateRefTest extends AbstractGitTestCase {
         
         GitRefUpdateResult res = client.updateReference("master", "BRANCH", NULL_PROGRESS_MONITOR);
         assertEquals(GitRefUpdateResult.FAST_FORWARD, res);
-        ReflogReader reflogReader = repository.getReflogReader("master");
+        Ref ref = repository.findRef("master");
+        assertNotNull(ref);
+        ReflogReader reflogReader = repository.getRefDatabase().getReflogReader(ref);
         assertEquals("merge BRANCH: Fast-forward", reflogReader.getLastEntry().getComment());
     }
 

--- a/ide/o.eclipse.jgit.gpg.bc/external/binaries-list
+++ b/ide/o.eclipse.jgit.gpg.bc/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-792FF306EA46E2734624D5C9176BA9C6E092E43C org.eclipse.jgit:org.eclipse.jgit.gpg.bc:7.0.0.202409031743-r
+0B53C4CF59B0A52E4E2C43E4FF096BBD8E389B30 org.eclipse.jgit:org.eclipse.jgit.gpg.bc:7.2.0.202503040940-r

--- a/ide/o.eclipse.jgit.gpg.bc/external/org.eclipse.jgit.gpg.bc-7.2.0.202503040940-r-license.txt
+++ b/ide/o.eclipse.jgit.gpg.bc/external/org.eclipse.jgit.gpg.bc-7.2.0.202503040940-r-license.txt
@@ -1,6 +1,6 @@
 Name: JGit Library
 Origin: Eclipse
-Version: 7.0.0.202409031743-r
+Version: 7.2.0.202503040940-r
 Description: Integration library for Git client
 License: EDL-1.0-jgit
 URL: http://www.eclipse.org/jgit/download/

--- a/ide/o.eclipse.jgit.gpg.bc/nbproject/project.properties
+++ b/ide/o.eclipse.jgit.gpg.bc/nbproject/project.properties
@@ -17,4 +17,4 @@
 
 is.autoload=true
 
-release.external/org.eclipse.jgit.gpg.bc-7.0.0.202409031743-r.jar=modules/org-eclipse-jgit-gpg-bc.jar
+release.external/org.eclipse.jgit.gpg.bc-7.2.0.202503040940-r.jar=modules/org-eclipse-jgit-gpg-bc.jar

--- a/ide/o.eclipse.jgit.gpg.bc/nbproject/project.xml
+++ b/ide/o.eclipse.jgit.gpg.bc/nbproject/project.xml
@@ -65,7 +65,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>org-eclipse-jgit-gpg-bc.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.jgit.gpg.bc-7.0.0.202409031743-r.jar</binary-origin>
+                <binary-origin>external/org.eclipse.jgit.gpg.bc-7.2.0.202503040940-r.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/o.eclipse.jgit.lfs/external/binaries-list
+++ b/ide/o.eclipse.jgit.lfs/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-95F28CA36011F9CBA2A95C9829B5844CF83D1493 org.eclipse.jgit:org.eclipse.jgit.lfs:7.0.0.202409031743-r
+21B6C0D03236D7889C80EBBD6B18FB79246F19D9 org.eclipse.jgit:org.eclipse.jgit.lfs:7.2.0.202503040940-r

--- a/ide/o.eclipse.jgit.lfs/external/org.eclipse.jgit.lfs-7.2.0.202503040940-r-license.txt
+++ b/ide/o.eclipse.jgit.lfs/external/org.eclipse.jgit.lfs-7.2.0.202503040940-r-license.txt
@@ -1,6 +1,6 @@
 Name: JGit Library
 Origin: Eclipse
-Version: 7.0.0.202409031743-r
+Version: 7.2.0.202503040940-r
 Description: Integration library for Git client
 License: EDL-1.0-jgit
 URL: http://www.eclipse.org/jgit/download/

--- a/ide/o.eclipse.jgit.lfs/nbproject/project.properties
+++ b/ide/o.eclipse.jgit.lfs/nbproject/project.properties
@@ -17,4 +17,4 @@
 
 is.autoload=true
 
-release.external/org.eclipse.jgit.lfs-7.0.0.202409031743-r.jar=modules/org-eclipse-jgit-lfs.jar
+release.external/org.eclipse.jgit.lfs-7.2.0.202503040940-r.jar=modules/org-eclipse-jgit-lfs.jar

--- a/ide/o.eclipse.jgit.lfs/nbproject/project.xml
+++ b/ide/o.eclipse.jgit.lfs/nbproject/project.xml
@@ -60,7 +60,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>org-eclipse-jgit-lfs.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.jgit.lfs-7.0.0.202409031743-r.jar</binary-origin>
+                <binary-origin>external/org.eclipse.jgit.lfs-7.2.0.202503040940-r.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/o.eclipse.jgit.ssh.jsch/external/binaries-list
+++ b/ide/o.eclipse.jgit.ssh.jsch/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-44AD1B1124EC81AC0ACC2280E27B0239DFFEC41F org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:7.0.0.202409031743-r
+D80BF5D740F8A8E4731F75489E6A9226402E6A67 org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:7.2.0.202503040940-r

--- a/ide/o.eclipse.jgit.ssh.jsch/external/org.eclipse.jgit.ssh.jsch-7.2.0.202503040940-r-license.txt
+++ b/ide/o.eclipse.jgit.ssh.jsch/external/org.eclipse.jgit.ssh.jsch-7.2.0.202503040940-r-license.txt
@@ -1,6 +1,6 @@
 Name: JGit Library
 Origin: Eclipse
-Version: 7.0.0.202409031743-r
+Version: 7.2.0.202503040940-r
 Description: Integration library for Git client
 License: EDL-1.0-jgit
 URL: http://www.eclipse.org/jgit/download/

--- a/ide/o.eclipse.jgit.ssh.jsch/nbproject/project.properties
+++ b/ide/o.eclipse.jgit.ssh.jsch/nbproject/project.properties
@@ -17,4 +17,4 @@
 
 is.autoload=true
 
-release.external/org.eclipse.jgit.ssh.jsch-7.0.0.202409031743-r.jar=modules/org-eclipse-jgit-ssh-jsch.jar
+release.external/org.eclipse.jgit.ssh.jsch-7.2.0.202503040940-r.jar=modules/org-eclipse-jgit-ssh-jsch.jar

--- a/ide/o.eclipse.jgit.ssh.jsch/nbproject/project.xml
+++ b/ide/o.eclipse.jgit.ssh.jsch/nbproject/project.xml
@@ -54,7 +54,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>org-eclipse-jgit-ssh-jsch.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.jgit.ssh.jsch-7.0.0.202409031743-r.jar</binary-origin>
+                <binary-origin>external/org.eclipse.jgit.ssh.jsch-7.2.0.202503040940-r.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/o.eclipse.jgit/external/binaries-list
+++ b/ide/o.eclipse.jgit/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-E11135DED2F1F78DA9A028002AD7837CC970EE8E org.eclipse.jgit:org.eclipse.jgit:7.0.0.202409031743-r
+8D9379845E9D37B58B187ABBAB2F7A6B63B59F65 org.eclipse.jgit:org.eclipse.jgit:7.2.0.202503040940-r

--- a/ide/o.eclipse.jgit/external/org.eclipse.jgit-7.2.0.202503040940-r-license.txt
+++ b/ide/o.eclipse.jgit/external/org.eclipse.jgit-7.2.0.202503040940-r-license.txt
@@ -1,6 +1,6 @@
 Name: JGit Library
 Origin: Eclipse
-Version: 7.0.0.202409031743-r
+Version: 7.2.0.202503040940-r
 Description: Integration library for Git client
 License: EDL-1.0-jgit
 URL: http://www.eclipse.org/jgit/download/

--- a/ide/o.eclipse.jgit/nbproject/project.properties
+++ b/ide/o.eclipse.jgit/nbproject/project.properties
@@ -17,4 +17,4 @@
 
 is.autoload=true
 
-release.external/org.eclipse.jgit-7.0.0.202409031743-r.jar=modules/org-eclipse-jgit.jar
+release.external/org.eclipse.jgit-7.2.0.202503040940-r.jar=modules/org-eclipse-jgit.jar

--- a/ide/o.eclipse.jgit/nbproject/project.xml
+++ b/ide/o.eclipse.jgit/nbproject/project.xml
@@ -52,7 +52,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>org-eclipse-jgit.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.jgit-7.0.0.202409031743-r.jar</binary-origin>
+                <binary-origin>external/org.eclipse.jgit-7.2.0.202503040940-r.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -56,7 +56,7 @@ extide/gradle/external/gradle-7.4-bin.zip ide/c.google.guava.failureaccess/exter
 extide/gradle/external/gradle-7.4-bin.zip ide/c.jcraft.jzlib/external/jzlib-1.1.3.jar
 extide/gradle/external/gradle-7.4-bin.zip ide/libs.commons_compress/external/commons-compress-1.26.2.jar
 extide/gradle/external/gradle-7.4-bin.zip ide/o.apache.commons.lang/external/commons-lang-2.6.jar
-extide/gradle/external/gradle-7.4-bin.zip ide/o.eclipse.jgit/external/org.eclipse.jgit-7.0.0.202409031743-r.jar
+extide/gradle/external/gradle-7.4-bin.zip ide/o.eclipse.jgit/external/org.eclipse.jgit-7.2.0.202503040940-r.jar
 extide/gradle/external/gradle-7.4-bin.zip java/debugger.jpda.truffle/external/antlr4-runtime-4.7.2.jar
 extide/gradle/external/gradle-7.4-bin.zip java/maven.embedder/external/apache-maven-3.9.9-bin.zip
 extide/gradle/external/gradle-7.4-bin.zip platform/libs.junit4/external/hamcrest-core-1.3.jar


### PR DESCRIPTION
 - Update jgit from 7.0.0 to 7.2.0
   -  changes: [7.1.0](https://projects.eclipse.org/projects/technology.jgit/releases/7.1.0), [7.2.0](https://projects.eclipse.org/projects/technology.jgit/releases/7.2.0)
 - Update gson from 2.11.0 to 2.12.1

skipped bouncycastle since NB osgi failed to load it the last time I tried https://github.com/apache/netbeans/pull/7569

dep trees:

<details>

```
mvn eu.maveniverse.maven.plugins:toolbox:gav-tree -Dgav=org.eclipse.jgit:org.eclipse.jgit.gpg.bc:7.0.0.202409031743-r
[INFO] org.eclipse.jgit:org.eclipse.jgit.gpg.bc:jar:7.0.0.202409031743-r
[INFO] ├─org.eclipse.jgit:org.eclipse.jgit:jar:7.0.0.202409031743-r [compile]
[INFO] │ ├─com.googlecode.javaewah:JavaEWAH:jar:1.2.3 [compile]
[INFO] │ ╰─commons-codec:commons-codec:jar:1.17.1 [compile]
[INFO] ├─org.bouncycastle:bcpg-jdk18on:jar:1.78.1 [compile]
[INFO] ├─org.bouncycastle:bcprov-jdk18on:jar:1.78.1 [compile]
[INFO] ├─org.bouncycastle:bcutil-jdk18on:jar:1.78.1 [compile]
[INFO] ├─org.bouncycastle:bcpkix-jdk18on:jar:1.78.1 [compile]
[INFO] ╰─org.slf4j:slf4j-api:jar:1.7.36 [compile]

mvn eu.maveniverse.maven.plugins:toolbox:gav-tree -Dgav=org.eclipse.jgit:org.eclipse.jgit.gpg.bc:7.2.0.202503040940-r
[INFO] org.eclipse.jgit:org.eclipse.jgit.gpg.bc:jar:7.2.0.202503040940-r
[INFO] ├─org.eclipse.jgit:org.eclipse.jgit:jar:7.2.0.202503040940-r [compile]
[INFO] │ ├─com.googlecode.javaewah:JavaEWAH:jar:1.2.3 [compile]
[INFO] │ ╰─commons-codec:commons-codec:jar:1.18.0 [compile]
[INFO] ├─org.bouncycastle:bcpg-jdk18on:jar:1.80 [compile]
[INFO] ├─org.bouncycastle:bcprov-jdk18on:jar:1.80 [compile]
[INFO] ├─org.bouncycastle:bcutil-jdk18on:jar:1.80 [compile]
[INFO] ├─org.bouncycastle:bcpkix-jdk18on:jar:1.80 [compile]
[INFO] ╰─org.slf4j:slf4j-api:jar:1.7.36 [compile]
```

```
mvn eu.maveniverse.maven.plugins:toolbox:gav-tree -Dgav=org.eclipse.jgit:org.eclipse.jgit.lfs:7.0.0.202409031743-r
[INFO] org.eclipse.jgit:org.eclipse.jgit.lfs:jar:7.0.0.202409031743-r
[INFO] ├─org.eclipse.jgit:org.eclipse.jgit:jar:7.0.0.202409031743-r [compile]
[INFO] │ ├─com.googlecode.javaewah:JavaEWAH:jar:1.2.3 [compile]
[INFO] │ ├─org.slf4j:slf4j-api:jar:1.7.36 [compile]
[INFO] │ ╰─commons-codec:commons-codec:jar:1.17.1 [compile]
[INFO] ╰─com.google.code.gson:gson:jar:2.11.0 [compile]
[INFO]   ╰─com.google.errorprone:error_prone_annotations:jar:2.27.0 [compile]

mvn eu.maveniverse.maven.plugins:toolbox:gav-tree -Dgav=org.eclipse.jgit:org.eclipse.jgit.lfs:7.2.0.202503040940-r
[INFO] org.eclipse.jgit:org.eclipse.jgit.lfs:jar:7.2.0.202503040940-r
[INFO] ├─org.eclipse.jgit:org.eclipse.jgit:jar:7.2.0.202503040940-r [compile]
[INFO] │ ├─com.googlecode.javaewah:JavaEWAH:jar:1.2.3 [compile]
[INFO] │ ├─org.slf4j:slf4j-api:jar:1.7.36 [compile]
[INFO] │ ╰─commons-codec:commons-codec:jar:1.18.0 [compile]
[INFO] ╰─com.google.code.gson:gson:jar:2.12.1 [compile]
[INFO]   ╰─com.google.errorprone:error_prone_annotations:jar:2.36.0 [compile]
```

```
mvn eu.maveniverse.maven.plugins:toolbox:gav-tree -Dgav=org.eclipse.jgit:org.eclipse.jgit:7.0.0.202409031743-r
[INFO] org.eclipse.jgit:org.eclipse.jgit:jar:7.0.0.202409031743-r
[INFO] ├─com.googlecode.javaewah:JavaEWAH:jar:1.2.3 [compile]
[INFO] ├─org.slf4j:slf4j-api:jar:1.7.36 [compile]
[INFO] ╰─commons-codec:commons-codec:jar:1.17.1 [compile]

mvn eu.maveniverse.maven.plugins:toolbox:gav-tree -Dgav=org.eclipse.jgit:org.eclipse.jgit:7.2.0.202503040940-r
[INFO] org.eclipse.jgit:org.eclipse.jgit:jar:7.2.0.202503040940-r
[INFO] ├─com.googlecode.javaewah:JavaEWAH:jar:1.2.3 [compile]
[INFO] ├─org.slf4j:slf4j-api:jar:1.7.36 [compile]
[INFO] ╰─commons-codec:commons-codec:jar:1.18.0 [compile]
```

```
mvn eu.maveniverse.maven.plugins:toolbox:gav-tree -Dgav=org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:7.0.0.202409031743-r
[INFO] org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:jar:7.0.0.202409031743-r
[INFO] ├─org.eclipse.jgit:org.eclipse.jgit:jar:7.0.0.202409031743-r [compile]
[INFO] │ ├─com.googlecode.javaewah:JavaEWAH:jar:1.2.3 [compile]
[INFO] │ ╰─commons-codec:commons-codec:jar:1.17.1 [compile]
[INFO] ├─com.jcraft:jsch:jar:0.1.55 [compile]
[INFO] ├─com.jcraft:jzlib:jar:1.1.3 [compile]
[INFO] ╰─org.slf4j:slf4j-api:jar:1.7.36 [compile]

mvn eu.maveniverse.maven.plugins:toolbox:gav-tree -Dgav=org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:7.2.0.202503040940-r
[INFO] org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:jar:7.2.0.202503040940-r
[INFO] ├─org.eclipse.jgit:org.eclipse.jgit:jar:7.2.0.202503040940-r [compile]
[INFO] │ ├─com.googlecode.javaewah:JavaEWAH:jar:1.2.3 [compile]
[INFO] │ ╰─commons-codec:commons-codec:jar:1.18.0 [compile]
[INFO] ├─com.jcraft:jsch:jar:0.1.55 [compile]
[INFO] ├─com.jcraft:jzlib:jar:1.1.3 [compile]
[INFO] ╰─org.slf4j:slf4j-api:jar:1.7.36 [compile]
```

</details>