### PR TITLE
Micronaut applications use --also-make for run+debug by default

### DIFF
--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/micronaut-actions-maven.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/micronaut-actions-maven.xml
@@ -46,6 +46,7 @@
             <goal>process-classes</goal>
             <goal>io.micronaut.maven:micronaut-maven-plugin:run</goal>
         </goals>
+        <reactor>am</reactor>
         <properties>
             <!-- will not be used by MN plugin -->
             <exec.args>-classpath %classpath</exec.args>
@@ -64,6 +65,7 @@
             <goal>process-classes</goal>
             <goal>io.micronaut.maven:micronaut-maven-plugin:run</goal>
         </goals>
+        <reactor>am</reactor>
         <properties>
             <!-- will not be used by MN plugin -->
             <exec.args>-classpath %classpath</exec.args>
@@ -101,6 +103,7 @@
             <goal>process-classes</goal>
             <goal>io.micronaut.maven:micronaut-maven-plugin:run</goal>
         </goals>
+        <reactor>am</reactor>
         <properties>
             <!-- will not be used by MN plugin -->
             <exec.args>-classpath %classpath</exec.args>
@@ -121,6 +124,7 @@
             <goal>process-test-classes</goal>
             <goal>io.micronaut.maven:micronaut-maven-plugin:run</goal>
         </goals>
+        <reactor>am</reactor>
         <properties>
             <!-- will not be used by MN plugin -->
             <exec.args>-classpath %classpath</exec.args>


### PR DESCRIPTION
Structured micronaut applications typically contains majority of the code in lib, while the actual runnable class is in a cloud/environment-specific subproject. Gradle understands this and builds prerequisite dependencies, but Maven must be told so.

This PR was originally tested as #8365 during 'vsnetbeans' testing.