### PR TITLE
fixing apidoc compliance post jdk23 part 1

### DIFF
--- a/ide/api.java.classpath/src/org/netbeans/api/java/classpath/package.html
+++ b/ide/api.java.classpath/src/org/netbeans/api/java/classpath/package.html
@@ -77,7 +77,7 @@ as in this example for getting compilation classpath:
 <div class="nonnormative">
 <pre>
 <span class="type"><a href="@org-openide-filesystems@/org/openide/filesystems/FileObject.html">FileObject</a></span> <span class="variable-name">f</span> = <span class="function-name">getSomeJavaSourceFile</span>();
-<span class="type"><a href="ClassPath.html">ClassPath</a></span> <span class="variable-name">cp</span> = ClassPath.<a href="ClassPath.html#getClassPath-org.openide.filesystems.FileObject-java.lang.String-"><span class="function-name">getClassPath</span></a>(f, ClassPath.<a href="ClassPath.html#COMPILE"><span class="constant">COMPILE</span></a>);
+<span class="type"><a href="ClassPath.html">ClassPath</a></span> <span class="variable-name">cp</span> = ClassPath.<a href="ClassPath.html#getClassPath(org.openide.filesystems.FileObject,java.lang.String)"><span class="function-name">getClassPath</span></a>(f, ClassPath.<a href="ClassPath.html#COMPILE"><span class="constant">COMPILE</span></a>);
 <span class="predefined">System.err.println</span>(cp);
 </pre>
 </div>
@@ -110,8 +110,8 @@ to find out what folders are the roots:
 
 <div class="nonnormative">
 <pre>
-<a href="ClassPath.html"><span class="type">ClassPath</span></a> <span class="variable-name">cp</span> = ClassPath.<a href="ClassPath.html#getClassPath-org.openide.filesystems.FileObject-java.lang.String-"><span class="function-name">getClassPath</span></a>(myClassFile, ClassPath.<a href="ClassPath.html#EXECUTE"><span class="constant">EXECUTE</span></a>);
-<a href="@org-openide-filesystems@/org/openide/filesystems/FileObject.html">FileObject</a>[] <span class="variable-name">roots</span> = cp.<a href="ClassPath.html#getRoots--"><span class="function-name">getRoots</span></a>();
+<a href="ClassPath.html"><span class="type">ClassPath</span></a> <span class="variable-name">cp</span> = ClassPath.<a href="ClassPath.html#getClassPath(org.openide.filesystems.FileObject,java.lang.String)"><span class="function-name">getClassPath</span></a>(myClassFile, ClassPath.<a href="ClassPath.html#EXECUTE"><span class="constant">EXECUTE</span></a>);
+<a href="@org-openide-filesystems@/org/openide/filesystems/FileObject.html">FileObject</a>[] <span class="variable-name">roots</span> = cp.<a href="ClassPath.html#getRoots()"><span class="function-name">getRoots</span></a>();
 <span class="keyword">for</span> (<span class="keyword">int</span> <span class="variable-name">i</span> = <span class="constant">0</span>; i &lt; roots.length; i++) {
     System.err.print(roots[i] + <span class="constant">":"</span>);
 }
@@ -124,15 +124,15 @@ more thoroughly using
 
 <div class="nonnormative">
 <pre>
-<a href="ClassPath.html"><span class="type">ClassPath</span></a> <span class="variable-name">cp</span> = ClassPath.<a href="ClassPath.html#getClassPath-org.openide.filesystems.FileObject-java.lang.String-"><span class="function-name">getClassPath</span></a>(myClassObject, ClassPath.<a href="ClassPath.html#EXECUTE"><span class="constant">EXECUTE</span></a>);
-<a href="@JDK@@JDKMODULE_JAVA_BASE@/java/util/List.html"><span class="type">List</span></a> <span class="variable-name">entries</span> = cp.<a href="ClassPath.html#entries--"><span class="function-name">entries</span></a>();
+<a href="ClassPath.html"><span class="type">ClassPath</span></a> <span class="variable-name">cp</span> = ClassPath.<a href="ClassPath.html#getClassPath(org.openide.filesystems.FileObject,java.lang.String)"><span class="function-name">getClassPath</span></a>(myClassObject, ClassPath.<a href="ClassPath.html#EXECUTE"><span class="constant">EXECUTE</span></a>);
+<a href="@JDK@@JDKMODULE_JAVA_BASE@/java/util/List.html"><span class="type">List</span></a> <span class="variable-name">entries</span> = cp.<a href="ClassPath.html#entries()"><span class="function-name">entries</span></a>();
 <span class="keyword">for</span> (Iterator <span class="variable-name">it</span> = entries.iterator(); it.hasNext(); ) {
     <a href="ClassPath.Entry.html"><span class="type">ClassPath.Entry</span></a> <span class="variable-name">en</span> = (ClassPath.Entry)it.next();
-    <span class="keyword">if</span> (!en.<a href="ClassPath.Entry.html#isValid--"><span class="function-name">isValid()</span></a>) {
-        <span class="type">IOException</span> <span class="variable-name">x</span> = en.<a href="ClassPath.Entry.html#getError--"><span class="function-name">getError</span></a>();
+    <span class="keyword">if</span> (!en.<a href="ClassPath.Entry.html#isValid()"><span class="function-name">isValid()</span></a>) {
+        <span class="type">IOException</span> <span class="variable-name">x</span> = en.<a href="ClassPath.Entry.html#getError()"><span class="function-name">getError</span></a>();
         <span class="comment">// Report the error somehow, perhaps using <a href="@org-openide-util-ui@/org/openide/ErrorManager.html"><code>org.openide.ErrorManager</code></a></span>.
     } <span class="keyword">else</span> {
-        <a href="@org-openide-filesystems@/org/openide/filesystems/FileObject.html"><span class="type">FileObject</span></a> <span class="variable-name">root</span> = en.<a href="ClassPath.Entry.html#getRoot--"><span class="function-name">getRoot</span></a>();
+        <a href="@org-openide-filesystems@/org/openide/filesystems/FileObject.html"><span class="type">FileObject</span></a> <span class="variable-name">root</span> = en.<a href="ClassPath.Entry.html#getRoot()"><span class="function-name">getRoot</span></a>();
         <span class="comment">// Do something with the root folder</span>
     }
 }
@@ -164,9 +164,9 @@ instance and ask it to compute the name for you:
 
 <div class="nonnormative">
 <pre>
-<a href="@org-openide-filesystems@/org/openide/filesystems/FileObject.html"><span class="type">FileObject</span></a> <span class="variable-name">f</span> = bundleDataObject.<a href="@org-openide-loaders@/org/openide/loaders/DataObject.html#getPrimaryFile--"><span class="function-name">getPrimaryFile</span></a>();
-<a href="ClassPath.html"><span class="type">ClassPath</span></a> <span class="variable-name">cp</span> = ClassPath.<a href="ClassPath.html#getClassPath-org.openide.filesystems.FileObject-java.lang.String-"><span class="function-name">getClassPath</span></a>(theSourceDataObject.getPrimaryFile(), ClassPath.<a href="ClassPath.html#EXECUTE"><span class="constant">EXECUTE</span></a>);
-String <span class="variable-name">bundleResource</span> = cp.<a href="ClassPath.html#getResourceName-org.openide.filesystems.FileObject-"><span class="function-name">getResourceName</span></a>(f);
+<a href="@org-openide-filesystems@/org/openide/filesystems/FileObject.html"><span class="type">FileObject</span></a> <span class="variable-name">f</span> = bundleDataObject.<a href="@org-openide-loaders@/org/openide/loaders/DataObject.html#getPrimaryFile()"><span class="function-name">getPrimaryFile</span></a>();
+<a href="ClassPath.html"><span class="type">ClassPath</span></a> <span class="variable-name">cp</span> = ClassPath.<a href="ClassPath.html#getClassPath(org.openide.filesystems.FileObject,java.lang.String)"><span class="function-name">getClassPath</span></a>(theSourceDataObject.getPrimaryFile(), ClassPath.<a href="ClassPath.html#EXECUTE"><span class="constant">EXECUTE</span></a>);
+String <span class="variable-name">bundleResource</span> = cp.<a href="ClassPath.html#getResourceName(org.openide.filesystems.FileObject)"><span class="function-name">getResourceName</span></a>(f);
 </pre>
 </div>
 
@@ -189,10 +189,10 @@ dependencies, you may do:
 <div class="nonnormative">
 <pre>
 <a href="@org-openide-filesystems@/org/openide/filesystems/FileObject.html"><span class="type">FileObject</span></a> <span class="variable-name">f</span>; <span class="comment">// some interesting FileObject.</span>
-<a href="ClassPath.html"><span class="type">ClassPath</span></a> <span class="variable-name">cp</span> = ClassPath.<a href="ClassPath.html#getClassPath-org.openide.filesystems.FileObject-java.lang.String-"><span class="function-name">getClassPath</span></a>(f, ClassPath.<a href="ClassPath.html#COMPILE"><span class="constant">COMPILE</span></a>);
-cp.<a href="ClassPath.html#addPropertyChangeListener-java.beans.PropertyChangeListener-"><span class="function-name">addPropertyChangeListener</span></a>(new <a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/java/beans/PropertyChangeListener.html"><span class="type">PropertyChangeListener</span></a>() {
+<a href="ClassPath.html"><span class="type">ClassPath</span></a> <span class="variable-name">cp</span> = ClassPath.<a href="ClassPath.html#getClassPath(org.openide.filesystems.FileObject,java.lang.String)"><span class="function-name">getClassPath</span></a>(f, ClassPath.<a href="ClassPath.html#COMPILE"><span class="constant">COMPILE</span></a>);
+cp.<a href="ClassPath.html#addPropertyChangeListener(java.beans.PropertyChangeListener)"><span class="function-name">addPropertyChangeListener</span></a>(new <a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/java/beans/PropertyChangeListener.html"><span class="type">PropertyChangeListener</span></a>() {
     <span class="keyword">public void</span> <span class="function-name">propertyChange</span>(<a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/java/beans/PropertyChangeEvent.html"><span class="type">PropertyChangeEvent</span></a> <span class="variable-name">evt</span>) {
-        <span class="keyword">if</span> (ClassPath.<a href="ClassPath.html#PROP_ROOTS"><span class="constant">PROP_ROOTS</span></a>.equals(evt.<a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/java/beans/PropertyChangeEvent.html#getPropertyName--"><span class="function-name">getPropertyName()</span></a>)) {
+        <span class="keyword">if</span> (ClassPath.<a href="ClassPath.html#PROP_ROOTS"><span class="constant">PROP_ROOTS</span></a>.equals(evt.<a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/java/beans/PropertyChangeEvent.html#getPropertyName()"><span class="function-name">getPropertyName()</span></a>)) {
             <span class="comment">// Update your stuff, because classpath roots have changed.</span>
         }
     }

--- a/ide/api.java.classpath/src/org/netbeans/spi/java/queries/SourceForBinaryQueryImplementation.java
+++ b/ide/api.java.classpath/src/org/netbeans/spi/java/queries/SourceForBinaryQueryImplementation.java
@@ -55,7 +55,7 @@ import org.netbeans.api.java.queries.SourceForBinaryQuery;
  * </div>
  * @see org.netbeans.api.java.queries.SourceForBinaryQuery
  * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/FileOwnerQuery.html">FileOwnerQuery</a>
- * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup--">org.netbeans.api.project.Project#getLookup</a>
+ * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup()">org.netbeans.api.project.Project#getLookup</a>
  * @since org.netbeans.api.java/1 1.4
  */
 public interface SourceForBinaryQueryImplementation {

--- a/ide/api.lsp/apichanges.xml
+++ b/ide/api.lsp/apichanges.xml
@@ -86,7 +86,7 @@
         <author login="sdedic"/>
         <compatibility binary="compatible" source="compatible" addition="yes" deletion="no" />
         <description>
-            Added API to request that a <a href="@TOP@/org/netbeans/api/lsp/WorkspaceEdit.html#applyEdits-java.util.List-boolean-">WorkspaceEdit</a> is applied
+            Added API to request that a <a href="@TOP@/org/netbeans/api/lsp/WorkspaceEdit.html#applyEdits(java.util.List,boolean)">WorkspaceEdit</a> is applied
             to the resources with an optional save.
         </description>
         <class package="org.netbeans.api.lsp" name="WorkspaceEdit"/>
@@ -114,9 +114,9 @@
         <author login="dbalek"/>
         <compatibility binary="compatible" source="compatible" addition="yes" deletion="no"/>
         <description>
-            <a href="@TOP@/org/netbeans/api/lsp/Completion.html#getLabelDetail--">Completion.getLabelDetail()</a>
+            <a href="@TOP@/org/netbeans/api/lsp/Completion.html#getLabelDetail()">Completion.getLabelDetail()</a>
             to get an optional string describing function signatures or type annotations.
-            <a href="@TOP@/org/netbeans/api/lsp/Completion.html#getLabelDescription--">Completion.getLabelDescription()</a>
+            <a href="@TOP@/org/netbeans/api/lsp/Completion.html#getLabelDescription()">Completion.getLabelDescription()</a>
             to get an optional string describing fully qualified names or file path.
         </description>
         <class package="org.netbeans.api.lsp" name="Completion"/>
@@ -185,7 +185,7 @@
         <author login="dbalek"/>
         <compatibility binary="compatible" source="compatible" addition="yes" deletion="no"/>
         <description>
-            <a href="@TOP@/org/netbeans/api/lsp/Completion.html#getCommand--">Completion.getCommand()</a> to get an optional command
+            <a href="@TOP@/org/netbeans/api/lsp/Completion.html#getCommand()">Completion.getCommand()</a> to get an optional command
             that is executed after inserting the completion.
         </description>
         <class package="org.netbeans.api.lsp" name="Completion"/>
@@ -226,7 +226,7 @@
             <a href="@TOP@/org/netbeans/spi/lsp/DiagnosticReporter.html">DiagnosticReporter</a> SPI should be implemented to allow
             alerting the LSP server core that diagnostics for certain file(s) may have changed. The core implementation should then poll 
             <a href="@TOP@/org/netbeans/spi/lsp/ErrorProvider.html">ErrorProviders</a> to collect the diagnostics.
-            API clients should call <a href="@TOP@/org/netbeans/api/lsp/Diagnostic.html#findReporterControl-org.openide.util.Lookup-org.openide.filesystems.FileObject-">Diagnostic.findReporterControl</a>
+            API clients should call <a href="@TOP@/org/netbeans/api/lsp/Diagnostic.html#findReporterControl(org.openide.util.Lookup,org.openide.filesystems.FileObject)">Diagnostic.findReporterControl</a>
             to obtain an accessor which can fire the alert.
         </description>
         <class package="org.netbeans.api.lsp" name="Diagnostic"/>

--- a/ide/db/arch.xml
+++ b/ide/db/arch.xml
@@ -19,8 +19,8 @@
     under the License.
 
 -->
-<!DOCTYPE api-answers PUBLIC "-//NetBeans//DTD Arch Answers//EN" "../nbbuild/antsrc/org/netbeans/nbbuild/Arch.dtd" [
-  <!ENTITY api-questions SYSTEM "../nbbuild/antsrc/org/netbeans/nbbuild/Arch-api-questions.xml">
+<!DOCTYPE api-answers PUBLIC "-//NetBeans//DTD Arch Answers//EN" "../../nbbuild/antsrc/org/netbeans/nbbuild/Arch.dtd" [
+  <!ENTITY api-questions SYSTEM "../../nbbuild/antsrc/org/netbeans/nbbuild/Arch-api-questions.xml">
 ]>
 
 <api-answers
@@ -189,7 +189,7 @@
   </usecase>
   <usecase id="get-jdbc-driver" name="Get the underlying JDBC Driver instance for a JDBCDriver">
    <p>
-      You can use the <a href="@TOP@org/netbeans/api/db/explorer/JDBCDriver.html#getDriver--">JDBCDriver.getDriver()</a>
+      You can use the <a href="@TOP@org/netbeans/api/db/explorer/JDBCDriver.html#getDriver()">JDBCDriver.getDriver()</a>
       method to obtain a reference to the underlying JDBC Driver instance.  This is useful if you want to use the registered
       drivers but create your own JDBC connections independent of the Database Explorer.
 
@@ -199,7 +199,7 @@
    <p>
     When creating a new connection the JDBC driver which it should use can be specified.
     A list of all the registered JDBC drivers can be retrieved using 
-    <a href="@TOP@org/netbeans/api/db/explorer/JDBCDriverManager.html#getDrivers--">JDBCDriverManager.getDrivers()</a>.
+    <a href="@TOP@org/netbeans/api/db/explorer/JDBCDriverManager.html#getDrivers()">JDBCDriverManager.getDrivers()</a>.
    </p>
   </usecase>
   <usecase id="register-runtimes" name="Registering database runtimes">
@@ -217,9 +217,9 @@
    <p>
     A module can create new database connections (for example to a bundled database).
     New connections can be added by calling 
-    <a href="@TOP@org/netbeans/api/db/explorer/DatabaseConnection.html#create-org.netbeans.api.db.explorer.JDBCDriver-java.lang.String-java.lang.String-java.lang.String-java.lang.String-boolean-">DatabaseConnection.create()</a>
+    <a href="@TOP@org/netbeans/api/db/explorer/DatabaseConnection.html#create(org.netbeans.api.db.explorer.JDBCDriver,java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean)">DatabaseConnection.create()</a>
     to create a new DatabaseConnection instance and then 
-    <a href="@TOP@org/netbeans/api/db/explorer/ConnectionManager.html#addConnection-org.netbeans.api.db.explorer.DatabaseConnection-">ConnectionManager.addConnection()</a> to
+    <a href="@TOP@org/netbeans/api/db/explorer/ConnectionManager.html#addConnection(org.netbeans.api.db.explorer.DatabaseConnection)">ConnectionManager.addConnection()</a> to
     add the connection to the Database Explorer.
    </p>
    <p>
@@ -265,7 +265,7 @@
     which allows the user to select the database connection which the SQL statement
     will be executed against in a combo box in the editor toolbar. 
     The list of connections can be obtained by calling
-    <a href="@TOP@org/netbeans/api/db/explorer/ConnectionManager.html#getConnections--">ConnectionManager.getConnections()</a>,
+    <a href="@TOP@org/netbeans/api/db/explorer/ConnectionManager.html#getConnections()">ConnectionManager.getConnections()</a>,
     which returns an array of 
     <a href="@TOP@org/netbeans/api/db/explorer/DatabaseConnection.html">DatabaseConnection</a>
     instances.
@@ -273,7 +273,7 @@
    <p>
     The client usually needs to show the display name of the connection. The
     display name can be retrieved using the 
-    <a href="@TOP@org/netbeans/api/db/explorer/DatabaseConnection.html#getDisplayName--">DatabaseConnection.getDisplayName()</a>
+    <a href="@TOP@org/netbeans/api/db/explorer/DatabaseConnection.html#getDisplayName()">DatabaseConnection.getDisplayName()</a>
     method.
    </p>
   </usecase>
@@ -293,28 +293,28 @@
     Usually when displaying a list of connections (usually in a combo box),
     the last item is "New Connection", which displays the standard New Database Connection 
     dialog of the Database Explorer. This can be achieved by calling one of the
-    <a href="@TOP@org/netbeans/api/db/explorer/ConnectionManager.html#showAddConnectionDialog-org.netbeans.api.db.explorer.JDBCDriver-">ConnectionManager.showAddConnectionDialog()</a> methods.
+    <a href="@TOP@org/netbeans/api/db/explorer/ConnectionManager.html#showAddConnectionDialog(org.netbeans.api.db.explorer.JDBCDriver)">ConnectionManager.showAddConnectionDialog()</a> methods.
    </p>
   </usecase>
   <usecase id="remove-connection" name="Remove a database connection">
    <p>
        A user of this API may want to remove a connection from the list of connections
        registered by the Database Explorer.  This is done using 
-       <a href="@TOP@org/netbeans/api/db/explorer/ConnectionManager.html#removeConnection-org.netbeans.api.db.explorer.DatabaseConnection-">ConnectionManager.removeConnection()</a>
+       <a href="@TOP@org/netbeans/api/db/explorer/ConnectionManager.html#removeConnection(org.netbeans.api.db.explorer.DatabaseConnection)">ConnectionManager.removeConnection()</a>
    </p>
   </usecase>
  <usecase id="connect-database" name="Connecting to a database">
    <p>
     A component which provides database functionality (such as the SQL Editor)
     will need to connect to a database. This can be achieved using the
-    <a href="@TOP@org/netbeans/api/db/explorer/ConnectionManager.html#showConnectionDialog-org.netbeans.api.db.explorer.DatabaseConnection-">DatabaseConnection.showConnectionDialog()</a>
+    <a href="@TOP@org/netbeans/api/db/explorer/ConnectionManager.html#showConnectionDialog(org.netbeans.api.db.explorer.DatabaseConnection)">DatabaseConnection.showConnectionDialog()</a>
     method and the <code>java.sql.Connection</code> instance can be retrieved using the 
-    <a href="@TOP@org/netbeans/api/db/explorer/DatabaseConnection.html#getJDBCConnection--">getJDBCConnection()</a>
+    <a href="@TOP@org/netbeans/api/db/explorer/DatabaseConnection.html#getJDBCConnection()">getJDBCConnection()</a>
     method.
    </p>
    <p>
      If you want to connect to the database without showing a dialog or any kind of UI, you can use the
-     <a href="@TOP@org/netbeans/api/db/explorer/ConnectionManager.html#connect-org.netbeans.api.db.explorer.DatabaseConnection-">DatabaseConnection.connect()</a>
+     <a href="@TOP@org/netbeans/api/db/explorer/ConnectionManager.html#connect(org.netbeans.api.db.explorer.DatabaseConnection)">DatabaseConnection.connect()</a>
      method.
    </p>
   </usecase>
@@ -322,7 +322,7 @@
    <p>
     You may want to test to make sure the underlying physical JDBC connection
     obtained from a DatabaseConnection is either valid or null.  This is done using the
-    <a href="@TOP@org/netbeans/api/db/explorer/DatabaseConnection.html#getJDBCConnection-boolean-">
+    <a href="@TOP@org/netbeans/api/db/explorer/DatabaseConnection.html#getJDBCConnection(boolean)">
         DatabaseConnection.getJDBCConnection(boolean test)</a>
     method, which validates the underlying connection before returning it.  If the
     connection is invalid, it marks the DatabaseConnection as disconnected and returns null.
@@ -334,9 +334,9 @@
     or a module providing support for data sources) will need to let the user
     select the a database connection, usually through a combo box.
     This can be achieved using the
-    <a href="@TOP@org/netbeans/api/db/explorer/support/DatabaseExplorerUIs.html#connect-javax.swing.JComboBox-org.netbeans.api.db.explorer.ConnectionManager-">DatabaseExplorerUIs.connect()</a>
+    <a href="@TOP@org/netbeans/api/db/explorer/support/DatabaseExplorerUIs.html#connect(javax.swing.JComboBox,org.netbeans.api.db.explorer.ConnectionManager)">DatabaseExplorerUIs.connect()</a>
     method. The <code>JComboBox</code> passed to the method will be filled with the list of connections as returned by 
-    <a href="@TOP@org/netbeans/api/db/explorer/ConnectionManager.html#getConnections--">ConnectionManager.getConnections()</a>, followed by a separator
+    <a href="@TOP@org/netbeans/api/db/explorer/ConnectionManager.html#getConnections()">ConnectionManager.getConnections()</a>, followed by a separator
     and a <em>New Database Connection</em> item which will display the dialog for adding a new database connection when selected.
    </p>
   </usecase>

--- a/ide/editor.lib/apichanges.xml
+++ b/ide/editor.lib/apichanges.xml
@@ -1107,7 +1107,7 @@ duplicate messages suppressed: 14
                     Using <code>DrawLayer</code> and related classes and methods
                     has been deprecated in favor of the new Highlighting SPI in
                     the editor/lib2 module. For more details see
-                    <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Highlighting SPI</a>.
+                    <a href="@org-netbeans-modules-editor-lib2@/index.html">Highlighting SPI</a>.
                 </p>
             </description>
         </change>
@@ -1154,11 +1154,11 @@ duplicate messages suppressed: 14
     </head>
     <body>
 
-<p class="overviewlink"><a href="overview-summary.html">Overview</a></p>
+<p class="overviewlink"><a href="index.html">Overview</a></p>
 
 <h1>Introduction</h1>
 
-<p>This document lists changes made to the <a href="overview-summary.html">Editor Library API</a>.</p>
+<p>This document lists changes made to the <a href="index.html">Editor Library API</a>.</p>
 
 <!-- The actual lists of changes, as summaries and details: -->
       <hr/>

--- a/ide/editor.lib/src/org/netbeans/editor/BaseDocument.java
+++ b/ide/editor.lib/src/org/netbeans/editor/BaseDocument.java
@@ -615,7 +615,7 @@ public class BaseDocument extends AbstractDocument implements AtomicLockDocument
 // XXX: formatting cleanup
 //    /**
 //     * @deprecated Please use Editor Indentation API instead, for details see
-//     *   <a href="@org-netbeans-modules-editor-indent@/overview-summary.html">Editor Indentation</a>.
+//     *   <a href="@org-netbeans-modules-editor-indent@/index.html">Editor Indentation</a>.
 //     */
 //    public Formatter getLegacyFormatter() {
 //        if (formatter == null) {
@@ -631,7 +631,7 @@ public class BaseDocument extends AbstractDocument implements AtomicLockDocument
 //     * Gets the formatter for this document.
 //     *
 //     * @deprecated Please use Editor Indentation API instead, for details see
-//     *   <a href="@org-netbeans-modules-editor-indent@/overview-summary.html">Editor Indentation</a>.
+//     *   <a href="@org-netbeans-modules-editor-indent@/index.html">Editor Indentation</a>.
 //     */
 //    public Formatter getFormatter() {
 //        Formatter f = getLegacyFormatter();
@@ -641,7 +641,7 @@ public class BaseDocument extends AbstractDocument implements AtomicLockDocument
 
     /**
      * @deprecated Please use Lexer instead, for details see
-     *   <a href="@org-netbeans-modules-lexer@/overview-summary.html">Lexer</a>.
+     *   <a href="@org-netbeans-modules-lexer@/index.html">Lexer</a>.
      */
     @Deprecated
     public SyntaxSupport getSyntaxSupport() {
@@ -1565,7 +1565,7 @@ public class BaseDocument extends AbstractDocument implements AtomicLockDocument
      *
      * @see #getTabSize()
      * @deprecated Please use Editor Indentation API instead, for details see
-     *   <a href="@org-netbeans-modules-editor-indent@/overview-summary.html">Editor Indentation</a>.
+     *   <a href="@org-netbeans-modules-editor-indent@/index.html">Editor Indentation</a>.
      */
     @Deprecated
     public int getShiftWidth() {

--- a/ide/editor.lib/src/org/netbeans/editor/BaseKit.java
+++ b/ide/editor.lib/src/org/netbeans/editor/BaseKit.java
@@ -547,7 +547,7 @@ public class BaseKit extends DefaultEditorKit {
      *   creation is not related to the particular document
      * 
      * @deprecated Please use Lexer instead, for details see
-     *   <a href="@org-netbeans-modules-lexer@/overview-summary.html">Lexer</a>.
+     *   <a href="@org-netbeans-modules-lexer@/index.html">Lexer</a>.
      */
     @Deprecated
     public Syntax createSyntax(Document doc) {
@@ -558,7 +558,7 @@ public class BaseKit extends DefaultEditorKit {
      * Create the syntax used for formatting.
      * 
      * @deprecated Please use Editor Indentation API instead, for details see
-     *   <a href="@org-netbeans-modules-editor-indent@/overview-summary.html">Editor Indentation</a>.
+     *   <a href="@org-netbeans-modules-editor-indent@/index.html">Editor Indentation</a>.
      */
     @Deprecated
     public Syntax createFormatSyntax(Document doc) {
@@ -569,7 +569,7 @@ public class BaseKit extends DefaultEditorKit {
      * Create syntax support
      * 
      * @deprecated Please use Lexer instead, for details see
-     *   <a href="@org-netbeans-modules-lexer@/overview-summary.html">Lexer</a>.
+     *   <a href="@org-netbeans-modules-lexer@/index.html">Lexer</a>.
      */
     @Deprecated
     public SyntaxSupport createSyntaxSupport(BaseDocument doc) {
@@ -580,7 +580,7 @@ public class BaseKit extends DefaultEditorKit {
 //    /**
 //     * Create the formatter appropriate for this kit
 //     * @deprecated Please use Editor Indentation API instead, for details see
-//     *   <a href="@org-netbeans-modules-editor-indent@/overview-summary.html">Editor Indentation</a>.
+//     *   <a href="@org-netbeans-modules-editor-indent@/index.html">Editor Indentation</a>.
 //     */
 //    public Formatter createFormatter() {
 //        return new Formatter(this.getClass());
@@ -1044,7 +1044,7 @@ public class BaseKit extends DefaultEditorKit {
      * Default typed action
      *
      * @deprecated Please do not subclass this class. Use Typing Hooks instead, for details see
-     *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
+     *   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a>.
      */
 //    @EditorActionRegistration(name = defaultKeyTypedAction)
     @Deprecated
@@ -1308,7 +1308,7 @@ public class BaseKit extends DefaultEditorKit {
          * to intercept inserted characters.
          *
          * @deprecated Please use Typing Hooks instead, for details see
-         *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
+         *   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a>.
          */
         protected void insertString(BaseDocument doc,
 				  int dotPos, 
@@ -1330,7 +1330,7 @@ public class BaseKit extends DefaultEditorKit {
          * to intercept inserted characters.
          *
          * @deprecated Please use Typing Hooks instead, for details see
-         *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
+         *   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a>.
          */
         protected void replaceSelection(
                 JTextComponent target,
@@ -1348,7 +1348,7 @@ public class BaseKit extends DefaultEditorKit {
          *
          * @deprecated Please use <a href="@org-netbeans-modules-editor-indent-support@/org/netbeans/modules/editor/indent/spi/support/AutomatedIndenting.html">AutomatedIndentig</a>
          *   or Typing Hooks instead, for details see
-         *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
+         *   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a>.
          */
         protected void checkIndent(JTextComponent target, String typedText) {
         }
@@ -1433,7 +1433,7 @@ public class BaseKit extends DefaultEditorKit {
 
     /** 
      * @deprecated Please do not subclass this class. Use Typing Hooks instead, for details see
-     *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
+     *   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a>.
      */
     @Deprecated
     public static class InsertBreakAction extends LocalBaseAction {
@@ -1559,7 +1559,7 @@ public class BaseKit extends DefaultEditorKit {
          * returned is passed intact to the other hook.
          * 
          * @deprecated Please use Typing Hooks instead, for details see
-         *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
+         *   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a>.
          */
         protected Object beforeBreak(JTextComponent target, BaseDocument doc, Caret caret) {
             return null;
@@ -1574,7 +1574,7 @@ public class BaseKit extends DefaultEditorKit {
          * By default <code>null</code>.
          * 
          * @deprecated Please use Typing Hooks instead, for details see
-         *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
+         *   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a>.
          */
         protected void afterBreak(JTextComponent target, BaseDocument doc, Caret caret, Object data) {
         }
@@ -2017,7 +2017,7 @@ public class BaseKit extends DefaultEditorKit {
 
     /** 
      * @deprecated Please do not subclass this class. Use Typing Hooks instead, for details see
-     *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
+     *   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a>.
      */
     @Deprecated
     public static class DeleteCharAction extends LocalBaseAction {
@@ -2216,14 +2216,14 @@ public class BaseKit extends DefaultEditorKit {
 
         /**
          * @deprecated Please use Typing Hooks instead, for details see
-         *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
+         *   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a>.
          */
         protected void charBackspaced(BaseDocument doc, int dotPos, Caret caret, char ch) throws BadLocationException {
         }
 
         /**
          * @deprecated Please use Typing Hooks instead, for details see
-         *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
+         *   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a>.
          */
         protected void charDeleted(BaseDocument doc, int dotPos, Caret caret, char ch) throws BadLocationException {
         }

--- a/ide/editor.lib/src/org/netbeans/editor/Registry.java
+++ b/ide/editor.lib/src/org/netbeans/editor/Registry.java
@@ -40,7 +40,7 @@ import org.openide.modules.PatchedPublic;
  * @author Miloslav Metelka
  * @version 1.00
  * @deprecated Use <code>EditorRegistry</code> from 
- *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a> instead.
+ *   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a> instead.
  */
 @Deprecated
 public class Registry {

--- a/ide/editor.lib/src/org/netbeans/editor/ext/ExtCaret.java
+++ b/ide/editor.lib/src/org/netbeans/editor/ext/ExtCaret.java
@@ -37,7 +37,7 @@ public class ExtCaret extends BaseCaret {
      * while this method is called.
      * 
      * @deprecated Please use Braces Matching SPI instead, for details see
-     *   <a href="@org-netbeans-modules-editor-bracesmatching@/overview-summary.html">Editor Braces Matching</a>.
+     *   <a href="@org-netbeans-modules-editor-bracesmatching@/index.html">Editor Braces Matching</a>.
      */
     @Deprecated
     protected void updateMatchBrace() {
@@ -50,7 +50,7 @@ public class ExtCaret extends BaseCaret {
      * for the key-typed action.
      * 
      * @deprecated Please use Braces Matching SPI instead, for details see
-     *   <a href="@org-netbeans-modules-editor-bracesmatching@/overview-summary.html">Editor Braces Matching</a>.
+     *   <a href="@org-netbeans-modules-editor-bracesmatching@/index.html">Editor Braces Matching</a>.
      */
     @Deprecated
     public void requestMatchBraceUpdateSync() {

--- a/ide/editor.lib/src/org/netbeans/editor/ext/ExtKit.java
+++ b/ide/editor.lib/src/org/netbeans/editor/ext/ExtKit.java
@@ -588,7 +588,7 @@ public class ExtKit extends BaseKit {
      * This action does nothing.
      * 
      * @deprecated Please use Braces Matching SPI instead, for details see
-     *   <a href="@org-netbeans-modules-editor-bracesmatching@/overview-summary.html">Editor Braces Matching</a>.
+     *   <a href="@org-netbeans-modules-editor-bracesmatching@/index.html">Editor Braces Matching</a>.
      */
     @Deprecated
     public static class MatchBraceAction extends BaseKitLocalizedAction {
@@ -1036,7 +1036,7 @@ public class ExtKit extends BaseKit {
 
     /** 
      * @deprecated Please do not subclass this class. Use Typing Hooks instead, for details see
-     *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
+     *   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a>.
      */
 //    @EditorActionRegistration(
 //            name = defaultKeyTypedAction,
@@ -1082,7 +1082,7 @@ public class ExtKit extends BaseKit {
          * 
          * @deprecated Please use <a href="@org-netbeans-modules-editor-indent-support@/org/netbeans/modules/editor/indent/spi/support/AutomatedIndenting.html">AutomatedIndentig</a>
          *   or Typing Hooks instead, for details see
-         *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
+         *   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a>.
          */
         protected void checkIndentHotChars(JTextComponent target, String typedText) {
         }
@@ -1091,7 +1091,7 @@ public class ExtKit extends BaseKit {
         /** 
          * Check and possibly popup, hide or refresh the completion 
          * @deprecated Please use Editor Code Completion API instead, for details see
-         *   <a href="@org-netbeans-modules-editor-completion@/overview-summary.html">Editor Code Completion</a>.
+         *   <a href="@org-netbeans-modules-editor-completion@/index.html">Editor Code Completion</a>.
          */
         protected void checkCompletion(JTextComponent target, String typedText) {
         }
@@ -1099,7 +1099,7 @@ public class ExtKit extends BaseKit {
 
     /** 
      * @deprecated Please use Editor Code Completion API instead, for details see
-     *   <a href="@org-netbeans-modules-editor-completion@/overview-summary.html">Editor Code Completion</a>.
+     *   <a href="@org-netbeans-modules-editor-completion@/index.html">Editor Code Completion</a>.
      */
     @Deprecated
     @EditorActionRegistration(
@@ -1120,7 +1120,7 @@ public class ExtKit extends BaseKit {
 
     /** 
      * @deprecated Please use Editor Code Completion API instead, for details see
-     *   <a href="@org-netbeans-modules-editor-completion@/overview-summary.html">Editor Code Completion</a>.
+     *   <a href="@org-netbeans-modules-editor-completion@/index.html">Editor Code Completion</a>.
      */
     @Deprecated
     @EditorActionRegistration(
@@ -1139,7 +1139,7 @@ public class ExtKit extends BaseKit {
 
     /** 
      * @deprecated Please use Editor Code Completion API instead, for details see
-     *   <a href="@org-netbeans-modules-editor-completion@/overview-summary.html">Editor Code Completion</a>.
+     *   <a href="@org-netbeans-modules-editor-completion@/index.html">Editor Code Completion</a>.
      */
     @Deprecated
     @EditorActionRegistration(
@@ -1158,7 +1158,7 @@ public class ExtKit extends BaseKit {
 
     /** 
      * @deprecated Please use Editor Code Completion API instead, for details see
-     *   <a href="@org-netbeans-modules-editor-completion@/overview-summary.html">Editor Code Completion</a>.
+     *   <a href="@org-netbeans-modules-editor-completion@/index.html">Editor Code Completion</a>.
      */
     @Deprecated
     @EditorActionRegistration(
@@ -1177,7 +1177,7 @@ public class ExtKit extends BaseKit {
 
     /** 
      * @deprecated Please do not subclass this class. Use Typing Hooks instead, for details see
-     *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
+     *   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a>.
      */
     @Deprecated
     public static class ExtDeleteCharAction extends DeleteCharAction {

--- a/ide/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawLayer.java
+++ b/ide/editor.lib/src/org/netbeans/modules/editor/lib/drawing/DrawLayer.java
@@ -32,7 +32,7 @@ package org.netbeans.modules.editor.lib.drawing;
 * at the appropriate positions or it can mix these two approaches.
 *
 * @deprecated Please use Highlighting SPI instead, for details see
-*   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
+*   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a>.
 * 
 * @author Miloslav Metelka
 * @version 1.00
@@ -132,7 +132,7 @@ package org.netbeans.modules.editor.lib.drawing;
      * Abstract implementation of the draw-layer. 
      * 
      * @deprecated Please use Highlighting SPI instead, for details see
-     *   <a href="@org-netbeans-modules-editor-lib2@/overview-summary.html">Editor Library 2</a>.
+     *   <a href="@org-netbeans-modules-editor-lib2@/index.html">Editor Library 2</a>.
      */
     public abstract static class AbstractLayer implements DrawLayer {
 

--- a/ide/editor.lib2/apichanges.xml
+++ b/ide/editor.lib2/apichanges.xml
@@ -622,11 +622,11 @@ is the proper place.
     </head>
     <body>
 
-<p class="overviewlink"><a href="overview-summary.html">Overview</a></p>
+<p class="overviewlink"><a href="index.html">Overview</a></p>
 
 <h1>Introduction</h1>
 
-<p>This document lists changes made to the <a href="overview-summary.html">Editor Library 2 API</a>.</p>
+<p>This document lists changes made to the <a href="index.html">Editor Library 2 API</a>.</p>
 
 <!-- The actual lists of changes, as summaries and details: -->
       <hr/>

--- a/ide/editor.lib2/src/org/netbeans/spi/editor/typinghooks/package.html
+++ b/ide/editor.lib2/src/org/netbeans/spi/editor/typinghooks/package.html
@@ -105,7 +105,7 @@
   <p>
   The <code>TTIFactory</code> class will simply return a new instance of
   the module's implementation of <code>TypedTextInterceptor</code> interface from its
-  <code><a href="@org-netbeans-modules-editor-lib2@/org/netbeans/spi/editor/typinghooks/TypedTextInterceptor.Factory.html#createTypedTextInterceptor-org.netbeans.api.editor.mimelookup.MimePath-">createTypedTextInterceptor</a></code>
+  {@link org.netbeans.spi.editor.typinghooks.TypedTextInterceptor.Factory#createTypedTextInterceptor(org.netbeans.api.editor.mimelookup.MimePath) createTypedTextInterceptor }
   method. 
   </p>
 
@@ -196,7 +196,7 @@
   </p>
 
   <p>
-  Moreover, the <a href="@org-netbeans-modules-editor-indent@/overview-summary.html">Editor Indentation API</a>
+  Moreover, the <a href="@org-netbeans-modules-editor-indent@/index.html">Editor Indentation API</a>
   provides an implementation of <code>TypedTextInterceptor</code>, which reindents lines that
   match provided regular expressions. Please see <code><a href="@org-netbeans-modules-editor-indent-support@/org/netbeans/modules/editor/indent/spi/support/AutomatedIndenting.html">AutomatedIndenting</a></code>
   class for more details.

--- a/ide/extexecution.base/arch.xml
+++ b/ide/extexecution.base/arch.xml
@@ -205,7 +205,7 @@
     <p>
       Client wants to destroy the process, trying to kill whole process tree.
       Method
-      <a href="@TOP@org/netbeans/api/extexecution/base/Processes.html#killTree-java.lang.Process-java.util.Map-">
+      <a href="@TOP@org/netbeans/api/extexecution/base/Processes.html#killTree(java.lang.Process,java.util.Map)">
       Processes.killTree(java.lang.Process process, Map&lt;String,String&gt; environment)</a>
       is designed for that. It will use a
       <a href="@TOP@org/netbeans/spi/extexecution/base/ProcessesImplementation.html">ProcessesImplementation</a>

--- a/ide/extexecution/arch.xml
+++ b/ide/extexecution/arch.xml
@@ -236,10 +236,10 @@
     The both default printing processors provide factory method accepting
     <a href="@TOP@org/netbeans/api/extexecution/print/LineConvertor.html">LineConvertor</a>.
     Namely
-    <a href="@TOP@org/netbeans/api/extexecution/print/InputProcessors.html#printing-org.openide.windows.OutputWriter-org.netbeans.api.extexecution.print.LineConvertor-boolean-">
+    <a href="@TOP@org/netbeans/api/extexecution/print/InputProcessors.html#printing(org.openide.windows.OutputWriter,org.netbeans.api.extexecution.print.LineConvertor,boolean)">
      InputProcessors.printing(org.openide.windows.OutputWriter out, LineConvertor convertor, boolean resetEnabled)</a>
     and
-    <a href="@TOP@org/netbeans/api/extexecution/print/LineProcessors.html#printing-org.openide.windows.OutputWriter-org.netbeans.api.extexecution.print.LineConvertor-boolean-">
+    <a href="@TOP@org/netbeans/api/extexecution/print/LineProcessors.html#printing(org.openide.windows.OutputWriter,org.netbeans.api.extexecution.print.LineConvertor,boolean)">
      LineProcessors.printing(org.openide.windows.OutputWriter out, LineConvertor convertor, boolean resetEnabled)</a>.
 
     Convertor is then used to convert received lines to printed ones.
@@ -268,7 +268,7 @@
       <span style="text-decoration:line-through;">Client wants to destroy the process, trying to kill whole process tree.</span>
       This usecase should be solved by External Execution Base API.
       Method
-      <a href="@TOP@org/netbeans/api/extexecution/ExternalProcessSupport.html#destroy-java.lang.Process-java.util.Map-">
+      <a href="@TOP@org/netbeans/api/extexecution/ExternalProcessSupport.html#destroy(java.lang.Process,java.util.Map)">
        ExternalProcessSupport.destroy(java.lang.Process process, Map&lt;String,String&gt; env)</a>
       is designed for that. It will use a
       <a href="@TOP@org/netbeans/spi/extexecution/destroy/ProcessDestroyPerformer.html">ProcessDestroyPerformer</a>

--- a/ide/lexer/arch.xml
+++ b/ide/lexer/arch.xml
@@ -92,7 +92,7 @@ class with its static methods that provide its instance for the given input sour
 
 <h2>TokenSequence and Token</h2>
 <p>
-<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenHierarchy.html#tokenSequence--">TokenHierarchy.tokenSequence()</a>
+<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenHierarchy.html#tokenSequence()">TokenHierarchy.tokenSequence()</a>
    allows to iterate over a list of
 <a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/Token.html">Token</a>
     instances.
@@ -100,21 +100,21 @@ class with its static methods that provide its instance for the given input sour
     The token carries a token identification
 <a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenId.html">TokenId</a>
     (returned by
-<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/Token.html#id--">Token.id()</a>
+<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/Token.html#id()">Token.id()</a>
     ) and a text (aka token body) represented as
 <a href="@JDK@@JDKMODULE_JAVA_BASE@/java/lang/CharSequence.html">CharSequence</a>
     (returned by
-<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/Token.html#text--">Token.text()</a>
+<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/Token.html#text()">Token.text()</a>
     ).
     <br/>
 <a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenUtilities.html">TokenUtilities</a>
     contains many useful methods related to operations with the token's text such as
-<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenUtilities.html#equals-java.lang.CharSequence-java.lang.Object-">TokenUtilities.equals(CharSequence text, Object o)</a>,
-<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenUtilities.html#startsWith-java.lang.CharSequence-java.lang.CharSequence-">TokenUtilities.startsWith(CharSequence text, CharSequence prefix)</a>,
+<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenUtilities.html#equals(java.lang.CharSequence,java.lang.Object)">TokenUtilities.equals(CharSequence text, Object o)</a>,
+<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenUtilities.html#startsWith(java.lang.CharSequence,java.lang.CharSequence)">TokenUtilities.startsWith(CharSequence text, CharSequence prefix)</a>,
    etc.
     <br/>
    It is also possible to debug the text of the token (replace special chars by escapes) by
-<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenUtilities.html#debugText-java.lang.CharSequence-">TokenUtilities.equals(CharSequence text)</a>.
+<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenUtilities.html#debugText(java.lang.CharSequence)">TokenUtilities.equals(CharSequence text)</a>.
     <br/>
     A typical token also carries offset of its occurrence in the input text.
 </p>
@@ -129,25 +129,25 @@ class with its static methods that provide its instance for the given input sour
     in all the inputs.
     <br/>
     Flyweight tokens can be determined by
-<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/Token.html#isFlyweight--">Token.isFlyweight()</a>.
+<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/Token.html#isFlyweight()">Token.isFlyweight()</a>.
     <br/>
     The flyweight tokens do not carry a valid offset (their internal offset is -1).
     <br/>
     Therefore
  <a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenSequence.html">TokenSequence</a>
     is used for iteration through the tokens (instead of a regular iterator) and it provides 
-<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenSequence.html#offset--">TokenSequence.offset()</a>
+<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenSequence.html#offset()">TokenSequence.offset()</a>
     which returns the proper offset even when positioned over a flyweight token.
     <br/>
     When holding a reference to the token's instance its offset can also be determined by
-<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/Token.html#offset-org.netbeans.api.lexer.TokenHierarchy-">Token.offset(TokenHierarchy tokenHierarchy)</a>.
+<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/Token.html#offset(org.netbeans.api.lexer.TokenHierarchy)">Token.offset(TokenHierarchy tokenHierarchy)</a>.
     The <code>tokenHierarchy</code> parameter should be always <code>null</code> and it will be used
     for the token hierarchy snapshot support in future releases.
     <br/>
     For flyweight tokens the 
-<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/Token.html#offset-org.netbeans.api.lexer.TokenHierarchy-">Token.offset(TokenHierarchy tokenHierarchy)</a>
+<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/Token.html#offset(org.netbeans.api.lexer.TokenHierarchy)">Token.offset(TokenHierarchy tokenHierarchy)</a>
     returns -1 and for regular tokens it gives the same value like 
-<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenSequence.html#offset--">TokenSequence.offset()</a>.
+<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenSequence.html#offset()">TokenSequence.offset()</a>.
 </p>
 
 <p>
@@ -158,7 +158,7 @@ class with its static methods that provide its instance for the given input sour
     could not generally be determined from the tokens only.
     <br/>
     Therefore there is a possibility to de-flyweight a token by using
-<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenSequence.html#offsetToken--">TokenSequence.offsetToken()</a>
+<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenSequence.html#offsetToken()">TokenSequence.offsetToken()</a>
     which checks the current token
     and if it's flyweight then it replaces it with a non-flyweight token instance
     with a valid offset and with the same properties as the original flyweight token.
@@ -180,13 +180,13 @@ class with its static methods that provide its instance for the given input sour
     tokens of the same type (e.g. keywords or operators).
     <br/>
     Each token id may define its primary category
-<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenId.html#primaryCategory--">TokenId.primaryCategory()</a>
+<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenId.html#primaryCategory()">TokenId.primaryCategory()</a>
     and
-<a href="@org-netbeans-modules-lexer@/org/netbeans/spi/lexer/LanguageHierarchy.html#createTokenCategories--">LanguageHierarchy.createTokenCategories()</a>
+<a href="@org-netbeans-modules-lexer@/org/netbeans/spi/lexer/LanguageHierarchy.html#createTokenCategories()">LanguageHierarchy.createTokenCategories()</a>
     may provide additional categories for the token ids for the given language.
     <br/>
     Each language description has a mandatory mime-type specification
-<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/Language.html#mimeType--">Language.mimeType()</a>
+<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/Language.html#mimeType()">Language.mimeType()</a>
     <br/>
     Although it's a bit non-related information it brings many benefits
     because with the mime-type the language can be accompanied
@@ -200,9 +200,9 @@ class with its static methods that provide its instance for the given input sour
     first need to define its SPI counterpart
 <a href="@org-netbeans-modules-lexer@/org/netbeans/spi/lexer/LanguageHierarchy.html">LanguageHierarchy</a>.
     It mainly needs to define token ids in
-<a href="@org-netbeans-modules-lexer@/org/netbeans/spi/lexer/LanguageHierarchy.html#createTokenIds--">LanguageHierarchy.createTokenIds()</a>
+<a href="@org-netbeans-modules-lexer@/org/netbeans/spi/lexer/LanguageHierarchy.html#createTokenIds()">LanguageHierarchy.createTokenIds()</a>
     and lexer in
-<a href="@org-netbeans-modules-lexer@/org/netbeans/spi/lexer/LanguageHierarchy.html#createLexer-org.netbeans.spi.lexer.LexerRestartInfo-">
+<a href="@org-netbeans-modules-lexer@/org/netbeans/spi/lexer/LanguageHierarchy.html#createLexer(org.netbeans.spi.lexer.LexerRestartInfo)">
     LanguageHierarchy.createLexer(LexerInput lexerInput, TokenFactory tokenFactory, Object state, LanguagePath languagePath, InputAttributes inputAttributes)</a>.
     <br/>
 <a href="@org-netbeans-modules-lexer@/org/netbeans/spi/lexer/Lexer.html">Lexer</a>
@@ -227,12 +227,12 @@ class with its static methods that provide its instance for the given input sour
 <a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenHierarchy.html">TokenHierarchy</a>
     class. Each token can potentially be broken into a sequence of embedded tokens.
     <br/>The 
-<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenSequence.html#embedded--">TokenSequence.embedded()</a>
+<a href="@org-netbeans-modules-lexer@/org/netbeans/api/lexer/TokenSequence.html#embedded()">TokenSequence.embedded()</a>
     method can be called to obtain the embedded tokens (when positioned on the branch token).
     <br/>
     There are two ways of specifying what language is embedded in a token. The language
     can either be specified explicitly (hardcoded) in the
-<a href="@org-netbeans-modules-lexer@/org/netbeans/spi/lexer/LanguageHierarchy.html#embedding-org.netbeans.api.lexer.Token-org.netbeans.api.lexer.LanguagePath-org.netbeans.api.lexer.InputAttributes-">LanguageHierarchy.embedding()</a>
+<a href="@org-netbeans-modules-lexer@/org/netbeans/spi/lexer/LanguageHierarchy.html#embedding(org.netbeans.api.lexer.Token,org.netbeans.api.lexer.LanguagePath,org.netbeans.api.lexer.InputAttributes)">LanguageHierarchy.embedding()</a>
     method or there can be a
 <a href="@org-netbeans-modules-lexer@/org/netbeans/spi/lexer/LanguageProvider.html">LanguageProvider</a>
     registered in the default Lookup, which will create a

--- a/ide/o.openidex.util/apichanges.xml
+++ b/ide/o.openidex.util/apichanges.xml
@@ -254,7 +254,7 @@ is the proper place.
             objects &ndash; it always searched
             projects' <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/SourceGroup.html"><code>SourceGroup</code></a>s.
             Now the action first checks the
-            <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup--">project's <code>Lookup</code></a>
+            <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup()">project's <code>Lookup</code></a>
             for presence of a <code>SearchInfo</code> object. If some
             <code>SearchInfo</code> is present, it is used for the search,
             and only if there is no <code>SearchInfo</code>,

--- a/ide/o.openidex.util/src/org/openidex/search/SearchInfo.java
+++ b/ide/o.openidex.util/src/org/openidex/search/SearchInfo.java
@@ -32,10 +32,10 @@ import org.openide.loaders.DataObject;
  * &ndash; in actions <em>Find</em> (since User Utilities 1.16)
  * and <em>Find in Projects</em> (since User Utilities 1.23).
  * Action <em>Find</em> obtains <code>SearchInfo</code> from
- * <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup--"><code>Lookup</code> of nodes</a>
+ * <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup()"><code>Lookup</code> of nodes</a>
  * the action was invoked on. Action <em>Find in Projects</em> obtains
  * <code>SearchInfo</code> from
- * <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup--"><code>Lookup</code>
+ * <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup()"><code>Lookup</code>
  * of the projects</a>.
  * </p>
  * <p>
@@ -45,8 +45,8 @@ import org.openide.loaders.DataObject;
  *
  * @see  SearchInfoFactory
  * @see  <a href="@org-openide-loaders@/org/openide/loaders/DataObject.html"><code>DataObject</code></a>
- * @see  <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup--"><code>Node.getLookup()</code></a>
- * @see  <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup--"><code>Project.getLookup()</code></a>
+ * @see  <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup()"><code>Node.getLookup()</code></a>
+ * @see  <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup()"><code>Project.getLookup()</code></a>
  * @since  org.openidex.util/3 3.2
  * @author  Marian Petras
  */

--- a/ide/parsing.indexing/apichanges.xml
+++ b/ide/parsing.indexing/apichanges.xml
@@ -96,7 +96,7 @@ is the proper place.
           <compatibility source="compatible" binary="compatible" semantic="compatible" addition="yes"/>
           <description>
               <p>
-                  Added the <a href="@TOP@/org/netbeans/modules/parsing/spi/indexing/ErrorsCache.html#getErrors-org.openide.filesystems.FileObject-org.netbeans.modules.parsing.spi.indexing.ErrorsCache.ReverseConvertor-">getErrors()</a> method to return errors or warnings for the given file.
+                  Added the <a href="@TOP@/org/netbeans/modules/parsing/spi/indexing/ErrorsCache.html#getErrors(org.openide.filesystems.FileObject,org.netbeans.modules.parsing.spi.indexing.ErrorsCache.ReverseConvertor)">getErrors()</a> method to return errors or warnings for the given file.
               </p>
           </description>
           <class package="org.netbeans.modules.parsing.spi.indexing" name="ErrorsCache"/>
@@ -110,7 +110,7 @@ is the proper place.
           <compatibility source="compatible" binary="compatible" semantic="compatible" addition="yes"/>
           <description>
               <p>
-                  Added the <a href="@TOP@/org/netbeans/modules/parsing/spi/indexing/ErrorsCache.html#getAllFilesWithRecord-java.net.URL-">getAllFilesWithRecord()</a> method to return all files with error or warning.
+                  Added the <a href="@TOP@/org/netbeans/modules/parsing/spi/indexing/ErrorsCache.html#getAllFilesWithRecord(java.net.URL)">getAllFilesWithRecord()</a> method to return all files with error or warning.
               </p>
           </description>
           <class package="org.netbeans.modules.parsing.spi.indexing" name="ErrorsCache"/>
@@ -153,7 +153,7 @@ is the proper place.
           <description>
               <p>
                   <a href="@org-netbeans-modules-parsing-api@/org/netbeans/modules/parsing/spi/Parser.html">Parsers</a> may need to provide reduced data for indexing, or enriched data for source parsing. The
-                  added <a href="@TOP@/org/netbeans/modules/parsing/spi/indexing/support/IndexingSupport.html#isIndexingTask-org.netbeans.modules.parsing.api.Task-">isIndexingTask()</a> method identifies tasks applied by indexing infrastructure.
+                  added <a href="@TOP@/org/netbeans/modules/parsing/spi/indexing/support/IndexingSupport.html#isIndexingTask(org.netbeans.modules.parsing.api.Task)">isIndexingTask()</a> method identifies tasks applied by indexing infrastructure.
               </p>
           </description>
           <class package="org.netbeans.modules.parsing.spi.indexing.support" name="IndexingSupport"/>

--- a/ide/projectuiapi.base/arch.xml
+++ b/ide/projectuiapi.base/arch.xml
@@ -522,7 +522,7 @@ Nothing.
    <api name="willOpenProjects" category="friend" group="property" type="export">
    Since version 1.55 a special <a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/java/beans/PropertyChangeEvent.html">
    PropertyChangeEvent</a> is generated for benefit of <code>ide.ergonomics</code>
-   module by <a href="@TOP@/org/netbeans/api/project/ui/OpenProjects.html#getDefault--">
+   module by <a href="@TOP@/org/netbeans/api/project/ui/OpenProjects.html#getDefault()">
    OpenProjects.getDefault()</a>. The property name of the event is <code>"willOpenProjects"</code>
    and its new value contains an array of projects that will be opened (a type
    <code>Project[]</code>). Ergonomics module uses this information to enable

--- a/ide/projectuiapi.base/src/org/netbeans/api/project/ui/OpenProjects.java
+++ b/ide/projectuiapi.base/src/org/netbeans/api/project/ui/OpenProjects.java
@@ -158,7 +158,7 @@ public final class OpenProjects {
      * {@link org.openide.WizardDescriptor.InstantiatingIterator#instantiate}
      * should return the project directory.
      * This should also not be used to provide a GUI to open subprojects;
-     * <a href="@org-netbeans-modules-projectuiapi@/org/netbeans/spi/project/ui/support/CommonProjectActions.html#openSubprojectsAction--">CommonProjectActions#openSubprojectsAction</a> should be used instead.
+     * <a href="@org-netbeans-modules-projectuiapi@/org/netbeans/spi/project/ui/support/CommonProjectActions.html#openSubprojectsAction()">CommonProjectActions#openSubprojectsAction</a> should be used instead.
      * </p>
      * @param projects to be opened. If some of the projects are already opened
      * these projects are ignored. If the list contain duplicates, the duplicated
@@ -184,7 +184,7 @@ public final class OpenProjects {
      * {@link org.openide.WizardDescriptor.InstantiatingIterator#instantiate}
      * should return the project directory.
      * This should also not be used to provide a GUI to open subprojects;
-     * <a href="@org-netbeans-modules-projectuiapi@/org/netbeans/spi/project/ui/support/CommonProjectActions.html#openSubprojectsAction--">CommonProjectActions#openSubprojectsAction</a> should be used instead.
+     * <a href="@org-netbeans-modules-projectuiapi@/org/netbeans/spi/project/ui/support/CommonProjectActions.html#openSubprojectsAction()">CommonProjectActions#openSubprojectsAction</a> should be used instead.
      * </p>
      * @param projects to be opened. If some of the projects are already opened
      * these projects are ignored. If the list contain duplicates, the duplicated

--- a/ide/projectuiapi.base/src/org/netbeans/spi/project/ui/ProjectOpenedHook.java
+++ b/ide/projectuiapi.base/src/org/netbeans/spi/project/ui/ProjectOpenedHook.java
@@ -79,9 +79,9 @@ public abstract class ProjectOpenedHook {
      * <ul>
      * <li><p>
      * Update build scripts using
-     * <a href="@org-netbeans-modules-project-ant@/org/netbeans/spi/project/support/ant/GeneratedFilesHelper.html#refreshBuildScript-java.lang.String-java.net.URL-boolean-"><code>GeneratedFilesHelper.refreshBuildScript(...)</code></a>.
+     * <a href="@org-netbeans-modules-project-ant@/org/netbeans/spi/project/support/ant/GeneratedFilesHelper.html#refreshBuildScript(java.lang.String,java.net.URL,boolean)"><code>GeneratedFilesHelper.refreshBuildScript(...)</code></a>.
      * </p></li>
-     * <li><p>Call <a href="@org-netbeans-api-java-classpath@/org/netbeans/api/java/classpath/GlobalPathRegistry.html#register-java.lang.String-org.netbeans.api.java.classpath.ClassPath:A-"><code>GlobalPathRegistry.register(...)</code></a>
+     * <li><p>Call <a href="@org-netbeans-api-java-classpath@/org/netbeans/api/java/classpath/GlobalPathRegistry.html#register(java.lang.String,org.netbeans.api.java.classpath.ClassPath[])"><code>GlobalPathRegistry.register(...)</code></a>
      * with source, compile, and boot paths known to the project.</p></li>
      * <li><p>Write property <code>user.properties.file</code> to <code>private.properties</code>
      * with absolute file path of the <code>build.properties</code> from 
@@ -105,7 +105,7 @@ public abstract class ProjectOpenedHook {
      * way (e.g. using
      * {@link org.netbeans.spi.project.AuxiliaryConfiguration}).
      * </p></li>
-     * <li><p>Call <a href="@org-netbeans-api-java-classpath@/org/netbeans/api/java/classpath/GlobalPathRegistry.html#unregister-java.lang.String-org.netbeans.api.java.classpath.ClassPath:A-"><code>GlobalPathRegistry.unregister(...)</code></a>
+     * <li><p>Call <a href="@org-netbeans-api-java-classpath@/org/netbeans/api/java/classpath/GlobalPathRegistry.html#unregister(java.lang.String,org.netbeans.api.java.classpath.ClassPath[])"><code>GlobalPathRegistry.unregister(...)</code></a>
      * with the same paths are were previously registered.</p></li>
      * </ul>
      * </div>

--- a/ide/projectuiapi/arch.xml
+++ b/ide/projectuiapi/arch.xml
@@ -522,7 +522,7 @@ Nothing.
    <api name="willOpenProjects" category="friend" group="property" type="export">
    Since version 1.55 a special <a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/java/beans/PropertyChangeEvent.html">
    PropertyChangeEvent</a> is generated for benefit of <code>ide.ergonomics</code>
-   module by <a href="@org-netbeans-modules-projectuiapi-base@/org/netbeans/api/project/ui/OpenProjects.html#getDefault--">
+   module by <a href="@org-netbeans-modules-projectuiapi-base@/org/netbeans/api/project/ui/OpenProjects.html#getDefault()">
    OpenProjects.getDefault()</a>. The property name of the event is <code>"willOpenProjects"</code>
    and its new value contains an array of projects that will be opened (a type
    <code>Project[]</code>). Ergonomics module uses this information to enable

--- a/ide/projectuiapi/src/org/netbeans/spi/project/ui/templates/support/package.html
+++ b/ide/projectuiapi/src/org/netbeans/spi/project/ui/templates/support/package.html
@@ -57,10 +57,10 @@ or <b>New Project...</b> wizard.
 it's <b>recommended</b> to use the standardized target chooser exposed in
 {@link org.netbeans.spi.project.ui.templates.support.Templates#buildSimpleTargetChooser},
 a similar target chooser offers
-<a href="@org-netbeans-modules-java-project-ui@/org/netbeans/spi/java/project/support/ui/templates/JavaTemplates.html#createPackageChooser-org.netbeans.api.project.Project-org.netbeans.api.project.SourceGroup:A-"><code>JavaTemplates.createPackageChooser(...)</code></a>
+<a href="@org-netbeans-modules-java-project-ui@/org/netbeans/spi/java/project/support/ui/templates/JavaTemplates.html#createPackageChooser(org.netbeans.api.project.Project,org.netbeans.api.project.SourceGroup[])"><code>JavaTemplates.createPackageChooser(...)</code></a>
 for Java-oriented projects.
 The project type also can use a <code>InstantiatingIterator</code> published by other module,
-i.e. <a href="@org-netbeans-modules-java-project-ui@/org/netbeans/spi/java/project/support/ui/templates/JavaTemplates.html#createJavaTemplateIterator--"><code>JavaTemplates.createJavaTemplateIterator()</code></a>
+i.e. <a href="@org-netbeans-modules-java-project-ui@/org/netbeans/spi/java/project/support/ui/templates/JavaTemplates.html#createJavaTemplateIterator()"><code>JavaTemplates.createJavaTemplateIterator()</code></a>
 useful for Java-oriented templates in case of no needs to own customization.
 The last possibility is declaration no iterator, in this case will be used a generic iterator
 useful for simple file types without any specific needs, i.e. <code>properties file</code>.<br>

--- a/ide/spi.navigator/arch.xml
+++ b/ide/spi.navigator/arch.xml
@@ -182,7 +182,7 @@
         for java sources. Infrastructure will automatically load and show
         your NavigatorPanel impl in UI, when <b>currently activated Node
         is backed by primary FileObject whose 
-        <a href="@org-openide-filesystems@/org/openide/filesystems/FileObject.html#getMIMEType--">FileObject.getMimeType()</a>
+        <a href="@org-openide-filesystems@/org/openide/filesystems/FileObject.html#getMIMEType()">FileObject.getMimeType()</a>
         equals to content type specified in your registering annotation</b> (see more options below).</p>
    </usecase> 
 
@@ -218,13 +218,13 @@
             <li>Alter your <a href="@org-openide-windows@/org/openide/windows/TopComponent.html">TopComponent</a>
              to contain your NavigatorLookupHint implementation (AmazingTypeLookupHint in this case)
             in its lookup, returned from 
-            <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup--">TopComponent.getLookup()</a>
+            <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup()">TopComponent.getLookup()</a>
              method.<p></p></li>
              
              <li>
              Another option you have is to alter lookup of your <code>Node</code> subclass 
              instead of directly altering lookup of your <code>TopComponent</code>.
-             See <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup--">Node.getLookup()</a> method.
+             See <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup()">Node.getLookup()</a> method.
              Then Navigator will show your desired content whenever your <code>Node</code>
              subclass will be active in the system.<br></br>             
              However, keep in mind that this option is less preferred, because it
@@ -265,7 +265,7 @@
                 See <a href="@org-openide-util@/org/openide/util/doc-files/api.html#instances">Instantiation rules</a>.<p></p>
             </li>
             
-            <li>Call <a href="@TOP@/org/netbeans/spi/navigator/NavigatorHandler.html#activatePanel-org.netbeans.spi.navigator.NavigatorPanel-">
+            <li>Call <a href="@TOP@/org/netbeans/spi/navigator/NavigatorHandler.html#activatePanel(org.netbeans.spi.navigator.NavigatorPanel)">
                 NavigatorHandler.activatePanel(NavigatorPanel panel)</a><p></p>.
             </li>
              
@@ -276,8 +276,8 @@
    <usecase id="activatedNode" name="Setting activated node of Navigator window" >
         <p>Sometimes clients need to alter activated Nodes of Navigator window,
             to better represent Navigator area content within the whole application.
-            See <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getActivatedNodes--">TopComponent.getActivatedNodes()</a>
-            and <a href="@org-openide-windows@/org/openide/windows/TopComponent.Registry.html#getActivatedNodes--">TopComponent.Registry.html#getActivatedNodes()</a>
+            See <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getActivatedNodes()">TopComponent.getActivatedNodes()</a>
+            and <a href="@org-openide-windows@/org/openide/windows/TopComponent.Registry.html#getActivatedNodes()">TopComponent.Registry.html#getActivatedNodes()</a>
             to find out what activated nodes of TopComponent and whole system mean.
         </p>
         <b>Use Case Example:</b>
@@ -346,7 +346,7 @@
         <ul>
             <li>Implement your navigation view as <a href="@TOP@/org/netbeans/spi/navigator/NavigatorPanelWithUndo.html">NavigatorPanelWithUndo</a>,
                 which is <code>NavigatorPanel</code> interface with extra method 
-                <a href="@TOP@/org/netbeans/spi/navigator/NavigatorPanelWithUndo.html#getUndoRedo--">getUndoRedo()</a>.
+                <a href="@TOP@/org/netbeans/spi/navigator/NavigatorPanelWithUndo.html#getUndoRedo()">getUndoRedo()</a>.
                 <p></p>
             </li>
             
@@ -354,7 +354,7 @@
                 <code>UndoRedo</code> support returned from <code>NavigatorPanelWithUndo.getUndoRedo()</code>
                 is propagated to the Navigator TopComponent and returned as its
                 <code>UndoRedo</code> support. For details see 
-                <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getUndoRedo--">TopComponent.getUndoRedo()</a>
+                <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getUndoRedo()">TopComponent.getUndoRedo()</a>
                 and <a href="@org-openide-awt@/org/openide/awt/UndoRedo.html">UndoRedo interface</a>.
                 <p></p>
             </li>
@@ -396,7 +396,7 @@
              <p></p>
         </li>
          <li>Put implementation instance into your TopComponent's subclass lookup,
-             see <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup--">TopComponent.getLookup()</a>
+             see <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup()">TopComponent.getLookup()</a>
              for details.
              <p></p>
          </li>
@@ -429,13 +429,13 @@
             </li>
             
             <li>Return lookup created using 
-                <a href="@org-openide-explorer@/org/openide/explorer/ExplorerUtils.html#createLookup-org.openide.explorer.ExplorerManager-javax.swing.ActionMap-">
+                <a href="@org-openide-explorer@/org/openide/explorer/ExplorerUtils.html#createLookup(org.openide.explorer.ExplorerManager,javax.swing.ActionMap)">
                 ExplorerUtils.createLookup(ExplorerManager, ActionMap)</a> 
                 from <code>getLookup()</code> method of <code>NavigatorPanel</code>.
                 <p></p>
             </li>
             
-            <li>Use <a href="@org-openide-explorer@/org/openide/explorer/ExplorerUtils.html#activateActions-org.openide.explorer.ExplorerManager-boolean-">
+            <li>Use <a href="@org-openide-explorer@/org/openide/explorer/ExplorerUtils.html#activateActions(org.openide.explorer.ExplorerManager,boolean)">
                 ExplorerUtils.activateActions(ExplorerManager, boolean)</a> for actions activation and
                 deactivation in <code>panelActivated</code> and <code>panelDeactivated</code>.
                 <p></p>

--- a/ide/spi.navigator/src/org/netbeans/spi/navigator/NavigatorLookupHint.java
+++ b/ide/spi.navigator/src/org/netbeans/spi/navigator/NavigatorLookupHint.java
@@ -24,7 +24,7 @@ package org.netbeans.spi.navigator;
  *
  * Usage: Implementation of this interface should be inserted into
  * client's specific topComponent's lookup, see
- * <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup--">TopComponent.getLookup()</a>
+ * {@link org.openide.windows.TopComponent#getLookup() TopComponent.getLookup() }
  * method. When mentioned <code>TopComponent</code> gets active in the system, system will
  * ask <code>NavigatorLookupHint</code> implementation for content type
  * to show in Navigator UI.
@@ -33,10 +33,10 @@ package org.netbeans.spi.navigator;
  */
 public interface NavigatorLookupHint {
 
-    /** Hint for content type that should be used in Navigator 
-     * 
+    /** Hint for content type that should be used in Navigator
+     *
      * @return String representation of content type (in mime-type style)
      */
     public String getContentType ();
-    
+
 }

--- a/ide/spi.navigator/src/org/netbeans/spi/navigator/NavigatorLookupPanelsPolicy.java
+++ b/ide/spi.navigator/src/org/netbeans/spi/navigator/NavigatorLookupPanelsPolicy.java
@@ -23,9 +23,9 @@ package org.netbeans.spi.navigator;
  * available NavigatorPanel implementations.<p>
  * 
  * Navigator infrastructure searches for instance of this interface in
- * <a href="@org-openide-util-ui@/org/openide/util/Utilities.html#actionsGlobalContext--">Utilities.actionsGlobalContext()</a>
+ * {@link org.openide.util.Utilities#actionsGlobalContext() Utilities.actionsGlobalContext()}
  * lookup and then applies found policy on set of available 
- * <a href="@TOP@/org/netbeans/spi/navigator/NavigatorPanel.html">NavigatorPanel</a>
+ * {@link org.netbeans.spi.navigator.NavigatorPanel NavigatorPanel}
  * implementations.<p>
  * 
  * Note that multiple instances of this interface are not supported in
@@ -37,7 +37,7 @@ package org.netbeans.spi.navigator;
  *      <li>Implement this interface, return kind of policy that suits you from
  *          <code>getPanelsPolicy()</code> method.</li>
  *      <li>Put implementation instance into your TopComponent's subclass lookup,
- *          see <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup--">TopComponent.getLookup()</a>
+ *          see {@link org.openide.windows.TopComponent#getLookup()  TopComponent.getLookup()}
  *          for details.</li>
  *      <li>Now when your TopComponent becomes active in the system, found
  *          panels policy is used to limit/affect set of available NavigatorPanel
@@ -51,7 +51,7 @@ package org.netbeans.spi.navigator;
 public interface NavigatorLookupPanelsPolicy {
     
     /** Shows only NavigatorPanel implementations available through
-     * <a href="@TOP@/org/netbeans/spi/navigator/NavigatorLookupHint.html">NavigatorLookupHint</a>
+     * {@link org.netbeans.spi.navigator.NavigatorLookupHint NavigatorLookupHint }
      * in Navigator window, hides NavigatorPanels
      * available from DataObject of active Node.<br>
      * 

--- a/ide/spi.palette/arch.xml
+++ b/ide/spi.palette/arch.xml
@@ -277,10 +277,10 @@ question-version="1.25"
           <p>
               When an item is selected in the palette and user clicks into the editor window
               then the module can ask for selected item by calling 
-              <a href="@TOP@/org/netbeans/spi/palette/PaletteController.html#getSelectedItem--">PaletteController.getSelectedItem()</a>.
+              <a href="@TOP@/org/netbeans/spi/palette/PaletteController.html#getSelectedItem()">PaletteController.getSelectedItem()</a>.
               This method returns a Lookup that holds object(s) representing the selected item.
               After the item is inserted into the editor window the module may clear palette's selection
-              (<a href="@TOP@/org/netbeans/spi/palette/PaletteController.html#clearSelection--">PaletteController.clearSelection()</a>)
+              (<a href="@TOP@/org/netbeans/spi/palette/PaletteController.html#clearSelection()">PaletteController.clearSelection()</a>)
               or leave the item selected to implement 'multi drop' insertion scenario.
           </p>
       </usecase>
@@ -321,7 +321,7 @@ question-version="1.25"
                 PaletteController controller = PaletteFactory.createPalette( "MyPalette", new MyPaletteActions(), filter, null );
           </pre>
           <p>It is necessary to call 
-          <a href="@TOP@/org/netbeans/spi/palette/PaletteController.html#refresh--">PaletteController.refresh()</a>
+          <a href="@TOP@/org/netbeans/spi/palette/PaletteController.html#refresh()">PaletteController.refresh()</a>
           to refresh and repaint the palette window whenever the filtering condition has changed:</p>
           <pre>
               myPaletteFilter.setShowSomeSpecialCategories( false );

--- a/ide/spi.tasklist/arch.xml
+++ b/ide/spi.tasklist/arch.xml
@@ -165,11 +165,11 @@
     <usecase id="task-scanners" name="Task Scanners">
         <p>The main feature of the Task List SPI is the ability to 'plug-in' additional task providing 
         modules that generate tasks for the task list window.</p>
-        <p>The plugable task scanners can either <a href="@TOP@/org/netbeans/spi/tasklist/PushTaskScanner.Callback.html#setTasks-org.openide.filesystems.FileObject-java.util.List-">push</a> 
+        <p>The plugable task scanners can either <a href="@TOP@/org/netbeans/spi/tasklist/PushTaskScanner.Callback.html#setTasks(org.openide.filesystems.FileObject,java.util.List)">push</a> 
         new <a href="@TOP@/org/netbeans/spi/tasklist/Task.html">Task</a>s to the Task List window whenever they want - 
         <a href="@TOP@/org/netbeans/spi/tasklist/PushTaskScanner.html">PushTaskScanner</a> - or they
         can inherit from <a href="@TOP@/org/netbeans/spi/tasklist/FileTaskScanner.html">FileTaskScanner</a>
-        and the Task List framework will actively <a href="@TOP@/org/netbeans/spi/tasklist/FileTaskScanner.html#scan-org.openide.filesystems.FileObject-">poll</a> 
+        and the Task List framework will actively <a href="@TOP@/org/netbeans/spi/tasklist/FileTaskScanner.html#scan(org.openide.filesystems.FileObject)">poll</a> 
         them for new tasks for each file under the current scanning scope (see below).</p>
         <p>Scanner instances are registered in XML layer in folder "/TaskList/Scanners". The framework keeps track of modified files
         and notifies the scanners whenever a file under the scanning scope needs to be rescanned.</p>

--- a/java/api.java/src/org/netbeans/spi/java/queries/AccessibilityQueryImplementation.java
+++ b/java/api.java/src/org/netbeans/spi/java/queries/AccessibilityQueryImplementation.java
@@ -36,7 +36,7 @@ import org.openide.filesystems.FileObject;
  * </p>
  * @see org.netbeans.api.java.queries.AccessibilityQuery
  * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/FileOwnerQuery.html">FileOwnerQuery</a>
- * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup--">Project#getLookup</a>
+ * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup()">Project#getLookup</a>
  * @author Jesse Glick
  * @since org.netbeans.api.java/1 1.4
  */

--- a/java/api.java/src/org/netbeans/spi/java/queries/AccessibilityQueryImplementation2.java
+++ b/java/api.java/src/org/netbeans/spi/java/queries/AccessibilityQueryImplementation2.java
@@ -38,7 +38,7 @@ import org.openide.filesystems.FileObject;
  * </p>
  * @see org.netbeans.api.java.queries.AccessibilityQuery
  * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/FileOwnerQuery.html">FileOwnerQuery</a>
- * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup--">Project#getLookup</a>
+ * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup()">Project#getLookup</a>
  * @author Tomas Zezula
  * @since 1.64
  */

--- a/java/api.java/src/org/netbeans/spi/java/queries/JavadocForBinaryQueryImplementation.java
+++ b/java/api.java/src/org/netbeans/spi/java/queries/JavadocForBinaryQueryImplementation.java
@@ -33,7 +33,7 @@ import org.netbeans.api.java.queries.JavadocForBinaryQuery;
  * this query, if it depends on the Java Project module and uses this style.
  * </p>
  * @see JavadocForBinaryQuery
- * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup--">Project#getLookup</a>
+ * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup()">Project#getLookup</a>
  * @author David Konecny, Jesse Glick
  * @since org.netbeans.api.java/1 1.4
  */

--- a/java/api.java/src/org/netbeans/spi/java/queries/MultipleRootsUnitTestForSourceQueryImplementation.java
+++ b/java/api.java/src/org/netbeans/spi/java/queries/MultipleRootsUnitTestForSourceQueryImplementation.java
@@ -39,7 +39,7 @@ import org.openide.filesystems.FileObject;
  * is used for example for unit test generation and for searching test for
  * source. Usage of any other pattern will break this functionality.</p>
  *
- * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup--"><code>Project.getLookup()</code></a>
+ * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup()"><code>Project.getLookup()</code></a>
  * @see org.netbeans.api.java.queries.UnitTestForSourceQuery
  * @author Tomas Zezula
  * @since org.netbeans.api.java/1 1.7

--- a/java/api.java/src/org/netbeans/spi/java/queries/SourceLevelQueryImplementation2.java
+++ b/java/api.java/src/org/netbeans/spi/java/queries/SourceLevelQueryImplementation2.java
@@ -39,7 +39,7 @@ import org.openide.filesystems.FileObject;
  * </p>
  * @see org.netbeans.api.java.queries.SourceLevelQuery
  * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/FileOwnerQuery.html">FileOwnerQuery</a>
- * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup--">Project#getLookup</a>
+ * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup()">Project#getLookup</a>
  * @see org.netbeans.api.java.classpath.ClassPath#BOOT
  * @author Tomas Zezula
  * @since 1.30

--- a/java/api.java/src/org/netbeans/spi/java/queries/UnitTestForSourceQueryImplementation.java
+++ b/java/api.java/src/org/netbeans/spi/java/queries/UnitTestForSourceQueryImplementation.java
@@ -39,7 +39,7 @@ import org.openide.filesystems.FileObject;
  * is used for example for unit test generation and for searching test for
  * source. Usage of any other pattern will break this functionality.</p>
  *
- * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup--"><code>Project.getLookup()</code></a>
+ * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup()"><code>Project.getLookup()</code></a>
  * @see org.netbeans.api.java.queries.UnitTestForSourceQuery
  * @deprecated Use {@link org.netbeans.spi.java.queries.MultipleRootsUnitTestForSourceQueryImplementation} instead.
  * @author David Konecny

--- a/java/java.source/src/org/netbeans/api/java/source/UiUtils.java
+++ b/java/java.source/src/org/netbeans/api/java/source/UiUtils.java
@@ -68,7 +68,7 @@ public final class  UiUtils {
     
     /** Gets correct icon for given ElementKind.
      * @param modifiers Can be null for empty modifiers collection
-     * @deprecated Use <a href="@org-netbeans-modules-java-sourceui@/org/netbeans/api/java/source/ui/ElementIcons.html#getElementIcon-javax.lang.model.element.ElementKind-java.util.Collection-">ElementIcons#getElementIcon(javax.lang.model.element.ElementKind, java.util.Collection)</a>
+     * @deprecated Use <a href="@org-netbeans-modules-java-sourceui@/org/netbeans/api/java/source/ui/ElementIcons.html#getElementIcon(javax.lang.model.element.ElementKind,java.util.Collection)">ElementIcons#getElementIcon(javax.lang.model.element.ElementKind, java.util.Collection)</a>
      *             of the <a href="@org-netbeans-modules-java-sourceui@">org.netbeans.modules.java.sourceui module</a>
      */
     @Deprecated
@@ -78,7 +78,7 @@ public final class  UiUtils {
 
     /**
      *
-     * @deprecated Use <a href="@org-netbeans-modules-java-sourceui@/org/netbeans/api/java/source/ui/ElementIcons.html#getElementIcon-javax.lang.model.element.ElementKind-java.util.Collection-">ElementIcons#getElementIcon(javax.lang.model.element.ElementKind, java.util.Collection)</a>
+     * @deprecated Use <a href="@org-netbeans-modules-java-sourceui@/org/netbeans/api/java/source/ui/ElementIcons.html#getElementIcon(javax.lang.model.element.ElementKind,java.util.Collection)">ElementIcons#getElementIcon(javax.lang.model.element.ElementKind, java.util.Collection)</a>
      *             of the <a href="@org-netbeans-modules-java-sourceui@">org.netbeans.modules.java.sourceui module</a>
      */
     @Deprecated
@@ -94,7 +94,7 @@ public final class  UiUtils {
      * @param el    declaration to open
      * @return true if and only if the declaration was correctly opened,
      *                false otherwise
-     * @deprecated Use <a href="@org-netbeans-modules-java-sourceui@/org/netbeans/api/java/source/ui/ElementOpen.html#open-org.netbeans.api.java.source.ClasspathInfo-javax.lang.model.element.Element-">org.netbeans.api.java.source.ui.ElementOpen#open(org.netbeans.api.java.source.ClasspathInfo, org.netbeans.api.java.source.ElementHandle</a>
+     * @deprecated Use <a href="@org-netbeans-modules-java-sourceui@/org/netbeans/api/java/source/ui/ElementOpen.html#open(org.netbeans.api.java.source.ClasspathInfo,javax.lang.model.element.Element)">org.netbeans.api.java.source.ui.ElementOpen#open(org.netbeans.api.java.source.ClasspathInfo, org.netbeans.api.java.source.ElementHandle</a>
      *             of the <a href="@org-netbeans-modules-java-sourceui@">org.netbeans.modules.java.sourceui module</a>
      */
     @Deprecated
@@ -110,7 +110,7 @@ public final class  UiUtils {
 
     /**
      *
-     * @deprecated Use <a href="@org-netbeans-modules-java-sourceui@/org/netbeans/api/java/source/ui/ElementOpen.html#open-org.openide.filesystems.FileObject-org.netbeans.api.java.source.ElementHandle-">org.netbeans.api.java.source.ui.ElementOpen#open(org.openide.filesystems.FileObject, org.netbeans.api.java.source.ElementHandle)</a>
+     * @deprecated Use <a href="@org-netbeans-modules-java-sourceui@/org/netbeans/api/java/source/ui/ElementOpen.html#open(org.openide.filesystems.FileObject,org.netbeans.api.java.source.ElementHandle)">org.netbeans.api.java.source.ui.ElementOpen#open(org.openide.filesystems.FileObject, org.netbeans.api.java.source.ElementHandle)</a>
      *             of the <a href="@org-netbeans-modules-java-sourceui@">org.netbeans.modules.java.sourceui module</a>
      */
     @Deprecated
@@ -167,7 +167,7 @@ public final class  UiUtils {
     /**
      * example of formatString:
      * "method " + PrintPart.NAME + PrintPart.PARAMETERS + " has return type " + PrintPart.TYPE
-     * @deprecated Use <a href="@org-netbeans-modules-java-sourceui@/org/netbeans/api/java/source/ui/ElementHeaders.html#getHeader-com.sun.source.util.TreePath-org.netbeans.api.java.source.CompilationInfo-java.lang.String-">org.netbeans.api.java.source.ui.ElementHeaders#getHeader(com.sun.source.util.TreePath, org.netbeans.api.java.source.CompilationInfo, java.lang.String)</a>
+     * @deprecated Use <a href="@org-netbeans-modules-java-sourceui@/org/netbeans/api/java/source/ui/ElementHeaders.html#getHeader(com.sun.source.util.TreePath,org.netbeans.api.java.source.CompilationInfo,java.lang.String)">org.netbeans.api.java.source.ui.ElementHeaders#getHeader(com.sun.source.util.TreePath, org.netbeans.api.java.source.CompilationInfo, java.lang.String)</a>
      *             of the <a href="@org-netbeans-modules-java-sourceui@">org.netbeans.modules.java.sourceui module</a>
      */
     @Deprecated
@@ -183,7 +183,7 @@ public final class  UiUtils {
     /**
      * example of formatString:
      * "method " + PrintPart.NAME + PrintPart.PARAMETERS + " has return type " + PrintPart.TYPE
-     * @deprecated Use <a href="@org-netbeans-modules-java-sourceui@/org/netbeans/api/java/source/ui/ElementHeaders.html#getHeader-javax.lang.model.element.Element-org.netbeans.api.java.source.CompilationInfo-java.lang.String-">org.netbeans.api.java.source.ui.ElementHeaders#getHeader(javax.lang.model.element.Element, org.netbeans.api.java.source.CompilationInfo, java.lang.String)</a>
+     * @deprecated Use <a href="@org-netbeans-modules-java-sourceui@/org/netbeans/api/java/source/ui/ElementHeaders.html#getHeader(javax.lang.model.element.Element,org.netbeans.api.java.source.CompilationInfo,java.lang.String)">org.netbeans.api.java.source.ui.ElementHeaders#getHeader(javax.lang.model.element.Element, org.netbeans.api.java.source.CompilationInfo, java.lang.String)</a>
      *             of the <a href="@org-netbeans-modules-java-sourceui@">org.netbeans.modules.java.sourceui module</a>
      */
     @Deprecated
@@ -240,7 +240,7 @@ public final class  UiUtils {
     }
     
     /** Computes distance between strings
-     * @deprecated Use <a href="@org-netbeans-modules-java-sourceui@/org/netbeans/api/java/source/ui/ElementHeaders.html#getDistance-java.lang.String-java.lang.String-">org.netbeans.api.java.source.ui.ElementHeaders#getDistance(java.lang.String, java.lang.String)</a>
+     * @deprecated Use <a href="@org-netbeans-modules-java-sourceui@/org/netbeans/api/java/source/ui/ElementHeaders.html#getDistance(java.lang.String,java.lang.String)">org.netbeans.api.java.source.ui.ElementHeaders#getDistance(java.lang.String, java.lang.String)</a>
      *             of the <a href="@org-netbeans-modules-java-sourceui@">org.netbeans.modules.java.sourceui module</a>
      */
     @Deprecated

--- a/java/maven/apichanges.xml
+++ b/java/maven/apichanges.xml
@@ -127,9 +127,9 @@ is the proper place.
             <author login="sdedic"/>
             <compatibility addition="yes" semantic="compatible"/>
             <description>
-                Added a <a href="@TOP@/org/netbeans/modules/maven/api/NbMavenProject.html#getPartialProject-org.apache.maven.project.MavenProject-">
-                getPartialProject</a> that returns potentially incompletely loaded project instead of a mocked-up fallback (see <a href="@TOP@/org/netbeans/modules/maven/api/NbMavenProject.html#isErrorPlaceholder-org.apache.maven.project.MavenProject-">isErrorPlaceholder()</a>.
-                Also added a <a href="@TOP@/org/netbeans/modules/maven/api/NbMavenProject.html#isIncomplete-org.apache.maven.project.MavenProject-">isIncomplete()</a> check that checks project's status.
+                Added a <a href="@TOP@/org/netbeans/modules/maven/api/NbMavenProject.html#getPartialProject(org.apache.maven.project.MavenProject)">
+                getPartialProject</a> that returns potentially incompletely loaded project instead of a mocked-up fallback (see <a href="@TOP@/org/netbeans/modules/maven/api/NbMavenProject.html#isErrorPlaceholder(org.apache.maven.project.MavenProject)">isErrorPlaceholder()</a>.
+                Also added a <a href="@TOP@/org/netbeans/modules/maven/api/NbMavenProject.html#isIncomplete(org.apache.maven.project.MavenProject)">isIncomplete()</a> check that checks project's status.
             </description>
             <class package="org.netbeans.modules.maven.api" name="NbMavenProject"/>
         </change>
@@ -160,10 +160,10 @@ is the proper place.
             <author login="sdedic"/>
             <compatibility addition="yes" semantic="compatible"/>
             <description>
-                Added a <a href="@TOP@/org/netbeans/modules/maven/api/execute/RunUtils.html#createRunConfig-java.lang.String-org.netbeans.api.project.Project-org.netbeans.spi.project.ProjectConfiguration-org.openide.util.Lookup-">
+                Added a <a href="@TOP@/org/netbeans/modules/maven/api/execute/RunUtils.html#createRunConfig(java.lang.String,org.netbeans.api.project.Project,org.netbeans.spi.project.ProjectConfiguration,org.openide.util.Lookup)">
                 RunUtils.createRunConfig()</a> variant that allows to create a <a href="@TOP@/org/netbeans/modules/maven/api/execute/RunConfig.html">RunConfig</a> for a project-defined action. 
                 Clients can use this function to use all user customizations that may have been configured for the project action before executing it using 
-                <a href="@TOP@/org/netbeans/modules/maven/api/execute/RunUtils.html#run-org.netbeans.modules.maven.api.execute.RunConfig-">RunUtils.run</a>.
+                <a href="@TOP@/org/netbeans/modules/maven/api/execute/RunUtils.html#run(org.netbeans.modules.maven.api.execute.RunConfig)">RunUtils.run</a>.
             </description>
             <class package="org.netbeans.modules.maven.api.execute" name="RunUtils"/>
         </change>
@@ -204,7 +204,7 @@ is the proper place.
             <description>
                 In addition to String property values, or String lists, artifact-based paths, that are convertible to
                 files, are sometimes present in plugin configuration. The new helper function 
-                <a href="@TOP@/org/netbeans/modules/maven/api/PluginPropertyUtils.html#getPluginPathProperty-org.netbeans.api.project.Project-org.netbeans.modules.maven.api.PluginPropertyUtils.PluginConfigPathParams-boolean-java.util.List-">getPluginPathProperty</a>
+                <a href="@TOP@/org/netbeans/modules/maven/api/PluginPropertyUtils.html#getPluginPathProperty(org.netbeans.api.project.Project,org.netbeans.modules.maven.api.PluginPropertyUtils.PluginConfigPathParams,boolean,java.util.List)">getPluginPathProperty</a>
                 resolves a list of artifacts from the POM configuration and reports errors encountered.
             </description>
         </change>
@@ -274,7 +274,7 @@ is the proper place.
             <compatibility addition="yes" source="incompatible" binary="compatible" semantic="compatible"/>
             <description>
                 <p>
-                    RunConfig now serves the originating action's context Lookup from <a href="@TOP@/org/netbeans/modules/maven/api/execute/RunConfig.html#getActionContext--">RunConfig.getActionContext()</a>
+                    RunConfig now serves the originating action's context Lookup from <a href="@TOP@/org/netbeans/modules/maven/api/execute/RunConfig.html#getActionContext()">RunConfig.getActionContext()</a>
                     so that the caller can pass extended one-time configuration for the action.
                 </p>
             </description>

--- a/java/maven/arch.xml
+++ b/java/maven/arch.xml
@@ -170,8 +170,8 @@
     <api group="lookup" name="ActionConfiguration" type="import" category="official">
         <p>
             Project API clients may place <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ProjectConfiguration.html">ProjectConfiguration</a> 
-            instance in the <b>context Lookup</b> passed to <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ActionProvider.html#isActionEnabled-java.lang.String-org.openide.util.Lookup-">ActionProvider.isActionEnabled()</a> or 
-            <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ActionProvider.html#invokeAction-java.lang.String-org.openide.util.Lookup-">ActionProvider.invokeAction()</a>. If such instance is present, the action is configured according to settings in the selected configuration.
+            instance in the <b>context Lookup</b> passed to <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ActionProvider.html#isActionEnabled(java.lang.String,org.openide.util.Lookup)">ActionProvider.isActionEnabled()</a> or 
+            <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ActionProvider.html#invokeAction(java.lang.String,org.openide.util.Lookup)">ActionProvider.invokeAction()</a>. If such instance is present, the action is configured according to settings in the selected configuration.
             If not present, the active configuration is used. See example in <a href="@TOP@/org/netbeans/modules/maven/api/NbMavenProject.html">NbMavenProject</a> documentation.
         </p>
     </api>

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
@@ -144,7 +144,7 @@ public class CheckLinks extends MatchingTask {
         JUnitReportWriter.writeReport(this, null, report, Collections.singletonMap("testBrokenLinks", testMessage));
     }
     
-    private static Pattern hrefOrAnchor = Pattern.compile("<(a|code|div|img|link|h1|h2|h3|h4|li|section|span)(\\s+class=\"[\\w\\-]*\")?(\\s+shape=\"rect\")?(?:\\s+rel=\"stylesheet\")?\\s+(href|name|id|src)=\"([^\"#]*)(#[^\"$]+)?\"(\\s+shape=\"rect\")?(?:\\s+type=\"text/css\")?(\\s+class=\"[\\w\\-]*\")?\\s*/?>", Pattern.CASE_INSENSITIVE);
+    private static Pattern hrefOrAnchor = Pattern.compile("<(a|code|div|img|link|h1|h2|h3|h4|h5|li|section|span)(\\s+class=\"[\\w\\-]*\")?(\\s+shape=\"rect\")?(?:\\s+rel=\"stylesheet\")?\\s+(href|name|id|src)=\"([^\"#]*)(#[^\"$]+)?\"(\\s+shape=\"rect\")?(?:\\s+type=\"text/css\")?(\\s+class=\"[\\w\\-]*\")?\\s*/?>", Pattern.CASE_INSENSITIVE);
     private static Pattern lineBreak = Pattern.compile("^", Pattern.MULTILINE);
     
     /**

--- a/platform/api.htmlui/apichanges.xml
+++ b/platform/api.htmlui/apichanges.xml
@@ -128,7 +128,7 @@
 </head>
 <body>
 <p class="overviewlink">
-<a href="overview-summary.html">Overview</a>
+<a href="index.html">Overview</a>
 </p>
 <standard-changelists module-code-name="$codebase"/>
 <hr/>

--- a/platform/api.htmlui/arch.xml
+++ b/platform/api.htmlui/arch.xml
@@ -89,7 +89,7 @@
   <usecase id="wizard" name="HTML and Java Wizard">
       It is possible to use this technology to
       create a wizard. See 
-      <a href="@org-netbeans-api-templates@/overview-summary.html#html-and-java">
+      <a href="@org-netbeans-api-templates@/index.html#html-and-java">
       HTML and Java Wizard
       </a> howto.
   </usecase>

--- a/platform/api.io/apichanges.xml
+++ b/platform/api.io/apichanges.xml
@@ -104,9 +104,9 @@ is the proper place.
               and new methods into class <a href="@TOP@/org/netbeans/spi/io/support/Hyperlinks.html">Hyperlinks</a>:
           </p>
           <ul>
-              <li><a href="@TOP@/org/netbeans/spi/io/support/Hyperlinks.html#getType-org.netbeans.api.io.Hyperlink-">Hyperlinks.getType(Hyperlink)</a></li>
-              <li><a href="@TOP@/org/netbeans/spi/io/support/Hyperlinks.html#getIntent-org.netbeans.api.io.Hyperlink-">Hyperlinks.getIntent(Hyperlink)</a></li>
-              <li><a href="@TOP@/org/netbeans/spi/io/support/Hyperlinks.html#getRunnable-org.netbeans.api.io.Hyperlink-">Hyperlinks.getRunnable(Hyperlink)</a></li>
+              <li><a href="@TOP@/org/netbeans/spi/io/support/Hyperlinks.html#getType(org.netbeans.api.io.Hyperlink)">Hyperlinks.getType(Hyperlink)</a></li>
+              <li><a href="@TOP@/org/netbeans/spi/io/support/Hyperlinks.html#getIntent(org.netbeans.api.io.Hyperlink)">Hyperlinks.getIntent(Hyperlink)</a></li>
+              <li><a href="@TOP@/org/netbeans/spi/io/support/Hyperlinks.html#getRunnable(org.netbeans.api.io.Hyperlink)">Hyperlinks.getRunnable(Hyperlink)</a></li>
           </ul>
       </description>
       <issue number="249321" />
@@ -127,8 +127,8 @@ is the proper place.
               Added new static methods into class <a href="@TOP@/org/netbeans/api/io/Hyperlink.html">Hyperlink</a>:
           </p>
           <ul>
-              <li><a href="@TOP@/org/netbeans/api/io/Hyperlink.html#from-org.netbeans.api.intent.Intent-">Hyperlink.from(Intent)</a></li>
-              <li><a href="@TOP@/org/netbeans/api/io/Hyperlink.html#from-org.netbeans.api.intent.Intent-boolean-">Hyperlink.from(Intent, boolean)</a></li>
+              <li><a href="@TOP@/org/netbeans/api/io/Hyperlink.html#from(org.netbeans.api.intent.Intent)">Hyperlink.from(Intent)</a></li>
+              <li><a href="@TOP@/org/netbeans/api/io/Hyperlink.html#from(org.netbeans.api.intent.Intent,boolean)">Hyperlink.from(Intent, boolean)</a></li>
           </ul>
       </description>
       <issue number="249321" />

--- a/platform/api.scripting/arch.xml
+++ b/platform/api.scripting/arch.xml
@@ -547,7 +547,7 @@
  <answer id="exec-component">
   <p>
       <api group="property" category="stable" name="allowAllAccess" type="export" url="@TOP@/org/netbeans/api/scripting/Scripting.html">
-          If <a href="@TOP@/org/netbeans/api/scripting/Scripting.html#allowAllAccess-boolean-">Scripting.allowAllAccess</a>
+          If <a href="@TOP@/org/netbeans/api/scripting/Scripting.html#allowAllAccess(boolean)">Scripting.allowAllAccess</a>
           is used, then a property <code>allowAllAccess</code> is placed into the
           <code>ScriptManager.getBindings()</code> with value <code>true</code>.
       </api>

--- a/platform/api.search/src/org/netbeans/spi/search/SearchInfoDefinition.java
+++ b/platform/api.search/src/org/netbeans/spi/search/SearchInfoDefinition.java
@@ -36,9 +36,9 @@ import org.openide.filesystems.FileObject;
  * <code>SearchInfoDefinition</code> objects are used in
  * action <em>Find in Projects</em>. Action obtains
  * <code>SearchInfoDefinition</code> from 
- * <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup--"><code>Lookup</code>
- * of nodes or projects</a> the action was invoked on.
- * </p>
+ * {@link org.openide.nodes.Node#getLookup() Lookup of nodes or projects}
+ * the action was invoked on.
+ *
  *
  * SearchInfoDefinition should be registered to lookups of nodes only if default
  * behavior is not appropriate. By default, recursive search is started in a
@@ -77,8 +77,8 @@ import org.openide.filesystems.FileObject;
  * 
  * @see SearchInfoDefinitionFactory
  * @see FileObject
- * @see <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getLookup--"><code>Node.getLookup()</code></a>
- * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup--"><code>Project.getLookup()</code></a>
+ * @see org.openide.nodes.Node#getLookup() Node.getLookup()
+ * @see <a href="@org-netbeans-modules-projectapi@/org/netbeans/api/project/Project.html#getLookup()"><code>Project.getLookup()</code></a>
  *
  * @author Marian Petras
  */

--- a/platform/api.templates/apichanges.xml
+++ b/platform/api.templates/apichanges.xml
@@ -79,7 +79,7 @@
           <description>
               One can now create project wizards that create new projects
               from Maven archetypes. See the
-              <a href="@TOP@overview-summary.html#html-and-maven">how-to</a>
+              <a href="@TOP@index.html#html-and-maven">how-to</a>
               for more details.
           </description>
           <class package="org.netbeans.api.templates" name="TemplateRegistration"/>
@@ -130,7 +130,7 @@
           <compatibility addition="yes" deletion="no" binary="compatible"
                          source="compatible" deprecation="yes"/>
           <description>
-              One can use <a href="@TOP@/overview-summary.html#javaTargetChooser">targetChooser:java</a>
+              One can use <a href="@TOP@/index.html#javaTargetChooser">targetChooser:java</a>
               to request Java-like target chooser showing java packages.
           </description>
           <issue number="249891"/>
@@ -145,7 +145,7 @@
                          source="compatible" deprecation="yes"/>
           <description>
               One new attribute
-              <a href="@org-netbeans-api-templates@/org/netbeans/api/templates/TemplateRegistration.html#page--">
+              <a href="@org-netbeans-api-templates@/org/netbeans/api/templates/TemplateRegistration.html#page()">
 page()</a>
               to allow usage of HTML based UI driven by Java or JavaScript.
           </description>
@@ -208,7 +208,7 @@ page()</a>
     </head>
     <body>
 
-<p class="overviewlink"><a href="overview-summary.html">Overview</a></p>
+<p class="overviewlink"><a href="index.html">Overview</a></p>
 
 <h1>Introduction</h1>
 

--- a/platform/api.templates/arch.xml
+++ b/platform/api.templates/arch.xml
@@ -87,7 +87,7 @@
         <p>
             Often many people require ability to create a "clever" template - e.g.
             write piece of simple text and at the time of its 
-            <a href="@TOP@/org/netbeans/api/templates/FileBuilder.html#createFromTemplate-org.openide.filesystems.FileObject-org.openide.filesystems.FileObject-java.lang.String-java.util.Map-org.netbeans.api.templates.FileBuilder.Mode-">
+            <a href="@TOP@/org/netbeans/api/templates/FileBuilder.html#createFromTemplate(org.openide.filesystems.FileObject,org.openide.filesystems.FileObject,java.lang.String,java.util.Map,org.netbeans.api.templates.FileBuilder.Mode)">
                 processing
             </a> 
             do some advanced changes to it using either 
@@ -128,7 +128,7 @@
      <usecase id="script" name="Using Scripting and Templating Languages" >
         <a id="script"></a>
         <p>
-        There is a built in <a href="@org-netbeans-api-scripting@/overview-summary.html">support for scripting languages</a>
+        There is a built in <a href="@org-netbeans-api-scripting@/index.html">support for scripting languages</a>
         in the NetBeans Platform. If a template is annotated with
         <api name="javax.script.ScriptEngine" category="official" group="property" type="export">
             a property that can be associated to templates that either should

--- a/platform/api.templates/src/org/netbeans/api/templates/CreateDescriptor.java
+++ b/platform/api.templates/src/org/netbeans/api/templates/CreateDescriptor.java
@@ -47,7 +47,7 @@ public final class CreateDescriptor {
      * include an extension (<code>*.*</code>), the handler should not append
      * any extension from the template.
      * @since org.openide.loaders 7.16
-     * @see <a href="@org-netbeans-modules-projectuiapi@/org/netbeans/spi/project/ui/templates/support/Templates.SimpleTargetChooserBuilder.html#freeFileExtension--"><code>Templates.SimpleTargetChooserBuilder.freeFileExtension</code></a>
+     * @see <a href="@org-netbeans-modules-projectuiapi@/org/netbeans/spi/project/ui/templates/support/Templates.SimpleTargetChooserBuilder.html#freeFileExtension()"><code>Templates.SimpleTargetChooserBuilder.freeFileExtension</code></a>
      */
     public static final String FREE_FILE_EXTENSION = "freeFileExtension"; // NOI18N
     

--- a/platform/api.templates/src/org/netbeans/api/templates/TemplateRegistration.java
+++ b/platform/api.templates/src/org/netbeans/api/templates/TemplateRegistration.java
@@ -135,9 +135,9 @@ public @interface TemplateRegistration {
      * </pre>
      * There is a tutorial describing usage of HTML UI in NetBeans wizards:
      * <ul>
-     *   <li>when coding <a href="@TOP@overview-summary.html#html-and-js">logic in JavaScript</a>
-     *   <li>when coding <a href="@TOP@overview-summary.html#html-and-java">logic in Java</a>
-     *   <li>when providing UI for <a href="@TOP@overview-summary.html#html-and-maven">Maven Archetypes</a>
+     *   <li>when coding <a href="@TOP@index.html#html-and-js">logic in JavaScript</a>
+     *   <li>when coding <a href="@TOP@index.html#html-and-java">logic in Java</a>
+     *   <li>when providing UI for <a href="@TOP@index.html#html-and-maven">Maven Archetypes</a>
      * </ul>
      * Creating portable UI for wizards has never been easier!
      * 

--- a/platform/api.visual/apichanges.xml
+++ b/platform/api.visual/apichanges.xml
@@ -724,7 +724,7 @@
             <author login="dkaspar"/>
             <compatibility addition="yes"/>
             <description>
-                <a href="@TOP@/org/netbeans/api/visual/action/ActionFactory.html#createContiguousSelectAction-org.netbeans.api.visual.action.ContiguousSelectProvider-">
+                <a href="@TOP@/org/netbeans/api/visual/action/ActionFactory.html#createContiguousSelectAction(org.netbeans.api.visual.action.ContiguousSelectProvider)">
                     <code>ActionFactory.createContiguousSelectAction</code></a> creates contiguous selection action.
                 <a href="@TOP@/org/netbeans/api/visual/action/ContiguousSelectProvider.html"><code>ContiguousSelectProvider</code></a>
                 provides logic for selection action. 

--- a/platform/api.visual/src/org/netbeans/api/visual/widget/doc-files/documentation.html
+++ b/platform/api.visual/src/org/netbeans/api/visual/widget/doc-files/documentation.html
@@ -23,7 +23,7 @@
 <head>
 <meta http-equiv="content-type" content="text/html; charset=ISO-8859-1">
 <meta name="author" content="david.kaspar@sun.com">
-<link rel="stylesheet" href="../../../../../../prose.css" type="text/css">
+<link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css">
 <title>netbeans.org : NetBeans Visual Library 2.0 - Documentation</title>
 <style type="text/css"><!--
 pre {

--- a/platform/autoupdate.ui/apichanges.xml
+++ b/platform/autoupdate.ui/apichanges.xml
@@ -44,8 +44,8 @@
             <description>
                 <p>
                 <code>PluginManager</code> ands its
-                <a href="@TOP@/org/netbeans/modules/autoupdate/ui/api/PluginManager.html#installSingle-java.lang.String-java.lang.String-java.lang.Object...-">installSingle</a>
-                and <a href="@TOP@/org/netbeans/modules/autoupdate/ui/api/PluginManager.html#install-java.util.Set-java.lang.Object...-">install</a>
+                <a href="@TOP@/org/netbeans/modules/autoupdate/ui/api/PluginManager.html#installSingle(java.lang.String,java.lang.String,java.lang.Object...)">installSingle</a>
+                and <a href="@TOP@/org/netbeans/modules/autoupdate/ui/api/PluginManager.html#install(java.util.Set,java.lang.Object...)">install</a>
                 shows standard UI for easy installation of single plugin based
                 on codenamebase.
                 </p>
@@ -65,7 +65,7 @@
             <description>
                 <p>
                 <code>PluginManager</code> ands its 
-                <a href="@TOP@/org/netbeans/modules/autoupdate/ui/api/PluginManager.html#openInstallWizard-org.netbeans.api.autoupdate.OperationContainer-">openInstallWizard</a>
+                <a href="@TOP@/org/netbeans/modules/autoupdate/ui/api/PluginManager.html#openInstallWizard(org.netbeans.api.autoupdate.OperationContainer)">openInstallWizard</a>
                 shows standard UI for installing of selected modules.
                 </p>
             </description>

--- a/platform/core.multiview/arch.xml
+++ b/platform/core.multiview/arch.xml
@@ -506,7 +506,7 @@ Nothing is executed.
 <api name="multiview.toolbarVisible" category="devel" group="preferences" type="export">
     <p>
     The visibility of 
-    <a href="@TOP@/org/netbeans/core/spi/multiview/MultiViewElement.html#getToolbarRepresentation--">toolbar</a>
+    <a href="@TOP@/org/netbeans/core/spi/multiview/MultiViewElement.html#getToolbarRepresentation()">toolbar</a>
     is controlled by a preference shared with editor module.
     The multiview implementation listens and uses following property:
     </p>

--- a/platform/core.multiview/src/org/netbeans/core/spi/multiview/package.html
+++ b/platform/core.multiview/src/org/netbeans/core/spi/multiview/package.html
@@ -30,17 +30,14 @@ influence the overall behaviour of the component.<br>
 This SPI handles the lifecycle of a multiview component.
 <h2>Creation</h2>
 New instance of MultiView TopComponent can be created by calling
-<a href="@TOP@/org/netbeans/core/spi/multiview/MultiViewFactory.html#createMultiView-org.netbeans.core.spi.multiview.MultiViewDescription:A-org.netbeans.core.spi.multiview.MultiViewDescription-">
-    MultiViewFactory.createMultiView
-</a>
-<!--{@link org.netbeans.core.spi.multiview.MultiViewFactory#createMultiView}.-->
+{@link org.netbeans.core.spi.multiview.MultiViewFactory#createMultiView(org.netbeans.core.spi.multiview.MultiViewDescription[],org.netbeans.core.spi.multiview.MultiViewDescription) MultiViewFactory.createMultiView }
+
 The resulting TopComponent can be docked in arbitrary mode at your
 convenience. The factory method requires an array of 
 {@link org.netbeans.core.spi.multiview.MultiViewDescription}s that
 describe the content of the view.<br>
-Each description in the View shall have a unique <a
- href="@TOP@/org/netbeans/core/spi/multiview/MultiViewDescription.html#getDisplayName--">display name</a>
-and <a href="@TOP@/org/netbeans/core/spi/multiview/MultiViewDescription.html#preferredID--">preferredId</a>.
+Each description in the View shall have a unique {@link org.netbeans.core.spi.multiview.MultiViewDescription#getDisplayName() display name }
+and {@link org.netbeans.core.spi.multiview.MultiViewDescription#preferredID() preferredId }.
 All the descriptions shall be lightweight classes, which create the
 actual visual components on demand in 
 {@link org.netbeans.core.spi.multiview.MultiViewDescription#createElement}<br>

--- a/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/api.html
+++ b/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/api.html
@@ -22,12 +22,12 @@
 <html>
 <head>
 <title>NetBeans JavaHelp Integration API</title>
-<link rel="stylesheet" href="../../../../../prose.css" type="text/css">
+<link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css">
 </head>
 
 <body>
-<p class="overviewlink"><a href="../package-summary.html">Overview</a></p>
-
+    {@link org.netbeans.api.javahelp Overview }
+    
 <h1>NetBeans JavaHelp Integration API</h1>
 
 <p>It is possible to add JavaHelp and context help capabilities to modules.
@@ -139,25 +139,25 @@ specify a <code>HelpCtx</code> in this fashion:
 
 <ul>
 
-<li> <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getHelpCtx--"><code>Node.getHelpCtx()</code></a>
+<li> <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getHelpCtx()"><code>Node.getHelpCtx()</code></a>
 
-<li> <a href="@org-openide-loaders@/org/openide/loaders/DataObject.html#getHelpCtx--"><code>DataObject.getHelpCtx()</code></a>
+<li> <a href="@org-openide-loaders@/org/openide/loaders/DataObject.html#getHelpCtx()"><code>DataObject.getHelpCtx()</code></a>
 
-<li> <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getHelpCtx--"><code>TopComponent.getHelpCtx()</code></a>
+<li> <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getHelpCtx()"><code>TopComponent.getHelpCtx()</code></a>
 
-<li> <a href="@org-openide-util-ui@/org/openide/util/actions/SystemAction.html#getHelpCtx--"><code>SystemAction.getHelpCtx()</code></a>
+<li> <a href="@org-openide-util-ui@/org/openide/util/actions/SystemAction.html#getHelpCtx()"><code>SystemAction.getHelpCtx()</code></a>
 
-<li> <a href="@org-openide-util-ui@/org/openide/util/datatransfer/NewType.html#getHelpCtx--"><code>NewType.getHelpCtx()</code></a>
+<li> <a href="@org-openide-util-ui@/org/openide/util/datatransfer/NewType.html#getHelpCtx()"><code>NewType.getHelpCtx()</code></a>
 
-<li> <a href="@org-openide-util-ui@/org/openide/util/datatransfer/PasteType.html#getHelpCtx--"><code>PasteType.getHelpCtx()</code></a>
+<li> <a href="@org-openide-util-ui@/org/openide/util/datatransfer/PasteType.html#getHelpCtx()"><code>PasteType.getHelpCtx()</code></a>
 
-<li> <a href="@org-openide-dialogs@/org/openide/DialogDescriptor.html#getHelpCtx--"><code>DialogDescriptor.getHelpCtx()</code></a>
+<li> <a href="@org-openide-dialogs@/org/openide/DialogDescriptor.html#getHelpCtx()"><code>DialogDescriptor.getHelpCtx()</code></a>
 
-<li> <a href="@org-openide-dialogs@/org/openide/WizardDescriptor.Panel.html#getHelp--"><code>WizardDescriptor.Panel.getHelpCtx()</code></a>
+<li> <a href="@org-openide-dialogs@/org/openide/WizardDescriptor.Panel.html#getHelp()"><code>WizardDescriptor.Panel.getHelpCtx()</code></a>
 
-<!-- deprecated <li> <a href="@org-openide-options@/org/openide/options/SystemOption.html#getHelpCtx--"><code>SystemOption.getHelpCtx()</code></a> -->
+<!-- deprecated <li> <a href="@org-openide-options@/org/openide/options/SystemOption.html#getHelpCtx()"><code>SystemOption.getHelpCtx()</code></a> -->
 
-<li> <a href="@org-openide-util-ui@/org/openide/ServiceType.html#getHelpCtx--"><code>ServiceType.getHelpCtx()</code></a>
+<li> <a href="@org-openide-util-ui@/org/openide/ServiceType.html#getHelpCtx()"><code>ServiceType.getHelpCtx()</code></a>
 
 (applies equally to executors and compiler types)
 
@@ -170,7 +170,7 @@ specify a <code>HelpCtx</code> in this fashion:
 <li> On any (Swing lightweight) component you use in a GUI, by
 means of
 
-<a href="@org-openide-util-ui@/org/openide/util/HelpCtx.html#setHelpIDString-javax.swing.JComponent-java.lang.String-"><code>HelpCtx.setHelpIDString(...)</code></a>.
+<a href="@org-openide-util-ui@/org/openide/util/HelpCtx.html#setHelpIDString(javax.swing.JComponent,java.lang.String)"><code>HelpCtx.setHelpIDString(...)</code></a>.
 
 This is especially useful for custom property editor components.
 
@@ -190,7 +190,7 @@ or <code>*.ser</code> files)
 
 that uses
 
-<a href="@org-openide-loaders@/org/openide/loaders/InstanceSupport.html#findHelp-org.openide.cookies.InstanceCookie-"><code>InstanceSupport.findHelp(...)</code></a>.
+<a href="@org-openide-loaders@/org/openide/loaders/InstanceSupport.html#findHelp(org.openide.cookies.InstanceCookie)"><code>InstanceSupport.findHelp(...)</code></a>.
 
 <p>This technique may also be used to add context help support to
 the editor kits used in the
@@ -212,7 +212,7 @@ the <code>PropertyDescriptor</code>.
 
 <li> As the <code>helpID</code>
 
-<a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/java/beans/FeatureDescriptor.html#getValue-java.lang.String-">value</a>
+{@link java.beans.FeatureDescriptor#getValue(java.lang.String) value }
 
 of a
 
@@ -248,8 +248,7 @@ custom windows using
 
 Programmatically, you may also display help by using
 the
-
-<a href="../Help.html">JavaHelp module API</a>:</p>
+{@link org.netbeans.api.javahelp.Help JavaHelp module API }:</p>
 
 <pre>
 <span class="type">String</span> <span class="variable-name">id</span> = ...;
@@ -262,7 +261,7 @@ the
 </pre>
 
 <p>However for most purposes you can use the simpler
-<a href="@org-openide-util-ui@/org/openide/util/HelpCtx.html#display--"><code>HelpCtx.display</code></a>
+<a href="@org-openide-util-ui@/org/openide/util/HelpCtx.html#display()"><code>HelpCtx.display</code></a>
 method and avoid a direct dependency on this API entirely:</p>
 
 <pre>

--- a/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/help-guide.html
+++ b/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/help-guide.html
@@ -22,11 +22,11 @@
 <html>
 <head>
 <title>Connecting Help in NetBeans: From Help Set Installation to Hooking up Context-Sensitive Help</title>
-<link rel="stylesheet" href="../../../../../prose.css" type="text/css">
+<link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css">
 </head>
 
 <body>
-<p class="overviewlink"><a href="../package-summary.html">Overview</a></p>
+{@link org.netbeans.api.javahelp Overview }
 
 <h1>Connecting Help in NetBeans: From Help Set Installation to Hooking up Context-Sensitive Help</h1>
 
@@ -161,7 +161,7 @@ provided there.</p>
     help ID for a dialog. There are a couple of ways to do this: 
     <ul>
       <li> Use one of the
-          <a href="@org-openide-dialogs@/org/openide/DialogDescriptor.html#DialogDescriptor-java.lang.Object-java.lang.String-boolean-int-java.lang.Object-int-org.openide.util.HelpCtx-java.awt.event.ActionListener-"><code>DialogDescriptor</code> constructors</a>
+          <a href="@org-openide-dialogs@/org/openide/DialogDescriptor.html#%3Cinit%3E(java.lang.Object,java.lang.String,boolean,int,java.lang.Object,int,org.openide.util.HelpCtx,java.awt.event.ActionListener)"><code>DialogDescriptor</code> constructors</a>
           that includes
         a <code>HelpCtx</code>.
       </li>

--- a/platform/openide.awt/apichanges.xml
+++ b/platform/openide.awt/apichanges.xml
@@ -307,7 +307,7 @@
             <p>
                 New attributes (popupText, menuText) in @ActionRegistration annotation to provide 
                 text for menu items or popup menu items according to the
-                <a href="@TOP@/org/openide/awt/Actions.html#connect-javax.swing.JMenuItem-javax.swing.Action-boolean-">Actions.connect</a>
+                <a href="@org-openide-awt@/org/openide/awt/Actions.html#connect(javax.swing.JMenuItem,javax.swing.Action,boolean)">Actions.connect</a>
                 method. 
             </p>
         </description>
@@ -358,7 +358,7 @@
         <compatibility addition="yes" binary="compatible" deletion="no" semantic="compatible"/>
         <description>
             <p>
-                <a href="@org-openide-awt@/org/openide/awt/Actions.html#context-java.lang.Class-boolean-boolean-org.openide.util.ContextAwareAction-java.lang.String-java.lang.String-java.lang.String-boolean-">
+                <a href="@org-openide-awt@/org/openide/awt/Actions.html#context(java.lang.Class,boolean,boolean,org.openide.util.ContextAwareAction,java.lang.String,java.lang.String,java.lang.String,boolean)">
                 Action.context</a>, when used from layer accepts <code>"context"</code>
                 attribute.
             </p>
@@ -391,7 +391,7 @@
         <compatibility addition="yes" binary="compatible" deletion="no" semantic="compatible"/>
         <description>
             <p>Instead of registering actions in layer as advocated by various
-            <a href="@TOP@/org/openide/awt/Actions.html#alwaysEnabled-java.awt.event.ActionListener-java.lang.String-java.lang.String-boolean-">
+            <a href="@TOP@/org/openide/awt/Actions.html#alwaysEnabled(java.awt.event.ActionListener,java.lang.String,java.lang.String,boolean)">
                 action factory methods</a> one can use newly created 
                 <a href="@TOP@/org/openide/awt/ActionRegistration.html">annotations</a>.
             </p>
@@ -461,7 +461,7 @@
         <author login="mmetelka"/>
         <compatibility addition="yes" binary="compatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
         <description>
-            <a href="@TOP@/org/openide/awt/Actions.html#checkbox-java.lang.String-java.lang.String-java.lang.String-java.lang.String-boolean-">
+            <a href="@TOP@/org/openide/awt/Actions.html#checkbox(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean)">
                 checkbox</a>
             added to create an action that represents a key in Preferences.
         </description>
@@ -476,7 +476,7 @@
         <author login="mmetelka"/>
         <compatibility addition="yes" binary="compatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
         <description>
-            <a href="@TOP@/org/openide/awt/Actions.html#alwaysEnabled-java.awt.event.ActionListener-java.lang.String-java.lang.String-boolean-">
+            <a href="@TOP@/org/openide/awt/Actions.html#alwaysEnabled(java.awt.event.ActionListener,java.lang.String,java.lang.String,boolean)">
                 alwaysEnabledAction</a>
             was enhanced to understand
             <code>&lt;attr name="PreferencesKey" stringvalue="boolean-key-name"/&gt;</code>
@@ -541,13 +541,13 @@
         <compatibility addition="yes" binary="compatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
         <description>
             The layer definition used by factory methods for
-            <a href="@TOP@/org/openide/awt/Actions.html#context-java.lang.Class-boolean-boolean-org.openide.util.ContextAwareAction-java.lang.String-java.lang.String-java.lang.String-boolean-">
+            <a href="@TOP@/org/openide/awt/Actions.html#context(java.lang.Class,boolean,boolean,org.openide.util.ContextAwareAction,java.lang.String,java.lang.String,java.lang.String,boolean)">
             context</a>
             and
-            <a href="@TOP@/org/openide/awt/Actions.html#callback-java.lang.String-javax.swing.Action-boolean-java.lang.String-java.lang.String-boolean-">
+            <a href="@TOP@/org/openide/awt/Actions.html#callback(java.lang.String,javax.swing.Action,boolean,java.lang.String,java.lang.String,boolean)">
             callback</a>
             and
-            <a href="@TOP@/org/openide/awt/Actions.html#alwaysEnabled-java.awt.event.ActionListener-java.lang.String-java.lang.String-boolean-">
+            <a href="@TOP@/org/openide/awt/Actions.html#alwaysEnabled(java.awt.event.ActionListener,java.lang.String,java.lang.String,boolean)">
                 alwaysEnabledAction</a>
             were enhanced to understand <code>&lt;attr name="asynchronous" boolvalue="true"/&gt;</code>
             attribute. This extends these new factories with capabilities
@@ -584,10 +584,10 @@
         <description>
             <p>
             Two new factory methods for creating
-            <a href="@TOP@/org/openide/awt/Actions.html#context-java.lang.Class-boolean-boolean-org.openide.util.ContextAwareAction-java.lang.String-java.lang.String-java.lang.String-boolean-">
+            <a href="@TOP@/org/openide/awt/Actions.html#context(java.lang.Class,boolean,boolean,org.openide.util.ContextAwareAction,java.lang.String,java.lang.String,java.lang.String,boolean)">
             context</a>
             and
-            <a href="@TOP@/org/openide/awt/Actions.html#callback-java.lang.String-javax.swing.Action-boolean-java.lang.String-java.lang.String-boolean-">
+            <a href="@TOP@/org/openide/awt/Actions.html#callback(java.lang.String,javax.swing.Action,boolean,java.lang.String,java.lang.String,boolean)">
             callback</a>
             actions and bunch of
             <a href="@TOP@/org/netbeans/api/actions/package-summary.html">
@@ -700,7 +700,7 @@
         <author login="jtulach"/>
         <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible" deprecation="yes" deletion="no" modification="no"/>
         <description>
-        In order to allow dynamic names of actions, the <a href="@TOP@/org/openide/awt/Actions.html#connect-javax.swing.JMenuItem-javax.swing.Action-boolean-">Actions.connect</a>
+        In order to allow dynamic names of actions, the <a href="@TOP@/org/openide/awt/Actions.html#connect(javax.swing.JMenuItem,javax.swing.Action,boolean)">Actions.connect</a>
         method now understands additional properties that influence the text 
         of menu items or popup menu items build for this action.
         </description>

--- a/platform/openide.awt/arch.xml
+++ b/platform/openide.awt/arch.xml
@@ -447,10 +447,10 @@
  <answer id="exec-component">
   <ul>
    <li>
-    <api name="menuText" category="stable" type="export" group="property" url="@TOP@/org/openide/awt/Actions.html#connect-javax.swing.JMenuItem-javax.swing.Action-boolean-"/>
+    <api name="menuText" category="stable" type="export" group="property" url="@TOP@/org/openide/awt/Actions.html#connect(javax.swing.JMenuItem,javax.swing.Action,boolean)"/>
    </li>
    <li>
-    <api name="popupText" category="stable" type="export" group="property" url="@TOP@/org/openide/awt/Actions.html#connect-javax.swing.JMenuItem-javax.swing.Action-boolean-"/>
+    <api name="popupText" category="stable" type="export" group="property" url="@TOP@/org/openide/awt/Actions.html#connect(javax.swing.JMenuItem,javax.swing.Action,boolean)"/>
    </li>
    <li> 
     <api name="org.openide.awt.USE_MNEMONICS" category="stable" type="export" group="branding">
@@ -965,11 +965,11 @@
    <api name="Actions.factories" type="export" group="layer" category="stable"
       url="@TOP@/org/openide/awt/Actions.html">
       Many action factories 
-      (<a href="org/openide/awt/Actions.html#alwaysEnabled-java.awt.event.ActionListener-java.lang.String-java.lang.String-boolean-">alwaysEnabled</a>,
-        <a href="org/openide/awt/Actions.html#context-java.lang.Class-boolean-boolean-org.openide.util.ContextAwareAction-java.lang.String-java.lang.String-java.lang.String-boolean-">
+      (<a href="org/openide/awt/Actions.html#alwaysEnabled(java.awt.event.ActionListener,java.lang.String,java.lang.String,boolean)">alwaysEnabled</a>,
+        <a href="org/openide/awt/Actions.html#context(java.lang.Class,boolean,boolean,org.openide.util.ContextAwareAction,java.lang.String,java.lang.String,java.lang.String,boolean)">
         context</a>
         and
-        <a href="org/openide/awt/Actions.html#callback-java.lang.String-javax.swing.Action-boolean-java.lang.String-java.lang.String-boolean-">
+        <a href="org/openide/awt/Actions.html#callback(java.lang.String,javax.swing.Action,boolean,java.lang.String,java.lang.String,boolean)">
             callback</a>,
         etc.)
 

--- a/platform/openide.awt/src/org/netbeans/api/actions/package.html
+++ b/platform/openide.awt/src/org/netbeans/api/actions/package.html
@@ -30,7 +30,8 @@ Usually
 one adds implementation of these interfaces into publically known
 <a href="@org-openide-util-lookup@/org/openide/util/Lookup.html">Lookup</a> (like
 those provided by <a href="@org-openide-nodes@/org/openide/nodes/Node.html">nodes</a>). These interfaces
-are primarily designed for use with <a href="@TOP@/org/openide/awt/Actions.html#context-java.lang.Class-boolean-boolean-org.openide.util.ContextAwareAction-java.lang.String-java.lang.String-java.lang.String-boolean-">
-context actions</a>.
+are primarily designed for use with 
+{@link org.openide.awt.Actions#context(java.lang.Class,boolean,boolean,org.openide.util.ContextAwareAction,java.lang.String,java.lang.String,java.lang.String,boolean)  context actions }
+.
 </body>
 </html>

--- a/platform/openide.dialogs/apichanges.xml
+++ b/platform/openide.dialogs/apichanges.xml
@@ -63,8 +63,8 @@
          <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
          <description>
              <p>
-                 <a href="@TOP@/org/openide/DialogDisplayer.html#notifyFuture-T-">DialogDisplayer.notifyFuture</a> now allows to chain processing after user closes the 
-                 dialog without blocking a thread as with <a href="@TOP@/org/openide/DialogDisplayer.html#notify-org.openide.NotifyDescriptor-">DialogDisplayer.notify</a>.
+                 <a href="@TOP@/org/openide/DialogDisplayer.html#notifyFuture(T)">DialogDisplayer.notifyFuture</a> now allows to chain processing after user closes the 
+                 dialog without blocking a thread as with <a href="@TOP@/org/openide/DialogDisplayer.html#notify(org.openide.NotifyDescriptor)">DialogDisplayer.notify</a>.
              </p>
          </description>
          <class package="org.openide" name="DialogDisplayer"/>
@@ -355,7 +355,7 @@
              Now it is simple to display a message box described by
              <a href="@TOP@/org/openide/NotifyDescriptor.html">NotifyDescriptor</a>
              asynchronously using
-             <a href="@TOP@/org/openide/DialogDisplayer.html#notifyLater-org.openide.NotifyDescriptor-">
+             <a href="@TOP@/org/openide/DialogDisplayer.html#notifyLater(org.openide.NotifyDescriptor)">
                  DialogDisplayer.notifyLater
              </a>.
            </description>

--- a/platform/openide.dialogs/arch.xml
+++ b/platform/openide.dialogs/arch.xml
@@ -67,7 +67,7 @@ of frequently asked questions and their answers:
   </em>
   <p>
   <b>A:</b> You can change the format of your wizard's title by 
-  <a href="@TOP@org/openide/WizardDescriptor.html#setTitleFormat-java.text.MessageFormat-">WizardDescriptor.setTitleFormat(MessageFormat format)</a>
+  <a href="@TOP@org/openide/WizardDescriptor.html#setTitleFormat(java.text.MessageFormat)">WizardDescriptor.setTitleFormat(MessageFormat format)</a>
   and rid of 'wizard' word in the default wizard's title.  
   </p>
 </usecase>

--- a/platform/openide.execution/src/org/openide/execution/NbClassLoader.java
+++ b/platform/openide.execution/src/org/openide/execution/NbClassLoader.java
@@ -43,7 +43,7 @@ import org.openide.windows.InputOutput;
 /** A class loader which is capable of loading classes from the Repository.
  * XXX the only useful thing this class does is effectively make
  * ExecutionEngine.createPermissions public! Consider deprecating this class...
- * @see <a href="@org-netbeans-api-java-classpath@/org/netbeans/api/java/classpath/ClassPath.html#getClassLoader-boolean-"><code>ClassPath.getClassLoader(...)</code></a>
+ * @see <a href="@org-netbeans-api-java-classpath@/org/netbeans/api/java/classpath/ClassPath.html#getClassLoader(boolean)"><code>ClassPath.getClassLoader(...)</code></a>
 * @author Ales Novak, Petr Hamernik, Jaroslav Tulach, Ian Formanek
 */
 public class NbClassLoader extends URLClassLoader {

--- a/platform/openide.explorer/apichanges.xml
+++ b/platform/openide.explorer/apichanges.xml
@@ -111,9 +111,9 @@
         <author login="mentlicher"/>
         <compatibility binary="compatible" source="compatible" deprecation="no" deletion="no" addition="yes"/>
         <description>
-            Added <a href="@TOP@/org/openide/explorer/view/OutlineView.html#isQuickSearchAllowed--">OutlineView.isQuickSearchAllowed()</a>,
-            <a href="@TOP@/org/openide/explorer/view/OutlineView.html#setQuickSearchAllowed-boolean-">OutlineView.setQuickSearchAllowed()</a>
-            and <a href="@TOP@/org/openide/explorer/view/OutlineView.html#setQuickSearchTableFilter-org.openide.explorer.view.QuickSearchTableFilter-boolean-">OutlineView.setQuickSearchTableFilter()</a>
+            Added <a href="@TOP@/org/openide/explorer/view/OutlineView.html#isQuickSearchAllowed()">OutlineView.isQuickSearchAllowed()</a>,
+            <a href="@TOP@/org/openide/explorer/view/OutlineView.html#setQuickSearchAllowed(boolean)">OutlineView.setQuickSearchAllowed()</a>
+            and <a href="@TOP@/org/openide/explorer/view/OutlineView.html#setQuickSearchTableFilter(org.openide.explorer.view.QuickSearchTableFilter,boolean)">OutlineView.setQuickSearchTableFilter()</a>
             methods to control quick search functionality on OutlineView.
             Interface <a href="@TOP@/org/openide/explorer/view/QuickSearchTableFilter.html">QuickSearchTableFilter</a>
             introduced to provide custom table cell data for quick search.
@@ -130,7 +130,7 @@
         <author login="tpavek"/>
         <compatibility binary="compatible" source="compatible" deprecation="no" deletion="no" addition="yes"/>
         <description>
-            Added <a href="@TOP@/org/openide/explorer/propertysheet/PropertyEnv.html#create-java.beans.FeatureDescriptor-java.lang.Object...-">PropertyEnv.create</a>
+            Added <a href="@TOP@/org/openide/explorer/propertysheet/PropertyEnv.html#create(java.beans.FeatureDescriptor,java.lang.Object...)">PropertyEnv.create</a>
             method for creating an instance of PropertyEnv for given property and beans (nodes).
             To be used when there is a need to initialize an ExPropertyEditor instance independently from
             PropertySheet or PropertyPanel infrastructure (e.g. before the property appears in UI).
@@ -226,7 +226,7 @@
         <compatibility binary="compatible" source="compatible" deprecation="no" deletion="no" addition="yes"/>
         <description>
             To simplify navigation "up" in the <code>ListView</code> one
-            can turn on <a href="@TOP@/org/openide/explorer/view/ListView.html#setShowParentNode-boolean-">showParentNode</a>
+            can turn on <a href="@TOP@/org/openide/explorer/view/ListView.html#setShowParentNode(boolean)">showParentNode</a>
             property.
         </description>
         <class package="org.openide.explorer.view" name="ListView"/>
@@ -300,7 +300,7 @@
         <description>Nodes can be removed outside of AWT thread while e.g. view can
         try to select them. This generated IllegalArgumentException during checking if
         such a node is under root context. Now
-        <a href="@TOP@/org/openide/explorer/ExplorerManager.html#setSelectedNodes-org.openide.nodes.Node:A-"><code>setSelectedNodes()</code></a>.
+        <a href="@TOP@/org/openide/explorer/ExplorerManager.html#setSelectedNodes(org.openide.nodes.Node%5B%5D)"><code>setSelectedNodes()</code></a>.
         does partial selection
         of valid nodes instead of throwing IllegalArgumentException.
         </description>

--- a/platform/openide.explorer/arch.xml
+++ b/platform/openide.explorer/arch.xml
@@ -445,11 +445,11 @@ and to Actions API to allow use Explorer API as standalone library.
 <answer id="format-clipboard">
 The module servers as a bridge between nodes and the clipboard. It takes what 
 Nodes provide 
-(<a href="@org-openide-nodes@/org/openide/nodes/Node.html#clipboardCopy--">Node.clipboardCopy</a>,
- <a href="@org-openide-nodes@/org/openide/nodes/Node.html#clipboardCut--">Node.clipboardCut</a>) and
+(<a href="@org-openide-nodes@/org/openide/nodes/Node.html#clipboardCopy()">Node.clipboardCopy</a>,
+ <a href="@org-openide-nodes@/org/openide/nodes/Node.html#clipboardCut()">Node.clipboardCut</a>) and
 inserts them into clipboard (as part of Copy/Cut action) and also retrive the
 content of clipboard and pases it to 
- <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getPasteTypes-java.awt.datatransfer.Transferable-">Node.getPasteTypes(Transferable)</a>)
+ <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getPasteTypes(java.awt.datatransfer.Transferable)">Node.getPasteTypes(Transferable)</a>)
 during paste action.
 </answer>
 

--- a/platform/openide.filesystems/apichanges.xml
+++ b/platform/openide.filesystems/apichanges.xml
@@ -33,7 +33,7 @@
             <author login="lkishalmi"/>
             <compatibility addition="yes" semantic="compatible"/>
             <description>
-                <a href="@TOP@/org/openide/filesystems/FileUtil.html#copyFile-org.openide.filesystems.FileObject-org.openide.filesystems.FileObject-java.lang.String-java.lang.String-">FileUtil.copyFile(...)</a> now preserve ATTRIBUTES and POSIX permissions.
+                <a href="@TOP@/org/openide/filesystems/FileUtil.html#copyFile(org.openide.filesystems.FileObject,org.openide.filesystems.FileObject,java.lang.String,java.lang.String)">FileUtil.copyFile(...)</a> now preserve ATTRIBUTES and POSIX permissions.
             </description>
             <class name="FileUtil" package="org.openide.filesystems"/>
         </change>
@@ -70,7 +70,7 @@
             <compatibility addition="yes" source="compatible" semantic="compatible" binary="compatible"/>
             <description>
                 <p>
-                    An utility method <a href="@TOP@/org/openide/filesystems/FileUtil.html#isValidFileName-java.lang.String-">isValidFileName()</a> was added
+                    An utility method <a href="@TOP@/org/openide/filesystems/FileUtil.html#isValidFileName(java.lang.String)">isValidFileName()</a> was added
                     to check for illegal characters that may vary on supported platforms/OSes.
                 </p>
             </description>
@@ -85,7 +85,7 @@
             <description>
                 <p>
                     New method 
-                    <a href="@TOP@/org/openide/filesystems/FileObject.html#getFileObject-java.lang.String-boolean-"><code>getFileObject(relativePath, false)</code></a>
+                    <a href="@TOP@/org/openide/filesystems/FileObject.html#getFileObject(java.lang.String,boolean)"><code>getFileObject(relativePath, false)</code></a>
                     in 
                     <a href="@TOP@/org/openide/filesystems/FileObject.html"><code>FileObject</code></a>
                     class to return a relative object even if it doesn't exist.
@@ -111,7 +111,7 @@
                     This change changes the default behaviour if NO 
                     <a href="@JDK@@JDKMODULE_JAVA_COMPILER@/javax/annotation/processing/SupportedSourceVersion.html"><code>@SupportedSourceVersion</code></a>
                     annotation is present on subclass. From 8.40, the Processor will report 
-                    <a href="@JDK@@JDKMODULE_JAVA_COMPILER@/javax/lang/model/SourceVersion.html#latest--"><code>@SourceVersion.latest()</code></a>.
+                    <a href="@JDK@@JDKMODULE_JAVA_COMPILER@/javax/lang/model/SourceVersion.html#latest()"><code>@SourceVersion.latest()</code></a>.
                 </p>
             </description>
             <class name="LayerGeneratingProcessor" package="org.openide.filesystems.annotations"/>
@@ -251,7 +251,7 @@
                     of splitting filesystems API into UI (e.g. depending
                     on Swing) and non-UI part (that can run on JDK8 compact
                     profile). Introducing general replacement 
-                    <a href="@TOP@org/openide/filesystems/FileSystem.html#findExtrasFor-java.util.Set-">findExtrasFor</a>
+                    <a href="@TOP@org/openide/filesystems/FileSystem.html#findExtrasFor(java.util.Set)">findExtrasFor</a>
                     instead...
                 </p>
             </description>
@@ -288,7 +288,7 @@
             <compatibility addition="yes" deprecation="no"/>
             <description>
                 <p>
-                    Added <a href="@org-openide-filesystems-nb@/org/openide/filesystems/FileChooserBuilder.html#setAcceptAllFileFilterUsed-boolean-">
+                    Added <a href="@org-openide-filesystems-nb@/org/openide/filesystems/FileChooserBuilder.html#setAcceptAllFileFilterUsed(boolean)">
                     new method</a> to <code>FileChooserBuilder</code> that determines whether the <code>AcceptAll FileFilter</code>
                     should be used in the created file chooser.
                 </p>
@@ -305,14 +305,14 @@
             <compatibility addition="yes" deprecation="no"/>
             <description>
                 <p>
-                    Added <a href="@org-openide-filesystems-nb@/org/openide/filesystems/FileChooserBuilder.html#addDefaultFileFilters--">
+                    Added <a href="@org-openide-filesystems-nb@/org/openide/filesystems/FileChooserBuilder.html#addDefaultFileFilters()">
                     new method</a> to <code>FileChooserBuilder</code> that adds all default
                     <code>FileFilter</code>s to created file chooser.
                 </p>
                 <p>
                     Default filters are registered using new parameters in annotations
-                    <a href="@TOP@org/openide/filesystems/MIMEResolver.Registration.html#showInFileChooser--">MimeResolver.Registration</a>
-                    and <a href="@TOP@org/openide/filesystems/MIMEResolver.ExtensionRegistration.html#showInFileChooser--">MimeResolver.ExtensionRegistration</a>.
+                    <a href="@TOP@org/openide/filesystems/MIMEResolver.Registration.html#showInFileChooser()">MimeResolver.Registration</a>
+                    and <a href="@TOP@org/openide/filesystems/MIMEResolver.ExtensionRegistration.html#showInFileChooser()">MimeResolver.ExtensionRegistration</a>.
                 </p>
             </description>
             <class package="org.openide.filesystems" name="FileChooserBuilder" link="no"/>
@@ -330,7 +330,7 @@
                 <p>
                     <code>FileObject</code> now implements <code>Lookup.Provider</code>
                     and thus has new
-                    <a href="@TOP@org/openide/filesystems/FileObject.html#getLookup--">
+                    <a href="@TOP@org/openide/filesystems/FileObject.html#getLookup()">
                     getLookup</a>() method.
                 </p>
             </description>
@@ -346,7 +346,7 @@
             <compatibility addition="yes" deprecation="no"/>
             <description>
                 <p>
-                    Added <a href="@TOP@org/openide/filesystems/FileUtil.html#addRecursiveListener-org.openide.filesystems.FileChangeListener-java.io.File-java.io.FileFilter-java.util.concurrent.Callable-">
+                    Added <a href="@TOP@org/openide/filesystems/FileUtil.html#addRecursiveListener(org.openide.filesystems.FileChangeListener,java.io.File,java.io.FileFilter,java.util.concurrent.Callable)">
                     new method</a> variant to register recursive listener
                     and control whether to recurse into a subtree or not via
                     <code>FileFilter</code>.
@@ -381,7 +381,7 @@
             <description>
                 <p>
                     Those who wish to influence content of 
-                    <a href="@TOP@/org/openide/filesystems/FileUtil.html#getConfigRoot--">
+                    <a href="@TOP@/org/openide/filesystems/FileUtil.html#getConfigRoot()">
                     configuration file system</a> have an easier
                     <a href="@TOP@/org/openide/filesystems/Repository.LayerProvider.html">
                     way</a> now.
@@ -507,7 +507,7 @@
             <compatibility addition="yes"/>
             <description>
                 <p>
-                    Introducing <a href="@TOP@/org/openide/filesystems/FileObject.html#getMIMEType-java.lang.String...-">
+                    Introducing <a href="@TOP@/org/openide/filesystems/FileObject.html#getMIMEType(java.lang.String...)">
                     FileObject.getMIMEType(String...)    
                     </a> that can be overriden by different implementations
                     of file system API.
@@ -565,7 +565,7 @@
                 <p>
                     One can convert files in SystemFileSystem to Object with
                     a
-                    <a href="@TOP@org/openide/filesystems/FileUtil.html#getConfigObject-java.lang.String-java.lang.Class-">
+                    <a href="@TOP@org/openide/filesystems/FileUtil.html#getConfigObject(java.lang.String,java.lang.Class)">
                     single utility method</a>.
                 </p>
             </description>
@@ -582,7 +582,7 @@
             <description>
                 <p>
                     Semantic of 
-                    <a href="@TOP@/org/openide/filesystems/FileObject.html#getFileObject-java.lang.String-">
+                    <a href="@TOP@/org/openide/filesystems/FileObject.html#getFileObject(java.lang.String)">
                     getFileObject
                     </a> method has been clarified to accept "..".
                 </p>
@@ -600,7 +600,7 @@
             <description>
                 <p>
                     You can use prefix <code>"methodvalue:"</code> to
-                    <a href="@TOP@/org/openide/filesystems/FileObject.html#setAttribute-java.lang.String-java.lang.Object-">
+                    <a href="@TOP@/org/openide/filesystems/FileObject.html#setAttribute(java.lang.String,java.lang.Object)">
                     setAttribute    
                     </a>
                     with type of <a href="@JDK@@JDKMODULE_JAVA_BASE@/java/lang/reflect/Method.html">Method</a>.
@@ -643,7 +643,7 @@
             <description>
                 <p>
                 Create a file and write its content (almost) atomically using the new
-                <a href="@TOP@/org/openide/filesystems/FileObject.html#createAndOpen-java.lang.String-">FileObject.createAndOpen</a>
+                <a href="@TOP@/org/openide/filesystems/FileObject.html#createAndOpen(java.lang.String)">FileObject.createAndOpen</a>
                 method.
                 </p>
             </description>
@@ -767,7 +767,7 @@
                  <p>
                      One can register a recursive listener on a file object by
                      calling
-                     <a href="@TOP@/org/openide/filesystems/FileObject.html#addRecursiveListener-org.openide.filesystems.FileChangeListener-">FileObject.addRecursiveListener(FileChangeListener)</a>.
+                     <a href="@TOP@/org/openide/filesystems/FileObject.html#addRecursiveListener(org.openide.filesystems.FileChangeListener)">FileObject.addRecursiveListener(FileChangeListener)</a>.
                  </p>
              </description>
              <class package="org.openide.filesystems" name="FileObject"/>
@@ -836,7 +836,7 @@
             <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
             <description>
                 <p>
-                    <a href="org/openide/filesystems/FileEvent.html#runWhenDeliveryOver-java.lang.Runnable-">
+                    <a href="org/openide/filesystems/FileEvent.html#runWhenDeliveryOver(java.lang.Runnable)">
                     FileEvent.runWhenDeliveryOver(Runnable)</a> method added to support
                     easier processing of <em>batch</em> sets of events.
                 </p>
@@ -871,11 +871,11 @@
             <compatibility addition="yes"/>
             <description>
                 <p>
-                    Added <a href="@TOP@/org/openide/filesystems/FileObject.html#asBytes--">
+                    Added <a href="@TOP@/org/openide/filesystems/FileObject.html#asBytes()">
                     asBytes()</a>,
-                    <a href="@TOP@/org/openide/filesystems/FileObject.html#asText-java.lang.String-">
+                    <a href="@TOP@/org/openide/filesystems/FileObject.html#asText(java.lang.String)">
                     asText(encoding)</a>,
-                    and <a href="@TOP@/org/openide/filesystems/FileObject.html#asLines-java.lang.String-">
+                    and <a href="@TOP@/org/openide/filesystems/FileObject.html#asLines(java.lang.String)">
                     asLines(encoding)</a> methods into
                     <a href="@TOP@/org/openide/filesystems/FileObject.html">FileObject</a>
                     to simplify reading of its content.
@@ -892,9 +892,9 @@
             <compatibility addition="yes"/>
             <description>
                 <p>
-                    Added <a href="@TOP@/org/openide/filesystems/FileUtil.html#addFileChangeListener-org.openide.filesystems.FileChangeListener-java.io.File-">
+                    Added <a href="@TOP@/org/openide/filesystems/FileUtil.html#addFileChangeListener(org.openide.filesystems.FileChangeListener,java.io.File)">
                     FileUtil.addFileChangeListener(FileChangeListener listener, File path)</a>
-                    and <a href="@TOP@/org/openide/filesystems/FileUtil.html#removeFileChangeListener-org.openide.filesystems.FileChangeListener-java.io.File-">
+                    and <a href="@TOP@/org/openide/filesystems/FileUtil.html#removeFileChangeListener(org.openide.filesystems.FileChangeListener,java.io.File)">
                     FileUtil.addFileChangeListener(FileChangeListener listener, File path)</a>.
                     It permits you to listen to a file which does not yet exist,
                     or continue listening to it after it is deleted and recreated, etc.
@@ -915,7 +915,7 @@
                     Rather than having to call
                     <code>Repository.getDefault().getDefaultFileSystem().getRoot().getFileObject(&quot;foo/bar&quot;)</code>,
                     you can simply call
-                    <a href="@TOP@/org/openide/filesystems/FileUtil.html#getConfigFile-java.lang.String-">FileUtil.getConfigFile(&quot;foo/bar&quot;)</a>.
+                    <a href="@TOP@/org/openide/filesystems/FileUtil.html#getConfigFile(java.lang.String)">FileUtil.getConfigFile(&quot;foo/bar&quot;)</a>.
                 </p>
             </description>
             <class package="org.openide.filesystems" name="FileUtil"/>
@@ -930,11 +930,11 @@
             <compatibility addition="yes" modification="yes"/>
             <description>
                 <p>
-                    Method <a href="@TOP@/org/openide/filesystems/FileUtil.html#setMIMEType-java.lang.String-java.lang.String-">
+                    Method <a href="@TOP@/org/openide/filesystems/FileUtil.html#setMIMEType(java.lang.String,java.lang.String)">
                     FileUtil.setMIMEType(String extension, String mimeType)</a>
                     resurrected to register file extension for specified MIME type.
                     It is persisted in userdir contrary to previous implementation.
-                    Added method <a href="@TOP@/org/openide/filesystems/FileUtil.html#getMIMETypeExtensions-java.lang.String-">
+                    Added method <a href="@TOP@/org/openide/filesystems/FileUtil.html#getMIMETypeExtensions(java.lang.String)">
                     FileUtil.getMIMETypeExtensions(String mimeType)</a>
                     to get list of file extensions associated with specified MIME type.
                 </p>
@@ -1017,7 +1017,7 @@
             <description>
                 <p>
                     To speed up MIME type recognition it is added an extra parameter
-                    to method <a href="@TOP@/org/openide/filesystems/FileUtil.html#getMIMEType-org.openide.filesystems.FileObject-java.lang.String...-">FileUtil.getMIMEType(FileObject, String...)</a>.
+                    to method <a href="@TOP@/org/openide/filesystems/FileUtil.html#getMIMEType(org.openide.filesystems.FileObject,java.lang.String...)">FileUtil.getMIMEType(FileObject, String...)</a>.
                     We can supply one or more MIME types which we are only interested in.
                     Module writers have to override
                     <a href="@TOP@/org/openide/filesystems/MIMEResolver.html">MIMEResolver</a>

--- a/platform/openide.filesystems/arch.xml
+++ b/platform/openide.filesystems/arch.xml
@@ -442,7 +442,7 @@ Periodic refresh can be set.
         </question>
 -->
 <answer id="exec-reflection">
-<api type="export" group="layer" category="stable" name="methodvalue-newvalue" url="@TOP@/org/openide/filesystems/FileObject.html#setAttribute-java.lang.String-java.lang.Object-">
+<api type="export" group="layer" category="stable" name="methodvalue-newvalue" url="@TOP@/org/openide/filesystems/FileObject.html#setAttribute(java.lang.String,java.lang.Object)">
 When special form of <code>setAttribute</code> is supported by the filesystem, the 
 <code>getAttribute</code> can behave like 
 <a href="@TOP@/org/openide/filesystems/XMLFileSystem.html">XMLFileSystem</a>'s

--- a/platform/openide.io/apichanges.xml
+++ b/platform/openide.io/apichanges.xml
@@ -215,22 +215,22 @@ is the proper place.
 	  <p>
 	      After fixing bug#185209
 	      <code>
-	      <a href="@TOP@/org/openide/windows/IOContainer.html#select-javax.swing.JComponent-">IOContainer.select()</a>
+	      <a href="@TOP@/org/openide/windows/IOContainer.html#select(javax.swing.JComponent)">IOContainer.select()</a>
 	      </code>
 	      no longer performs these operations for us so implementations of IOProvider
 	      have to do them:
 	      <code>
-	      <a href="@TOP@/org/openide/windows/IOContainer.html#open--">IOContainer.open()</a>
+	      <a href="@TOP@/org/openide/windows/IOContainer.html#open()">IOContainer.open()</a>
 	      </code>
 	      ,
 	      <code>
-	      <a href="@TOP@/org/openide/windows/IOContainer.html#requestVisible--">IOContainer.requestVisible()</a>
+	      <a href="@TOP@/org/openide/windows/IOContainer.html#requestVisible()">IOContainer.requestVisible()</a>
 	      </code>
 	      .
 	  </p>
 	  <p>
 	      Existing implementation of
-	      <a href="@TOP@/org/openide/windows/InputOutput.html#select--">InputOutput.select()</a>
+	      <a href="@TOP@/org/openide/windows/InputOutput.html#select()">InputOutput.select()</a>
 	      has been adjusted and is still compatible.
 	  </p>
       </description>
@@ -287,14 +287,14 @@ is the proper place.
       <author login="t_h"/>
       <compatibility addition="yes" binary="compatible" semantic="compatible" />
       <description>
-        <p>Added static <a href="@TOP@/org/openide/windows/IOProvider.html#get-java.lang.String-">
+        <p>Added static <a href="@TOP@/org/openide/windows/IOProvider.html#get(java.lang.String)">
         <code>IOProvider.get(String name)</code></a> to get specific implementation of IOProvider. Added
-        <a href="@TOP@/org/openide/windows/IOProvider.html#getName--"><code>IOProvider.getName()</code></a>
+        <a href="@TOP@/org/openide/windows/IOProvider.html#getName()"><code>IOProvider.getName()</code></a>
         which should be overriden by subclasses to provide its name (ID).
         </p>
         <p><a href="@TOP@/org/openide/windows/IOContainer.html"><code>IOContainer</code></a>
         was introduced as an accessor to "parent container" for IO components (tab).
-        <a href="@TOP@/org/openide/windows/IOProvider.html#getIO-java.lang.String-javax.swing.Action:A-org.openide.windows.IOContainer-">
+        <a href="@TOP@/org/openide/windows/IOProvider.html#getIO(java.lang.String,javax.swing.Action%5B%5D,org.openide.windows.IOContainer)">
         <code>IOProvider.getIO(String name, Action[] additionalActions, IOContainer ioContainer)</code></a>
         can be used to specify alternative container.
         </p>

--- a/platform/openide.loaders/apichanges.xml
+++ b/platform/openide.loaders/apichanges.xml
@@ -129,7 +129,7 @@ is the proper place.
           <description>
               <p>
                   Creation of TargetFolder can be deferred by using
-                  <a href="@org-openide-loaders@/org/openide/loaders/TemplateWizard.html#setTargetFolderLazy-java.util.function.Supplier-">
+                  <a href="@org-openide-loaders@/org/openide/loaders/TemplateWizard.html#setTargetFolderLazy(java.util.function.Supplier)">
                   TemplateWizard.setTargetFolderLazy(Supplier&lt;DataFolder&gt;)
                   </a>.
               </p>
@@ -381,10 +381,10 @@ is the proper place.
           <description>
               <p>
                   New way to subclass <code>MultiDataObject</code>: override
-                  <a href="@TOP@/org/openide/loaders/MultiDataObject.html#associateLookup--">
+                  <a href="@TOP@/org/openide/loaders/MultiDataObject.html#associateLookup()">
                   int associateLookup()
                   </a> to return <code>1</code>. In constructor call
-                  <a href="@TOP@/org/openide/loaders/MultiDataObject.html#registerEditor-java.lang.String-boolean-">
+                  <a href="@TOP@/org/openide/loaders/MultiDataObject.html#registerEditor(java.lang.String,boolean)">
                   registerEditor("your/mimetype", ...)</a> to get default
                   editor support. No need to override any other methods to get
                   well performing <code>MultiDataObject</code>.
@@ -634,7 +634,7 @@ is the proper place.
         <p>
             There is new method to register new DataObject types without
             the need to write own DataLoader. Use
-            <a href="@TOP@/org/openide/loaders/DataLoaderPool.html#factory-java.lang.Class-java.lang.String-java.awt.Image-">
+            <a href="@TOP@/org/openide/loaders/DataLoaderPool.html#factory(java.lang.Class,java.lang.String,java.awt.Image)">
                 DataLoaderPool.factory</a> method.
         </p>
         </description>
@@ -686,7 +686,7 @@ is the proper place.
         <p>
             When <a href="@TOP@/org/openide/loaders/TemplateWizard.html">TemplateWizard</a> invokes 
             <a href="@TOP@/org/openide/loaders/DataObject.html">DataObject</a>.createFromTemplate,
-            it passes as argument all its <a href="@org-openide-dialogs@/org/openide/WizardDescriptor.html#getProperties--">properties</a>
+            it passes as argument all its <a href="@org-openide-dialogs@/org/openide/WizardDescriptor.html#getProperties()">properties</a>
             to it with <code>wizard.</code> as a prefix. That way they are available to
             underlying <a href="@TOP@/architecture-summary.html#loaders-script">scripting and templating
             engines</a>.
@@ -807,14 +807,14 @@ is the proper place.
         <p>
             Since now, each DataNode constructed without using own lookup,
             shall have <code>FileObject</code>(s) associated with its
-            <a href="@TOP@/org/openide/loaders/DataObject.html#files--">DataObject</a> 
+            <a href="@TOP@/org/openide/loaders/DataObject.html#files()">DataObject</a> 
             available in its own lookup.
             Also a 
             <a href="@TOP@/org/openide/loaders/DataObject.html">DataObject</a> 
             has been retrofitted to implement a 
             <a href="@org-openide-util-lookup@/org/openide/util/Lookup.Provider.html">Lookup.Provider</a>
             interface and thus have its
-            <a href="@TOP@/org/openide/loaders/DataObject.html#getLookup--">getLookup</a> 
+            <a href="@TOP@/org/openide/loaders/DataObject.html#getLookup()">getLookup</a> 
             method that can be used instead of the old <code>getCookie</code> one.
         </p>
         </description>

--- a/platform/openide.loaders/arch.xml
+++ b/platform/openide.loaders/arch.xml
@@ -60,7 +60,7 @@
         <p>
         Often many people require ability to create a "clever" template - e.g.
         write piece of simple text and at the time of its 
-        <a href="@TOP@/org/openide/loaders/DataObject.html#createFromTemplate-org.openide.loaders.DataFolder-java.lang.String-java.util.Map-">
+        <a href="@TOP@/org/openide/loaders/DataObject.html#createFromTemplate(org.openide.loaders.DataFolder,java.lang.String,java.util.Map)">
             processing
         </a>
         do some advanced changes to it using either 
@@ -537,7 +537,7 @@ for more information about this.
     <api group="property" category="stable" name="wizard.anything" type="export" >
         When <a href="@TOP@/org/openide/loaders/TemplateWizard.html">TemplateWizard</a> invokes 
         <a href="@TOP@/org/openide/loaders/DataObject.html">DataObject</a>.createFromTemplate,
-        it passes as argument all its <a href="@org-openide-dialogs@/org/openide/WizardDescriptor.html#getProperties--">properties</a>
+        it passes as argument all its <a href="@org-openide-dialogs@/org/openide/WizardDescriptor.html#getProperties()">properties</a>
         to it with prefix <code>wizard.</code>. That way they are available to
         underlaying <a href="@TOP@/architecture-summary.html#loaders-script">scripting and templating
         engines</a>.

--- a/platform/openide.loaders/src/org/openide/loaders/doc-files/api.html
+++ b/platform/openide.loaders/src/org/openide/loaders/doc-files/api.html
@@ -24,7 +24,7 @@
 <link rel="stylesheet" href="../../../../prose.css" type="text/css">
 </head><body>
 
-<p class="overviewlink"><a href="../../../../overview-summary.html">Overview</a></p>
+<p class="overviewlink"><a href="../../../../index.html">Overview</a></p>
 
 <h1>Javadoc</h1>
 
@@ -32,8 +32,7 @@ There are three packages in this API:
 
 <ul>
 
-<li><a href="../package-summary.html"><code>org.openide.loaders</code></a>
-
+<li>{@link org.openide.loaders org.openide.loaders}
 handles the association of files together into groups and assigning
 types to data.
 
@@ -99,22 +98,15 @@ creation of structured, high-level data based on files found on a
 
 <a href="@org-openide-filesystems@/org/openide/filesystems/FileSystem.html">filesystem</a>.
 
-In summary, the system
-
-<a href="../DataLoaderPool.html">loader pool</a>
-
+In summary, the system {@link org.openide.loaders.DataLoaderPool loader pool}
 is responsible for scanning files in a directory on disk, weeding out
 irrelevant files of no interest, and grouping the rest into
 logical chunks, or just determining what type of data each represents.
 It does this scanning by asking each registered
-
-<a href="../DataLoader.html">data loader</a>
-
+{@link org.openide.loaders.DataLoader data loader}
 whether or not the given file(s) should be handled. The first loader
 to recognize a file takes ownership of it, and creates a matching
-
-<a href="../DataObject.html">data object</a>
-
+{@link org.openide.loaders.DataObject data object}
 to represent it to the rest of NetBeans.
 
 <h3 id="intro-loader">What is a loader used for?</h3>

--- a/platform/openide.nodes/apichanges.xml
+++ b/platform/openide.nodes/apichanges.xml
@@ -278,7 +278,7 @@
             Added the class 
             <a href="@TOP@/org/openide/nodes/ChildFactory.html">ChildFactory</a>
             and the method 
-            <a href="@TOP@/org/openide/nodes/Children.html#create-org.openide.nodes.ChildFactory-boolean-">Children.create(ChildFactory factory, boolean asynchronous)</a>
+            <a href="@TOP@/org/openide/nodes/Children.html#create(org.openide.nodes.ChildFactory,boolean)">Children.create(ChildFactory factory, boolean asynchronous)</a>
             to the API.  This simplifies creation of Node children which need
             to be computed on a background thread for performance reasons.
             Anyone wishing to do this can simply extend ChildFactory and
@@ -305,7 +305,7 @@
         <author login="jtulach"/>
         <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
         <description>
-            New method <a href="@TOP@/org/openide/nodes/CookieSet.html#createGeneric-org.openide.nodes.CookieSet.Before-">
+            New method <a href="@TOP@/org/openide/nodes/CookieSet.html#createGeneric(org.openide.nodes.CookieSet.Before)">
             CookieSet.createGeneric</a> has been added. It allows to create 
             an instance of <a href="@TOP@/org/openide/nodes/CookieSet.html">
             CookieSet</a> that can contain any object, not just 
@@ -316,7 +316,7 @@
             Lookup.Provider</a> and thus has a method <code>getLookup</code> to 
             allow queries for of its content.
             Also there is a new method 
-            <a href="@TOP@/org/openide/nodes/CookieSet.html#assign-java.lang.Class-T...-">
+            <a href="@TOP@/org/openide/nodes/CookieSet.html#assign(java.lang.Class,T...)">
             assign(clazz, instances)</a> that allows to add/remove 
             plain old java objects to the <code>CookieSet</code>.
         </description>

--- a/platform/openide.nodes/arch.xml
+++ b/platform/openide.nodes/arch.xml
@@ -401,9 +401,9 @@ the test uses reflection to retrieve the <code>ProjectManager.mutex()</code> ins
 <answer id="format-clipboard">
 Nodes provide default implementation of clipboard operations on nodes. This
 can be extendeded by specific implementation of nodes by overloading:
-<a href="@TOP@/org/openide/nodes/Node.html#clipboardCopy--">Node.clipboardCopy()</a>, 
-<a href="@TOP@/org/openide/nodes/Node.html#clipboardCut--">Node.cliboardCut()</a>, 
-<a href="@TOP@/org/openide/nodes/Node.html#getPasteTypes-java.awt.datatransfer.Transferable-">Node.getPasteTypes()</a>
+<a href="@TOP@/org/openide/nodes/Node.html#clipboardCopy()">Node.clipboardCopy()</a>, 
+<a href="@TOP@/org/openide/nodes/Node.html#clipboardCut()">Node.cliboardCut()</a>, 
+<a href="@TOP@/org/openide/nodes/Node.html#getPasteTypes(java.awt.datatransfer.Transferable)">Node.getPasteTypes()</a>
 Default Transferables for nodes can be obtained using.
 <a href="@TOP@/org/openide/nodes/NodeTransfer.html">NodeTransfer</a> class
 
@@ -424,8 +424,8 @@ provides own DataFlavor transfering indices.
 <answer id="format-dnd">
 Nodes provide default implementation of d'n'd operations on nodes. This
 can be extendeded by specific implementation of nodes by overloading:
-<a href="@TOP@/org/openide/nodes/Node.html#drag--">Node.drag()</a>
-<a href="@TOP@/org/openide/nodes/Node.html#getDropType-java.awt.datatransfer.Transferable-int-int-">Node.getDropTye()</a>
+<a href="@TOP@/org/openide/nodes/Node.html#drag()">Node.drag()</a>
+<a href="@TOP@/org/openide/nodes/Node.html#getDropType(java.awt.datatransfer.Transferable,int,int)">Node.getDropTye()</a>
 
 Default Transferables for nodes can be obtained using.
 <a href="@TOP@/org/openide/nodes/NodeTransfer.html">NodeTransfer</a> class

--- a/platform/openide.nodes/src/org/openide/cookies/InstanceCookie.java
+++ b/platform/openide.nodes/src/org/openide/cookies/InstanceCookie.java
@@ -61,7 +61,7 @@ public interface InstanceCookie/*<T>*/ extends Node.Cookie {
 
     /**
      * Create or obtain an instance. For example 
-     * <a href="@org-openide-loaders@/org/openide/loaders/InstanceDataObject.html#instanceCreate--">InstanceDataObject</a>
+     * <a href="@org-openide-loaders@/org/openide/loaders/InstanceDataObject.html#instanceCreate()">InstanceDataObject</a>
      * (one of the most often used implementations of {@link InstanceCookie}) caches
      * previously returned instances.
      * 

--- a/platform/openide.nodes/src/org/openide/nodes/NodeOperation.java
+++ b/platform/openide.nodes/src/org/openide/nodes/NodeOperation.java
@@ -89,7 +89,7 @@ public abstract class NodeOperation {
      * @param property The property to be edited (its property editor to be used).
      * @param beans The objects the property belongs to. Typically one item
      *   array with the Node of the property. The meaning is the same as in
-     *   <a href="@org-openide-explorer@/org/openide/explorer/propertysheet/PropertyEnv.html#getBeans--">PropertyEnv#getBeans()</a>.
+     *   <a href="@org-openide-explorer@/org/openide/explorer/propertysheet/PropertyEnv.html#getBeans()">PropertyEnv#getBeans()</a>.
      * @since 7.24
      */
     public void showCustomEditorDialog(Node.Property<?> property, Object... beans) {

--- a/platform/openide.nodes/src/org/openide/nodes/doc-files/api.html
+++ b/platform/openide.nodes/src/org/openide/nodes/doc-files/api.html
@@ -22,23 +22,17 @@
 <html>
 <head>
 <title>Nodes API</title>
-<link rel="Stylesheet" href="../../../../prose.css" type="text/css" title="NetBeans Open APIs Style">
+<link rel="Stylesheet" href="../../../../resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </head>
 <body>
 
-<p class="overviewlink"><a href="../../../../overview-summary.html">Overview</a></p>
+<p class="overviewlink"><a href="../../../../index.html">Overview</a></p>
 
 <h1>Javadoc</h1>
 
-The Javadoc for this API resides in
+The Javadoc for this API resides in {@link org.openide.nodes}.
 
-<a href="../package-summary.html"><code>org.openide.nodes</code></a>.
-
-In particular, the class
-
-<a href="../Node.html"><code>Node</code></a>
-
-is the logical starting point.
+In particular, the class {@link org.openide.nodes.Node Node} is the logical starting point.
 
 
 <h1>Contents</h1>
@@ -119,9 +113,7 @@ key components that were missing from the
 
 <ul>
 
-<li>Full hierarchy support. The Java 2
-
-<a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/java/beans/beancontext/package-summary.html">Bean Context API</a>
+<li>Full hierarchy support. The Java 2 {@link java.beans.beancontext Bean Context API }
 
 provides basic support for hierarchies of Beans in a tree structure,
 but not enough to handle the requirements of NetBeans, such as special
@@ -250,21 +242,14 @@ subclassing existing supports.
 
 <h3 id="create-genl">General Aspects</h3>
 
-All nodes must subclass the general
-
-<a href="../Node.html"><code>Node</code></a>
+All nodes must subclass the general {@link org.openide.nodes.Node Node}
 
 abstract class. However, in practice it is most common to actually
-subclass a convenient base class,
-
-<a href="../AbstractNode.html"><code>AbstractNode</code></a>,
-
+subclass a convenient base class, {@link org.openide.nodes.AbstractNode AbstractNode},
 or one of its subclasses. Your node class needs to specify a list of
 child nodes in the constructor (the contents of which may be changed
 later, but not the identity of the <code>Children</code> object
-itself); for the case of a leaf node, just pass in
-
-<a href="../Children.html#LEAF"><code>Children.LEAF</code></a>.
+itself); for the case of a leaf node, just pass in {@link org.openide.nodes.Children#LEAF Children.LEAF }.
 
 <p>As this class is not abstract, there are no strict requirements on
 what needs to be overridden. However, the following general methods
@@ -272,8 +257,7 @@ you are likely to want to override:
 
 <ul>
 
-<li><a href="../AbstractNode.html#canCopy--"><code>AbstractNode.canCopy()</code></a>
-
+<li>{@link org.openide.nodes.AbstractNode#canCopy() AbstractNode.canCopy() }
 and related methods (for cutting, renaming, and destroying) are all
 true by default, so that the node may be moved around somewhat
 arbitrarily (though to paste requires the permission of the new
@@ -926,10 +910,7 @@ arbitrary Node A.
 <a href="@org-openide-actions@/org/openide/actions/CopyAction.html">Copy</a>
 
 is enabled (from a context menu, the Edit menu, etc.), because node A
-indicated it could be copied using
-
-<a href="../Node.html#canCopy--"><code>Node.canCopy()</code></a>
-
+indicated it could be copied using {@link org.openide.nodes.Node#canCopy() Node.canCopy() }
 (turned on in <code>AbstractNode</code>).
 
 Note that

--- a/platform/openide.nodes/src/org/openide/util/actions/CookieAction.java
+++ b/platform/openide.nodes/src/org/openide/util/actions/CookieAction.java
@@ -31,7 +31,7 @@ import java.util.*;
 
 
 /** Not the preferred solution anymore, rather use
-* <a href="@org-openide-awt@/org/openide/awt/Actions.html#context-java.lang.Class-boolean-boolean-org.openide.util.ContextAwareAction-java.lang.String-java.lang.String-java.lang.String-boolean-">Actions.context</a>.
+* <a href="@org-openide-awt@/org/openide/awt/Actions.html#context(java.lang.Class,boolean,boolean,org.openide.util.ContextAwareAction,java.lang.String,java.lang.String,java.lang.String,boolean)">Actions.context</a>.
 * To replace your action
 * <a href="@org-openide-modules@/org/openide/modules/doc-files/api.html#how-layer">
 * layer definition</a> use more delarative way:

--- a/platform/openide.text/apichanges.xml
+++ b/platform/openide.text/apichanges.xml
@@ -197,7 +197,7 @@
             <p>
                 Subclasses of <code>CloneableEditor</code> can manually request own 
                 initialization by calling its
-                <a href="@TOP@/org/openide/text/CloneableEditor.html#initializeBySupport--">initializeBySupport</a>
+                <a href="@TOP@/org/openide/text/CloneableEditor.html#initializeBySupport()">initializeBySupport</a>
                 method.
             </p>
         </description>

--- a/platform/openide.text/arch.xml
+++ b/platform/openide.text/arch.xml
@@ -462,7 +462,7 @@ in methods
         </question>
 -->
 <answer id="exec-reflection">
-Yes, it calls protected method <a href="@org-openide-loaders@/org/openide/loaders/MultiDataObject.html#getCookieSet--">MultiDataObject.getCookieSet()</a>.
+Yes, it calls protected method <a href="@org-openide-loaders@/org/openide/loaders/MultiDataObject.html#getCookieSet()">MultiDataObject.getCookieSet()</a>.
 The class which calls this is deprecated, but it is still in use by clients.
 <p/>
 Another reflection is used in QuietEditorPane, where DelegatingTransferHandler delegates
@@ -783,7 +783,7 @@ No.
 The Editor module operate with plain Swing <a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/javax/swing/text/Document.html">Document</a> in 
 its APIs and checks whether the document does not implement some of the Netbeans extensions defined in
 <a href="@org-openide-text@/org/openide/text/NbDocument.html">NbDocument</a>.
-It also tries to retype <a href="@org-openide-windows@/org/openide/windows/CloneableTopComponent.Ref.html#getComponents--">CloneableTopComponent.Ref.getComponents()</a>
+It also tries to retype <a href="@org-openide-windows@/org/openide/windows/CloneableTopComponent.Ref.html#getComponents()">CloneableTopComponent.Ref.getComponents()</a>
 to its <a href="@org-openide-text@/org/openide/text/CloneableEditor.html">CloneableEditor</a>. If some document does not implement 
 <a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/javax/swing/text/StyledDocument.html">StyledDocument</a>,
 it is wrapped into <a href="@org-openide-text@/org/openide/text/FilterDocument.html">FilterDocument</a> which implements limited StyledDocument functionality.

--- a/platform/openide.text/src/org/openide/text/doc-files/api.html
+++ b/platform/openide.text/src/org/openide/text/doc-files/api.html
@@ -21,7 +21,7 @@
 
 <html><head>
 <title>Editor API</title>
-<link rel="stylesheet" href="../../../../prose.css" type="text/css">
+<link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css">
 </head><body>
 
 <p class="overviewlink"><a href="../../../../overview-summary.html">Overview</a></p>

--- a/platform/openide.util.lookup/apichanges.xml
+++ b/platform/openide.util.lookup/apichanges.xml
@@ -37,14 +37,14 @@
             <p>
                 One of the most common usages of  <a href="@TOP@/org/openide/util/lookup/ProxyLookup.html">ProxyLookup</a>
                 is to dynamically change the set of lookups being delegated to. However the 
-                <a href="@TOP@/org/openide/util/lookup/ProxyLookup.html#setLookups-org.openide.util.Lookup...-">setLookups(...)</a>
+                <a href="@TOP@/org/openide/util/lookup/ProxyLookup.html#setLookups(org.openide.util.Lookup...)">setLookups(...)</a>
                 method is <code>protected</code>. To avoid the need to subclass 
                 <a href="@TOP@/org/openide/util/lookup/ProxyLookup.html">ProxyLookup</a>
                 this change introduces
                 <a href="@TOP@/org/openide/util/lookup/ProxyLookup.Controller.html">ProxyLookup.Controller</a>
                 that gives the creator of <a href="@TOP@/org/openide/util/lookup/ProxyLookup.html">ProxyLookup</a>
                 a way to call 
-                <a href="@TOP@/org/openide/util/lookup/ProxyLookup.Controller.html#setLookups-org.openide.util.Lookup...-">setLookups(...)</a>
+                <a href="@TOP@/org/openide/util/lookup/ProxyLookup.Controller.html#setLookups(org.openide.util.Lookup...)">setLookups(...)</a>
                 without exposing the method to others having just a reference to 
                 the <a href="@TOP@/org/openide/util/lookup/ProxyLookup.html">ProxyLookup</a>.
             </p>
@@ -70,7 +70,7 @@
                 This change changes the default behaviour if NO 
                 <a href="@JDK@@JDKMODULE_JAVA_COMPILER@/javax/annotation/processing/SupportedSourceVersion.html"><code>@SupportedSourceVersion</code></a>
                 annotation is present on subclass. From 8.40, the Processor will report 
-                <a href="@JDK@@JDKMODULE_JAVA_COMPILER@/javax/lang/model/SourceVersion.html#latest--"><code>@SourceVersion.latest()</code></a>.
+                <a href="@JDK@@JDKMODULE_JAVA_COMPILER@/javax/lang/model/SourceVersion.html#latest()"><code>@SourceVersion.latest()</code></a>.
             </p>
         </description>
         <class name="LayerGeneratingProcessor" package="org.openide.filesystems.annotations" link="no" /> <!-- external -->
@@ -87,7 +87,7 @@
             binary="compatible" deletion="no" deprecation="no"
             modification="no" semantic="incompatible" source="compatible"
         >
-            The clients of <a href="@TOP@/org/openide/util/Lookup.html#getDefault--">
+            The clients of <a href="@TOP@/org/openide/util/Lookup.html#getDefault()">
             Lookup.getDefault()</a> are mostly unaffected by this change,
             just they need to be ready for the fact that the return 
             value of the method may no longer be fixed one, but can mutate
@@ -95,10 +95,10 @@
         </compatibility>
         <description>
             <p>
-                One can use <a href="@TOP@/org/openide/util/lookup/Lookups.html#executeWith-org.openide.util.Lookup-java.lang.Runnable-">
+                One can use <a href="@TOP@/org/openide/util/lookup/Lookups.html#executeWith(org.openide.util.Lookup,java.lang.Runnable)">
                 Lookups.execute(yourLookup, yourRunnable)
                 </a> to temporarily influence return value from
-                <a href="@TOP@/org/openide/util/Lookup.html#getDefault--">
+                <a href="@TOP@/org/openide/util/Lookup.html#getDefault()">
                 Lookup.getDefault()</a>. 
             </p>
         </description>
@@ -122,7 +122,7 @@
                 <a href="@TOP@org/openide/util/lookup/NamedServiceDefinition.html">NamedServiceDefinition</a> 
                 for those who define their own annotations that register
                 something into 
-                <a href="@TOP@org/openide/util/lookup/Lookups.html#forPath-java.lang.String-">
+                <a href="@TOP@org/openide/util/lookup/Lookups.html#forPath(java.lang.String)">
                 Lookups.forPath</a> registration area.
             </p>
         </description>
@@ -162,7 +162,7 @@
                 waiting for or creating all of them:
             </p>
            <pre>
-for (<a href="@JDK@@JDKMODULE_JAVA_BASE@/java/net/URLStreamHandlerFactory.html">URLStreamHandlerFactory</a> first : <a href="@TOP@/org/openide/util/Lookup.html#getDefault--">Lookup.getDefault()</a>.lookupAll(<a href="@JDK@@JDKMODULE_JAVA_BASE@/java/net/URLStreamHandlerFactory.html">URLStreamHandlerFactory</a>.class)) {
+for (<a href="@JDK@@JDKMODULE_JAVA_BASE@/java/net/URLStreamHandlerFactory.html">URLStreamHandlerFactory</a> first : <a href="@TOP@/org/openide/util/Lookup.html#getDefault()">Lookup.getDefault()</a>.lookupAll(<a href="@JDK@@JDKMODULE_JAVA_BASE@/java/net/URLStreamHandlerFactory.html">URLStreamHandlerFactory</a>.class)) {
     return first;
 }
            </pre>
@@ -288,7 +288,7 @@ for (<a href="@JDK@@JDKMODULE_JAVA_BASE@/java/net/URLStreamHandlerFactory.html">
         <compatibility addition="yes"/>
         <description>
             <p>
-                New method <a href="@TOP@/org/openide/util/lookup/Lookups.html#forPath-java.lang.String-">Lookups.forPath(String)</a>
+                New method <a href="@TOP@/org/openide/util/lookup/Lookups.html#forPath(java.lang.String)">Lookups.forPath(String)</a>
                 has been added to replace now deprecated <a href="@org-openide-loaders@/org/openide/loaders/FolderLookup.html">FolderLookup</a>
                 and allow modules who wants to read settings from layers
                 to do so with a simpler code, without dependency on DataSystems API.

--- a/platform/openide.util.lookup/arch.xml
+++ b/platform/openide.util.lookup/arch.xml
@@ -106,7 +106,7 @@ In general there are three ways to achieve this.
     as described at 
     <a href="@org-openide-util@/org/openide/util/doc-files/api.html#ido-methodvalue">services
     </a> documentation and in your factory method either return the instance 
-    your want or <code>null</code> depending on result of <a href="@org-openide-util@/org/openide/util/BaseUtilities.html#isWindows--">
+    your want or <code>null</code> depending on result of <a href="@org-openide-util@/org/openide/util/BaseUtilities.html#isWindows()">
     Utilities.isWindows()</a> call.</p>
     </li>
                 <li>
@@ -161,7 +161,7 @@ In general there are three ways to achieve this.
 <span class="java-keywords">import</span> <span class="java-identifier">org</span><span class="java-operators">.</span><span class="java-identifier">openide</span><span class="java-operators">.</span><span class="java-identifier">util</span><span class="java-operators">.</span><span class="java-identifier">Lookup</span><span class="java-operators">;</span>
 
 <a href="@TOP@org/openide/util/Lookup.Result.html"><span class="java-identifier">Lookup</span><span class="java-operators">.</span><span class="java-identifier">Result</span></a> <span class="java-identifier">result</span> <span class="java-operators">=</span> <a href="@TOP@org/openide/util/Lookup.html"><span class="java-identifier">Lookup</span></a><span class="java-operators">.</span><span class="java-layer-method">getDefault</span> <span class="java-operators">(</span><span class="java-operators">)</span><span class="java-operators">.</span><span class="java-layer-method">lookup</span> <span class="java-operators">(</span><span class="java-keywords">new</span> <a href="@TOP@org/openide/util/Lookup.Template.html"><span class="java-identifier">Lookup</span><span class="java-operators">.</span><span class="java-layer-method">Template</span></a> <span class="java-operators">(</span><span class="java-identifier">TipsOfTheDayProvider</span><span class="java-operators">.</span><span class="java-keywords">class</span><span class="java-operators">)</span><span class="java-operators">)</span><span class="java-operators">;</span>
-<span class="java-identifier">Collection</span> <span class="java-identifier">c</span> <span class="java-operators">=</span> <span class="java-identifier">result</span><span class="java-operators">.</span><a href="@TOP@org/openide/util/Lookup.Result.html#allInstances--"><span class="java-layer-method">allInstances</span></a> <span class="java-operators">(</span><span class="java-operators">)</span><span class="java-operators">;</span>
+<span class="java-identifier">Collection</span> <span class="java-identifier">c</span> <span class="java-operators">=</span> <span class="java-identifier">result</span><span class="java-operators">.</span><a href="@TOP@org/openide/util/Lookup.Result.html#allInstances()"><span class="java-layer-method">allInstances</span></a> <span class="java-operators">(</span><span class="java-operators">)</span><span class="java-operators">;</span>
 <span class="java-identifier">Collections</span><span class="java-operators">.</span><span class="java-layer-method">shuffle</span> <span class="java-operators">(</span><span class="java-identifier">c</span><span class="java-operators">)</span><span class="java-operators">;</span>
 <span class="java-identifier">TipsOfTheDayProvider</span> <span class="java-identifier">selected</span> <span class="java-operators">=</span> <span class="java-operators">(</span><span class="java-identifier">TipsOfTheDayProvider</span><span class="java-operators">)</span><span class="java-identifier">c</span><span class="java-operators">.</span><span class="java-layer-method">iterator</span> <span class="java-operators">(</span><span class="java-operators">)</span><span class="java-operators">.</span><span class="java-layer-method">next</span> <span class="java-operators">(</span><span class="java-operators">)</span><span class="java-operators">;</span>
 </pre><p>    
@@ -320,19 +320,19 @@ org.my.netbeans.extramodule.ExtraTip
     <li>
     <api type="export" group="systemproperty" name="org.openide.util.Lookup" category="devel">
         checked by the initialization of the 
-        <a href="@TOP@/org/openide/util/Lookup.html#getDefault--">Lookup.getDefault()</a>
+        <a href="@TOP@/org/openide/util/Lookup.html#getDefault()">Lookup.getDefault()</a>
         and can
         contain name of a class that extends <code>org.openide.util.Lookup</code> and
         has public constructor, that should be instantiated and returned from 
-        <a href="@TOP@/org/openide/util/Lookup.html#getDefault--">Lookup.getDefault()</a>
+        <a href="@TOP@/org/openide/util/Lookup.html#getDefault()">Lookup.getDefault()</a>
         the class will be loaded by 
-        <a href="@JDK@@JDKMODULE_JAVA_BASE@/java/lang/Thread.html#getContextClassLoader--">
+        <a href="@JDK@@JDKMODULE_JAVA_BASE@/java/lang/Thread.html#getContextClassLoader()">
         Thread.currentThread().getContextClassLoader()</a>
         classloader the first time <code>Lookup.getDefault</code> is invoked.
         <p>
         The property can also contain value <code>"-"</code> which means to completely
         disable the lookup instantiation and return <a href="@TOP@/org/openide/util/Lookup.html#EMPTY">Lookup.EMPTY</a>
-        from <a href="@TOP@/org/openide/util/Lookup.html#getDefault--">Lookup.getDefault()</a>.
+        from <a href="@TOP@/org/openide/util/Lookup.html#getDefault()">Lookup.getDefault()</a>.
         </p>
         If the property is unspecified, the default <code>MetaInfServicesLookup</code>
         is constructed for <code>Thread.currentThread().getContextclassLoader()</code>
@@ -341,7 +341,7 @@ org.my.netbeans.extramodule.ExtraTip
         <a href="@TOP@/org/openide/util/Lookup.Provider.html">Lookup.Provider</a>
         is found
         in there, its lookup is returned as result. Otherwise the <code>MetaInfServicesLookup</code>
-        is the result of <a href="@TOP@/org/openide/util/Lookup.html#getDefault--">Lookup.getDefault()</a>.
+        is the result of <a href="@TOP@/org/openide/util/Lookup.html#getDefault()">Lookup.getDefault()</a>.
     </api>
     </li>
 
@@ -351,11 +351,11 @@ org.my.netbeans.extramodule.ExtraTip
         some system file system folder. This can be done with
         <code>org.openide.util.Lookup.paths=Folder1:Folder2:Folder3</code>.
         If this property is set prior to first call to
-        <a href="@TOP@/org/openide/util/Lookup.html#getDefault--">Lookup.getDefault()</a>,
+        <a href="@TOP@/org/openide/util/Lookup.html#getDefault()">Lookup.getDefault()</a>,
         it is split into pieces (separator is <code>':'</code>) and individual
         parts are then used to construct <code>Lookups.forPath("Folder1")</code>,
         etc. All these lookups then become part of the
-        <a href="@TOP@/org/openide/util/Lookup.html#getDefault--">Lookup.getDefault()</a>
+        <a href="@TOP@/org/openide/util/Lookup.html#getDefault()">Lookup.getDefault()</a>
         one. This property works since version 7.24
     </api>
     </li>
@@ -367,7 +367,7 @@ org.my.netbeans.extramodule.ExtraTip
 
  <answer id="exec-reflection">
   <p>
-   <api category="devel" group="java" name="Lookups.metaInfServices" type="export" url="@TOP@/org/openide/util/lookup/Lookups.html#metaInfServices-java.lang.ClassLoader-">
+   <api category="devel" group="java" name="Lookups.metaInfServices" type="export" url="@TOP@/org/openide/util/lookup/Lookups.html#metaInfServices(java.lang.ClassLoader)">
    calls constructor of registered classes using reflection
    </api>. 
    <api category="friend" group="java" name="Lookup.resetDefaultLookup" type="export">
@@ -383,7 +383,7 @@ org.my.netbeans.extramodule.ExtraTip
   <p>
    Everything is synchronous, except pluggable use of <code>java.util.concurrent.Executor</code>
    that allows to make calls asynchronous. The default implementation only delivers
-   changes from <a href="@TOP@/org/openide/util/lookup/Lookups.html#metaInfServices-java.lang.ClassLoader-">metaInfServices</a>
+   changes from <a href="@TOP@/org/openide/util/lookup/Lookups.html#metaInfServices(java.lang.ClassLoader)">metaInfServices</a>
    lookup in asynchronous thread.
   </p>
  </answer>
@@ -416,7 +416,7 @@ org.my.netbeans.extramodule.ExtraTip
     <ul>
     <li><api name="LookupInitializationLookup" category="devel" group="lookup" type="export" url="#systemproperty-org.openide.util.Lookup">
     during 
-    initialization of the <a href="@TOP@/org/openide/util/Lookup.html#getDefault--">Lookup.getDefault()</a>
+    initialization of the <a href="@TOP@/org/openide/util/Lookup.html#getDefault()">Lookup.getDefault()</a>
     the <a href="@TOP@/org/openide/util/Lookup.Provider.html">Lookup.Provider</a>
     is being searched</api>.
     </li>
@@ -429,7 +429,7 @@ org.my.netbeans.extramodule.ExtraTip
     <li><api name="LookupClassLoader" category="devel" group="lookup" type="export">
     Nearly all resource looking functions and reflective code
     uses <a href="@JDK@@JDKMODULE_JAVA_BASE@/java/lang/ClassLoader.html">ClassLoader</a>
-    obtained from <a href="@TOP@/org/openide/util/Lookup.html#getDefault--">Lookup.getDefault()</a>
+    obtained from <a href="@TOP@/org/openide/util/Lookup.html#getDefault()">Lookup.getDefault()</a>
     for loading system wide resources.
     </api>.</li>
     

--- a/platform/openide.util.lookup/src/org/openide/util/lookup/NamedServiceDefinition.java
+++ b/platform/openide.util.lookup/src/org/openide/util/lookup/NamedServiceDefinition.java
@@ -33,8 +33,8 @@ import java.lang.annotation.Target;
  * The above instructs the annotation processor that handles {@link NamedServiceDefinition}s
  * to verify the annotated type is subclass of <code>URLStreamHandler</code> and
  * if so, register it into <code>URLStreamHandler/@protocol</code> where the
- * value of <code>@protocol()</code> is replaced by the value of annotation's
- * <a href="@org-openide-util@/org/openide/util/URLStreamHandlerRegistration.html#protocol--">
+ * value of <code>@protocol()</code> is replaced by the value of annotation's 
+ * <a href="@org-openide-util@/org/openide/util/URLStreamHandlerRegistration.html#protocol()">
  * protocol attribute</a>. The registration can later be found by using
  * {@link Lookups#forPath(java.lang.String) Lookups.forPath("URLStreamHandler/ftp")}
  * (in case the protocol was ftp).

--- a/platform/openide.util.lookup/src/org/openide/util/lookup/doc-files/index.html
+++ b/platform/openide.util.lookup/src/org/openide/util/lookup/doc-files/index.html
@@ -22,7 +22,7 @@
 <HTML>
 <HEAD>
 <TITLE>Lookup Library</TITLE>
-<link rel="Stylesheet" href="@TOP@/prose.css" type="text/css" title="NetBeans Open APIs Style">
+<link rel="Stylesheet" href="@TOP@/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </HEAD>
 <BODY>
 <H1>Lookup library HomePage</H1>
@@ -104,7 +104,7 @@ the search algorithm with an easy interface. Just write:
 <pre>
     <span class="keyword">import</span> <span class="type">java.awt.Toolkit</span>;
     <span class="keyword">import</span> <span class="type">org.openide.util.Lookup;</span>;
-    <span class="type">Toolkit</span> <span class="variable-name">t</span> = (<span class="type">Toolkit</span>)Lookup.getDefault().<a href="@TOP@org/openide/util/Lookup.html#lookup-java.lang.Class-">lookup</a>(Toolkit.<span class="keyword">class</span>);
+    <span class="type">Toolkit</span> <span class="variable-name">t</span> = (<span class="type">Toolkit</span>)Lookup.getDefault().<a href="@TOP@org/openide/util/Lookup.html#lookup(java.lang.Class)">lookup</a>(Toolkit.<span class="keyword">class</span>);
 </PRE>
 and if the JAR with <code>MyToolkit</CODE> is in the class path, the simple call 
 above will do the rest.
@@ -150,7 +150,7 @@ whether the object supports a given interface like this:
 <span class="type">MorphingObject</span> <span class="variable-name">morph</span> = ...
 <span class="type">AnInterface</span> <span class="variable-name">impl</span> = (<span
 class="type">AnInterface</span>)morph.getLookup().<a
-href="@TOP@org/openide/util/Lookup.html#lookup-java.lang.Class-">lookup</a>(AnInterface.<span class="keyword">class</span>);
+href="@TOP@org/openide/util/Lookup.html#lookup(java.lang.Class)">lookup</a>(AnInterface.<span class="keyword">class</span>);
 <span class="keyword">if</span> (impl == <span class="constant">null</span>) {
     <span class="keyword">return;</span><span class="comment">/* AnInterface not supported now! */</span>
 }

--- a/platform/openide.util.lookup/src/org/openide/util/lookup/doc-files/lookup-api.html
+++ b/platform/openide.util.lookup/src/org/openide/util/lookup/doc-files/lookup-api.html
@@ -22,7 +22,7 @@
 <HTML>
 <HEAD>
 <TITLE>Lookup Library API</TITLE>
-<link rel="Stylesheet" href="@TOP@/prose.css" type="text/css" title="NetBeans Open APIs Style">
+<link rel="Stylesheet" href="@TOP@/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </HEAD>
 <BODY>
 <H1>Lookup library API</H1>
@@ -38,13 +38,9 @@ The first question you might ask is this: how can I get hold of a
 lookup instance? There are basically two ways how you can get it.
 
 <H3> Global lookup </H3>
-As you can see in the
+As you can see in the {@link org.openide.util.Lookup Lookup } Javadoc there is a static method
 
-<a href="@TOP@org/openide/util/Lookup.html">Lookup</a>
-
-Javadoc there is a static method
-
-<pre><a href="@TOP@org/openide/util/Lookup.html#getDefault--">public static Lookup getDefault()</a></pre>
+{@link org.openide.util.Lookup#getDefault() public static Lookup getDefault() }
 
 The object returned from this method is
 a global lookup that can serve as a central place for registering services.

--- a/platform/openide.util.lookup/src/org/openide/util/lookup/doc-files/lookup-spi.html
+++ b/platform/openide.util.lookup/src/org/openide/util/lookup/doc-files/lookup-spi.html
@@ -22,7 +22,7 @@
 <HTML>
 <HEAD>
 <TITLE>Lookup Library SPI</TITLE>
-<link rel="Stylesheet" href="@TOP@/prose.css" type="text/css" title="NetBeans Open APIs Style">
+<link rel="Stylesheet" href="@TOP@/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </HEAD>
 <BODY>
 <H1>Lookup library SPI</H1>
@@ -39,14 +39,10 @@ the SPI has its own package <em>org.openide.util.lookup.*</EM>.
 Let us start with the simplest case. You have decided that your newly created
 object will provide an API in the form of a getLookup() method. You have to
 return a functional lookup from this call. You can use static methods in class
-<a href="@TOP@org/openide/util/lookup/Lookups.html">
-<code>Lookups</code></A> to create a lookup for you. If you want only one
-object to be returned, just call 
-<a href="@TOP@org/openide/util/lookup/Lookups.html#singleton-java.lang.Object-">
-<code>Lookups.singleton(x)</code></A> where x is the object to be 
-returned by the lookup. Or if you want to supply more objects, use a call to the method
-<a href="@TOP@org/openide/util/lookup/Lookups.html#fixed-java.lang.Object...-">
-<code>fixed(Object []x)</CODE></A>.
+{@link org.openide.util.lookup.Lookups Lookups} to create a lookup for you. If you want only one
+object to be returned, just call {@link org.openide.util.lookup.Lookups#singleton(java.lang.Object) Lookups.singleton(x)} 
+where x is the object to be returned by the lookup. Or if you want to supply more objects, use a call to the method
+{@link org.openide.util.lookup.Lookups#fixed(java.lang.Object...) fixed(Object []x) }.
 <EM> Note: </EM> The lookups returned from methods <code>singleton(...)</code> and
 <code>fixed(...)</code> do <EM>
 not </EM> support dynamic changes and attaching listeners. Their content is
@@ -76,27 +72,22 @@ You simply create a new lookup like this:
 
 <p>The most powerful way to provide a lookup is to directly define
 what instances and items it should provide, by subclassing. For this,
-
-<a href="@TOP@org/openide/util/lookup/AbstractLookup.html"><code>AbstractLookup</code></a>
-
+{@link org.openide.util.lookup.AbstractLookup AbstractLookup }
 is recommended as it is easiest to use.
 
 <p>The simplest way to use <code>AbstractLookup</code> is to use its
 public constructor (in which case you need not subclass it). Here you
 provide an
-
-<a href="@TOP@org/openide/util/lookup/AbstractLookup.Content.html"><code>AbstractLookup.Content</code></a>
-
+{@link org.openide.util.lookup.AbstractLookup.Content AbstractLookup.Content }
 object which you have created and hold on to privately, and which
 keeps track of instances and permits them to be registered and
 deregistered. Often
 
-<a href="@TOP@org/openide/util/lookup/InstanceContent.html"><code>InstanceContent</code></a>
+{@link org.openide.util.lookup.InstanceContent InstanceContent }
 
 is used as the content implementation. To add something to the lookup,
 simply use
-
-<a href="@TOP@org/openide/util/lookup/InstanceContent.html#add-java.lang.Object-"><code>add(Object)</code></a>
+{@link org.openide.util.lookup.InstanceContent#add(java.lang.Object) add(Object) }
 
 (and <code>remove(Object)</code> for the reverse). These may be called
 at any time and will update the set of registered instances (firing
@@ -112,8 +103,7 @@ result changes as needed).
 <p>In case it is expensive to actually compute the object in the
 lookup, but there is some cheap "key" which can easily generate it,
 you may instead register the key by passing in an
-
-<a href="@TOP@org/openide/util/lookup/InstanceContent.Convertor.html"><code>InstanceContent.Convertor</code></a>.
+{@link org.openide.util.lookup.InstanceContent.Convertor InstanceContent.Convertor }.
 
 This convertor translates the key to the real instance that the lookup
 client sees, if and when needed. For example, if you have a long list

--- a/platform/openide.util.ui/apichanges.xml
+++ b/platform/openide.util.ui/apichanges.xml
@@ -81,9 +81,9 @@
          <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
          <description>
              <p>
-                 Added a variant <a href="@TOP@/org/openide/util/Utilities.html#actionsForPath-java.lang.String-org.openide.util.Lookup-">actionsToPath</a> that instantiates context-bound actions if the registered action(s) implements 
+                 Added a variant <a href="@TOP@/org/openide/util/Utilities.html#actionsForPath(java.lang.String,org.openide.util.Lookup)">actionsToPath</a> that instantiates context-bound actions if the registered action(s) implements 
                  <a href="@TOP@/org/openide/util/ContextAwareAction.html">ContextAwareAction</a>.
-                 Improves consistency with <a href="@TOP@/org/openide/util/Utilities.html#actionsToPopup-javax.swing.Action:A-org.openide.util.Lookup-">actionsToPopup</a> that supports contextual actions. 
+                 Improves consistency with <a href="@TOP@/org/openide/util/Utilities.html#actionsToPopup(javax.swing.Action%5B%5D,org.openide.util.Lookup)">actionsToPopup</a> that supports contextual actions. 
              </p>
          </description>
          <class package="org.openide.util" name="Utilities"/>
@@ -114,7 +114,7 @@
       <description>
           The property <code>url</code> is documented in Javadoc <b>since 8.12</b> but the key string was not
           added to the API. <a href="@TOP@/org/openide/util/ImageUtilities.html#PROPERTY_URL">It is now</a>, along with a 
-          <a href="@TOP@/org/openide/util/ImageUtilities.html#findImageBaseURL-java.awt.Image-">convenience method</a>, which should be used in preference.
+          <a href="@TOP@/org/openide/util/ImageUtilities.html#findImageBaseURL(java.awt.Image)">convenience method</a>, which should be used in preference.
       </description>
       <class package="org.openide.util" name="ImageUtilities"/>
     </change>
@@ -222,7 +222,7 @@
         <description>
             <p>
                 The following classes were spinned of into 
-                <a href="@org-openide-util@/overview-summary.html">org.openide.util.base module</a>:
+                <a href="@org-openide-util@/index.html">org.openide.util.base module</a>:
             </p>
             <ul>
                 <li><a href="@org-openide-util@/org/openide/util/Cancellable.html">Cancellable</a></li>
@@ -483,7 +483,7 @@
             <p>
                 Some plugins needs a way to suppress <a href="@JDK@@JDKMODULE_JAVA_BASE@/java/net/Authenticator.html"><code>java.net.Authenticator</code></a> without asking
                 user a question about the credentials. 
-                Invoke <a href="@TOP@/org/openide/util/NetworkSettings.html#suppressAuthenticationDialog-java.util.concurrent.Callable-">
+                Invoke <a href="@TOP@/org/openide/util/NetworkSettings.html#suppressAuthenticationDialog(java.util.concurrent.Callable)">
                 suppressAuthenticationDialog</a> with a block of code where authentication dialog will be suppressed.                
                 See <a href="https://netbeans.apache.org/wiki/Authenticator">https://netbeans.apache.org/wiki/Authenticator</a>
             </p>
@@ -515,7 +515,7 @@
         <compatibility addition="yes"/>
         <description>
             <p>
-            Images loaded by <a href="@TOP@/org/openide/util/ImageUtilities.html#loadImage-java.lang.String-boolean-">
+            Images loaded by <a href="@TOP@/org/openide/util/ImageUtilities.html#loadImage(java.lang.String,boolean)">
             ImageUtilities.loadImage</a> now
             respond to <code>getProperty("url", null)</code> calls.
             </p>
@@ -1180,7 +1180,7 @@
       <description>
           When one calls <a href="@org-openide-util@/org/openide/util/RequestProcessor.Task.html">RequestProcessor.Task</a>.cancel(), 
           the running thread gets interrupted if the 
-          <a href="@org-openide-util@/org/openide/util/RequestProcessor.html#RequestProcessor-java.lang.String-int-boolean-">
+          <a href="@org-openide-util@/org/openide/util/RequestProcessor.html#RequestProcessor(java.lang.String,int,boolean)">
           RequestProcessor(string, int, boolean) 
           </a> 
           constructor is used.

--- a/platform/openide.util.ui/arch.xml
+++ b/platform/openide.util.ui/arch.xml
@@ -120,7 +120,7 @@
    indirectly communicates with <a href="@org-openide-awt@/overview-summary.html">UI Utilities</a>
    module using <api name="DefaultAWTBridge" category="private" group="java" type="export" 
    url="https://github.com/apache/netbeans/tree/master/platform/openide.awt/src/org/netbeans/modules/openide/awt/DefaultAWTBridge.java">
-   a class that is looked up in <a href="@org-openide-util-lookup@/org/openide/util/Lookup.html#getDefault--">Lookup.getDefault()</a>
+   a class that is looked up in <a href="@org-openide-util-lookup@/org/openide/util/Lookup.html#getDefault()">Lookup.getDefault()</a>
    and if registered can provide better UI elements for <a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/javax/swing/Action.html">Action</a>s.
    </api>
   </p>
@@ -300,7 +300,7 @@
  <answer id="exec-property">
      <ul>
          <li>
-             <api type="export" group="property" name="url" category="private">Images loaded by <a href="@TOP@/org/openide/util/ImageUtilities.html#loadImage-java.lang.String-">ImageUtilities.loadImage</a>
+             <api type="export" group="property" name="url" category="private">Images loaded by <a href="@TOP@/org/openide/util/ImageUtilities.html#loadImage(java.lang.String)">ImageUtilities.loadImage</a>
              defines <code>"url"</code> image property for the loaded image.
              </api>
          </li>
@@ -418,10 +418,10 @@
     </api>.</li>
 
     <li><api name="LookupContextGlobalProvider" category="stable" group="lookup" type="export">
-    <a href="@TOP@/org/openide/util/Utilities.html#actionsGlobalContext--">actionsGlobalContext</a>
+    <a href="@TOP@/org/openide/util/Utilities.html#actionsGlobalContext()">actionsGlobalContext</a>
     searches for <a href="@TOP@/org/openide/util/ContextGlobalProvider.html">ContextGlobalProvider</a> in 
-    <a href="@org-openide-util-lookup@/org/openide/util/Lookup.html#getDefault--">Lookup.getDefault()</a>.
-    The provider is usually provided by <a href="@org-openide-windows@/overview-summary.html">window 
+    <a href="@org-openide-util-lookup@/org/openide/util/Lookup.html#getDefault()">Lookup.getDefault()</a>.
+    The provider is usually provided by <a href="@org-openide-windows@/index.html">window 
     system implementation</a>.
     </api>.</li>
 
@@ -577,7 +577,7 @@
 -->
  <answer id="perf-progress">
   <p>
-   Actions declared as <a href="@TOP@/org/openide/util/actions/CallableSystemAction.html#asynchronous--">CallableSystemAction.asynchronous()</a> 
+   Actions declared as <a href="@TOP@/org/openide/util/actions/CallableSystemAction.html#asynchronous()">CallableSystemAction.asynchronous()</a> 
    are executed outside of AWT thread on a dedicated request processor one.
   </p>
  </answer>

--- a/platform/openide.util.ui/src/org/openide/util/ContextAwareAction.java
+++ b/platform/openide.util.ui/src/org/openide/util/ContextAwareAction.java
@@ -32,7 +32,7 @@ import javax.swing.Action;
  * presenter for the generic action, the menu will contain a presenter for the
  * context-aware instance. The context will then be taken from the GUI
  * environment where the context menu was shown; for example it may be a
- * <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup--">TopComponent's context</a>,
+ * <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup()">TopComponent's context</a>,
  * often taken from an activated node selection. The context action might be
  * enabled only if a certain "cookie" is present in that selection. When invoked,
  * the action need not search for an object to act on, since it can use the context.

--- a/platform/openide.util.ui/src/org/openide/util/ContextGlobalProvider.java
+++ b/platform/openide.util.ui/src/org/openide/util/ContextGlobalProvider.java
@@ -28,7 +28,7 @@ package org.openide.util;
  * in current state it is reasonable to put there all currently active
  * <a href="@org-openide-nodes@/org/openide/nodes/Node.html">Node</a>, their cookies and {@link javax.swing.ActionMap}.
  * By default this interface is implemented by window system to delegate
- * to currently activated <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup--">TopComponent's  lookup</a>.
+ * to currently activated <a href="@org-openide-windows@/org/openide/windows/TopComponent.html#getLookup()">TopComponent's  lookup</a>.
  * <p>
  * There is an external FAQ entry describing how to
  * <a href="https://netbeans.apache.org/wiki/DevFaqAddGlobalContext">add content to

--- a/platform/openide.util.ui/src/org/openide/util/Utilities.java
+++ b/platform/openide.util.ui/src/org/openide/util/Utilities.java
@@ -1420,7 +1420,7 @@ public final class Utilities {
      * frequently does the wrong thing in a multi-screen setup.
      * <p>
      * The use of the NetBeans API
-     * <a href="@org-openide-dialogs@/org/openide/DialogDisplayer.html#getDefault--">DialogDisplayer.getDefault*</a>
+     * <a href="@org-openide-dialogs@/org/openide/DialogDisplayer.html#getDefault()">DialogDisplayer.getDefault*</a>
      * is encouraged to display a dialog.
      *
      * @return A suitable parent component for swing dialogs

--- a/platform/openide.util.ui/src/org/openide/util/actions/BooleanStateAction.java
+++ b/platform/openide.util.ui/src/org/openide/util/actions/BooleanStateAction.java
@@ -26,7 +26,7 @@ package org.openide.util.actions;
 * <p>
 * This action is not the most effective way to implement checkbox in
 * a menu. Consider using more modern alternative:
-* <a href="@org-openide-awt@/org/openide/awt/Actions.html#checkbox-java.lang.String-java.lang.String-java.lang.String-java.lang.String-boolean-">
+* <a href="@org-openide-awt@/org/openide/awt/Actions.html#checkbox(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean)">
 * Actions.checkbox</a>, or declarative <a href="@org-openide-awt@/org/openide/awt/ActionState.html">ActionState annotation</a>.
 *
 * @author   Ian Formanek, Petr Hamernik

--- a/platform/openide.util.ui/src/org/openide/util/actions/CallableSystemAction.java
+++ b/platform/openide.util.ui/src/org/openide/util/actions/CallableSystemAction.java
@@ -26,7 +26,7 @@ import java.util.logging.Logger;
 import org.openide.util.Utilities;
 import org.openide.util.WeakSet;
 
-/** Not preferred anymore, use <a href="@org-openide-awt@/org/openide/awt/Actions.html#alwaysEnabled-java.awt.event.ActionListener-java.lang.String-java.lang.String-boolean-">Actions.alwaysEnabled</a>
+/** Not preferred anymore, use <a href="@org-openide-awt@/org/openide/awt/Actions.html#alwaysEnabled(java.awt.event.ActionListener,java.lang.String,java.lang.String,boolean)">Actions.alwaysEnabled</a>
 * instead. To migrate your
 * <a href="@org-openide-modules@/org/openide/modules/doc-files/api.html#how-layer">
 * layer definition</a> use:

--- a/platform/openide.util.ui/src/org/openide/util/actions/CallbackSystemAction.java
+++ b/platform/openide.util.ui/src/org/openide/util/actions/CallbackSystemAction.java
@@ -45,7 +45,7 @@ import org.openide.util.WeakListeners;
 import org.openide.util.WeakSet;
 
 /** Not preferred anymore, the replacement is
-* <a href="@org-openide-awt@/org/openide/awt/Actions.html#callback-java.lang.String-javax.swing.Action-boolean-java.lang.String-java.lang.String-boolean-">Actions.callback</a> factory method.
+* <a href="@org-openide-awt@/org/openide/awt/Actions.html#callback(java.lang.String,javax.swing.Action,boolean,java.lang.String,java.lang.String,boolean)">Actions.callback</a> factory method.
 * To migrate to the new API just remove the definition of your action in
 * <a href="@org-openide-modules@/org/openide/modules/doc-files/api.html#how-layer">
 * layer file</a> and replace it with:

--- a/platform/openide.util.ui/src/org/openide/util/actions/SystemAction.java
+++ b/platform/openide.util.ui/src/org/openide/util/actions/SystemAction.java
@@ -291,7 +291,7 @@ public abstract class SystemAction extends SharedClassObject implements Action, 
     * If e.g. myIcon.gif is accompanied with myIcon_pressed.gif, myIcon_disabled.gif
     * and/or myIcon_rollover.gif these images are used to call methods on JButton.setPressedIcon(),
     * JButton.setDisabledIcon() and/or JButton.setRolloverIcon() with appropriate images.
-    * Please check <a href="@org-openide-awt@/org/openide/awt/Actions.html#connect-javax.swing.AbstractButton-javax.swing.Action-">Actions.connect</a> for
+    * Please check <a href="@org-openide-awt@/org/openide/awt/Actions.html#connect(javax.swing.AbstractButton,javax.swing.Action)">Actions.connect</a> for
     * additional info how this is achieved (using special "iconBase" key for getValue).
     * As of APIs version 3.24, this path will be used for a localized search automatically.
     * If you do not want an icon, do <em>not</em> override this to return a blank icon. Leave it null,

--- a/platform/openide.util.ui/src/org/openide/util/datatransfer/NewType.java
+++ b/platform/openide.util.ui/src/org/openide/util/datatransfer/NewType.java
@@ -24,7 +24,7 @@ import org.openide.util.NbBundle;
 import java.io.IOException;
 
 
-/** Describes a type that can be created anew. Used by <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getNewTypes--">Node.getNewTypes</a>.
+/** Describes a type that can be created anew. Used by <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getNewTypes()">Node.getNewTypes</a>.
 *
 * @author Jaroslav Tulach
 */

--- a/platform/openide.util.ui/src/org/openide/util/datatransfer/PasteType.java
+++ b/platform/openide.util.ui/src/org/openide/util/datatransfer/PasteType.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 
 
 /** Clipboard operation providing one kind of paste action. Used by
-* <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getPasteTypes-java.awt.datatransfer.Transferable-">Node.getPasteTypes</a>.
+* <a href="@org-openide-nodes@/org/openide/nodes/Node.html#getPasteTypes(java.awt.datatransfer.Transferable)">Node.getPasteTypes</a>.
 *
 * @author Petr Hamernik
 */

--- a/platform/openide.util.ui/src/org/openide/util/doc-files/api.html
+++ b/platform/openide.util.ui/src/org/openide/util/doc-files/api.html
@@ -22,11 +22,11 @@
 <html>
 <head>
 <title>Utility Classes</title>
-<link rel="Stylesheet" href="../../../../prose.css" type="text/css" title="NetBeans Open APIs Style">
+<link rel="Stylesheet" href="@TOP@/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </head>
 <body>
 
-<p class="overviewlink"><a href="@TOP@overview-summary.html">Overview</a></p>
+<p class="overviewlink"><a href="@TOP@/index.html">Overview</a></p>
 
 <h1>Utility Classes</h1>
 

--- a/platform/openide.util/apichanges.xml
+++ b/platform/openide.util/apichanges.xml
@@ -54,7 +54,7 @@
                 <p>
                     <a href="@TOP@/org/openide/util/Mutex.html#EVENT">Mutex.EVENT</a>
                     methods have been enhanced to work well with
-                    <a href="@org-openide-util-lookup@/org/openide/util/lookup/Lookups.html#executeWith-org.openide.util.Lookup-java.lang.Runnable-">Lookups.executeWith(...)</a>.
+                    <a href="@org-openide-util-lookup@/org/openide/util/lookup/Lookups.html#executeWith(org.openide.util.Lookup,java.lang.Runnable)">Lookups.executeWith(...)</a>.
                 </p>
             </description>
             <class package="org.openide.util" name="Mutex"/>

--- a/platform/openide.util/arch.xml
+++ b/platform/openide.util/arch.xml
@@ -240,8 +240,8 @@
   <p>
     The <a href="https://docs.oracle.com/javase/1.5.0/docs/guide/jar/jar.html#Provider%20Configuration%20File">META-INF/services/...</a> files.
     <api name="TranslateNames" category="official" type="export" group="java.io.File" 
-    url="@TOP@/org/openide/util/BaseUtilities.html#translate-java.lang.String-">
-    <a href="@TOP@/org/openide/util/BaseUtilities.html#translate-java.lang.String-">Utilities.translate</a> 
+    url="@TOP@/org/openide/util/BaseUtilities.html#translate(java.lang.String)">
+    <a href="@TOP@/org/openide/util/BaseUtilities.html#translate(java.lang.String)">Utilities.translate</a> 
     reads <code>META-INF/netbeans/translate.names</code> files from JARs</api>.
   </p>
  </answer>

--- a/platform/openide.util/src/org/openide/util/NbBundle.java
+++ b/platform/openide.util/src/org/openide/util/NbBundle.java
@@ -358,7 +358,7 @@ public class NbBundle extends Object {
     * safer when used from a module as this method relies on the module's
     * classloader to currently be part of the system classloader. NetBeans
     * does add enabled modules to this classloader, however calls to
-    * this variant of the method made in <a href="@org-openide-modules@/org/openide/modules/ModuleInstall.html#validate--">ModuleInstall.validate</a>,
+    * this variant of the method made in <a href="@org-openide-modules@/org/openide/modules/ModuleInstall.html#validate()">ModuleInstall.validate</a>,
     * or made soon after a module is uninstalled (due to background threads)
     * could fail unexpectedly.
     * @param baseName bundle basename

--- a/platform/openide.util/src/org/openide/util/doc-files/api.html
+++ b/platform/openide.util/src/org/openide/util/doc-files/api.html
@@ -22,11 +22,11 @@
 <html>
 <head>
 <title>Utility Classes</title>
-<link rel="Stylesheet" href="../../../prose.css" type="text/css" title="NetBeans Open APIs Style">
+<link rel="Stylesheet" href="@TOP/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </head>
 <body>
 
-<p class="overviewlink"><a href="@TOP@overview-summary.html">Overview</a></p>
+<p class="overviewlink"><a href="@TOP@/index.html">Overview</a></p>
 
 <h1>Utility Classes</h1>
 
@@ -34,12 +34,12 @@ Not all of the classes in this package are of interest for all module
 writers, but some of them may or even are as they are used through out
 our sources.
 
-<h2>Package <a href="../package-summary.html"><code>org.openide.util</code></a></h2>
+<h2>Package {@link org.openide.util org.openide.util }</h2>
 
 <ol>
-    <li><a href="../NbBundle.html">NbBundle</a> as our specialized support
+    <li>{@link org.openide.util.NbBundle NbBundle} as our specialized support
     for localization and replacement to
-    <a href="@JDK@@JDKMODULE_JAVA_BASE@/java/util/ResourceBundle.html">ResourceBundle</a>.
+    {@link java.util.ResourceBundle ResourceBundle}.
     </li>
 
     <li><a href="../Task.html"><code>Task</code></a> and especially

--- a/platform/openide.windows/apichanges.xml
+++ b/platform/openide.windows/apichanges.xml
@@ -537,7 +537,7 @@
     <author login="saubrecht"/>
     <compatibility addition="yes" binary="incompatible" source="incompatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
     <description>
-        Added method <a href="@TOP@org/openide/windows/WindowManager.html#isOpenedEditorTopComponent-org.openide.windows.TopComponent-">WindowManager.isOpenedEditorTopComponent(TopComponent)</a>
+        Added method <a href="@TOP@org/openide/windows/WindowManager.html#isOpenedEditorTopComponent(org.openide.windows.TopComponent)">WindowManager.isOpenedEditorTopComponent(TopComponent)</a>
         for checking of the TopComponent type - editor or view. The method returns true if the given TopComponent is opened and is docked into an editor-type Mode.
         It is safe to call this method outside the event dispatch thread.
      </description>
@@ -553,9 +553,9 @@
     <author login="dsimonek"/>
     <compatibility addition="yes" binary="incompatible" source="incompatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
     <description>
-        Added method <a href="@TOP@org/openide/windows/TopComponent.html#openAtTabPosition-int-">TopComponent.openAtTabPosition(int)</a>
+        Added method <a href="@TOP@org/openide/windows/TopComponent.html#openAtTabPosition(int)">TopComponent.openAtTabPosition(int)</a>
         for opening and inserting top component at specified position. For retrieving current position, 
-        method <a href="@TOP@org/openide/windows/TopComponent.html#getTabPosition--">TopComponent.getTabPosition()</a>
+        method <a href="@TOP@org/openide/windows/TopComponent.html#getTabPosition()">TopComponent.getTabPosition()</a>
         was added.
      </description>
     <class package="org.openide.windows" name="TopComponent"/>
@@ -664,7 +664,7 @@
     <author login="dsimonek"/>
     <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
     <description>
-        New method <a href="@TOP@org/openide/windows/WindowManager.html#invokeWhenUIReady-java.lang.Runnable-">WindowManager.invokeWhenUIReady</a>
+        New method <a href="@TOP@org/openide/windows/WindowManager.html#invokeWhenUIReady(java.lang.Runnable)">WindowManager.invokeWhenUIReady</a>
         has been added that can be used to execute a code
         that is supposed to run after main window is shown.
     </description>

--- a/platform/openide.windows/arch.xml
+++ b/platform/openide.windows/arch.xml
@@ -1153,11 +1153,11 @@ Module configuration is stored in XML files.
 <answer id="lookup-lookup">
 Window Manager implementation (from core) registers itself and lookup is used 
 from API part to  get the instance and return as 
-<a href="@TOP@/org/openide/windows/WindowManager.html#getDefault--">WindowManager.getDefault ()</a>
-and also <a href="@TOP@/org/openide/windows/WindowManager.html#componentRegistry--">WindowManager.componentRegistry()</a>.
+<a href="@TOP@/org/openide/windows/WindowManager.html#getDefault()">WindowManager.getDefault ()</a>
+and also <a href="@TOP@/org/openide/windows/WindowManager.html#componentRegistry()">WindowManager.componentRegistry()</a>.
 gets the registered instance of <code>TopComponent.Registry</code>.
-Also there are provided implementations of <a href="@org-openide-dialogs@/org/openide/DialogDisplayer.html#getDefault--">DialogDisplayer.getDefault()</a> 
-and <a href="@org-openide-nodes@/org/openide/nodes/NodeOperation.html#getDefault--">NodeOperation.getDefault()</a> services.
+Also there are provided implementations of <a href="@org-openide-dialogs@/org/openide/DialogDisplayer.html#getDefault()">DialogDisplayer.getDefault()</a> 
+and <a href="@org-openide-nodes@/org/openide/nodes/NodeOperation.html#getDefault()">NodeOperation.getDefault()</a> services.
 <p/>
 There is also provided service which implements <api category="friend" group="java" name="NbTopManager.WindowSystem" type="import">org.netbeans.core.NbTopManager$WindowSystem interface</api>, 
 which is used in core module. It is used for starting window system (loading and show) in startup sequence and finishiing of window system (hiding and saving)
@@ -1195,7 +1195,7 @@ instance by singleton accessor.
         </question>
 -->
 <answer id="lookup-remove">
-Yes. It removes implementation of <a href="@org-openide-nodes@/org/openide/nodes/NodeOperation.html#getDefault--">NodeOperation.getDefault()</a>
+Yes. It removes implementation of <a href="@org-openide-nodes@/org/openide/nodes/NodeOperation.html#getDefault()">NodeOperation.getDefault()</a>
 service provided by openide-explorer module.
 </answer>
 

--- a/platform/openide.windows/src/org/openide/windows/TopComponent.java
+++ b/platform/openide.windows/src/org/openide/windows/TopComponent.java
@@ -797,7 +797,7 @@ public class TopComponent extends JComponent implements Externalizable, Accessib
      * if it is not already.
      * <p>Subclasses should override this method to transfer focus to desired
      * focusable component. <code>TopComponent</code> itself is not focusable.
-     * See for example <a href="@org-openide-text@/org/openide/text/CloneableEditor.html#requestFocus--">CloneableEditor#requestFocus</a>.
+     * See for example <a href="@org-openide-text@/org/openide/text/CloneableEditor.html#requestFocus()">CloneableEditor#requestFocus</a>.
      * <p><strong>Note:</strong> Use {@link #requestActive} instead to make TopComponent active
      * in the window system (not only focused). This method should be considered deprecated
      * for calling from outside; but it may be overridden (inside of which you may call super).
@@ -817,7 +817,7 @@ public class TopComponent extends JComponent implements Externalizable, Accessib
      * if it is not already.
      * <p>Subclasses should override this method to transfer focus to desired
      * focusable component. <code>TopComponent</code> itself is not focusable.
-     * See for example <a href="@org-openide-text@/org/openide/text/CloneableEditor.html#requestFocusInWindow--">CloneableEditor#requestFocusInWindow</a>.
+     * See for example <a href="@org-openide-text@/org/openide/text/CloneableEditor.html#requestFocusInWindow()">CloneableEditor#requestFocusInWindow</a>.
      * <p><strong>Note:</strong> Use {@link #requestActive} instead to make TopComponent active
      * in the window system (not only focused). This method should be considered deprecated
      * for calling from outside; but it may be overridden (inside of which you may call super).

--- a/platform/openide.windows/src/org/openide/windows/doc-files/api.html
+++ b/platform/openide.windows/src/org/openide/windows/doc-files/api.html
@@ -21,7 +21,7 @@
 <html>
 <head>
 <title>Window System API</title>
-<link rel="Stylesheet" href="../../../../prose.css" type="text/css" title="NetBeans Open APIs Style">
+<link rel="Stylesheet" href="@TOP@/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </head>
 <body>
 
@@ -31,21 +31,16 @@ changed is major version. Comparing to the older version it has changed its
 laout significantly, introduced group, and released support of workspaces</em>
 <br>
 
-<p class="overviewlink"><a href="../../../../overview-summary.html">Overview</a></p>
+<p class="overviewlink"><a href="@TOP@/index.html">Overview</a></p>
 
 <h1>Javadoc</h1>
 
-The Javadoc is present in the
-
-<a href="../package-summary.html"><code>org.openide.windows</code></a>
-
+The Javadoc is present in the {@link org.openide.windows org.openide.windows }
 package. Most module authors will want to look at
-
-<a href="../TopComponent.html"><code>TopComponent</code></a>
-
+{@link org.openide.windows.TopComponent TopComponent }
 to subclass it, or perhaps at
-
-<a href="../CloneableTopComponent.html"><code>CloneableTopComponent</code></a>.
+{@link org.openide.windows.CloneableTopComponent CloneableTopComponent }
+.
 
 <h1>Contents</h1>
 
@@ -100,9 +95,7 @@ smoothly by the NetBeans window manager implementation.
 <h2 id="overview">Overview of the Window System</h2>
 
 As a rule, modules should not create their own top-level windows
-(e.g.
-
-<a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/java/awt/Window.html"><code>java.awt.Window</code></a>),
+(e.g. {@link java.awt.Window java.awt.Window }),
 
 since these would exist without the knowledge of NetBeans' window
 manager. This window manager is capable of manipulating application
@@ -170,63 +163,50 @@ proper docking mode, is not generally difficult.
 <h3 id="create-top">Subclassing <code>TopComponent</code></h3>
 
 To create a simple top component, it suffices to subclass
-
-<a href="../TopComponent.html"><code>TopComponent</code></a>.
+{@link org.openide.windows.TopComponent TopComponent }
 
 This is a subclass of
 
-<a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/javax/swing/JComponent.html"><code>JComponent</code></a>,
+{@link javax.swing.JComponent JComponent},
 
 which means that it is possible to draw on it using a variety of
 mechanisms; typically, it is treated as a container, and its layout
-may be
-
-<a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/java/awt/Container.html#setLayout-java.awt.LayoutManager-">set</a>
-
+may be {@link java.awt.Container#setLayout(java.awt.LayoutManager) set}
 and components
-
-<a href="@JDK@@JDKMODULE_JAVA_DESKTOP@/java/awt/Container.html#add-java.awt.Component-java.lang.Object-">added</a>
-
-to it. 
+{@link java.awt.Container#add(java.awt.Component,java.lang.Object) added } to it. 
 
 <p>There are a few general ways in which you can customize the
 component besides painting subcomponents on it:
 
 <ul>
 
-<li>You may set a
-
-<a href="../TopComponent.html#setName-java.lang.String-">display name</a>
+<li>You may set a {@link org.openide.windows.TopComponent#setName(java.lang.String) display name }
 
 and
-
-<a href="../TopComponent.html#setIcon-java.awt.Image-">icon</a>
+{@link org.openide.windows.TopComponent#setIcon(java.awt.Image) icon }
 
 for the component, affecting its appearance in window title bars
 and tabs. These ought generally be set in the constructor.
 
-<li><a href="../TopComponent.html#getHelpCtx--"><code>TopComponent.getHelpCtx()</code></a>
+<li>
+{@link org.openide.windows.TopComponent#getHelpCtx() TopComponent.getHelpCtx() }
 
 should be overridden to provide a help link for the component as a
 whole, if you have any context help. Or, subcomponents may have their
 own more specific help. By default, context help is taken from the activated
 node selection, if there is any to be found.
 
-<li><a href="../TopComponent.html#getUndoRedo--"><code>TopComponent.getUndoRedo()</code></a>
-
+<li>{@link org.openide.windows.TopComponent#getUndoRedo() TopComponent.getUndoRedo() }
 allows you to associate undo/redo actions with the component, so
 that these actions will work properly when your component is
 focussed.
 
-<li><a href="../TopComponent.html#getActions--"><code>TopComponent.getActions()</code></a>
-
+<li>{@link org.openide.windows.TopComponent#getActions() TopComponent.getActions() }
 permits you to provide a list of actions which will appear in a
 popup menu, e.g. on a tab for the component. The system should
 provide a few standard actions such as "Close"; you may want to add
 more (for example, "Save" for an Editor pane). The
-
 <a href="@org-openide-actions@/org/openide/actions/doc-files/api.html">Actions API</a>
-
 describes how to write these.
 
 </ul>
@@ -237,16 +217,15 @@ Finding <a href="#overview-top">modes</a> is straightforward.
 
 <p>You cannot create mode directly, however you can specify
 new mode in XML layer. Then you can find such a mode by call
-
-<a href="../WindowManager.html#findMode-java.lang.String-"><code>WindowManager.findMode(String)</code></a>
+{@link org.openide.windows.WindowManager#findMode(java.lang.String) WindowManager.findMode(String) }
 
 . Do not keep references to modes, Rather use the above method to access them.
 Modes could be removed from window system inbetween, thus manipulating with such
 a mode wouldn't achieve desired goal.
 
 <p>To add top components to a mode, just call
-
-<a href="../Mode.html#dockInto-org.openide.windows.TopComponent-"><code>Mode.dockInto(TopComponent)</code></a>.
+{@link org.openide.windows.Mode#dockInto(org.openide.windows.TopComponent) Mode.dockInto(TopComponent) }
+.
 
 For example:
 
@@ -283,19 +262,16 @@ myComponent2.requestActive();
 
 <h3 id="create-clone">Creating a cloneable component</h3>
 
-Just by subclassing
-
-<a href="../CloneableTopComponent.html"><code>CloneableTopComponent</code></a>,
-
+Just by subclassing {@link org.openide.windows.CloneableTopComponent CloneableTopComponent }
 you can create a component which is capable of <em>cloning</em>
 itself, like the Editor does with the popup action "Clone View". If
 
-<a href="@JDK@@JDKMODULE_JAVA_BASE@/java/lang/Object.html#clone--"><code>Object.clone()</code></a>
+{@link java.lang.Object#clone() Object.clone() }
 
 takes care of all of your instance state satisfactorily, then you
 need do little more; otherwise, you can override
+{@link org.openide.windows.CloneableTopComponent#createClonedObject() CloneableTopComponent.createClonedObject() }
 
-<a href="../CloneableTopComponent.html#createClonedObject--"><code>CloneableTopComponent.createClonedObject()</code></a>
 
 to specify exactly what fields should be shared with the original
 top component. Typically all clones of a component should share any
@@ -304,8 +280,7 @@ different display parameters or other noncritical settings.
 
 <p>You may specify how these cloned windows act when they are
 closed, by overriding
-
-<a href="../CloneableTopComponent.html#closeLast--"><code>CloneableTopComponent.closeLast()</code></a>.
+{@link org.openide.windows.CloneableTopComponent#closeLast() CloneableTopComponent.closeLast() }
 
 (There are more general methods for all top components pertaining
 to closing them; this method is specific to cloneable top
@@ -334,17 +309,13 @@ Focus works naturally with top components: the focussed multitabbed
 window has the activated component on its selected tab.
 
 <p>You can explicitly request that a top component be activated by calling
-
-<a href="../TopComponent.html#requestActive--"><code>TopComponent.requestActive()</code></a>.
+{@link org.openide.windows.TopComponent#requestActive() TopComponent.requestActive() }.
 
 (It should be opened first.)
 
-<a href="../TopComponent.html#getRegistry--"><code>TopComponent.getRegistry()</code></a>
-
+{@link org.openide.windows.TopComponent#getRegistry() TopComponent.getRegistry() }
 and then
-
-<a href="../TopComponent.Registry.html#getActivated--"><code>TopComponent.Registry.getActivated()</code></a>
-
+{@link org.openide.windows.TopComponent.Registry#getActivated() TopComponent.Registry.getActivated() }
 correspondingly finds the last-activated component.
 
 <h4>The node selection</h4>
@@ -367,7 +338,7 @@ pay attention to it.
 
 <p>The selection may be set using
 
-<a href="../TopComponent.html#setActivatedNodes-org.openide.nodes.Node:A-"><code>TopComponent.setActivatedNodes(...)</code></a>.
+{@link org.openide.windows.TopComponent#setActivatedNodes(org.openide.nodes.Node[]) TopComponent.setActivatedNodes(...) }.
 
 <p>Explorer views embedded in as described at
 
@@ -557,53 +528,43 @@ A few method calls may be used to find modes, groups and top components:
 
 <li><code>WindowManager</code> instance is obtained by
 
-<a href="../WindowManager.html#getDefault--"><code>WindowManager.getDefault()</code></a>.
+{@link org.openide.windows.WindowManager#getDefault() WindowManager.getDefault() }.
 
-<li>The modes in a window systeme may be gotten
+<li>The modes in a window system may be gotten
 with
-
-<a href="../WindowManager.html#getModes--"><code>WindowManager.getModes()</code></a>
-
+{@link org.openide.windows.WindowManager#getModes() WindowManager.getModes() }
 or
-
-<a href="../WindowManager.html#findMode-java.lang.String-"><code>WindowManager.findMode(String)</code></a>
+{@link org.openide.windows.WindowManager#findMode(java.lang.String) WindowManager.findMode(String) }
 
 (or also
-
-<a href="../WindowManager.html#findMode-org.openide.windows.TopComponent-"><code>WindowManager.findMode(TopComponent)</code></a>).
+{@link org.openide.windows.WindowManager#findMode(org.openide.windows.TopComponent) WindowManager.findMode(TopComponent) }).
 
 
 <li>Each mode has some top components in it, obtainable with
-
-<a href="../Mode.html#getTopComponents--"><code>Mode.getTopComponents()</code></a>.
+{@link org.openide.windows.Mode#getTopComponents() Mode.getTopComponents() }.
 
 <li>Groups can be retrieved via
-
-<a href="../WindowManager.html#findTopComponentGroup-java.lang.String-"><code>WindowManager.findTopComponentGroup(String)</code></a>
+{@link org.openide.windows.WindowManager#findTopComponentGroup(java.lang.String) WindowManager.findTopComponentGroup(String) }
 
 <li>To get the currently selected top component, use
-
-<a href="../TopComponent.html#getRegistry--"><code>TopComponent.getRegistry()</code></a>
+{@link org.openide.windows.TopComponent#getRegistry() TopComponent.getRegistry() }
 
 followed by
+{@link org.openide.windows.TopComponent.Registry#getActivated() TopComponent.Registry.getActivated() }.
 
-<a href="../TopComponent.Registry.html#getActivated--"><code>TopComponent.Registry.getActivated()</code></a>.
 
 You can also get all opened components with
-
-<a href="../TopComponent.Registry.html#getOpened--"><code>TopComponent.Registry.getOpened()</code></a>.
+{@link org.openide.windows.TopComponent.Registry#getOpened() TopComponent.Registry.getOpened() }.
 
 </ul>
 
 <h3 id="manip-misc">Activating and closing</h3>
 
 Any top component may be activated just by calling
-
-<a href="../TopComponent.html#requestActive--"><code>TopComponent.requestActive()</code></a>.
+{@link org.openide.windows.TopComponent#requestActive() TopComponent.requestActive() }.
 
 <p>To close a top component programmatically, call
-
-<a href="../TopComponent.html#close--"><code>TopComponent.close()</code></a>.
+{@link org.openide.windows.TopComponent#close() TopComponent.close() }.
 
 <h3 id="listen">Listening to window system events</h3>
 
@@ -615,13 +576,11 @@ possible too.
 <ul>
 
 <li>All properties of the window manager (i.e. contained modes) may be listened to with
-
-<a href="../WindowManager.html#addPropertyChangeListener-java.beans.PropertyChangeListener-"><code>WindowManager.addPropertyChangeListener(PropertyChangeListener)</code></a>.
+{@link org.openide.windows.WindowManager#addPropertyChangeListener(java.beans.PropertyChangeListener) WindowManager.addPropertyChangeListener(PropertyChangeListener) }.
 
 <li>All properties of the top component registry (i.e. available
 and selected components, and the node selection) may be listened to with
-
-<a href="../TopComponent.Registry.html#addPropertyChangeListener-java.beans.PropertyChangeListener-"><code>TopComponent.Registry.addPropertyChangeListener(PropertyChangeListener)</code></a>.
+{@link org.openide.windows.TopComponent.Registry#addPropertyChangeListener(java.beans.PropertyChangeListener) TopComponent.Registry.addPropertyChangeListener(PropertyChangeListener) }.
 
 
 <!-- No longer exists...why?
@@ -743,7 +702,7 @@ Further, exact format of folders and files which hold layout information is
 specified, together with examples. 
 </P>
 
-<H4>Storage of Configurations</H4>
+<h4>Storage of Configurations</h4>
 
 <P>Physical storage of layout configuration documents is determined by layers
 support. Until modified, layout configuration files lives in modules that defined
@@ -761,7 +720,7 @@ system of the repository is responsible for holding the files and applying
 any changes made.)
 </P>
 
-<H4>Directory structure</H4>
+<h4>Directory structure</h4>
 
 <P>To effectively use XML layers, it's necessary to define directory structure
 for modes layout description. Following directory structure is fixed and
@@ -898,7 +857,7 @@ Modules now can:
 
 </div>
 
-<H4>Global properties</H4>
+<h4>Global properties</h4>
 Window system as a whole stores several properties which have global nature.
 They are always defined by a folder <samp>Windows/WindowManager/</samp> and data file
 <samp>Windows/WindowManager.wswmgr</samp>. Core implementation defines default values
@@ -933,12 +892,12 @@ Modules will typically never need to access these global properties, and
 modules should never try to change them.  
 
 
-<H4>Modes</H4>
+<h4>Modes</h4>
 
 <p class="nonnormative">Modules can either define own mode
 from scratch or reference mode defined by other modules.</p>
 
-<H5>Mode definition</H5>
+<h5>Mode definition</h5>
 
 <p>Module defines mode by creating proper mode folder
 <samp>Windows2/Modes/<em>MODE_UID</em>/</samp> and data file
@@ -969,7 +928,7 @@ from scratch or reference mode defined by other modules.</p>
 
 <div class="nonnormative">
 
-<H5>Mode referencing</H5>
+<h5>Mode referencing</h5>
 
 <p>Module references mode defined by other module in order to place own components
 into such mode to complete its layout. Module specifies
@@ -978,12 +937,12 @@ with own top component reference files. The mode data file should not be given.<
 
 </div>
 
-<H4>Groups</H4>
+<h4>Groups</h4>
 
 <p class="nonnormative">Modules can either define own group
 from scratch or reference grouo defined by other modules.</p>
 
-<H5>Group definition</H5>
+<h5>Group definition</h5>
 
 <p>Module defines group by creating proper group folder
 <samp>Windows2/Groups/<em>GROUP_UID</em>/</samp> and data file
@@ -1007,7 +966,7 @@ from scratch or reference grouo defined by other modules.</p>
 
 <div class="nonnormative">
 
-<H5>Group referencing</H5>
+<h5>Group referencing</h5>
 
 <p>Module references group defined by other module in order to place own components
 into such group to complete its layout. Module specifies
@@ -1017,7 +976,7 @@ with own top component reference files. The group data file should not be given.
 </div>
 
 
-<H4>Top component references in modes</H4>
+<h4>Top component references in modes</h4>
 
 <p>For top component to appear in mode, reference file needs to be put into
 mode folder, for example file <samp>Windows2/Modes/<em>MODE_UID</em>/<em>COMP_UID</em>.wstcref</samp>.
@@ -1042,7 +1001,7 @@ have to provide file <samp><em>COMP_UID</em>.settings</samp> or <samp><em>COMP_U
 &lt;/tc-ref&gt;
 </pre>
 
-<H4>Top component references in groups</H4>
+<h4>Top component references in groups</h4>
 
 <p>For top component to appear in group, reference file needs to be put into
 group folder, for example file
@@ -1069,7 +1028,7 @@ have to provide file <samp><em>COMP_UID</em>.settings</samp> or <samp><em>COMP_U
 </pre>
 
 
-<H4>Top component data</H4>
+<h4>Top component data</h4>
 
 <p>Stored in folder <samp>Windows2/Components/</samp> as <samp>*.settings</samp> or <samp>*.ser</samp> files, which holds
 data of top component. Top components are instantiated using information stored
@@ -1140,7 +1099,7 @@ from template is performed, resulting in creation of new instance with propertie
 and data inherited from template info.
 -->
 
-<H4>Automatic deinstallation support</H4>
+<h4>Automatic deinstallation support</h4>
 
 <p>Modules that define modes, groups or component references can
 "mark" these items so that the system can perform automatic removal of
@@ -1173,7 +1132,7 @@ have been.</p>
 
 <!--<h3 id="xml-visual">Visual Display</h3>
 
-<H4>Defining layout for multiple interfaces of the system</H4>
+<h4>Defining layout for multiple interfaces of the system</h4>
 
 <p>System currently supports both Single Document Interface (SDI) and Multiple Document
 Interface (MDI). It's possible to define special property set for each interface
@@ -1216,7 +1175,7 @@ default layout for the mode of property sheet - property sheet has
 its own mode only in SDI, in MDI it is part of explorer mode.
 </P>
 
-<H4>Playing with bounds of modes</H4>
+<h4>Playing with bounds of modes</h4>
 
 <p>Bounds of modes or mode areas can be specified either in absolute or relative form, and
 coordination space is different for SDI and MDI modes. Absolute bounds are
@@ -1338,7 +1297,7 @@ you might for example retrieve a mode as follows:</p>
 <span class="comment">// now use it as desired...
 </span></pre>
 
-<H4>Writing from the Java-level API</H4>
+<h4>Writing from the Java-level API</h4>
 
 <p>As for reading, you may not write the entire window to disk from
 module code; and handling of top component data is determined by the
@@ -1374,7 +1333,7 @@ component.</p>
 top component references. Whether these have an instance cookie, and
 if so what it is an instance of, is undefined.</p>
 
-<H4>Synchronization issues</h4>
+<h4>Synchronization issues</h4>
 
 <p>Currently there is no defined synchronization mechanism
 guaranteeing when changes made at the Filesystems level will be
@@ -1407,7 +1366,7 @@ modes using the Java-level API.</p>
 features of XML mode layout. Each procedure is detailed into steps which
 module writers are required or supposed to do.
 
-<H4>Creating new mode</H4>
+<h4>Creating new mode</h4>
 Following section shows creation of new mode defined by module.
 
 <OL>
@@ -1454,7 +1413,7 @@ class="string">"my_own_mode"</span>/&gt;
 </OL>
 
 
-<H4>Add components to foreign modes</H4>
+<h4>Add components to foreign modes</h4>
 It's even possible to add own top components into frames defined by other modules
 or core. To add top component "shower" into frame "bathroom", specify layer
 like this (ser or settings file shower.ser or shower.settings is expected in
@@ -1495,7 +1454,7 @@ There are several other notes that developer should be aware of:
     </LI>
 </OL>
 
-<H4>Overriding components and modes defined by other modules</H4>
+<h4>Overriding components and modes defined by other modules</h4>
 In some cases, it's useful to override mode and components layout defined by
 other module. To achieve this, the modules in question must have dependency
 defined.<P>

--- a/platform/sendopts/apichanges.xml
+++ b/platform/sendopts/apichanges.xml
@@ -36,7 +36,7 @@
       <author login="jtulach"/>
       <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible"/>
       <description>
-          <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#create-java.lang.Object...-">Create</a>
+          <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#create(java.lang.Object...)">Create</a>
           command line with instances of
           <a href="@TOP@/org/netbeans/spi/sendopts/OptionProcessor.html">OptionProcessor</a>
           and
@@ -52,7 +52,7 @@
       <author login="jtulach"/>
       <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible"/>
       <description>
-          <a href="@TOP@/org/netbeans/spi/sendopts/Env.html#usage-java.io.OutputStream-">Env.usage</a>
+          <a href="@TOP@/org/netbeans/spi/sendopts/Env.html#usage(java.io.OutputStream)">Env.usage</a>
           method now takes an optional <code>OutputStream</code> parameter.
      </description>
      <class package="org.netbeans.spi.sendopts" name="Env"/>
@@ -65,7 +65,7 @@
       <author login="jtulach"/>
       <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible"/>
       <description>
-          <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#create-java.lang.Class...-">CommandLine.html.create(Class...)</a>
+          <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#create(java.lang.Class...)">CommandLine.html.create(Class...)</a>
           can now be called with classes that extend
           <a href="@TOP@/org/netbeans/spi/sendopts/OptionProcessor.html">OptionProcessor</a>.
      </description>
@@ -79,7 +79,7 @@
       <author login="jtulach"/>
       <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible"/>
       <description>
-          <a href="@TOP@/org/netbeans/spi/sendopts/Env.html#usage--">Env.usage</a> 
+          <a href="@TOP@/org/netbeans/spi/sendopts/Env.html#usage()">Env.usage</a> 
           can be called when one wants to process own <code>--help</code> option.
      </description>
      <class package="org.netbeans.spi.sendopts" name="Env"/>
@@ -94,7 +94,7 @@
       <description>
           <a href="@TOP@/org/netbeans/spi/sendopts/Arg.html">@Arg</a> annotation
           and associated classes allow to register options declaratively. There
-          is a new  <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#create-java.lang.Class...-">
+          is a new  <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#create(java.lang.Class...)">
             factory method
           </a> to create multiple instances of differently configured
           <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html">command lines</a>.
@@ -113,7 +113,7 @@
       <description>
           Those processors that wish to be informed about every command line
           processing, can register themselves as providers of 
-          <a href="@TOP@/org/netbeans/spi/sendopts/Option.html#always--">always</a>
+          <a href="@TOP@/org/netbeans/spi/sendopts/Option.html#always()">always</a>
           option. This one is automatically present in each successfully parsed
           command line.
      </description>
@@ -168,7 +168,7 @@
       <author login="jtulach"/>
       <compatibility addition="yes" modification="no" binary="compatible" source="compatible" semantic="compatible" deprecation="no" deletion="no"/>
       <description>
-          There is new method <a href="@TOP@org/netbeans/api/sendopts/CommandLine.html#usage-java.io.PrintWriter-">usage</a>
+          There is new method <a href="@TOP@org/netbeans/api/sendopts/CommandLine.html#usage(java.io.PrintWriter)">usage</a>
           that
           allows to print description of all available options in the command
           line.

--- a/platform/sendopts/arch.xml
+++ b/platform/sendopts/arch.xml
@@ -139,12 +139,12 @@
        Since version 2.20 one can define own classes with fields and annotate
        them with <a href="@TOP@/org/netbeans/spi/sendopts/Arg.html">@Arg</a>
        annotation. Those classes can then be passed into a 
-       <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#create-java.lang.Class...-">
+       <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#create(java.lang.Class...)">
        factory method
        </a>
-       that creates new <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#create-java.lang.Class...-">command line</a>.
+       that creates new <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#create(java.lang.Class...)">command line</a>.
        One can then process the arguments as many times as needed via the
-        <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#process-java.lang.String...-">process</a>
+        <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#process(java.lang.String...)">process</a>
         method. Example:
         <pre>
 public final class MyOption implements <a href="@JDK@@JDKMODULE_JAVA_BASE@/java/lang/Runnable.html">Runnable</a> {
@@ -156,8 +156,8 @@ public final class MyOption implements <a href="@JDK@@JDKMODULE_JAVA_BASE@/java/
   }
   
   public static void main(String... args) {
-    <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html">CommandLine</a> line = <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#create-java.lang.Class...-">CommandLine.create</a>(MyOption.class);
-    line.<a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#process-java.lang.String...-">process</a>(args);
+    <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html">CommandLine</a> line = <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#create(java.lang.Class...)">CommandLine.create</a>(MyOption.class);
+    line.<a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#process(java.lang.String...)">process</a>(args);
   }
 }
 </pre>
@@ -182,7 +182,7 @@ public final class MyOption implements <a href="@JDK@@JDKMODULE_JAVA_BASE@/java/
        One can create an <a href="@TOP@org/netbeans/spi/sendopts/Option.html">Option</a>
        by calling any of its factory methods 
        (like 
-        <a href="@TOP@org/netbeans/spi/sendopts/Option.html#withoutArgument-char-java.lang.String-">withoutArgument</a>)
+        <a href="@TOP@org/netbeans/spi/sendopts/Option.html#withoutArgument(char,java.lang.String)">withoutArgument</a>)
         and provider <code>char</code> for the one letter option and/or string for
         the long getopts option.
    </usecase>
@@ -352,7 +352,7 @@ public final class MyOption implements <a href="@JDK@@JDKMODULE_JAVA_BASE@/java/
        That is why
        every option can be associated with a short description providing info
        about what it is useful for using
-       <a href="@TOP@/org/netbeans/spi/sendopts/Option.html#shortDescription-org.netbeans.spi.sendopts.Option-java.lang.String-java.lang.String-">
+       <a href="@TOP@/org/netbeans/spi/sendopts/Option.html#shortDescription(org.netbeans.spi.sendopts.Option,java.lang.String,java.lang.String)">
            Option.shortDescription
        </a> method. When using the 
        <a href="@TOP@/org/netbeans/spi/sendopts/Arg.html">@Arg</a> style, there
@@ -361,7 +361,7 @@ public final class MyOption implements <a href="@JDK@@JDKMODULE_JAVA_BASE@/java/
        and short description with the option.
        To get such descriptions for all available options one 
        can use 
-       <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#usage-java.io.PrintWriter-">
+       <a href="@TOP@/org/netbeans/api/sendopts/CommandLine.html#usage(java.io.PrintWriter)">
         CommandLine.getDefault().usage(java.io.PrintWriter)</a>.
    </usecase>
    <usecase id="cli-errorrecovery" name="Finding and Reporting when Options Are Not Correct" >
@@ -384,7 +384,7 @@ public final class MyOption implements <a href="@JDK@@JDKMODULE_JAVA_BASE@/java/
        parse them. It is an error if more than one or no handler expresses 
        an interest in extra arguments and those are given. One can register
        such option by using the <code>
-       <a href="@TOP@org/netbeans/spi/sendopts/Option.html#additionalArguments-char-java.lang.String-">
+       <a href="@TOP@org/netbeans/spi/sendopts/Option.html#additionalArguments(char,java.lang.String)">
            Option.additionalArgument
        </a>
        </code> factory method.
@@ -419,11 +419,11 @@ public final class MyOption implements <a href="@JDK@@JDKMODULE_JAVA_BASE@/java/
        It is an error if such non-options are provided and no or more than one
        handler is around to handle them. One can create such option by 
        using <code>
-       <a href="@TOP@org/netbeans/spi/sendopts/Option.html#defaultArguments--">Option.defaultArguments</a>
+       <a href="@TOP@org/netbeans/spi/sendopts/Option.html#defaultArguments()">Option.defaultArguments</a>
        </code> factory method. With the
        <a href="@TOP@/org/netbeans/spi/sendopts/Arg.html">declarative annotation style</a>
        one can annotate a field of type <code>String[]</code> and specify that
-       it is supposed to be <a href="@TOP@/org/netbeans/spi/sendopts/Arg.html#implicit--">implicit</a>.
+       it is supposed to be <a href="@TOP@/org/netbeans/spi/sendopts/Arg.html#implicit()">implicit</a>.
    </usecase>
    <usecase id="cli-lazy-handler-initiliazation" name="Only those processor need to process the options are created" >
        For purposes of usage in NetBeans, it is needed to not-initialize those
@@ -441,9 +441,9 @@ public final class MyOption implements <a href="@JDK@@JDKMODULE_JAVA_BASE@/java/
        and then also tell what to do with the output. It is unconvenient 
        to process that as one option with argument(s), that is why one can 
        use the 
-<a href="@TOP@org/netbeans/spi/sendopts/OptionGroups.html#allOf-org.netbeans.spi.sendopts.Option...-">
+<a href="@TOP@org/netbeans/spi/sendopts/OptionGroups.html#allOf(org.netbeans.spi.sendopts.Option...)">
 OptionGroups.allOf</a>,
-<a href="@TOP@org/netbeans/spi/sendopts/OptionGroups.html#someOf-org.netbeans.spi.sendopts.Option...-">
+<a href="@TOP@org/netbeans/spi/sendopts/OptionGroups.html#someOf(org.netbeans.spi.sendopts.Option...)">
 OptionGroups.someOf</a>, for example like: <pre>
 class PP extends OptionProcessor {
     private static Option tune = Option.requiredArgument(Option.NO_SHORT_NAME, "tune");
@@ -451,7 +451,7 @@ class PP extends OptionProcessor {
     
     public Set&lt;Option&gt; getOptions() {
       return Collections.singleton(
-        <a href="@TOP@org/netbeans/spi/sendopts/OptionGroups.html#allOf-org.netbeans.spi.sendopts.Option...-">OptionGroups.allOf</a>(tune, stream)
+        <a href="@TOP@org/netbeans/spi/sendopts/OptionGroups.html#allOf(org.netbeans.spi.sendopts.Option...)">OptionGroups.allOf</a>(tune, stream)
       );
     }
     
@@ -480,7 +480,7 @@ registration.
        For example is there is a way to tune the radio with direct frequency
        or with name of the station. Just one can be provided and one is needed.
        This can be specified by using 
-<a href="@TOP@org/netbeans/spi/sendopts/OptionGroups.html#oneOf-org.netbeans.spi.sendopts.Option...-">
+<a href="@TOP@org/netbeans/spi/sendopts/OptionGroups.html#oneOf(org.netbeans.spi.sendopts.Option...)">
 OptionGroups.oneOf</a> factory methods:
 <pre>
 Option freq = Option.requiredArgument(Option.NO_SHORT_NAME, "tune");

--- a/platform/settings/apichanges.xml
+++ b/platform/settings/apichanges.xml
@@ -192,7 +192,7 @@ is the proper place.
         <author login="jtulach"/>
         <compatibility addition="yes"/>
         <description> 
-            Provides support for <a href="@org-openide-util-lookup@/org/openide/util/lookup/Lookups.html#forPath-java.lang.String-">Lookups.forPath(String)</a>
+            Provides support for <a href="@org-openide-util-lookup@/org/openide/util/lookup/Lookups.html#forPath(java.lang.String)">Lookups.forPath(String)</a>
             method in order to replace now deprecated <a href="@org-openide-loaders@/org/openide/loaders/FolderLookup.html">FolderLookup</a>.
         </description>
         <issue number="98426"/>

--- a/platform/spi.quicksearch/apichanges.xml
+++ b/platform/spi.quicksearch/apichanges.xml
@@ -41,7 +41,7 @@
           <description>
               A <a href="@TOP@/org/netbeans/spi/quicksearch/SearchProvider.html">SearchProvider</a> that 
               is searching and cannot find a result can check whether the result is still valid, using
-              <a href="@TOP@/org/netbeans/spi/quicksearch/SearchResponse.html#isObsolete--"><code>SearchResponse.isObsolete()</code></a>.
+              <a href="@TOP@/org/netbeans/spi/quicksearch/SearchResponse.html#isObsolete()"><code>SearchResponse.isObsolete()</code></a>.
               It was only possible to check for terminated search when a new item was added.
           </description>
           <class package="org.netbeans.spi.quicksearch" name="SearchResponse"/>

--- a/platform/uihandler/arch.xml
+++ b/platform/uihandler/arch.xml
@@ -205,7 +205,7 @@
                     <a href="@JDK@@JDKMODULE_JAVA_LOGGING@/java/util/logging/LogRecord.html">LogRecord</a>
                     (where the MSG_KEY is the string returned by <code>record.getMessage()</code>)
                     and the value is then going to be used for the 
-                    <a href="@org-openide-nodes@/org/openide/nodes/AbstractNode.html#setIconBaseWithExtension-java.lang.String-">
+                    <a href="@org-openide-nodes@/org/openide/nodes/AbstractNode.html#setIconBaseWithExtension(java.lang.String)">
                         Node
                     </a> representing the UI gesture.
                 </api>


### PR DESCRIPTION
this is a first step to reduce to 300 linkage error. (was around 900)

Basically our previous link class.html#method-type- should be rewritten with class.html#method(type)

constructor link use #<init> and need to be xml compatible using the following #%3Cinit%3E
same applied to array [] 

doc-files content is parsed by javadoc, so {@link } and others  tag can be used. Make the javadoc a bit more semanticaly linked.
I started using @link when in text. I keep the old reference system when it's a code block. Could be nice to later have snippet instead the fuzzy html.

On infra side, h5 need to be checked for anchor reference


