### PR TITLE
fix issue #8344 include css revert property

### DIFF
--- a/ide/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarResolver.java
+++ b/ide/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarResolver.java
@@ -106,7 +106,8 @@ public class GrammarResolver {
         this.globalValues = new ValueGrammarElement[]{
             new FixedTextGrammarElement(this.grammar, "inherit", "inherit"),
             new FixedTextGrammarElement(this.grammar, "initial", "initial"),
-            new FixedTextGrammarElement(this.grammar, "unset", "unset")
+            new FixedTextGrammarElement(this.grammar, "unset", "unset"),
+            new FixedTextGrammarElement(this.grammar, "revert", "revert"),
         };
     }
     

--- a/ide/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/PropertyValueTest.java
+++ b/ide/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/PropertyValueTest.java
@@ -81,7 +81,7 @@ public class PropertyValueTest extends CssTestBase {
 
     public void testAlternativesSet() {
         //set
-        assertAlternatives("a | b | c", "", "a", "b", "c", "initial", "inherit", "unset");
+        assertAlternatives("a | b | c", "", "a", "b", "c", "initial", "inherit", "unset", "revert");
         assertAlternatives("a | b | c", "a");
         assertAlternatives("a | b | c", "b");
         assertAlternatives("a | b | c", "c");
@@ -90,7 +90,7 @@ public class PropertyValueTest extends CssTestBase {
 
     public void testAlternativesList() {
         //list
-        assertAlternatives("a || b || c", "", "a", "b", "c", "initial", "inherit", "unset");
+        assertAlternatives("a || b || c", "", "a", "b", "c", "initial", "inherit", "unset", "revert");
         assertAlternatives("a || b || c", "a", "b", "c");
         assertAlternatives("a || b || c", "b", "a", "c");
         assertAlternatives("a || b || c", "c", "a", "b");
@@ -105,7 +105,7 @@ public class PropertyValueTest extends CssTestBase {
 
     public void testAlternativesSequence() {
         //sequence
-        assertAlternatives("a b c", "", "a", "inherit", "initial", "unset");
+        assertAlternatives("a b c", "", "a", "inherit", "initial", "unset", "revert");
         assertAlternatives("a b c", "a", "b");
         assertAlternatives("a b c", "a b", "c");
         assertAlternatives("a b c", "a b c");
@@ -139,7 +139,7 @@ public class PropertyValueTest extends CssTestBase {
     public void testPaddingAlternatives() {
         PropertyDefinition p = Properties.getPropertyDefinition( "padding");
         assertAlternatives(p.getGrammar(), "", "auto", "!percentage", "!length",
-                "-", "calc", "inherit", "initial", "unset", "var", "mod", "log",
+                "-", "calc", "inherit", "initial", "unset", "revert", "var", "mod", "log",
                 "cos", "sign", "atan", "min", "sqrt", "hypot", "sin", "pow",
                 "rem", "exp", "clamp", "atan2", "tan", "max", "acos", "abs",
                 "asin", "round");
@@ -240,7 +240,7 @@ public class PropertyValueTest extends CssTestBase {
 
         assertAlternatives(p.getGrammar(), "",
                 "fantasy", "serif", "sans-serif", "monospace", "cursive",
-                "!string", "!identifier", "var", "initial", "inherit", "unset");
+                "!string", "!identifier", "var", "initial", "inherit", "unset", "revert");
 
     }
 
@@ -253,7 +253,7 @@ public class PropertyValueTest extends CssTestBase {
     public void testTheBorderCaseSimplified() {
         String g = " a || b || c";
 
-        assertAlternatives(g, "", "a", "b", "c", "initial", "inherit", "unset");
+        assertAlternatives(g, "", "a", "b", "c", "initial", "inherit", "unset", "revert");
         assertAlternatives(g, "a", "b", "c");
 
         assertAlternatives(g, "a b", "c");
@@ -314,7 +314,7 @@ public class PropertyValueTest extends CssTestBase {
 
     public void testTheBackgroundCaseSimplified() {
         String g = " [ a , ]* b";
-        assertAlternatives(g, "", "a", "b", "inherit", "initial", "unset");
+        assertAlternatives(g, "", "a", "b", "inherit", "initial", "unset", "revert");
         assertAlternatives(g, "a", ",");
         assertAlternatives(g, "a,", "b", "a");
         assertAlternatives(g, "a,a,", "b", "a");
@@ -325,7 +325,7 @@ public class PropertyValueTest extends CssTestBase {
 
     public void testTheBackgroundCaseSimplified2() {
         String g = " [ [ a || b ] , ]* [ a || c ]";
-        assertAlternatives(g, "", "a", "b", "c", "inherit", "initial", "unset");
+        assertAlternatives(g, "", "a", "b", "c", "inherit", "initial", "unset", "revert");
 
         assertAlternatives(g, "a", ",", "b", "c");
 
@@ -368,7 +368,7 @@ public class PropertyValueTest extends CssTestBase {
 
     public void testAltsMinus() {
         String g = "-? x";
-        assertAlternatives(g, "", "x", "-", "initial", "inherit", "unset");
+        assertAlternatives(g, "", "x", "-", "initial", "inherit", "unset", "revert");
     }
 
     public void testGetParseTree() {


### PR DESCRIPTION
In response of the issue #8344 

Include the **revert** property in css property validator.
It is considered similar to "unset" so, it should be safe to add in the `ValueGrammarElement[]` list.

Before

![image](https://github.com/user-attachments/assets/4f6cfb2b-33f3-4610-bc0a-b8b2a28094a7)
![image](https://github.com/user-attachments/assets/dca6c2c5-9dd3-4288-826d-4481e80b108a)

After
![image](https://github.com/user-attachments/assets/888e30e7-e2e1-4393-ae8c-616b5588bc53)

This also required an update on the **PropertyValueTest** unit test.

---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [ ] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [ ] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [ ] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [ ] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>