### PR TITLE
Bump FormDesigner module to JDK 17 and adjust javac task

### DIFF
--- a/java/form/build.xml
+++ b/java/form/build.xml
@@ -25,7 +25,7 @@
 
     <target name="absolute-layout" depends="build-init">
         <mkdir dir="${build.dir}/absolutelayoutclasses"/>
-        <javac srcdir="release/sources" target="${javac.target}" source="${javac.source}" destdir="${build.dir}/absolutelayoutclasses"/>
+        <javac srcdir="release/sources" release="${absolutelayout.javac.release}" destdir="${build.dir}/absolutelayoutclasses"/>
         <mkdir dir="${cluster}/modules/ext"/>
         <nb-ext-jar jarfile="${cluster}/modules/ext/AbsoluteLayout.jar">
             <manifest>

--- a/java/form/nbproject/project.properties
+++ b/java/form/nbproject/project.properties
@@ -15,8 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
+
+# 'error: exporting a package from system module java.desktop is not allowed with --release'
+javac.source=17
+javac.target=17
+
+absolutelayout.javac.release=8
 extra.module.files=modules/ext/AbsoluteLayout.jar
-javac.source=1.8
+
+# see o.n.m.form.fakepeer package
+javac.compilerargs=--add-exports=java.desktop/java.awt.peer=ALL-UNNAMED
+
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=1.88.0
 test-unit-sys-prop.org.netbeans.modules.form.layoutdesign.test=0

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
@@ -78,7 +78,7 @@ public class CustomJavac extends Javac {
             if (tgr.matches("\\d+")) {
                 tgr = "1." + tgr;
             }
-            if (!isBootclasspathOptionUsed()) {
+            if (canUseRelease()) {
                 setRelease(tgr.substring(2));
             }
             String src = getSource();
@@ -135,13 +135,14 @@ public class CustomJavac extends Javac {
         super.compile();
     }
 
-    private boolean isBootclasspathOptionUsed() {
+    private boolean canUseRelease() {
+        // 'error: exporting a package from system module java.desktop is not allowed with --release'
         for (String arg : getCurrentCompilerArgs()) {
-            if (arg.contains("-Xbootclasspath")) {
-                return true;
+            if (arg.contains("-Xbootclasspath") || arg.contains("--add-exports=java.")) {
+                return false;
             }
         }
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
I remember trying to bump the javac target on `java/form` a few times already but it failed since as soon `--release` was set it couldn't find the peer classes anymore. This tries to resolve it.

 - FormDesigner needs to access the `java.awt.peer` package
 - javac ant task should not upgrade to `--release` in that case since it will fail when `--add-exports` is used on JDK modules
 - keep `AbsoluteLayout.jar` on Java 8 level

@lahodaj would this be the right approach?

meta issue https://github.com/apache/netbeans/issues/8813