### PR TITLE
fix issue #8364 recognize css container units

### DIFF
--- a/ide/css.lib/src/org/netbeans/modules/css/lib/api/properties/TokenAcceptor.java
+++ b/ide/css.lib/src/org/netbeans/modules/css/lib/api/properties/TokenAcceptor.java
@@ -303,8 +303,9 @@ public abstract class TokenAcceptor {
         //!!! if a longer postfix has sub-postfix which equals to any of the shortest
         //postfixes, then it needs to be before the sub-postfix postfix (e.g. rem - em)!!!
         private static final List<String> POSTFIXES = Arrays.asList(new String[]{
-            "rem", "vmin", "vmax", "ex", "em", "vw", "vh", "ch",
-            "cm", "mm", "in", "pt", "pc", "px"}); //NOI18N
+            "rem", "vmin", "vmax", "cqmin", "cqmax", "ex", "em", "vw", "vh", "ch",
+            "cm", "mm", "in", "pt", "pc", "px",
+            "cqw", "cqh", "cqi", "cqb"}); //NOI18N
 
         public Length(String id) {
             super(id);

--- a/ide/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/TokenAcceptorsTest.java
+++ b/ide/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/TokenAcceptorsTest.java
@@ -57,6 +57,12 @@ public class TokenAcceptorsTest extends NbTestCase {
         assertTrue(ta.accepts(getToken("1rem")));
         assertTrue(ta.accepts(getToken("2em")));
         assertTrue(ta.accepts(getToken("8vmin")));
+        assertTrue(ta.accepts(getToken("1cqw")));
+        assertTrue(ta.accepts(getToken("2cqh")));
+        assertTrue(ta.accepts(getToken("3cqi")));
+        assertTrue(ta.accepts(getToken("4cqb")));
+        assertTrue(ta.accepts(getToken("5cqmin")));
+        assertTrue(ta.accepts(getToken("6cqmax")));
     }
     
     private Token getToken(String tokenImg) {


### PR DESCRIPTION
Regarding issue #8364

I have a pull request with the included container units :

"cqw", "cqh", "cqi", "cqb", "cqmin", "cqmax"

Before:
![image](https://github.com/user-attachments/assets/81e74840-99e1-4b79-b678-602142c26ca8)

After:
![image](https://github.com/user-attachments/assets/fa1718f7-1820-4fa8-910e-8e636bd5ea69)
