### PR TITLE
Replace WeakSet usage with JDK equivalent and deprecate class.

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/ProjectWhiteListQueryImplementation.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/ProjectWhiteListQueryImplementation.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TreeSet;
+import java.util.WeakHashMap;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import javax.swing.event.ChangeEvent;
@@ -43,7 +44,6 @@ import org.netbeans.modules.apisupport.project.ProjectXMLManager;
 import org.netbeans.spi.whitelist.WhiteListQueryImplementation;
 import org.openide.filesystems.FileObject;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -56,7 +56,7 @@ public class ProjectWhiteListQueryImplementation implements WhiteListQueryImplem
     private SoftReference<TreeSet<String>> cachedPrivatePackages;
     private boolean isCached = false;
     private static final WhiteListQuery.Result OK = new WhiteListQuery.Result();
-    private final Set<ProjectWhiteListImplementation> results = Collections.synchronizedSet(new WeakSet<ProjectWhiteListImplementation>());
+    private final Set<ProjectWhiteListImplementation> results = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
     private static final RequestProcessor RP = new RequestProcessor(ProjectWhiteListQueryImplementation.class.getName(), 3);
 
     /**

--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenWhiteListQueryImpl.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenWhiteListQueryImpl.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -61,7 +62,6 @@ import org.netbeans.spi.whitelist.WhiteListQueryImplementation;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -80,7 +80,7 @@ public class MavenWhiteListQueryImpl implements WhiteListQueryImplementation {
     private static final RequestProcessor RP = new RequestProcessor(MavenWhiteListQueryImpl.class.getName(), 3);
     private static final Logger LOG = Logger.getLogger(MavenWhiteListQueryImpl.class.getName());
 
-    private final Set<MavenWhiteListImplementation> results = Collections.synchronizedSet(new WeakSet<MavenWhiteListImplementation>());
+    private final Set<MavenWhiteListImplementation> results = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
     
     //TODO add static cache across projects for dependency jar's contents.
     

--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/breakpoints/BreakpointAnnotationProvider.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/breakpoints/BreakpointAnnotationProvider.java
@@ -22,11 +22,13 @@ package org.netbeans.modules.cpplite.debugger.breakpoints;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 
 import org.netbeans.api.debugger.Breakpoint;
 import org.netbeans.api.debugger.Breakpoint.VALIDITY;
@@ -42,7 +44,6 @@ import org.openide.text.Line;
 import org.openide.util.Lookup;
 import org.openide.util.RequestProcessor;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 
 
 /**
@@ -55,7 +56,7 @@ import org.openide.util.WeakSet;
 public class BreakpointAnnotationProvider extends DebuggerManagerAdapter implements AnnotationProvider {
 
     private final Map<CPPLiteBreakpoint, Set<Annotation>> breakpointToAnnotations = new IdentityHashMap<>();
-    private final Set<FileObject> annotatedFiles = new WeakSet<>();
+    private final Set<FileObject> annotatedFiles = Collections.newSetFromMap(new WeakHashMap<>());
     private Set<PropertyChangeListener> dataObjectListeners;
     private volatile boolean breakpointsActive = true;
     private final RequestProcessor annotationProcessor = new RequestProcessor("CPP BP Annotation Refresh", 1);
@@ -199,7 +200,7 @@ public class BreakpointAnnotationProvider extends DebuggerManagerAdapter impleme
                 }
             }
             if (add) {
-                breakpointToAnnotations.put(b, new WeakSet<>());
+                breakpointToAnnotations.put(b, Collections.newSetFromMap(new WeakHashMap<>()));
                 for (FileObject fo : annotatedFiles) {
                     if (isAt(b, fo)) {
                         addAnnotationTo(b);
@@ -237,7 +238,7 @@ public class BreakpointAnnotationProvider extends DebuggerManagerAdapter impleme
         }
         Set<Annotation> bpAnnotations = breakpointToAnnotations.get(b);
         if (bpAnnotations == null) {
-            Set<Annotation> set = new WeakSet<>();
+            Set<Annotation> set = Collections.newSetFromMap(new WeakHashMap<>());
             set.add(annotation);
             breakpointToAnnotations.put(b, set);
         } else {

--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/debuggingview/DebuggingModel.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/debuggingview/DebuggingModel.java
@@ -24,6 +24,7 @@ import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -49,7 +50,6 @@ import org.netbeans.spi.viewmodel.UnknownTypeException;
 
 import org.openide.util.RequestProcessor;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 import org.openide.util.datatransfer.PasteType;
 
 @DebuggerServiceRegistration(path="CPPLiteSession/DebuggingView",
@@ -70,8 +70,8 @@ public class DebuggingModel extends CachedChildrenTreeModel implements ExtendedN
     private final Map<CPPThread, ThreadStateListener> threadStateListeners = new WeakHashMap<>();
     private final Reference<CPPThread> lastCurrentThreadRef = new WeakReference<>(null);
     private final Reference<CPPFrame> lastCurrentFrameRef = new WeakReference<>(null);
-    private final Set<Object> expandedExplicitly = new WeakSet<Object>();
-    private final Set<Object> collapsedExplicitly = new WeakSet<Object>();
+    private final Set<Object> expandedExplicitly = Collections.newSetFromMap(new WeakHashMap<>());
+    private final Set<Object> collapsedExplicitly = Collections.newSetFromMap(new WeakHashMap<>());
     private final RequestProcessor RP = new RequestProcessor("Debugging Tree View Refresh", 1); // NOI18N
 
     public DebuggingModel(ContextProvider contextProvider) {

--- a/enterprise/weblogic.common/src/org/netbeans/modules/weblogic/common/api/WebLogicConfiguration.java
+++ b/enterprise/weblogic.common/src/org/netbeans/modules/weblogic/common/api/WebLogicConfiguration.java
@@ -24,15 +24,12 @@ import java.util.Objects;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullUnknown;
-import org.openide.util.WeakSet;
 
 /**
  *
  * @author Petr Hejl
  */
 public final class WebLogicConfiguration {
-
-    private static final WeakSet<WebLogicConfiguration> INSTANCES = new WeakSet<WebLogicConfiguration>();
 
     private final String id;
 
@@ -82,19 +79,13 @@ public final class WebLogicConfiguration {
         if (config == null) {
             return null;
         }
-        WebLogicConfiguration instance = new WebLogicConfiguration(serverHome, domainHome, config, null, null, null, credentials);
-        synchronized (INSTANCES) {
-            return INSTANCES.putIfAbsent(instance);
-        }
+        return new WebLogicConfiguration(serverHome, domainHome, config, null, null, null, credentials);
     }
 
     @NonNull
     public static WebLogicConfiguration forRemoteDomain(File serverHome, String host,
             int port, boolean secured, Credentials credentials) {
-        WebLogicConfiguration instance = new WebLogicConfiguration(serverHome, null, null, host, port, secured, credentials);
-        synchronized (INSTANCES) {
-            return INSTANCES.putIfAbsent(instance);
-        }
+        return new WebLogicConfiguration(serverHome, null, null, host, port, secured, credentials);
     }
 
     public String getId() {

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FodDataObjectFactory.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FodDataObjectFactory.java
@@ -21,8 +21,10 @@ package org.netbeans.modules.ide.ergonomics.fod;
 
 import java.beans.PropertyVetoException;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -46,7 +48,6 @@ import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.openide.util.WeakListeners;
 import org.openide.util.Lookup;
-import org.openide.util.WeakSet;
 
 /** Support for special dataobjects that can dynamically FoD objects.
  *
@@ -54,7 +55,7 @@ import org.openide.util.WeakSet;
  */
 public class FodDataObjectFactory implements DataObject.Factory {
     private static MultiFileLoader delegate;
-    private static final Set<FileObject> ignore = new WeakSet<FileObject>();
+    private static final Set<FileObject> ignore = Collections.newSetFromMap(new WeakHashMap<>());
 
     private final FileObject definition;
     private final FeatureInfo info;

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/OpenAdvancedAction.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/OpenAdvancedAction.java
@@ -19,7 +19,9 @@
 package org.netbeans.modules.ide.ergonomics.fod;
 
 import java.beans.PropertyVetoException;
+import java.util.Collections;
 import java.util.Set;
+import java.util.WeakHashMap;
 import org.netbeans.modules.ide.ergonomics.Utilities;
 import org.openide.cookies.OpenCookie;
 import org.openide.filesystems.FileObject;
@@ -32,11 +34,10 @@ import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.RequestProcessor.Task;
-import org.openide.util.WeakSet;
 import org.openide.util.actions.CookieAction;
 
 public final class OpenAdvancedAction extends CookieAction {
-    private static Set<FileObject> candidates = new WeakSet<FileObject>();
+    private static Set<FileObject> candidates = Collections.newSetFromMap(new WeakHashMap<>());
 
     public static void registerCandidate(FileObject fo) {
         synchronized (candidates) {

--- a/extide/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/NbBuildLogger.java
+++ b/extide/o.apache.tools.ant.module/src-bridge/org/apache/tools/ant/module/bridge/impl/NbBuildLogger.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -66,7 +67,6 @@ import org.openide.util.NbBundle;
 import org.openide.util.NbCollections;
 import org.openide.util.Parameters;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 import org.openide.windows.InputOutput;
 import org.openide.windows.OutputListener;
 import org.openide.windows.OutputWriter;
@@ -116,9 +116,9 @@ final class NbBuildLogger implements BuildListener, LoggerTrampoline.AntSessionI
     private Map<String/*|null*/,Collection<AntLogger>> interestedLoggersByTask = new HashMap<String,Collection<AntLogger>>();
     private Map<Integer,Collection<AntLogger>> interestedLoggersByLevel = new HashMap<Integer,Collection<AntLogger>>();
     
-    private final Set<Project> projectsWithProperties = Collections.synchronizedSet(new WeakSet<Project>());
+    private final Set<Project> projectsWithProperties = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
     
-    private final Set<Throwable> consumedExceptions = new WeakSet<Throwable>();
+    private final Set<Throwable> consumedExceptions = Collections.newSetFromMap(new WeakHashMap<>());
     
     /** whether this process should be halted at the next safe point */
     private boolean stop = false;

--- a/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/Hyperlink.java
+++ b/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/Hyperlink.java
@@ -23,7 +23,9 @@ import java.awt.EventQueue;
 import java.awt.Toolkit;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -41,7 +43,6 @@ import org.openide.text.Line;
 import org.openide.util.Exceptions;
 import org.openide.util.RequestProcessor;
 import org.openide.util.UserQuestionException;
-import org.openide.util.WeakSet;
 import org.openide.windows.OutputEvent;
 import org.openide.windows.OutputListener;
 
@@ -53,7 +54,7 @@ import org.openide.windows.OutputListener;
  */
 public final class Hyperlink implements OutputListener {
 
-    static final Set<Hyperlink> hyperlinks = new WeakSet<Hyperlink>();
+    static final Set<Hyperlink> hyperlinks = Collections.newSetFromMap(new WeakHashMap<>());
     private static final RequestProcessor RP = new RequestProcessor(Hyperlink.class);
 
     private final URL url;

--- a/extide/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/run/StandardLoggerTest.java
+++ b/extide/o.apache.tools.ant.module/test/unit/src/org/apache/tools/ant/module/run/StandardLoggerTest.java
@@ -41,7 +41,6 @@ import org.netbeans.junit.NbTestCase;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.NbBundle;
 import org.openide.util.Utilities;
-import org.openide.util.WeakSet;
 import org.openide.windows.IOProvider;
 import org.openide.windows.InputOutput;
 import org.openide.windows.OutputEvent;
@@ -210,7 +209,7 @@ public class StandardLoggerTest extends NbTestCase {
         private final AntLogger[] loggers;
         private final int verbosity;
         private final Map<AntLogger,Object> customData = new WeakHashMap<AntLogger,Object>();
-        private final Set<Throwable> consumedExceptions = new WeakSet<Throwable>();
+        private final Set<Throwable> consumedExceptions = Collections.newSetFromMap(new WeakHashMap<>());
         public final List<Message> messages = new ArrayList<Message>();
         
         public MockAntSession(AntLogger[] loggers, int verbosity) {

--- a/ide/api.debugger/src/org/netbeans/api/debugger/Lookup.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/Lookup.java
@@ -40,6 +40,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -57,7 +58,6 @@ import org.openide.util.Lookup.Item;
 import org.openide.util.LookupEvent;
 import org.openide.util.RequestProcessor;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 import org.openide.util.Lookup.Result;
 import org.openide.util.lookup.AbstractLookup;
 
@@ -346,7 +346,7 @@ abstract class Lookup implements ContextProvider {
                 = new HashMap<ClassLoader, ModuleChangeListener>();
         private final Map<ModuleInfo, ModuleChangeListener> disabledModuleChangeListeners
                 = new HashMap<ModuleInfo, ModuleChangeListener>();
-        private final Set<MetaInfLookupList> lookupLists = new WeakSet<MetaInfLookupList>();
+        private final Set<MetaInfLookupList> lookupLists = Collections.newSetFromMap(new WeakHashMap<>());
         private RequestProcessor.Task refreshListEnabled;
         private RequestProcessor.Task refreshListDisabled;
         private final RequestProcessor.Task listenOnDisabledModulesTask;

--- a/ide/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HgQueueHookImpl.java
+++ b/ide/bugtracking.bridge/src/org/netbeans/modules/bugtracking/vcs/HgQueueHookImpl.java
@@ -26,8 +26,10 @@ import java.io.File;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import javax.swing.JPanel;
 import org.netbeans.modules.bugtracking.api.Issue;
@@ -42,7 +44,6 @@ import org.openide.filesystems.FileUtil;
 import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 
 /**
  * Mercurial queue hook implementation
@@ -60,7 +61,7 @@ public class HgQueueHookImpl extends HgQueueHook {
     private final String name;
     private static final String HOOK_NAME = "HG"; //NOI18N
     private final VCSHooksConfig globalConfig;
-    private static final Set<Issue> cachedIssues = new WeakSet<Issue>();
+    private static final Set<Issue> cachedIssues = Collections.newSetFromMap(new WeakHashMap<>());
     private Format issueMessageTemplate;
 
     public HgQueueHookImpl() {

--- a/ide/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/Actions.java
+++ b/ide/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/Actions.java
@@ -20,9 +20,12 @@ package org.netbeans.modules.bugtracking.tasks.actions;
 
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JCheckBoxMenuItem;
@@ -62,7 +65,6 @@ import org.openide.NotifyDescriptor;
 import org.openide.util.Cancellable;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 import org.openide.util.actions.Presenter;
 
 /**
@@ -94,12 +96,14 @@ public class Actions {
     //<editor-fold defaultstate="collapsed" desc="default actions">
     public static class RefreshAction extends AbstractAction {
 
-        private final WeakSet<Refreshable> nodes;
+        private final Set<Refreshable> nodes;
 
         private RefreshAction(List<Refreshable> nodes) {
             super(NbBundle.getMessage(Actions.class, "CTL_Refresh"));
             putValue(ACCELERATOR_KEY, REFRESH_KEY);
-            this.nodes = new WeakSet<Refreshable>(nodes);
+            Set<Refreshable> set = Collections.newSetFromMap(new WeakHashMap<>());
+            set.addAll(nodes);
+            this.nodes = set;
         }
 
         @Override

--- a/ide/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/QueryAction.java
+++ b/ide/bugtracking/src/org/netbeans/modules/bugtracking/tasks/actions/QueryAction.java
@@ -19,9 +19,11 @@
 package org.netbeans.modules.bugtracking.tasks.actions;
 
 import java.util.Arrays;
+import java.util.Set;
+import java.util.Collections;
+import java.util.WeakHashMap;
 import javax.swing.AbstractAction;
 import org.netbeans.modules.bugtracking.tasks.dashboard.QueryNode;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -29,11 +31,13 @@ import org.openide.util.WeakSet;
  */
 public abstract class QueryAction extends AbstractAction {
 
-    private WeakSet<QueryNode> queryNodes;
+    private final Set<QueryNode> queryNodes;
 
     public QueryAction(String name, QueryNode... queryNodes) {
         super(name);
-        this.queryNodes = new WeakSet<QueryNode>(Arrays.asList(queryNodes));
+        Set<QueryNode> set = Collections.newSetFromMap(new WeakHashMap<>());
+        set.addAll(Arrays.asList(queryNodes));
+        this.queryNodes = set;
     }
 
     public QueryNode[] getQueryNodes() {

--- a/ide/bugzilla/src/org/netbeans/modules/bugzilla/autoupdate/BugzillaAutoupdate.java
+++ b/ide/bugzilla/src/org/netbeans/modules/bugzilla/autoupdate/BugzillaAutoupdate.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.bugzilla.autoupdate;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.eclipse.mylyn.internal.bugzilla.core.BugzillaVersion;
@@ -29,7 +30,6 @@ import org.netbeans.modules.bugzilla.Bugzilla;
 import org.netbeans.modules.bugzilla.repository.BugzillaConfiguration;
 import org.netbeans.modules.bugzilla.repository.BugzillaRepository;
 import org.openide.util.NbBundle;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -48,7 +48,7 @@ public class BugzillaAutoupdate {
 
     private static BugzillaAutoupdate instance;
 
-    private final Set<BugzillaRepository> repos = new WeakSet<BugzillaRepository>();
+    private final Set<BugzillaRepository> repos = Collections.newSetFromMap(new WeakHashMap<>());
     
     private final AutoupdateSupport support = new AutoupdateSupport(new AutoupdateCallback(), BUGZILLA_MODULE_CODE_NAME, NbBundle.getMessage(Bugzilla.class, "LBL_ConnectorName"));
     

--- a/ide/bugzilla/src/org/netbeans/modules/bugzilla/repository/BugzillaRepository.java
+++ b/ide/bugzilla/src/org/netbeans/modules/bugzilla/repository/BugzillaRepository.java
@@ -71,7 +71,6 @@ import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.RequestProcessor.Task;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 import org.eclipse.mylyn.tasks.core.IRepositoryQuery;
 
 /**

--- a/ide/editor.bookmarks/src/org/netbeans/lib/editor/bookmarks/api/BookmarkList.java
+++ b/ide/editor.bookmarks/src/org/netbeans/lib/editor/bookmarks/api/BookmarkList.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
@@ -53,7 +54,6 @@ import org.openide.cookies.EditorCookie.Observable;
 import org.openide.loaders.DataObject;
 import org.openide.util.Exceptions;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 
 
 /**
@@ -78,7 +78,7 @@ public final class BookmarkList {
 
     private static final String PROP_BOOKMARKS = "bookmarks"; //NOI18N
 
-    private static Set<Observable> observedObservables = new WeakSet<Observable> ();
+    private static Set<Observable> observedObservables = Collections.newSetFromMap(new WeakHashMap<>());
 
     /**
      * Document for which the bookmark list was created.

--- a/ide/editor.lib/src/org/netbeans/editor/BaseKit.java
+++ b/ide/editor.lib/src/org/netbeans/editor/BaseKit.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.prefs.PreferenceChangeEvent;
 import javax.swing.Action;
 import javax.swing.InputMap;
@@ -63,12 +64,14 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.plaf.TextUI;
 import javax.swing.text.AbstractDocument;
+
 import static javax.swing.text.DefaultEditorKit.selectionBackwardAction;
 import static javax.swing.text.DefaultEditorKit.selectionBeginLineAction;
 import static javax.swing.text.DefaultEditorKit.selectionDownAction;
 import static javax.swing.text.DefaultEditorKit.selectionEndLineAction;
 import static javax.swing.text.DefaultEditorKit.selectionForwardAction;
 import static javax.swing.text.DefaultEditorKit.selectionUpAction;
+
 import javax.swing.text.EditorKit;
 import javax.swing.text.Position;
 import javax.swing.text.View;
@@ -111,7 +114,6 @@ import org.openide.util.LookupEvent;
 import org.openide.util.LookupListener;
 import org.openide.util.NbBundle;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 
 /**
 * Editor kit implementation for base document
@@ -4049,7 +4051,7 @@ public class BaseKit extends DefaultEditorKit {
         private final String mimeType;
         private final Lookup.Result<KeyBindingSettings> lookupResult;
         private final Preferences prefs;
-        private final Set<JTextComponent> components = new WeakSet<JTextComponent>();
+        private final Set<JTextComponent> components = Collections.newSetFromMap(new WeakHashMap<>());
         
         public KeybindingsAndPreferencesTracker(String mimeType) {
             this.mimeType = mimeType;

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/PresenterEditorAction.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/PresenterEditorAction.java
@@ -27,8 +27,10 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.Action;
@@ -44,7 +46,6 @@ import javax.swing.text.TextAction;
 import org.netbeans.api.editor.EditorRegistry;
 import org.netbeans.api.editor.EditorUtilities;
 import org.openide.awt.Actions;
-import org.openide.util.WeakSet;
 import org.openide.util.actions.Presenter;
 
 /**
@@ -73,7 +74,7 @@ public final class PresenterEditorAction extends TextAction
 
     private static boolean activeKitLastFocused;
 
-    private static final Set<PresenterEditorAction> presenterActions = new WeakSet<PresenterEditorAction>();
+    private static final Set<PresenterEditorAction> presenterActions = Collections.newSetFromMap(new WeakHashMap<>());
 
     private static final ChangeListener actionsChangeListener = new ChangeListener() {
         public void stateChanged(ChangeEvent e) {

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/PresenterUpdater.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/actions/PresenterUpdater.java
@@ -24,8 +24,10 @@ import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.lang.ref.Reference;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.AbstractButton;
@@ -42,7 +44,6 @@ import org.netbeans.spi.editor.AbstractEditorAction;
 import org.openide.awt.Mnemonics;
 import org.openide.util.Utilities;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 
 /**
  * Handler servicing menu, popup menu and toolbar presenters of a typical editor action.
@@ -124,7 +125,7 @@ public final class PresenterUpdater implements PropertyChangeListener, ActionLis
 
         action.addPropertyChangeListener(WeakListeners.propertyChange(this, action));
         if (type == MENU) {
-            listenedContextActions = new WeakSet<Action>();
+            listenedContextActions = Collections.newSetFromMap(new WeakHashMap<>());
             EditorRegistryWatcher.get().registerPresenterUpdater(this); // Includes notification of active component
         } else {
             listenedContextActions = null;

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DebugRepaintManager.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DebugRepaintManager.java
@@ -20,12 +20,13 @@
 package org.netbeans.modules.editor.lib2.view;
 
 import java.awt.Rectangle;
+import java.util.Collections;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import javax.swing.JComponent;
 import javax.swing.RepaintManager;
 import javax.swing.SwingUtilities;
-import org.openide.util.WeakSet;
 
 /**
  * Repaint manager showing repaints in a particular component.
@@ -44,7 +45,7 @@ final class DebugRepaintManager extends RepaintManager {
         INSTANCE.addLogComponent(component);
     }
 
-    private final Set<JComponent> logComponents = new WeakSet<JComponent>();
+    private final Set<JComponent> logComponents = Collections.newSetFromMap(new WeakHashMap<>());
     
 
     private DebugRepaintManager() {

--- a/ide/git/src/org/netbeans/modules/git/ui/output/OutputLogger.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/output/OutputLogger.java
@@ -23,6 +23,9 @@ import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.AbstractAction;
@@ -30,7 +33,6 @@ import javax.swing.Action;
 import org.netbeans.modules.git.GitModuleConfig;
 import org.netbeans.modules.versioning.util.OpenInEditorAction;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 import org.openide.windows.IOColorPrint;
 import org.openide.windows.IOColors;
 import org.openide.windows.IOProvider;
@@ -50,7 +52,7 @@ public class OutputLogger {
     private boolean writable;
     private static final RequestProcessor rp = new RequestProcessor("GitOutput", 1); //NOI18N
     private static final Logger LOG = Logger.getLogger(OutputLogger.class.getName());
-    private static final WeakSet<InputOutput> openWindows = new WeakSet<InputOutput>(5);
+    private static final Set<InputOutput> openWindows = Collections.newSetFromMap(new WeakHashMap<>(5));
 
     public static OutputLogger getLogger (File repositoryRoot) {
         if (repositoryRoot != null) {

--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestMethodFinderImpl.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/TestMethodFinderImpl.java
@@ -27,10 +27,13 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.logging.Logger;
@@ -47,7 +50,6 @@ import org.netbeans.modules.parsing.spi.indexing.Indexable;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -59,7 +61,7 @@ public final class TestMethodFinderImpl extends EmbeddingIndexer {
     public static final int VERSION = 2;
     public static final TestMethodFinderImpl INSTANCE = new TestMethodFinderImpl();
 
-    private final WeakSet<BiConsumer<FileObject, Collection<TestMethodController.TestMethod>>> listeners = new WeakSet<>();
+    private final Set<BiConsumer<FileObject, Collection<TestMethodController.TestMethod>>> listeners = Collections.newSetFromMap(new WeakHashMap<>());
 
     @Override
     protected void index(Indexable indexable, Parser.Result parserResult, Context context) {
@@ -80,7 +82,9 @@ public final class TestMethodFinderImpl extends EmbeddingIndexer {
 
     public void addListener(BiConsumer<FileObject, Collection<TestMethodController.TestMethod>> listener) {
         synchronized(listeners) {
-            listeners.putIfAbsent(listener);
+            if (!listeners.contains(listener)) {
+                listeners.add(listener);
+            }
             Logger.getLogger(TestMethodFinderImpl.class.getName()).info("Listener added: " + listener);
         }
     }

--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/Manager.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/api/Manager.java
@@ -24,6 +24,7 @@ import java.awt.event.ActionListener;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -75,7 +76,7 @@ public final class Manager {
     /**
      * The current test sessions.
      */
-    private final Set<TestSession> testSessions = new WeakSet<TestSession>(5);
+    private final Set<TestSession> testSessions = Collections.newSetFromMap(new WeakHashMap<>(5));
 
     /**
      * if {@code true}, the window will only be promoted

--- a/ide/hudson/src/org/netbeans/modules/hudson/impl/HudsonRemoteFileSystem.java
+++ b/ide/hudson/src/org/netbeans/modules/hudson/impl/HudsonRemoteFileSystem.java
@@ -32,12 +32,14 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.modules.hudson.api.ConnectionBuilder;
@@ -52,7 +54,6 @@ import org.openide.filesystems.FileSystem;
 import org.openide.filesystems.URLMapper;
 import org.openide.util.Enumerations;
 import org.openide.util.NbCollections;
-import org.openide.util.WeakSet;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -81,7 +82,7 @@ final class HudsonRemoteFileSystem extends RemoteFileSystem implements
         info = this;
         synchronized (Mapper.class) {
             if (Mapper.workspaces == null) {
-                Mapper.workspaces = new WeakSet<HudsonRemoteFileSystem>();
+                Mapper.workspaces = Collections.newSetFromMap(new WeakHashMap<>());
             }
             Mapper.workspaces.add(this);
         }

--- a/ide/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/annotation/BreakpointAnnotationManager.java
+++ b/ide/javascript2.debug.ui/src/org/netbeans/modules/javascript2/debug/ui/annotation/BreakpointAnnotationManager.java
@@ -24,11 +24,13 @@ import java.beans.PropertyChangeListener;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.debugger.Breakpoint;
@@ -44,7 +46,6 @@ import org.openide.text.Line;
 import org.openide.util.Lookup;
 import org.openide.util.RequestProcessor;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -70,7 +71,7 @@ class BreakpointAnnotationManager implements PropertyChangeListener {
     private static final Logger logger = Logger.getLogger(BreakpointAnnotationManager.class.getName());
     
     private final Map<JSLineBreakpoint, Annotation> breakpointAnnotations = new HashMap<>();
-    private final Set<FileObject> annotatedFiles = new WeakSet<>();
+    private final Set<FileObject> annotatedFiles = Collections.newSetFromMap(new WeakHashMap<>());
     private Set<PropertyChangeListener> dataObjectListeners;
     private final RequestProcessor annotationProcessor = new RequestProcessor("Annotation Refresh", 1);
     private volatile Boolean active = null;

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/breakpoints/BreakpointAnnotationProvider.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/breakpoints/BreakpointAnnotationProvider.java
@@ -22,10 +22,12 @@ package org.netbeans.modules.lsp.client.debugger.breakpoints;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 
 import org.netbeans.api.debugger.Breakpoint;
 import org.netbeans.api.debugger.Breakpoint.VALIDITY;
@@ -39,7 +41,6 @@ import org.openide.text.AnnotationProvider;
 import org.openide.text.Line;
 import org.openide.util.Lookup;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 
 
 /**
@@ -51,7 +52,7 @@ import org.openide.util.WeakSet;
 public final class BreakpointAnnotationProvider extends DebuggerManagerAdapter implements AnnotationProvider {
 
     private final Map<DAPLineBreakpoint, Set<Annotation>> breakpointToAnnotations = new IdentityHashMap<>();
-    private final Set<FileObject> annotatedFiles = new WeakSet<>();
+    private final Set<FileObject> annotatedFiles = Collections.newSetFromMap(new WeakHashMap<>());
     private volatile boolean breakpointsActive = true;
     private final RequestProcessor annotationProcessor = new RequestProcessor("CPP BP Annotation Refresh", 1);
 
@@ -187,7 +188,7 @@ public final class BreakpointAnnotationProvider extends DebuggerManagerAdapter i
                 }
             }
             if (add) {
-                breakpointToAnnotations.put(b, new WeakSet<>());
+                breakpointToAnnotations.put(b, Collections.newSetFromMap(new WeakHashMap<>()));
                 for (FileObject fo : annotatedFiles) {
                     if (isAt(b, fo)) {
                         addAnnotationTo(b);
@@ -225,7 +226,7 @@ public final class BreakpointAnnotationProvider extends DebuggerManagerAdapter i
         }
         Set<Annotation> bpAnnotations = breakpointToAnnotations.get(b);
         if (bpAnnotations == null) {
-            Set<Annotation> set = new WeakSet<>();
+            Set<Annotation> set = Collections.newSetFromMap(new WeakHashMap<>());
             set.add(annotation);
             breakpointToAnnotations.put(b, set);
         } else {

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/debuggingview/DebuggingModel.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/debugger/debuggingview/DebuggingModel.java
@@ -24,6 +24,7 @@ import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,7 +51,6 @@ import org.netbeans.spi.viewmodel.UnknownTypeException;
 
 import org.openide.util.RequestProcessor;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 import org.openide.util.datatransfer.PasteType;
 
 @DebuggerServiceRegistration(path="DAPDebuggerSession/DebuggingView",
@@ -71,8 +71,8 @@ public class DebuggingModel extends CachedChildrenTreeModel implements ExtendedN
     private final Map<DAPThread, ThreadStateListener> threadStateListeners = new WeakHashMap<>();
     private final Reference<DAPThread> lastCurrentThreadRef = new WeakReference<>(null);
     private final Reference<DAPFrame> lastCurrentFrameRef = new WeakReference<>(null);
-    private final Set<Object> expandedExplicitly = new WeakSet<Object>();
-    private final Set<Object> collapsedExplicitly = new WeakSet<Object>();
+    private final Set<Object> expandedExplicitly = Collections.newSetFromMap(new WeakHashMap<>());
+    private final Set<Object> collapsedExplicitly = Collections.newSetFromMap(new WeakHashMap<>());
     private final RequestProcessor RP = new RequestProcessor("Debugging Tree View Refresh", 1); // NOI18N
 
     public DebuggingModel(ContextProvider contextProvider) {

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskProvider.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/errors/TaskProvider.java
@@ -48,7 +48,6 @@ import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.TaskListener;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -192,7 +191,7 @@ public final class TaskProvider extends PushTaskScanner {
         Set<FileObject> result = root2FilesWithAttachedErrors.get(root);
         
         if (result == null) {
-            root2FilesWithAttachedErrors.put(root, result = new WeakSet<FileObject>());
+            root2FilesWithAttachedErrors.put(root, result = Collections.newSetFromMap(new WeakHashMap<>()));
         }
         
         return result;

--- a/ide/project.ant/src/org/netbeans/spi/project/support/ant/AntProjectHelper.java
+++ b/ide/project.ant/src/org/netbeans/spi/project/support/ant/AntProjectHelper.java
@@ -25,10 +25,12 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -69,7 +71,6 @@ import org.openide.util.Mutex.Action;
 import org.openide.util.MutexException;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 import org.openide.xml.XMLUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -191,7 +192,7 @@ public final class AntProjectHelper {
     
     
     /** Atomic actions in use to save XML files. */
-    private final Set<AtomicAction> saveActions = new WeakSet<AtomicAction>();
+    private final Set<AtomicAction> saveActions = Collections.newSetFromMap(new WeakHashMap<>());
     
     /**
      * Hook waiting to be called. See issue #57794.

--- a/ide/project.ant/src/org/netbeans/spi/project/support/ant/ProjectProperties.java
+++ b/ide/project.ant/src/org/netbeans/spi/project/support/ant/ProjectProperties.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -51,7 +52,6 @@ import org.openide.util.ChangeSupport;
 import org.openide.util.Mutex;
 import org.openide.util.NbCollections;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 
 /**
  * Manages the loaded property files for {@link AntProjectHelper}.
@@ -148,7 +148,7 @@ final class ProjectProperties {
         private Throwable reloadedStackTrace;
         private final ChangeSupport cs = new ChangeSupport(this);
         /** Atomic actions in use to save XML files. */
-        private final Set<AtomicAction> saveActions = new WeakSet<AtomicAction>();
+        private final Set<AtomicAction> saveActions = Collections.newSetFromMap(new WeakHashMap<>());
         private final AtomicBoolean fileListenerSet = new AtomicBoolean(false);
         
         //#239999 - preventing properties file from saving, when no changes are done

--- a/ide/project.ant/src/org/netbeans/spi/project/support/ant/SourcesHelper.java
+++ b/ide/project.ant/src/org/netbeans/spi/project/support/ant/SourcesHelper.java
@@ -35,6 +35,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -61,7 +62,6 @@ import org.openide.filesystems.FileUtil;
 import org.openide.util.ChangeSupport;
 import org.openide.util.Parameters;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 
 // XXX should perhaps be legal to call add* methods at any time (should update things)
 // and perhaps also have remove* methods
@@ -871,7 +871,7 @@ public final class SourcesHelper {
     }
 
     // #143633: notify Sources impls that new source group has been created
-    private WeakSet<SourcesImpl> knownSources = new WeakSet<SourcesImpl>();
+    private Set<SourcesImpl> knownSources = Collections.newSetFromMap(new WeakHashMap<>());
 
     /**
      * Create a source list object.

--- a/ide/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesTestUtil.java
+++ b/ide/project.libraries/test/unit/src/org/netbeans/modules/project/libraries/LibrariesTestUtil.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.WeakHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.netbeans.api.annotations.common.NonNull;
@@ -61,7 +62,6 @@ import org.openide.filesystems.FileSystem;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Lookup;
 import org.openide.util.Mutex;
-import org.openide.util.WeakSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -159,7 +159,7 @@ public class LibrariesTestUtil {
 
         final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
         public final Map<Area,List<TestLibrary>> libs = new HashMap<Area,List<TestLibrary>>();
-        final Set<LP> lps = new WeakSet<LP>();
+        final Set<LP> lps = Collections.newSetFromMap(new WeakHashMap<>());
         final Set<Area> open = new HashSet<Area>();
 
         public void addPropertyChangeListener(PropertyChangeListener listener) {

--- a/ide/projectapi.nb/src/org/netbeans/modules/projectapi/nb/NbProjectInformationProvider.java
+++ b/ide/projectapi.nb/src/org/netbeans/modules/projectapi/nb/NbProjectInformationProvider.java
@@ -23,7 +23,9 @@ import java.awt.Image;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
+import java.util.Collections;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.Icon;
@@ -111,7 +113,7 @@ public final class NbProjectInformationProvider implements ProjectInformationPro
 
         private final ProjectInformation pinfo;
         private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
-        private final Set<ProjectIconAnnotator> annotators = new WeakSet<ProjectIconAnnotator>();
+        private final Set<ProjectIconAnnotator> annotators = Collections.newSetFromMap(new WeakHashMap<>());
         private boolean annotatorsInitialized = false;
         private boolean addedPropertyListener = false;
         private final Object LOCK = new Object(); //protects access to annotatorsInitialized, addedPropertyListener and icon

--- a/ide/projectapi.nb/src/org/netbeans/modules/projectapi/nb/NbProjectManager.java
+++ b/ide/projectapi.nb/src/org/netbeans/modules/projectapi/nb/NbProjectManager.java
@@ -57,7 +57,6 @@ import org.openide.util.Mutex.ExceptionAction;
 import org.openide.util.MutexException;
 import org.openide.util.Parameters;
 import org.openide.util.Union2;
-import org.openide.util.WeakSet;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.spi.MutexImplementation;
 
@@ -129,7 +128,7 @@ public final class NbProjectManager implements ProjectManagerImplementation {
      */
     private final Set<Project> modifiedProjects = new HashSet<Project>();
     
-    private final Set<Project> removedProjects = Collections.synchronizedSet(new WeakSet<Project>());
+    private final Set<Project> removedProjects = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
     
     /**
      * Mapping from projects to the factories that created them.

--- a/ide/projectapi/src/org/netbeans/modules/projectapi/SimpleFileOwnerQueryImplementation.java
+++ b/ide/projectapi/src/org/netbeans/modules/projectapi/SimpleFileOwnerQueryImplementation.java
@@ -49,7 +49,6 @@ import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
 import org.openide.util.BaseUtilities;
 import org.openide.util.NbPreferences;
-import org.openide.util.WeakSet;
 
 /**
  * Finds a project by searching the directory tree.
@@ -92,7 +91,7 @@ public class SimpleFileOwnerQueryImplementation implements FileOwnerQueryImpleme
         return getOwner(file);
     }
     
-    private final Set<FileObject> warnedAboutBrokenProjects = new WeakSet<FileObject>();
+    private final Set<FileObject> warnedAboutBrokenProjects = Collections.newSetFromMap(new WeakHashMap<>());
         
     private Map<FileObject, Reference<Project>> projectCache = new WeakHashMap<>();    
     /**

--- a/ide/projectui/src/org/netbeans/modules/project/ui/ProjectsRootNode.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/ProjectsRootNode.java
@@ -88,7 +88,6 @@ import org.openide.util.RequestProcessor;
 import org.openide.util.Union2;
 import org.openide.util.Utilities;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 import org.openide.util.lookup.Lookups;
 import org.openide.util.lookup.ProxyLookup;
 import org.openide.util.lookup.ServiceProvider;
@@ -99,7 +98,7 @@ import org.openide.xml.XMLUtil;
 public class ProjectsRootNode extends AbstractNode {
 
     private static final Logger LOG = Logger.getLogger(ProjectsRootNode.class.getName());
-    private static final Set<ProjectsRootNode> all = new WeakSet<ProjectsRootNode>();
+    private static final Set<ProjectsRootNode> all = Collections.newSetFromMap(new WeakHashMap<>());
     private static final RequestProcessor RP = new RequestProcessor(ProjectsRootNode.class);
 
     static final int PHYSICAL_VIEW = 0;
@@ -566,7 +565,7 @@ public class ProjectsRootNode extends AbstractNode {
         private final ProjectChildren ch;
         private final boolean logicalView;
         private final ProjectChildren.Pair pair;
-        private final Set<FileObject> projectDirsListenedTo = new WeakSet<FileObject>();
+        private final Set<FileObject> projectDirsListenedTo = Collections.newSetFromMap(new WeakHashMap<>());
         private static final int DELAY = 50;
         private final FileChangeListener newSubDirListener = new FileChangeAdapter() {
             public @Override void fileDataCreated(FileEvent fe) {
@@ -592,7 +591,7 @@ public class ProjectsRootNode extends AbstractNode {
         private final Lookup.Result<ProjectIconAnnotator> result = Lookup.getDefault().lookupResult(ProjectIconAnnotator.class);
         
         static class AnnotationListener implements LookupListener, ChangeListener {
-            private final Set<ProjectIconAnnotator> annotators = new WeakSet<ProjectIconAnnotator>();
+            private final Set<ProjectIconAnnotator> annotators = Collections.newSetFromMap(new WeakHashMap<>());
             private final Reference<BadgingNode> node;
             
             public AnnotationListener(BadgingNode node) {

--- a/ide/projectui/src/org/netbeans/modules/project/ui/actions/ShortcutManager.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/actions/ShortcutManager.java
@@ -19,12 +19,13 @@
 
 package org.netbeans.modules.project.ui.actions;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import javax.swing.Action;
-import org.openide.util.WeakSet;
 
 /**
  * Manages shortcuts based on the action's command.
@@ -45,7 +46,7 @@ class ShortcutManager {
         synchronized (this) {
             Set<Action> commandActions = actions.get(command);
             if (commandActions == null) {
-                commandActions = new WeakSet<Action>();
+                commandActions = Collections.newSetFromMap(new WeakHashMap<>());
                 actions.put(command, commandActions);
             }
             commandActions.add(action);

--- a/ide/properties/src/org/netbeans/modules/properties/PropertiesOpen.java
+++ b/ide/properties/src/org/netbeans/modules/properties/PropertiesOpen.java
@@ -36,10 +36,13 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.Action;
@@ -73,7 +76,6 @@ import org.openide.util.ImageUtilities;
 import org.openide.util.Mutex;
 import org.openide.util.NbBundle;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 import org.openide.util.actions.SystemAction;
 import org.openide.windows.CloneableOpenSupport;
 import org.openide.windows.CloneableTopComponent;
@@ -1427,7 +1429,7 @@ public class PropertiesOpen extends CloneableOpenSupport
     private static class CompoundUndoRedoManager implements UndoRedo {
         
         /** Set of weak references to all "underlying" editor support undoredo managers. */
-        private WeakSet<Manager> managers = new WeakSet<Manager>(5);
+        private Set<Manager> managers = Collections.newSetFromMap(new WeakHashMap<>(5));
         
         // Constructor
         

--- a/ide/spellchecker/src/org/netbeans/modules/spellchecker/ComponentPeer.java
+++ b/ide/spellchecker/src/org/netbeans/modules/spellchecker/ComponentPeer.java
@@ -92,7 +92,6 @@ import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -418,7 +417,7 @@ public class ComponentPeer implements PropertyChangeListener, DocumentListener, 
         }
     }
 
-    private static Set<Document> knownDocuments = new WeakSet<Document>();
+    private static Set<Document> knownDocuments = Collections.newSetFromMap(new WeakHashMap<>());
     private static Map<Locale, DictionaryImpl> locale2UsersLocalDictionary = new HashMap<Locale, DictionaryImpl>();
     private static Map<Project, Reference<DictionaryImpl>> project2Reference = new WeakHashMap<Project, Reference<DictionaryImpl>>();
     

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/DebugMainProjectAction.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/actions/DebugMainProjectAction.java
@@ -28,11 +28,13 @@ import java.beans.PropertyChangeListener;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.WeakHashMap;
 import javax.swing.Action;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -64,7 +66,6 @@ import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 import org.openide.util.actions.Presenter;
 
 /**
@@ -73,7 +74,7 @@ import org.openide.util.actions.Presenter;
  */
 public class DebugMainProjectAction implements Action, Presenter.Toolbar, PopupMenuListener {
 
-    private static WeakSet<AttachHistorySupport> ahs = null;
+    private static Set<AttachHistorySupport> ahs = null;
     
     private final Action delegate;
     private final DebugHistorySupport debugHistorySupport;
@@ -175,7 +176,7 @@ public class DebugMainProjectAction implements Action, Presenter.Toolbar, PopupM
 
     private static synchronized void addAttachHistorySupport(AttachHistorySupport support) {
         if (ahs == null) {
-            ahs = new WeakSet<AttachHistorySupport>();
+            ahs = Collections.newSetFromMap(new WeakHashMap<>());
         }
         ahs.add(support);
     }

--- a/ide/spi.viewmodel/src/org/netbeans/modules/viewmodel/DefaultTreeExpansionManager.java
+++ b/ide/spi.viewmodel/src/org/netbeans/modules/viewmodel/DefaultTreeExpansionManager.java
@@ -19,13 +19,13 @@
 
 package org.netbeans.modules.viewmodel;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 
 import org.netbeans.spi.viewmodel.Models;
-import org.openide.util.WeakSet;
 
 /**
  * Ugly class, that takes care that the expansion state is always managed for the object under the given node.
@@ -88,7 +88,7 @@ public class DefaultTreeExpansionManager {
         try {
             Set<Object> expanded = expandedNodes.get(currentChildren);
             if (expanded == null) {
-                expanded = new WeakSet<Object>();
+                expanded = Collections.newSetFromMap(new WeakHashMap<>());
                 expandedNodes.put(currentChildren, expanded);
             }
             expanded.add(child);

--- a/ide/subversion/src/org/netbeans/modules/subversion/notifications/NotificationsManager.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/notifications/NotificationsManager.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JTextPane;
@@ -47,7 +48,6 @@ import org.netbeans.modules.subversion.util.SvnUtils;
 import org.netbeans.modules.versioning.util.VCSNotificationDisplayer;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 import org.tigris.subversion.svnclientadapter.ISVNInfo;
 import org.tigris.subversion.svnclientadapter.ISVNStatus;
 import org.tigris.subversion.svnclientadapter.SVNClientException;
@@ -63,7 +63,7 @@ public class NotificationsManager {
 
     private static NotificationsManager instance;
     private static final Logger LOG = Logger.getLogger(NotificationsManager.class.getName());
-    private static final Set<File> alreadySeen = Collections.synchronizedSet(new WeakSet<File>());
+    private static final Set<File> alreadySeen = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
     private static final String CMD_DIFF = "cmd.diff";                  //NOI18N
 
     private final HashSet<File> files;

--- a/ide/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskList.java
+++ b/ide/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskList.java
@@ -29,7 +29,6 @@ import org.netbeans.spi.tasklist.FileTaskScanner;
 import org.netbeans.spi.tasklist.PushTaskScanner;
 import org.netbeans.spi.tasklist.Task;
 import org.openide.filesystems.FileObject;
-import org.openide.util.WeakSet;
 
 /**
  * @author S. Aubrecht
@@ -45,7 +44,7 @@ public class TaskList {
     
     private Map<TaskGroup, List<Task>> group2tasks = new HashMap<TaskGroup,List<Task>>( 10 );
     
-    private final WeakSet<Listener> listeners = new WeakSet<Listener>( 2 );
+    private final Set<Listener> listeners = Collections.newSetFromMap(new WeakHashMap<>(2));
     
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
     

--- a/ide/versioning.core/src/org/netbeans/modules/versioning/core/VersioningManager.java
+++ b/ide/versioning.core/src/org/netbeans/modules/versioning/core/VersioningManager.java
@@ -641,7 +641,8 @@ public class VersioningManager implements PropertyChangeListener, ChangeListener
     }
 
     public static synchronized void statusListener(VCSAnnotationListener listener, boolean add) {
-        WeakSet<VCSAnnotationListener> newSet = new WeakSet<>(statusListeners);
+        Set<VCSAnnotationListener> newSet = Collections.newSetFromMap(new WeakHashMap<>());
+        newSet.addAll(statusListeners);
         if (add) {
             newSet.add(listener);
         } else {

--- a/ide/xml/src/org/netbeans/modules/xml/actions/InputOutputReporter.java
+++ b/ide/xml/src/org/netbeans/modules/xml/actions/InputOutputReporter.java
@@ -34,7 +34,6 @@ import org.openide.*;
 import org.openide.nodes.*;
 import org.openide.cookies.*;
 import org.openide.windows.*;
-import org.openide.util.WeakSet;
 
 
 import org.netbeans.api.xml.cookies.*;
@@ -65,7 +64,7 @@ public final class InputOutputReporter implements CookieObserver {
 
     // remember all attached annotations
     private static final Set hyperlinks = 
-        Collections.synchronizedSet(new WeakSet()); // Set<Hyperlink>
+        Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap())); // Set<Hyperlink>
     
     /** 
      * Creates new InputOutputReporter regirecting ProcessorListener

--- a/ide/xml/src/org/netbeans/modules/xml/util/LookupManager.java
+++ b/ide/xml/src/org/netbeans/modules/xml/util/LookupManager.java
@@ -98,7 +98,7 @@ public abstract class LookupManager {
         // @GuardedBy(this)
         private Collection lastResult = null;
         // @GuardedBy(self)
-        private final Set<LookupManager> lms = new WeakSet<LookupManager>(300);
+        private final Set<LookupManager> lms = Collections.newSetFromMap(new WeakHashMap<>(300));
 
         //
         // init

--- a/java/ant.freeform/test/unit/data/example-projects/simple/src/org/foo/myapp/MyApp.java
+++ b/java/ant.freeform/test/unit/data/example-projects/simple/src/org/foo/myapp/MyApp.java
@@ -19,7 +19,6 @@
 package org.foo.myapp;
 import java.io.IOException;
 import java.util.Set;
-import org.openide.util.WeakSet;
 import org.openide.util.io.NullInputStream;
 public class MyApp {
     public static void main(String[] args) throws IOException {

--- a/java/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSFramesInJavaModelFilter.java
+++ b/java/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSFramesInJavaModelFilter.java
@@ -23,6 +23,7 @@ import java.awt.event.ActionEvent;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.prefs.Preferences;
 import javax.swing.AbstractAction;
@@ -42,7 +43,6 @@ import org.netbeans.spi.viewmodel.UnknownTypeException;
 import org.openide.awt.Actions;
 import org.openide.util.NbBundle;
 import org.openide.util.NbPreferences;
-import org.openide.util.WeakSet;
 import org.openide.util.actions.Presenter;
 
 /**
@@ -57,7 +57,7 @@ public class DebuggingJSFramesInJavaModelFilter implements TreeModelFilter, Node
     static final Preferences preferences = NbPreferences.forModule(DebuggingJSFramesInJavaModelFilter.class);
     static final String PREF_DISPLAY_JS_STACKS = "displayJSStacks";     // NOI18N
     
-    private final Set<DebuggingView.DVThread> threadsWithJSStacks = Collections.synchronizedSet(new WeakSet<DebuggingView.DVThread>());
+    private final Set<DebuggingView.DVThread> threadsWithJSStacks = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
     // By default, filter frames to display just JS frames, where appropriate
     private volatile boolean displayJSStacks = preferences.getBoolean(PREF_DISPLAY_JS_STACKS, true);
     private final DisplayJSStacksAction displayJSStacksAction = new DisplayJSStacksAction();

--- a/java/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSTreeExpansionModelFilter.java
+++ b/java/debugger.jpda.jsui/src/org/netbeans/modules/debugger/jpda/jsui/frames/models/DebuggingJSTreeExpansionModelFilter.java
@@ -26,6 +26,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.WeakHashMap;
 import org.netbeans.api.debugger.jpda.CallStackFrame;
 import org.netbeans.api.debugger.jpda.JPDADebugger;
 import org.netbeans.api.debugger.jpda.JPDAThread;
@@ -41,7 +42,6 @@ import org.netbeans.spi.viewmodel.TreeExpansionModelFilter;
 import org.netbeans.spi.viewmodel.UnknownTypeException;
 import org.openide.util.Exceptions;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 
 /**
  * Assure that the thread we stop in is automatically expanded.
@@ -57,7 +57,7 @@ public class DebuggingJSTreeExpansionModelFilter implements TreeExpansionModelFi
     private final JPDADebugger debugger;
     private final DVSupport dvSupport;
     private volatile Reference<JPDAThread> suspendedNashornThread = NO_THREAD;
-    private final Set<Object> collapsedExplicitly = new WeakSet<>();
+    private final Set<Object> collapsedExplicitly = Collections.newSetFromMap(new WeakHashMap<>());
     private final Set<ModelListener> listeners = Collections.synchronizedSet(new HashSet<ModelListener>());
 
     public DebuggingJSTreeExpansionModelFilter(ContextProvider context) {

--- a/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/FieldLNCache.java
+++ b/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/FieldLNCache.java
@@ -26,13 +26,13 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.WeakHashMap;
 import org.openide.filesystems.FileAttributeEvent;
 import org.openide.filesystems.FileChangeListener;
 import org.openide.filesystems.FileEvent;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileRenameEvent;
 import org.openide.util.BaseUtilities;
-import org.openide.util.WeakSet;
 
 /**
  * Field line number cache.
@@ -40,7 +40,7 @@ import org.openide.util.WeakSet;
  */
 final class FieldLNCache {
     
-    private final Set<FileObject> knownFiles = Collections.synchronizedSet(new WeakSet<>());
+    private final Set<FileObject> knownFiles = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
     private final Set<FileKey> knownFileRefs = Collections.synchronizedSet(new HashSet<>());
     private final Map<FieldKey, Integer> fieldLines = new LinkedHashMap<>();
     

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/RemoteServices.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/RemoteServices.java
@@ -86,7 +86,6 @@ import org.netbeans.modules.debugger.jpda.models.JPDAThreadImpl;
 
 import org.openide.util.Exceptions;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 
 /**
  * Upload backend classed to the JVM.
@@ -111,7 +110,7 @@ public final class RemoteServices {
     
     private static final RequestProcessor AUTORESUME_AFTER_SUSPEND_RP = new RequestProcessor("Autoresume after suspend", 1);    // NOI18N
     
-    private static final Set<PropertyChangeListener> serviceListeners = new WeakSet<>();
+    private static final Set<PropertyChangeListener> serviceListeners = Collections.newSetFromMap(new WeakHashMap<>());
 
     private RemoteServices() {}
     

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/DebuggingTruffleNodeModel.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/DebuggingTruffleNodeModel.java
@@ -26,6 +26,8 @@ import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.netbeans.api.debugger.jpda.CallStackFrame;
@@ -52,7 +54,6 @@ import org.netbeans.spi.viewmodel.UnknownTypeException;
 import org.openide.util.NbBundle;
 
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 import org.openide.util.datatransfer.PasteType;
 
 @DebuggerServiceRegistration(path="netbeans-JPDASession/DebuggingView",
@@ -61,8 +62,8 @@ import org.openide.util.datatransfer.PasteType;
 public class DebuggingTruffleNodeModel implements ExtendedNodeModelFilter {
     
     private final JPDADebugger debugger;
-    private final List<ModelListener> listeners = new CopyOnWriteArrayList<ModelListener>();
-    private final WeakSet<CurrentPCInfo> cpisListening = new WeakSet<CurrentPCInfo>();
+    private final List<ModelListener> listeners = new CopyOnWriteArrayList<>();
+    private final Set<CurrentPCInfo> cpisListening = Collections.newSetFromMap(new WeakHashMap<>());
     private final CurrentInfoPropertyChangeListener cpiChL = new CurrentInfoPropertyChangeListener();
     
     public DebuggingTruffleNodeModel(ContextProvider lookupProvider) {

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/DebuggingTruffleTreeExpansionModelFilter.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/DebuggingTruffleTreeExpansionModelFilter.java
@@ -27,6 +27,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.WeakHashMap;
 
 import org.netbeans.api.debugger.jpda.CallStackFrame;
 import org.netbeans.api.debugger.jpda.JPDADebugger;
@@ -45,7 +46,6 @@ import org.netbeans.spi.viewmodel.TreeExpansionModelFilter;
 import org.netbeans.spi.viewmodel.UnknownTypeException;
 import org.openide.util.Exceptions;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 
 /**
  * Assure that the thread we stop in is automatically expanded.
@@ -59,7 +59,7 @@ public class DebuggingTruffleTreeExpansionModelFilter implements TreeExpansionMo
     private final JPDADebugger debugger;
     private final DVSupport dvSupport;
     private volatile Reference<JPDAThread> suspendedTruffleThread = NO_THREAD;
-    private final Set<Object> collapsedExplicitly = new WeakSet<>();
+    private final Set<Object> collapsedExplicitly = Collections.newSetFromMap(new WeakHashMap<>());
     private final Set<ModelListener> listeners = Collections.synchronizedSet(new HashSet<ModelListener>());
 
     public DebuggingTruffleTreeExpansionModelFilter(ContextProvider context) {

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/vars/models/TruffleLocalVariablesTreeModel.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/vars/models/TruffleLocalVariablesTreeModel.java
@@ -21,6 +21,9 @@ package org.netbeans.modules.debugger.jpda.truffle.vars.models;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
 
 import org.netbeans.modules.debugger.jpda.truffle.access.CurrentPCInfo;
 import org.netbeans.modules.debugger.jpda.truffle.access.TruffleAccess;
@@ -36,12 +39,11 @@ import org.netbeans.spi.viewmodel.TreeModel;
 import org.netbeans.spi.viewmodel.TreeModelFilter;
 import org.netbeans.spi.viewmodel.UnknownTypeException;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 
 @DebuggerServiceRegistration(path="netbeans-JPDASession/"+TruffleStrataProvider.TRUFFLE_STRATUM+"/LocalsView",  types = TreeModelFilter.class)
 public class TruffleLocalVariablesTreeModel extends TruffleVariablesTreeModel {
 
-    private final WeakSet<CurrentPCInfo> cpisListening = new WeakSet<CurrentPCInfo>();
+    private final Set<CurrentPCInfo> cpisListening = Collections.newSetFromMap(new WeakHashMap<>());
     private final CurrentInfoPropertyChangeListener cpiChL = new CurrentInfoPropertyChangeListener();
     
     public TruffleLocalVariablesTreeModel(ContextProvider lookupProvider) {

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsHitCountModel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsHitCountModel.java
@@ -18,8 +18,10 @@
  */
 package org.netbeans.modules.debugger.jpda.ui.models;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import javax.swing.JToolTip;
 import org.netbeans.api.debugger.LazyActionsManagerListener;
@@ -37,7 +39,6 @@ import org.netbeans.spi.viewmodel.TableModel;
 import org.netbeans.spi.viewmodel.TableModelFilter;
 import org.netbeans.spi.viewmodel.UnknownTypeException;
 import org.openide.util.NbBundle;
-import org.openide.util.WeakSet;
 
 /**
  * Displays the breakpoints hit count.
@@ -52,7 +53,7 @@ public class BreakpointsHitCountModel implements TableModelFilter, BreakpointImp
     private final List<ModelListener> listeners = new CopyOnWriteArrayList<ModelListener>();
     private final ContextProvider lookupProvider;
     private BreakpointsEngineListener breakpointsEngineListener;
-    private final Set<BreakpointImpl> bpImplListeningOn = new WeakSet<BreakpointImpl>();
+    private final Set<BreakpointImpl> bpImplListeningOn = Collections.newSetFromMap(new WeakHashMap<>());
     
     public BreakpointsHitCountModel(ContextProvider lookupProvider) {
         this.lookupProvider = lookupProvider;

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingMonitorModel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingMonitorModel.java
@@ -29,12 +29,14 @@ import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EventListener;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.prefs.PreferenceChangeEvent;
 import java.util.prefs.PreferenceChangeListener;
 import java.util.prefs.Preferences;
@@ -70,7 +72,6 @@ import org.openide.util.NbBundle;
 import org.openide.util.NbPreferences;
 import org.openide.util.RequestProcessor;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 import org.openide.util.datatransfer.PasteType;
 
 
@@ -109,8 +110,8 @@ NodeActionsProviderFilter, TableModel, Constants {
 
         private final JPDADebugger debugger;
         private final DebuggingViewSupportImpl dvSupport;
-        private final Set<JPDAThread> threadsAskedForMonitors = new WeakSet<JPDAThread>();
-        private final Set<CallStackFrame> framesAskedForMonitors = new WeakSet<CallStackFrame>();
+        private final Set<JPDAThread> threadsAskedForMonitors = Collections.newSetFromMap(new WeakHashMap<>());
+        private final Set<CallStackFrame> framesAskedForMonitors = Collections.newSetFromMap(new WeakHashMap<>());
         private final DeadlockDetector deadlockDetector;
         private Preferences preferences = DebuggingViewSupportImpl.getFilterPreferences();
         private PreferenceChangeListener prefListener;

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingTreeExpansionModelFilter.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingTreeExpansionModelFilter.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.debugger.jpda.ui.models;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -38,7 +39,6 @@ import org.netbeans.spi.viewmodel.ModelListener;
 import org.netbeans.spi.viewmodel.TreeExpansionModel;
 import org.netbeans.spi.viewmodel.TreeExpansionModelFilter;
 import org.netbeans.spi.viewmodel.UnknownTypeException;
-import org.openide.util.WeakSet;
 
 
 /**
@@ -52,9 +52,9 @@ public class DebuggingTreeExpansionModelFilter implements TreeExpansionModelFilt
     
     private static final Map<JPDADebugger, DebuggingTreeExpansionModelFilter> FILTERS = new WeakHashMap<JPDADebugger, DebuggingTreeExpansionModelFilter>();
     
-    private final Set<Object> expandedNodes = new WeakSet<Object>();
-    private final Set<Object> expandedExplicitly = new WeakSet<Object>();
-    private final Set<Object> collapsedExplicitly = new WeakSet<Object>();
+    private final Set<Object> expandedNodes = Collections.newSetFromMap(new WeakHashMap<>());
+    private final Set<Object> expandedExplicitly = Collections.newSetFromMap(new WeakHashMap<>());
+    private final Set<Object> collapsedExplicitly = Collections.newSetFromMap(new WeakHashMap<>());
     private final List<ModelListener> listeners = new ArrayList<ModelListener>();
     private final Reference<JPDADebugger> debuggerRef;
     

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/PinWatchValueProvider.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/PinWatchValueProvider.java
@@ -56,7 +56,6 @@ import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.openide.util.Pair;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 
 /**
  *

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsTableModel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsTableModel.java
@@ -38,7 +38,6 @@ import org.netbeans.spi.viewmodel.UnknownTypeException;
 import org.openide.ErrorManager;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 
 
 

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsTreeExpansionModel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/ThreadsTreeExpansionModel.java
@@ -19,13 +19,14 @@
 
 package org.netbeans.modules.debugger.jpda.ui.models;
 
+import java.util.Collections;
 import java.util.Set;
+import java.util.WeakHashMap;
 import org.netbeans.api.debugger.jpda.JPDAThread;
 import org.netbeans.api.debugger.jpda.JPDAThreadGroup;
 import org.netbeans.spi.debugger.DebuggerServiceRegistration;
 import org.netbeans.spi.viewmodel.TreeExpansionModel;
 import org.netbeans.spi.viewmodel.UnknownTypeException;
-import org.openide.util.WeakSet;
 
 
 /**
@@ -34,8 +35,8 @@ import org.openide.util.WeakSet;
 @DebuggerServiceRegistration(path="netbeans-JPDASession/ThreadsView", types=TreeExpansionModel.class)
 public class ThreadsTreeExpansionModel implements TreeExpansionModel {
 
-    private Set expandedNodes = new WeakSet();
-    private Set collapsedNodes = new WeakSet();
+    private Set expandedNodes = Collections.newSetFromMap(new WeakHashMap());
+    private Set collapsedNodes = Collections.newSetFromMap(new WeakHashMap());
 
     /**
      * Defines default state (collapsed, expanded) of given node.

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesTableModel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesTableModel.java
@@ -24,6 +24,7 @@ import java.awt.Color;
 import java.io.InvalidObjectException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -55,7 +56,6 @@ import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
-import org.openide.util.WeakSet;
 
 
 /**
@@ -83,7 +83,7 @@ public class VariablesTableModel implements TableModel, Constants {
     private static final Map<Variable, String> errorValueMsg = new WeakHashMap<Variable, String>();
     private static final Map<Variable, String> errorToStringMsg = new WeakHashMap<Variable, String>();
     private final Map<Variable, Value> origValues = new WeakHashMap<Variable, Value>();
-    private static final Set<Variable> checkReadOnlyMutables = new WeakSet<Variable>();
+    private static final Set<Variable> checkReadOnlyMutables = Collections.newSetFromMap(new WeakHashMap<>());
     
     private JPDADebugger debugger;
     private final List<ModelListener> modelListeners = new ArrayList<ModelListener>();

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesTreeExpansionModel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/VariablesTreeExpansionModel.java
@@ -19,13 +19,14 @@
 
 package org.netbeans.modules.debugger.jpda.ui.models;
 
+import java.util.Collections;
 import java.util.Set;
+import java.util.WeakHashMap;
 import org.netbeans.spi.debugger.DebuggerServiceRegistration;
 import org.netbeans.spi.debugger.DebuggerServiceRegistrations;
 import org.netbeans.spi.debugger.jpda.EditorContext.Operation;
 import org.netbeans.spi.viewmodel.TreeExpansionModel;
 import org.netbeans.spi.viewmodel.UnknownTypeException;
-import org.openide.util.WeakSet;
 
 
 /**
@@ -44,8 +45,8 @@ import org.openide.util.WeakSet;
 })
 public class VariablesTreeExpansionModel implements TreeExpansionModel {
 
-    private Set expandedNodes = new WeakSet();
-    private Set collapsedNodes = new WeakSet();
+    private final Set<Object> expandedNodes = Collections.newSetFromMap(new WeakHashMap<>());
+    private final Set<Object> collapsedNodes = Collections.newSetFromMap(new WeakHashMap<>());
 
     /**
      * Defines default state (collapsed, expanded) of given node.

--- a/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RemoteServices.java
+++ b/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RemoteServices.java
@@ -95,7 +95,6 @@ import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.openide.util.Pair;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -115,7 +114,7 @@ public class RemoteServices {
     
     private static final RequestProcessor AUTORESUME_AFTER_SUSPEND_RP = new RequestProcessor("Autoresume after suspend", 1);
     
-    private static final Set<PropertyChangeListener> serviceListeners = new WeakSet<PropertyChangeListener>();
+    private static final Set<PropertyChangeListener> serviceListeners = Collections.newSetFromMap(new WeakHashMap<>());
 
     private RemoteServices() {}
     

--- a/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/GestureSubmitter.java
+++ b/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/GestureSubmitter.java
@@ -21,13 +21,14 @@ package org.netbeans.modules.debugger.jpda.visual.actions;
 
 import org.openide.util.NbBundle;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import org.netbeans.api.debugger.jpda.JPDADebugger;
-import org.openide.util.WeakSet;
 
 
 /**
@@ -39,7 +40,7 @@ class GestureSubmitter {
 
     private static final Logger USG_LOGGER = Logger.getLogger("org.netbeans.ui.metrics.debugger"); // NOI18N
     
-    private static final Set reportedDebuggers = new WeakSet();
+    private static final Set reportedDebuggers = Collections.newSetFromMap(new WeakHashMap());
 
     //~ Methods ------------------------------------------------------------------------------------------------------------------
 

--- a/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/TakeScreenshotActionProvider.java
+++ b/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/actions/TakeScreenshotActionProvider.java
@@ -22,6 +22,7 @@ import com.sun.jdi.ObjectReference;
 import java.beans.PropertyChangeEvent;
 import java.util.Collections;
 import java.util.Set;
+import java.util.WeakHashMap;
 import org.netbeans.api.debugger.Breakpoint;
 import org.netbeans.api.debugger.DebuggerEngine;
 import org.netbeans.api.debugger.DebuggerManager;
@@ -49,7 +50,6 @@ import org.openide.NotifyDescriptor;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 
 /**
  * Grabs screenshot of remote application.
@@ -166,7 +166,7 @@ public class TakeScreenshotActionProvider extends ActionsProviderSupport {
     
     private class BPListener implements DebuggerManagerListener {
         
-        private final Set<RemoteScreenshot> screenshots = new WeakSet<RemoteScreenshot>();
+        private final Set<RemoteScreenshot> screenshots = Collections.newSetFromMap(new WeakHashMap<>());
         
         void addScreenshot(RemoteScreenshot screenshot) {
             synchronized (screenshots) {

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/DeadlockDetectorImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/DeadlockDetectorImpl.java
@@ -27,6 +27,7 @@ import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.WeakHashMap;
 
 import org.netbeans.api.debugger.jpda.CallStackFrame;
 import org.netbeans.api.debugger.jpda.DeadlockDetector;
@@ -46,7 +48,6 @@ import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.RequestProcessor.Task;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -57,7 +58,7 @@ import org.openide.util.WeakSet;
 })
 public class DeadlockDetectorImpl extends DeadlockDetector implements PropertyChangeListener {
     
-    private final Set<JPDAThread> suspendedThreads = new WeakSet<JPDAThread>();
+    private final Set<JPDAThread> suspendedThreads = Collections.newSetFromMap(new WeakHashMap<>());
     private final RequestProcessor rp = new RequestProcessor("Deadlock Detector", 1); // NOI18N
     private final Set<Task> unfinishedTasks = new HashSet<Task>();
     

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JPDADebuggerImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JPDADebuggerImpl.java
@@ -140,7 +140,6 @@ import org.openide.util.Lookup;
 import org.openide.util.Mutex;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 import org.openide.util.lookup.Lookups;
 
 /**
@@ -1909,7 +1908,7 @@ public class JPDADebuggerImpl extends JPDADebugger {
         this.currentSuspendedNoFireThread = thread;
     }
 
-    private Set<JPDAThreadGroup> interestedThreadGroups = new WeakSet<JPDAThreadGroup>();
+    private Set<JPDAThreadGroup> interestedThreadGroups = Collections.newSetFromMap(new WeakHashMap<>());
 
     public void interestedInThreadGroup(JPDAThreadGroup tg) {
         interestedThreadGroups.add(tg);

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/JPDADebuggerActionProvider.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/JPDADebuggerActionProvider.java
@@ -27,10 +27,12 @@ import com.sun.jdi.request.StepRequest;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.WeakHashMap;
 import org.netbeans.api.debugger.ActionsManager;
 import org.netbeans.api.debugger.jpda.JPDADebugger;
 import org.netbeans.api.debugger.jpda.JPDAThread;
@@ -46,7 +48,6 @@ import org.netbeans.modules.debugger.jpda.jdi.request.StepRequestWrapper;
 import org.netbeans.modules.debugger.jpda.models.JPDAThreadImpl;
 import org.netbeans.spi.debugger.ActionsProviderSupport;
 
-import org.openide.util.WeakSet;
 
 
 /**
@@ -60,7 +61,7 @@ implements PropertyChangeListener {
     
     protected JPDADebuggerImpl debugger;
     
-    private static final Set<JPDADebuggerActionProvider> providersToDisableOnLazyActions = new WeakSet<JPDADebuggerActionProvider>();
+    private static final Set<JPDADebuggerActionProvider> providersToDisableOnLazyActions = Collections.newSetFromMap(new WeakHashMap<>());
     
     private volatile boolean disabled;
     

--- a/java/form/src/org/netbeans/modules/form/FormEditor.java
+++ b/java/form/src/org/netbeans/modules/form/FormEditor.java
@@ -53,7 +53,6 @@ import org.netbeans.modules.form.project.ClassSource;
 import org.netbeans.modules.form.project.ClassPathUtils;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
-import org.openide.util.WeakSet;
 
 /**
  * Form editor.
@@ -1237,7 +1236,7 @@ public class FormEditor {
 
     void registerNodeWithPropertiesWindow(FormNode node) {
         if (nodesWithPropertiesWindows == null) {
-            nodesWithPropertiesWindows = new WeakSet<FormNode>();
+            nodesWithPropertiesWindows = Collections.newSetFromMap(new WeakHashMap<>());
         }
         nodesWithPropertiesWindows.add(node);
     }

--- a/java/form/src/org/netbeans/modules/form/palette/PaletteUtils.java
+++ b/java/form/src/org/netbeans/modules/form/palette/PaletteUtils.java
@@ -553,8 +553,8 @@ public final class PaletteUtils {
 
         ClassPathFilter(ClassPath cp) {
             if (cp != null) {
-                validItems = new WeakSet<PaletteItem>();
-                invalidItems = new WeakSet<PaletteItem>();
+                validItems = Collections.newSetFromMap(new WeakHashMap<>());
+                invalidItems = Collections.newSetFromMap(new WeakHashMap<>());
             }
             classPath = cp;
         }

--- a/java/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationModelHelper.java
+++ b/java/j2ee.metadata.model.support/src/org/netbeans/modules/j2ee/metadata/model/api/support/annotation/AnnotationModelHelper.java
@@ -21,9 +21,11 @@ package org.netbeans.modules.j2ee.metadata.model.api.support.annotation;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -45,7 +47,6 @@ import org.netbeans.api.java.source.SourceUtils;
 import org.netbeans.api.java.source.TypesEvent;
 import org.netbeans.modules.j2ee.metadata.model.api.MetadataModelException;
 import org.openide.util.Exceptions;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -58,9 +59,9 @@ public final class AnnotationModelHelper {
 
     private final ClasspathInfo cpi;
     // @GuardedBy("this")
-    private final Set<JavaContextListener> javaContextListeners = new WeakSet<JavaContextListener>();
+    private final Set<JavaContextListener> javaContextListeners = Collections.newSetFromMap(new WeakHashMap<>());
     // @GuardedBy("this")
-    private final Set<PersistentObjectManager<? extends PersistentObject>> managers = new WeakSet<PersistentObjectManager<? extends PersistentObject>>();
+    private final Set<PersistentObjectManager<? extends PersistentObject>> managers = Collections.newSetFromMap(new WeakHashMap<>());
 
     // @GuardedBy("this")
     private ClassIndex classIndex;

--- a/java/java.editor/src/org/netbeans/modules/java/editor/rename/InstantRenamePerformer.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/rename/InstantRenamePerformer.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -118,7 +119,6 @@ import org.openide.text.NbDocument;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
-import org.openide.util.WeakSet;
 import org.openide.util.lookup.AbstractLookup;
 import org.openide.util.lookup.InstanceContent;
 import org.openide.util.lookup.ServiceProvider;
@@ -130,7 +130,7 @@ import org.openide.util.lookup.ServiceProvider;
 public class InstantRenamePerformer implements DocumentListener, KeyListener {
     
     private static final Logger LOG = Logger.getLogger(InstantRenamePerformer.class.getName());
-    private static final Set<InstantRenamePerformer> registry = Collections.synchronizedSet(new WeakSet<InstantRenamePerformer>());
+    private static final Set<InstantRenamePerformer> registry = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
 
     private SyncDocumentRegion region;
     private int span;

--- a/java/java.editor/src/org/netbeans/modules/java/editor/whitelist/WhiteListTaskProvider.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/whitelist/WhiteListTaskProvider.java
@@ -51,7 +51,6 @@ import org.openide.filesystems.URLMapper;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.TaskListener;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -96,7 +95,7 @@ public class WhiteListTaskProvider extends  PushTaskScanner {
         if (scope == null || callback == null)
             return ;
 
-        final Set<FileObject> files = new WeakSet<FileObject>();
+        final Set<FileObject> files = Collections.newSetFromMap(new WeakHashMap<>());
         for (FileObject file : scope.getLookup().lookupAll(FileObject.class)) {
             files.add(file);
         }
@@ -173,7 +172,7 @@ public class WhiteListTaskProvider extends  PushTaskScanner {
         synchronized (root2FilesWithAttachedErrors) {
             Set<FileObject> result = root2FilesWithAttachedErrors.get(root);
             if (result == null) {
-                root2FilesWithAttachedErrors.put(root, result = new WeakSet<FileObject>());
+                root2FilesWithAttachedErrors.put(root, result = Collections.newSetFromMap(new WeakHashMap<>()));
             }
             return result;
         }

--- a/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/debugging/ToggleDebuggingAction.java
+++ b/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/debugging/ToggleDebuggingAction.java
@@ -22,6 +22,7 @@ import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.util.Collections;
 import java.util.Set;
+import java.util.WeakHashMap;
 import javax.swing.Action;
 import javax.swing.Icon;
 import javax.swing.JEditorPane;
@@ -32,7 +33,6 @@ import org.netbeans.editor.BaseAction;
 import org.openide.util.ContextAwareAction;
 import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
-import org.openide.util.WeakSet;
 import org.openide.util.actions.Presenter;
 
 /**
@@ -44,8 +44,8 @@ public class ToggleDebuggingAction extends BaseAction implements Presenter.Toolb
     public static final String toggleDebuggingAction = "toggle-debugging-action";
     static final long serialVersionUID = 0L;
 
-    static final Set<Document> debuggingEnabled = Collections.synchronizedSet(new WeakSet<>());
-    static final Set<ToggleDebuggingAction> actions = Collections.synchronizedSet(new WeakSet<>());
+    static final Set<Document> debuggingEnabled = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
+    static final Set<ToggleDebuggingAction> actions = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
     
     private JEditorPane pane;
 

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -69,6 +69,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -288,7 +289,6 @@ import org.openide.util.NbBundle;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.Pair;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 import org.openide.util.lookup.Lookups;
 import org.openide.util.lookup.ProxyLookup;
 import org.openide.util.lookup.ServiceProvider;
@@ -338,7 +338,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
     @ServiceProvider(service=IndexingAware.class, position=0)
     public static final class RefreshDocument implements IndexingAware {
 
-        private final Set<TextDocumentServiceImpl> delegates = new WeakSet<>();
+        private final Set<TextDocumentServiceImpl> delegates = Collections.newSetFromMap(new WeakHashMap<>());
 
         public synchronized void register(TextDocumentServiceImpl delegate) {
             delegates.add(delegate);

--- a/java/java.source.base/src/org/netbeans/api/java/source/ElementHandle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ElementHandle.java
@@ -26,8 +26,11 @@ import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.jvm.Target;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.Name;
+import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 import javax.lang.model.element.Element;
@@ -421,8 +424,6 @@ public final class ElementHandle<T extends Element> {
     public @NonNull ElementKind getKind () {
         return this.kind;
     }
-    
-    private static final WeakSet<ElementHandle<?>> NORMALIZATION_CACHE = new WeakSet<ElementHandle<?>>();
 
     /**
      * Factory method for creating {@link ElementHandle}.
@@ -436,9 +437,7 @@ public final class ElementHandle<T extends Element> {
      * @throws IllegalArgumentException if the element is of an unsupported {@link ElementKind}
      */
     public static @NonNull <T extends Element> ElementHandle<T> create (@NonNull final T element) throws IllegalArgumentException {
-        ElementHandle<T> eh = createImpl(element);
-
-        return (ElementHandle<T>) NORMALIZATION_CACHE.putIfAbsent(eh);
+        return createImpl(element);
     }
     
     /**
@@ -492,9 +491,8 @@ public final class ElementHandle<T extends Element> {
     private static @NonNull <T extends Element> ElementHandle<T> createImpl (@NonNull final T element) throws IllegalArgumentException {
         Parameters.notNull("element", element);
         ElementKind kind = element.getKind();
-        ElementKind simplifiedKind = kind;
         String[] signatures;
-        switch (simplifiedKind) {
+        switch (kind) {
             case PACKAGE:
                 assert element instanceof PackageElement;
                 signatures = new String[]{((PackageElement)element).getQualifiedName().toString()};

--- a/java/java.source.base/src/org/netbeans/modules/java/source/usages/BuildArtifactMapperImpl.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/usages/BuildArtifactMapperImpl.java
@@ -32,6 +32,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -80,7 +81,6 @@ import org.openide.util.RequestProcessor;
 import org.openide.util.BaseUtilities;
 import org.openide.util.Lookup;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -125,7 +125,7 @@ public class BuildArtifactMapperImpl {
         }
     }
 
-    private static final Set<Object> alreadyWarned = new WeakSet<Object>();
+    private static final Set<Object> alreadyWarned = Collections.newSetFromMap(new WeakHashMap<>());
 
     private static boolean protectAgainstErrors(URL targetFolder, FileObject[][] sources, Object context) throws MalformedURLException {
         Preferences pref = NbPreferences.forModule(BuildArtifactMapperImpl.class).node(BuildArtifactMapperImpl.class.getSimpleName());
@@ -589,7 +589,7 @@ public class BuildArtifactMapperImpl {
 
         private RequestProcessor NOTIFY = new RequestProcessor(FileChangeListenerImpl.class.getName());
         
-        private Set<ChangeListener> notify = new WeakSet<ChangeListener>();
+        private Set<ChangeListener> notify = Collections.newSetFromMap(new WeakHashMap<>());
         
         public void fileCreated(FileChangeSupportEvent event) {
             notifyListeners();

--- a/java/java.source.base/src/org/netbeans/modules/java/source/usages/ExecutableFilesIndex.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/usages/ExecutableFilesIndex.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,6 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.netbeans.modules.java.source.indexing.JavaIndex;
 import org.openide.util.Exceptions;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -105,7 +105,7 @@ public class ExecutableFilesIndex {
         Set<ChangeListener> ls = file2Listener.get(ext);
         
         if (ls == null) {
-            file2Listener.put(ext, ls = new WeakSet<ChangeListener>());
+            file2Listener.put(ext, ls = Collections.newSetFromMap(new WeakHashMap<>()));
         }
         
         ls.add(l);

--- a/java/java.source/src/org/netbeans/api/java/source/support/OpenedEditors.java
+++ b/java/java.source/src/org/netbeans/api/java/source/support/OpenedEditors.java
@@ -46,7 +46,6 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
 import org.openide.util.Parameters;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -54,7 +53,7 @@ import org.openide.util.WeakSet;
  */
 class OpenedEditors implements PropertyChangeListener {
 
-    private Set<JTextComponent> visibleEditors = new WeakSet<JTextComponent>();
+    private Set<JTextComponent> visibleEditors = Collections.newSetFromMap(new WeakHashMap<>());
     private Map<JTextComponent, DataObject> visibleEditors2Files = new WeakHashMap<JTextComponent, DataObject>();
     private List<ChangeListener> listeners = new ArrayList<ChangeListener>();
 

--- a/java/jshell.support/src/org/netbeans/modules/jshell/navigation/SnippetNodes.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/navigation/SnippetNodes.java
@@ -27,6 +27,7 @@ import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -59,7 +60,6 @@ import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
 import org.openide.util.Utilities;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 import org.openide.util.lookup.Lookups;
 
 /**
@@ -483,7 +483,7 @@ public class SnippetNodes extends Children.Keys implements ShellListener, Consum
     }
     
     static class NF {
-        private Set<N>                    nodes = new WeakSet<>();
+        private Set<N>                    nodes = Collections.newSetFromMap(new WeakHashMap<>());
         private java.util.Map<SnippetHandle, Reference<N>> handledNodes = new WeakHashMap<>();
         
         public void register(SnippetHandle h, N n) {

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/Cancellation.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/Cancellation.java
@@ -19,9 +19,10 @@
 
 package org.netbeans.modules.maven.indexer;
 
+import java.util.Collections;
 import java.util.Set;
+import java.util.WeakHashMap;
 import org.openide.util.Cancellable;
-import org.openide.util.WeakSet;
 
 /**
  * Thrown when a task is canceled.
@@ -33,7 +34,7 @@ final class Cancellation extends Error {
         super("canceled");
     }
 
-    private static final Set<Cancellable> cancellables = new WeakSet<>();
+    private static final Set<Cancellable> cancellables = Collections.newSetFromMap(new WeakHashMap<>());
 
     public static synchronized void register(Cancellable c) {
         cancellables.add(c);

--- a/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.BackingStoreException;
@@ -51,7 +52,6 @@ import org.openide.filesystems.URLMapper;
 import org.openide.util.NbBundle;
 import org.openide.util.NbPreferences;
 import org.openide.util.Utilities;
-import org.openide.util.WeakSet;
 
 /**
  * a netbeans settings for global options that cannot be put into the settings file.
@@ -91,7 +91,7 @@ public final class MavenSettings  {
 
     private static final MavenSettings INSTANCE = new MavenSettings();
     
-    private final Set<PropertyChangeListener> listeners = new WeakSet<>();
+    private final Set<PropertyChangeListener> listeners = Collections.newSetFromMap(new WeakHashMap<>());
     
     /**
      * Specifies how should be proxies handled by default, if no setting is given.

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InstantRefactoringPerformer.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/InstantRefactoringPerformer.java
@@ -37,6 +37,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -83,7 +84,9 @@ import org.netbeans.modules.refactoring.api.Problem;
 import org.netbeans.modules.refactoring.api.ProgressEvent;
 import org.netbeans.modules.refactoring.api.ProgressListener;
 import org.netbeans.modules.refactoring.api.RefactoringSession;
+
 import static org.netbeans.modules.refactoring.java.ui.ContextAnalyzer.SHOW;
+
 import org.netbeans.modules.refactoring.java.ui.InstantRefactoringUI;
 import org.netbeans.modules.refactoring.java.ui.SyncDocumentRegion;
 import org.netbeans.modules.refactoring.java.ui.UIUtilities;
@@ -102,7 +105,6 @@ import org.openide.text.CloneableEditorSupport;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.windows.TopComponent;
 
@@ -114,7 +116,7 @@ import org.openide.windows.TopComponent;
 public final class InstantRefactoringPerformer implements DocumentListener, KeyListener, ProgressListener, PropertyChangeListener {
     
     private static final Logger LOG = Logger.getLogger(InstantRefactoringPerformer.class.getName());
-    private static final Set<InstantRefactoringPerformer> registry = Collections.synchronizedSet(new WeakSet<InstantRefactoringPerformer>());
+    private static final Set<InstantRefactoringPerformer> registry = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
     private CompletionLayout compl;
 
     private SyncDocumentRegion region;

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/code/CodeHintProviderImpl.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/code/CodeHintProviderImpl.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -32,6 +33,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -65,7 +67,6 @@ import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.NbCollections;
-import org.openide.util.WeakSet;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -329,7 +330,7 @@ public class CodeHintProviderImpl implements HintProvider {
                 boolean newOccurrence;
                 
                 synchronized (this) {
-                    if (exceptionThrownFor == null) exceptionThrownFor = new WeakSet<>();
+                    if (exceptionThrownFor == null) exceptionThrownFor = Collections.newSetFromMap(new WeakHashMap<>());
                     newOccurrence = exceptionThrownFor.add(ctx.getInfo().getFileObject());
                 }
                 

--- a/php/php.project/src/org/netbeans/modules/php/project/PhpProject.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/PhpProject.java
@@ -38,6 +38,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -138,7 +139,6 @@ import org.openide.util.Mutex;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 import org.openide.util.lookup.Lookups;
 import org.openide.windows.WindowManager;
 import org.openide.windows.WindowSystemEvent;
@@ -200,7 +200,7 @@ public final class PhpProject implements Project {
     public static final String PROP_FRAMEWORKS = "frameworks"; // NOI18N
     public static final String PROP_WEB_ROOT = "webRoot"; // NOI18N
     final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
-    private final Set<PropertyChangeListener> propertyChangeListeners = new WeakSet<>();
+    private final Set<PropertyChangeListener> propertyChangeListeners = Collections.newSetFromMap(new WeakHashMap<>());
 
     // css preprocessors
     final CssPreprocessorsListener cssPreprocessorsListener = new CssPreprocessorsListener() {

--- a/php/php.project/src/org/netbeans/modules/php/project/classpath/IncludePathClassPathProvider.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/classpath/IncludePathClassPathProvider.java
@@ -20,8 +20,10 @@ package org.netbeans.modules.php.project.classpath;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.netbeans.api.java.classpath.ClassPath;
@@ -30,7 +32,6 @@ import org.netbeans.modules.php.project.api.PhpSourcePath;
 import org.netbeans.spi.java.classpath.ClassPathProvider;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
-import org.openide.util.WeakSet;
 
 /**
  * Provides ClassPath for php files on include path or without a project.
@@ -41,7 +42,7 @@ public class IncludePathClassPathProvider implements ClassPathProvider {
     private static final boolean RUNNING_IN_TEST = Boolean.getBoolean("nb.php.test.run"); // NOI18N
 
     // @GuardedBy(PROJECT_INCLUDES_LOCK)
-    private static final Set<ClassPath> PROJECT_INCLUDES = new WeakSet<>();
+    private static final Set<ClassPath> PROJECT_INCLUDES = Collections.newSetFromMap(new WeakHashMap<>());
     private static final ReadWriteLock PROJECT_INCLUDES_LOCK = new ReentrantReadWriteLock();
 
     // @GuardedBy("IncludePathClassPathProvider.class")

--- a/platform/api.search/src/org/netbeans/modules/search/ActionManager.java
+++ b/platform/api.search/src/org/netbeans/modules/search/ActionManager.java
@@ -22,7 +22,9 @@ package org.netbeans.modules.search;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.lang.ref.WeakReference;
+import java.util.Collections;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.Action;
@@ -32,7 +34,6 @@ import org.openide.actions.ReplaceAction;
 import org.openide.text.CloneableEditorSupport;
 import org.openide.util.Mutex;
 import org.openide.util.SharedClassObject;
-import org.openide.util.WeakSet;
 import org.openide.util.actions.CallbackSystemAction;
 import org.openide.util.actions.SystemAction;
 import org.openide.windows.TopComponent;
@@ -60,7 +61,7 @@ public abstract class ActionManager<A extends SystemAction, S extends CallbackSy
      * holds set of windows for which their ActionMap was modified
      */
     private final Set<TopComponent> activatedOnWindows =
-            new WeakSet<>(8);
+            Collections.newSetFromMap(new WeakHashMap<>(8));
     /**
      *
      */

--- a/platform/core.startup/src/org/netbeans/core/startup/ModuleList.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/ModuleList.java
@@ -47,6 +47,7 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.WeakHashMap;
 import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -73,7 +74,6 @@ import org.openide.util.BaseUtilities;
 import org.openide.util.Parameters;
 import org.openide.util.RequestProcessor;
 import org.openide.util.RequestProcessor.Task;
-import org.openide.util.WeakSet;
 import org.openide.xml.EntityCatalog;
 import org.openide.xml.XMLUtil;
 import org.xml.sax.Attributes;
@@ -118,7 +118,7 @@ final class ModuleList implements Stamps.Updater {
     private final Listener listener = new Listener();
     private FileChangeListener weakListener;
     /** atomic actions I have used to change Modules/*.xml */
-    private final Set<FileSystem.AtomicAction> myAtomicActions = Collections.<FileSystem.AtomicAction>synchronizedSet(new WeakSet<FileSystem.AtomicAction>(100));
+    private final Set<FileSystem.AtomicAction> myAtomicActions = Collections.<FileSystem.AtomicAction>synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>(100)));
     
     /** Create the list manager.
      * @param mgr the module manager which will actually control the modules at runtime

--- a/platform/core.windows/src/org/netbeans/core/windows/RegistryImpl.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/RegistryImpl.java
@@ -22,7 +22,6 @@ package org.netbeans.core.windows;
 import java.util.Collection;
 import java.util.Iterator;
 import org.openide.nodes.Node;
-import org.openide.util.WeakSet;
 import org.openide.windows.TopComponent;
 
 import javax.swing.*;
@@ -31,8 +30,10 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.WeakHashMap;
 
 /** Implementstion of registry of top components. This implementation
  * receives information about top component changes from the window
@@ -49,7 +50,7 @@ public final class RegistryImpl extends Object implements TopComponent.Registry 
     /** Previouly activated top component */
     private WeakReference<TopComponent> previousActivated;
     /** Set of opened TopComponents */
-    private final Set<TopComponent> openSet = new WeakSet<TopComponent>(30);
+    private final Set<TopComponent> openSet = Collections.newSetFromMap(new WeakHashMap<>(30));
     /** Currently selected nodes. */
     private Node[] currentNodes;
     /** Last non-null value of current nodes. (If null -> it means they are

--- a/platform/core.windows/src/org/netbeans/core/windows/TopComponentTracker.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/TopComponentTracker.java
@@ -18,14 +18,15 @@
  */
 package org.netbeans.core.windows;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 import org.openide.util.NbPreferences;
-import org.openide.util.WeakSet;
 import org.openide.windows.TopComponent;
 
 /**
@@ -40,7 +41,7 @@ public final class TopComponentTracker {
     
     private final Set<String> viewIds = new HashSet<String>(30);
     private final Set<String> editorIds = new HashSet<String>(30);
-    private final Set<TopComponent> editors = new WeakSet<TopComponent>( 100 );
+    private final Set<TopComponent> editors = Collections.newSetFromMap(new WeakHashMap<>(100));
     
     private static TopComponentTracker theInstance;
     

--- a/platform/core.windows/src/org/netbeans/core/windows/model/SplitSubModel.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/model/SplitSubModel.java
@@ -25,7 +25,6 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.core.windows.*;
-import org.openide.util.WeakSet;
 
 
 /**
@@ -42,7 +41,7 @@ class SplitSubModel {
     protected final Model parentModel;
     
     /** Maps modes to nodes of this n-branch tree model. */
-    private final Set<ModeNode> nodes = new WeakSet<ModeNode>(20);
+    private final Set<ModeNode> nodes = Collections.newSetFromMap(new WeakHashMap<>(20));
     
     /** Root <code>Node</code> which represents the split panes structure
      * with modes as leaves. */

--- a/platform/core.windows/src/org/netbeans/core/windows/services/NodeOperationImpl.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/services/NodeOperationImpl.java
@@ -27,6 +27,7 @@ import java.awt.FocusTraversalPolicy;
 import java.awt.Window;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.WeakHashMap;
 import java.util.HashSet;
@@ -52,7 +53,6 @@ import org.openide.util.Mutex;
 import org.openide.util.NbBundle;
 import org.openide.util.UserCancelException;
 import org.openide.util.Utilities;
-import org.openide.util.WeakSet;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.windows.Mode;
 import org.openide.windows.TopComponent;
@@ -288,7 +288,7 @@ public final class NodeOperationImpl extends NodeOperation {
     
     //#79126 - cache the open properties windows and reuse them if the Nodes 
     //are the same
-    private static WeakSet<Node[]> nodeCache = new WeakSet<Node[]>();
+    private static Set<Node[]> nodeCache = Collections.newSetFromMap(new WeakHashMap<>());
     private static WeakHashMap<Node[], Dialog> dialogCache = new WeakHashMap<Node[], Dialog>();
     
     private static Dialog findCachedPropertiesDialog( Node n ) {

--- a/platform/core.windows/src/org/netbeans/core/windows/view/DefaultView.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/DefaultView.java
@@ -26,13 +26,14 @@ import java.util.logging.Logger;
 import javax.swing.*;
 import java.awt.*;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.WeakHashMap;
 import javax.swing.SwingUtilities;
 
 import org.openide.awt.ToolbarPool; // Why is this in open API?
-import org.openide.util.WeakSet;
 import org.openide.windows.TopComponent;
 
 import org.netbeans.core.windows.Constants;
@@ -57,7 +58,7 @@ class DefaultView implements View, Controller, WindowDnDManager.ViewAccessor {
     
     private final ControllerHandler controllerHandler;
     
-    private final Set<TopComponent> showingTopComponents = new WeakSet<TopComponent>(10);
+    private final Set<TopComponent> showingTopComponents = Collections.newSetFromMap(new WeakHashMap<>(10));
 
     /** Debugging flag. */
     private static final boolean DEBUG = Debug.isLoggable(DefaultView.class);

--- a/platform/core.windows/src/org/netbeans/core/windows/view/dnd/WindowDnDManager.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/dnd/WindowDnDManager.java
@@ -36,7 +36,6 @@ import org.netbeans.core.windows.view.*;
 import org.netbeans.core.windows.view.ui.*;
 import org.openide.util.Lookup;
 import org.openide.util.Utilities;
-import org.openide.util.WeakSet;
 import org.openide.windows.TopComponent;
 
 
@@ -73,7 +72,7 @@ implements DropTargetGlassPane.Observer, DropTargetGlassPane.Informer {
     private final Map<JRootPane,Component> root2glass = new HashMap<JRootPane, Component>();
     
     /** Set of floating frame types, i.e. separate windows. */
-    private final Set<Component> floatingFrames = new WeakSet<Component>(4);
+    private final Set<Component> floatingFrames = Collections.newSetFromMap(new WeakHashMap<>(4));
     
     /** Used to hack the last Drop target to clear its indication. */ 
     private Reference<DropTargetGlassPane> lastTargetWRef = new WeakReference<DropTargetGlassPane>(null);

--- a/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectFactory.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectFactory.java
@@ -51,7 +51,6 @@ import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
 import org.openide.util.Mutex;
 import org.openide.util.BaseUtilities;
-import org.openide.util.WeakSet;
 
 /**
  * @author Radek Matous
@@ -496,7 +495,7 @@ public final class FileObjectFactory {
         final Set<BaseFileObj> all2Refresh;
         allIBaseLock.writeLock().lock();
         try {
-            all2Refresh = new WeakSet<BaseFileObj>(allIBaseFileObjects.size() * 3 + 11);
+            all2Refresh = Collections.newSetFromMap(new WeakHashMap<>(allIBaseFileObjects.size() * 3 + 11));
             final Iterator<Object> it = allIBaseFileObjects.values().iterator();
             while (it.hasNext()) {
                 final Object obj = it.next();

--- a/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/MutualExclusionSupport.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/MutualExclusionSupport.java
@@ -20,7 +20,6 @@
 package org.netbeans.modules.masterfs.filebasedfs.fileobjects;
 
 
-import org.openide.util.WeakSet;
 
 import java.io.IOException;
 import java.lang.ref.Reference;
@@ -58,7 +57,7 @@ public final class MutualExclusionSupport<K> {
 
             if (!isInUse) {            
                 if (expectedCounter == null) {
-                    expectedCounter = new WeakSet<Closeable>();
+                    expectedCounter = Collections.newSetFromMap(new WeakHashMap<>());
                     expected.put(key, expectedCounter);
                 }
                 isInUse = !isShared && expectedCounter.size() > 0;            

--- a/platform/masterfs/src/org/netbeans/modules/masterfs/watcher/Watcher.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/watcher/Watcher.java
@@ -24,6 +24,7 @@ import java.awt.Image;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.ReferenceQueue;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +41,6 @@ import org.netbeans.modules.masterfs.providers.BaseAnnotationProvider;
 import org.openide.util.Lookup;
 import org.openide.util.Lookup.Item;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakSet;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
 
@@ -426,7 +426,7 @@ public final class Watcher extends BaseAnnotationProvider {
         synchronized(lock) {
             if (pending == null) {
                 refreshTask.schedule(1500);
-                pending = new WeakSet<FileObject>();
+                pending = Collections.newSetFromMap(new WeakHashMap<>());
             }
             pending.add(fo);
         }
@@ -439,7 +439,7 @@ public final class Watcher extends BaseAnnotationProvider {
         synchronized(lock) {
             if (pending == null) {
                 refreshTask.schedule(1500);
-                pending = new WeakSet<FileObject>();
+                pending = Collections.newSetFromMap(new WeakHashMap<>());
             }
             pending.addAll(fos);
         }

--- a/platform/o.n.bootstrap/src/org/netbeans/NbInstrumentation.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/NbInstrumentation.java
@@ -19,7 +19,6 @@
 
 package org.netbeans;
 
-import java.lang.instrument.ClassDefinition;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.lang.instrument.Instrumentation;
@@ -30,14 +29,13 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.security.ProtectionDomain;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -69,7 +67,8 @@ final class NbInstrumentation implements InvocationHandler {
     static void unregisterAgent(NbInstrumentation instr) {
         synchronized (LOCK) {
             if (ACTIVE != null) {
-                Collection<NbInstrumentation> clone = new WeakSet<>(ACTIVE);
+                Collection<NbInstrumentation> clone = Collections.newSetFromMap(new WeakHashMap<>());
+                clone.addAll(ACTIVE);
                 clone.remove(instr);
                 ACTIVE = clone;
             }
@@ -80,9 +79,11 @@ final class NbInstrumentation implements InvocationHandler {
         final NbInstrumentation inst = new NbInstrumentation();
         synchronized (LOCK) {
             if (ACTIVE == null) {
-                ACTIVE = new WeakSet<>();
+                ACTIVE = Collections.newSetFromMap(new WeakHashMap<>());
             } else {
-                ACTIVE = new WeakSet<>(ACTIVE);
+                Set<NbInstrumentation> clone = Collections.newSetFromMap(new WeakHashMap<>());
+                clone.addAll(ACTIVE);
+                ACTIVE = clone;
             }
             ACTIVE.add(inst);
         }

--- a/platform/o.n.bootstrap/src/org/netbeans/Util.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/Util.java
@@ -457,7 +457,7 @@ public final class Util {
     static final class ModuleLookup extends Lookup {
         ModuleLookup() {}
         private final Set<Module> modules = new HashSet<Module>(100);
-        private final Set<ModuleResult> results = new WeakSet<ModuleResult>(10);
+        private final Set<ModuleResult> results = Collections.newSetFromMap(new WeakHashMap<>(10));
         /** Add a module to the set. */
         public void add(Module m) {
             synchronized (modules) {

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BusyTabsSupport.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BusyTabsSupport.java
@@ -21,7 +21,9 @@ package org.netbeans.swing.tabcontrol.plaf;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.Collections;
 import java.util.Set;
+import java.util.WeakHashMap;
 import javax.swing.Icon;
 import javax.swing.Timer;
 import javax.swing.event.ChangeEvent;
@@ -29,7 +31,6 @@ import javax.swing.event.ChangeListener;
 import org.netbeans.swing.tabcontrol.TabDataModel;
 import org.netbeans.swing.tabcontrol.customtabs.Tabbed;
 import org.openide.util.Lookup;
-import org.openide.util.WeakSet;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.windows.TopComponent;
 
@@ -60,8 +61,8 @@ public abstract class BusyTabsSupport {
         }
     };
 
-    private final Set<Tabbed> containers = new WeakSet<Tabbed>(10);
-    private final Set<Tabbed> busyContainers = new WeakSet<Tabbed>(10);
+    private final Set<Tabbed> containers = Collections.newSetFromMap(new WeakHashMap<>(10));
+    private final Set<Tabbed> busyContainers = Collections.newSetFromMap(new WeakHashMap<>(10));
 
     /**
      * @return The default implementation registered in global Lookup.

--- a/platform/openide.awt/src/org/openide/awt/AlwaysEnabledAction.java
+++ b/platform/openide.awt/src/org/openide/awt/AlwaysEnabledAction.java
@@ -21,7 +21,6 @@ package org.openide.awt;
 
 import java.awt.EventQueue;
 import java.awt.Image;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
@@ -29,7 +28,10 @@ import java.beans.PropertyChangeListener;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.BackingStoreException;
@@ -50,7 +52,6 @@ import org.openide.util.LookupEvent;
 import org.openide.util.LookupListener;
 import org.openide.util.NbPreferences;
 import org.openide.util.Utilities;
-import org.openide.util.WeakSet;
 import org.openide.util.WeakListeners;
 import org.openide.util.actions.Presenter;
 import org.openide.util.actions.ActionInvoker;
@@ -315,7 +316,7 @@ implements PropertyChangeListener, ContextAwareAction {
 
         private JCheckBoxMenuItem popupItem;
 
-        private WeakSet<AbstractButton> toolbarItems;
+        private Set<AbstractButton> toolbarItems;
 
         private Preferences preferencesNode;
 
@@ -359,7 +360,7 @@ implements PropertyChangeListener, ContextAwareAction {
 
         public AbstractButton getToolbarPresenter() {
             if(toolbarItems == null) {
-                toolbarItems = new WeakSet<AbstractButton>(4);
+                toolbarItems = Collections.newSetFromMap(new WeakHashMap<>(4));
             }
             AbstractButton b = new DefaultIconToggleButton();
             toolbarItems.add(b);

--- a/platform/openide.awt/src/org/openide/awt/ContextManager.java
+++ b/platform/openide.awt/src/org/openide/awt/ContextManager.java
@@ -27,15 +27,16 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiFunction;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.swing.Action;
 import org.openide.util.Lookup;
 import org.openide.util.Lookup.Item;
 import org.openide.util.Lookup.Provider;
@@ -45,7 +46,6 @@ import org.openide.util.LookupListener;
 import org.openide.util.Mutex;
 import org.openide.util.Utilities;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 import org.openide.util.lookup.Lookups;
 import org.openide.util.lookup.ProxyLookup;
 
@@ -413,9 +413,9 @@ class ContextManager extends Object {
     /** Special set, that is weakly holding its actions, but also
      * listens on changes in lookup.
      */
-    static final class LSet<T> extends WeakSet<ContextAction> 
-    implements LookupListener, Runnable {
+    static final class LSet<T> implements Set<ContextAction>, LookupListener, Runnable {
         final Lookup.Result<T> result;
+        private final Set<ContextAction> delegate = Collections.newSetFromMap(new WeakHashMap<>());
         
         public LSet(Lookup.Result<T> context, Class<T> type) {
             this.result = context;
@@ -427,7 +427,7 @@ class ContextManager extends Object {
         @Override
         public boolean add(ContextAction e) {
             assert e != null;
-            return super.add(e);
+            return delegate.add(e);
         }
 
         @Override
@@ -460,6 +460,66 @@ class ContextManager extends Object {
 
         private void cleanup() {
             this.result.removeLookupListener(this);
+        }
+
+        @Override
+        public int size() {
+            return delegate.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return delegate.isEmpty();
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            return delegate.contains(o);
+        }
+
+        @Override
+        public Iterator<ContextAction> iterator() {
+            return delegate.iterator();
+        }
+
+        @Override
+        public Object[] toArray() {
+            return delegate.toArray();
+        }
+
+        @Override
+        public <T> T[] toArray(T[] a) {
+            return delegate.toArray(a);
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            return delegate.remove(o);
+        }
+
+        @Override
+        public boolean containsAll(Collection<?> c) {
+            return delegate.containsAll(c);
+        }
+
+        @Override
+        public boolean addAll(Collection<? extends ContextAction> c) {
+            return delegate.addAll(c);
+        }
+
+        @Override
+        public boolean retainAll(Collection<?> c) {
+            return delegate.retainAll(c);
+        }
+
+        @Override
+        public boolean removeAll(Collection<?> c) {
+            return delegate.removeAll(c);
+        }
+
+        @Override
+        public void clear() {
+            delegate.clear();
         }
     }
 

--- a/platform/openide.awt/src/org/openide/awt/GlobalManager.java
+++ b/platform/openide.awt/src/org/openide/awt/GlobalManager.java
@@ -25,10 +25,12 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.Action;
@@ -38,7 +40,6 @@ import org.openide.util.Lookup;
 import org.openide.util.LookupListener;
 import org.openide.util.Mutex;
 import org.openide.util.Utilities;
-import org.openide.util.WeakSet;
 
 
 /** Listener on a global context.
@@ -105,7 +106,7 @@ class GlobalManager extends Object implements LookupListener {
         synchronized (CACHE) {
             Set<GeneralAction.BaseDelAction> existing = listeners.get(key);
             if (existing == null) {
-                existing = new WeakSet<GeneralAction.BaseDelAction>();
+                existing = Collections.newSetFromMap(new WeakHashMap<>());
                 listeners.put(key, existing);
             }
             existing.add(a);

--- a/platform/openide.dialogs/src/org/openide/WizardDescriptor.java
+++ b/platform/openide.dialogs/src/org/openide/WizardDescriptor.java
@@ -1157,21 +1157,6 @@ public class WizardDescriptor extends DialogDescriptor {
         changeStateInProgress = false;
     }
 
-    /* commented out - issue #32927. Replaced by javadoc info in WizardDescriptor.Panel
-    private static final Set warnedPanelIsComponent = new WeakSet(); // Set<Class>
-    private static synchronized void warnPanelIsComponent(Class c) {
-        if (warnedPanelIsComponent.add(c)) {
-            StringBuffer buffer = new StringBuffer(150);
-            buffer.append("WARNING - the WizardDescriptor.Panel implementation "); // NOI18N
-            buffer.append(c.getName());
-            buffer.append(" provides itself as the result of getComponent().\n"); // NOI18N
-            buffer.append("This hurts performance and can cause a clash when Component.isValid() is overridden.\n"); // NOI18N
-            buffer.append("Please use a separate component class, see details at http://performance.netbeans.org/howto/dialogs/wizard-panels.html."); // NOI18N
-            err.log(ErrorManager.WARNING, buffer.toString());
-        }
-    }
-    */
-
     /** Tryes to get property from getProperty() if doesn't succeed then tryes at
      * supplied <CODE>JComponent</CODE>s client property.
      * @param c origin of property

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/RadioInplaceEditor.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/RadioInplaceEditor.java
@@ -23,7 +23,6 @@
 */
 package org.openide.explorer.propertysheet;
 
-import org.openide.util.WeakSet;
 
 import java.awt.Color;
 import java.awt.Component;
@@ -42,8 +41,11 @@ import java.awt.event.KeyEvent;
 import java.beans.PropertyEditor;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.WeakHashMap;
 
 import javax.swing.ButtonGroup;
 import javax.swing.JComponent;
@@ -69,7 +71,7 @@ class RadioInplaceEditor extends JPanel implements InplaceEditor, ActionListener
     protected transient ButtonGroup group = null;
     private boolean tableUI = false;
     boolean isFirstEvent = false;
-    private WeakSet<InvRadioButton> buttonCache = new WeakSet<InvRadioButton>();
+    private Set<InvRadioButton> buttonCache = Collections.newSetFromMap(new WeakHashMap<>());
     private boolean useTitle = false;
 
     public RadioInplaceEditor(boolean tableUI) {

--- a/platform/openide.filesystems/src/org/openide/filesystems/DeepListener.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/DeepListener.java
@@ -26,11 +26,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.openide.util.BaseUtilities;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -186,7 +186,7 @@ implements FileChangeListener, Runnable, Callable<Boolean>, FileFilter {
         return hash;
     }
 
-    private Set<FileEvent> delivered = Collections.synchronizedSet(new WeakSet<FileEvent>());
+    private Set<FileEvent> delivered = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
     private FileChangeListener get(FileEvent fe, boolean fromHolder) {
         if (removed) {
             return null;

--- a/platform/openide.filesystems/src/org/openide/filesystems/StreamPool.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/StreamPool.java
@@ -264,7 +264,7 @@ final class StreamPool extends Object {
 
     private Set<InputStream> iStream() {
         if (iStreams == null) {
-            iStreams = new WeakSet<InputStream>();
+            iStreams = Collections.newSetFromMap(new WeakHashMap<>());
         }
 
         return iStreams;
@@ -272,7 +272,7 @@ final class StreamPool extends Object {
 
     private Set<OutputStream> oStream() {
         if (oStreams == null) {
-            oStreams = new WeakSet<OutputStream>();
+            oStreams = Collections.newSetFromMap(new WeakHashMap<>());
         }
 
         return oStreams;

--- a/platform/openide.filesystems/src/org/openide/filesystems/annotations/LayerGeneratingProcessor.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/annotations/LayerGeneratingProcessor.java
@@ -28,6 +28,7 @@ import java.io.OutputStream;
 import java.nio.file.NoSuchFileException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +46,6 @@ import javax.tools.Diagnostic.Kind;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 import org.openide.filesystems.XMLFileSystem;
-import org.openide.util.WeakSet;
 import org.openide.xml.XMLUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.ls.DOMImplementationLS;
@@ -209,7 +209,7 @@ public abstract class LayerGeneratingProcessor extends AbstractProcessor {
         Filer filer = processingEnv.getFiler();
         Collection<Element> originatingElementsL = originatingElementsByProcessor.get(filer);
         if (originatingElementsL == null) {
-            originatingElementsL = new WeakSet<Element>();
+            originatingElementsL = Collections.newSetFromMap(new WeakHashMap<>());
             originatingElementsByProcessor.put(filer, originatingElementsL);
         }
         originatingElementsL.addAll(Arrays.asList(originatingElements));

--- a/platform/openide.loaders/src/org/openide/loaders/DataObject.java
+++ b/platform/openide.loaders/src/org/openide/loaders/DataObject.java
@@ -1183,7 +1183,7 @@ implements Node.Cookie, Serializable, HelpCtx.Provider, Lookup.Provider {
             return createNodeDelegate().getLookup();
         }
     }
-    private static final Set<Class<?>> warnedClasses = Collections.synchronizedSet(new WeakSet<Class<?>>());
+    private static final Set<Class<?>> warnedClasses = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
     
     /** When a request for a cookie is done on a DataShadow of this DataObject
      * this methods gets called (by default) so the DataObject knows which

--- a/platform/openide.loaders/src/org/openide/loaders/DataObjectPool.java
+++ b/platform/openide.loaders/src/org/openide/loaders/DataObjectPool.java
@@ -61,7 +61,7 @@ implements ChangeListener {
     private Map<FileObject,List<Item>> children = new HashMap<FileObject, List<Item>>();
     
     /** covers all FileSystems we're listening on */
-    private final Set<FileSystem> knownFileSystems = new WeakSet<FileSystem>();
+    private final Set<FileSystem> knownFileSystems = Collections.newSetFromMap(new WeakHashMap<>());
     
     /** error manager to log what is happening here */
     private static final Logger err = Logger.getLogger("org.openide.loaders.DataObject.find"); // NOI18N

--- a/platform/openide.loaders/src/org/openide/loaders/InstanceDataObject.java
+++ b/platform/openide.loaders/src/org/openide/loaders/InstanceDataObject.java
@@ -856,7 +856,7 @@ public class InstanceDataObject extends MultiDataObject implements InstanceCooki
         return superName;
     }
 
-    private static final Set<FileObject> warnedAboutBrackets = new WeakSet<FileObject>();
+    private static final Set<FileObject> warnedAboutBrackets = Collections.newSetFromMap(new WeakHashMap<>());
     /** Make sure people stop using this syntax eventually.
      * It is better to use the file attribute, not least because some VMs
      * do not much like [] in file names (OpenVMS had problems at one point, e.g.).

--- a/platform/openide.loaders/src/org/openide/loaders/OpenSupport.java
+++ b/platform/openide.loaders/src/org/openide/loaders/OpenSupport.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -40,7 +41,6 @@ import org.openide.cookies.OpenCookie;
 import org.openide.filesystems.FileStateInvalidException;
 import org.openide.filesystems.FileSystem;
 import org.openide.util.NbBundle;
-import org.openide.util.WeakSet;
 import org.openide.windows.CloneableOpenSupport;
 import org.openide.windows.CloneableTopComponent;
 
@@ -348,7 +348,7 @@ public abstract class OpenSupport extends CloneableOpenSupport {
     private static final class FileSystemNameListener
     implements PropertyChangeListener, VetoableChangeListener {
         /** Set of Env's interested in changes on fs name. */
-        private final Set<Env> environments = new WeakSet<Env>(30);
+        private final Set<Env> environments = Collections.newSetFromMap(new WeakHashMap<>(30));
         
         public FileSystemNameListener() {
         }

--- a/platform/openide.loaders/src/org/openide/text/DataEditorSupport.java
+++ b/platform/openide.loaders/src/org/openide/text/DataEditorSupport.java
@@ -49,6 +49,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
@@ -475,7 +476,7 @@ public class DataEditorSupport extends CloneableEditorSupport {
         };
     }
 
-    private static Set<FileObject> warnedEncodingFiles = new WeakSet<FileObject>();
+    private static Set<FileObject> warnedEncodingFiles = Collections.newSetFromMap(new WeakHashMap<>());
 
     /** can hold the right charset to be used during save, needed for communication
      * between saveFromKitToStream and saveDocument

--- a/platform/openide.nodes/src/org/openide/nodes/FilterNode.java
+++ b/platform/openide.nodes/src/org/openide/nodes/FilterNode.java
@@ -26,7 +26,6 @@ import org.openide.util.HelpCtx;
 import org.openide.util.Lookup;
 import org.openide.util.LookupEvent;
 import org.openide.util.LookupListener;
-import org.openide.util.WeakSet;
 import org.openide.util.actions.SystemAction;
 import org.openide.util.datatransfer.NewType;
 import org.openide.util.datatransfer.PasteType;
@@ -2098,7 +2097,7 @@ public class FilterNode extends Node {
 
             synchronized (this) {
                 if (results == null) {
-                    results = new WeakSet<ProxyResult>();
+                    results = Collections.newSetFromMap(new WeakHashMap<>());
                 }
 
                 results.add(p);

--- a/platform/openide.nodes/src/org/openide/util/actions/NodeAction.java
+++ b/platform/openide.nodes/src/org/openide/util/actions/NodeAction.java
@@ -29,9 +29,11 @@ import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.Action;
@@ -46,7 +48,6 @@ import org.openide.util.LookupListener;
 import org.openide.util.Mutex;
 import org.openide.util.Utilities;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 
 /**
  * A type of action that listens on change in activated nodes selection and
@@ -84,7 +85,7 @@ public abstract class NodeAction extends CallableSystemAction implements Context
     private static NodesL l;
 
     /** set of actions with listeners */
-    private static final Set<NodeAction> listeningActions = new WeakSet<NodeAction>(100);
+    private static final Set<NodeAction> listeningActions = Collections.newSetFromMap(new WeakHashMap<>(100));
 
     /* Initialize the listener.
     */

--- a/platform/openide.text/src/org/openide/text/CloneableEditorSupport.java
+++ b/platform/openide.text/src/org/openide/text/CloneableEditorSupport.java
@@ -71,7 +71,6 @@ import org.openide.util.Exceptions;
 import org.openide.util.Mutex;
 import org.openide.util.Parameters;
 import org.openide.util.UserCancelException;
-import org.openide.util.WeakSet;
 
 
 /** Support for associating an editor and a Swing {@link Document}.
@@ -218,7 +217,7 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
     private final Object checkModificationLock = new Object();
 
     /** Classes that have been warned about overriding asynchronousOpen() */
-    private static final Set<Class<?>> warnedClasses = new WeakSet<Class<?>>();
+    private static final Set<Class<?>> warnedClasses = Collections.newSetFromMap(new WeakHashMap<>());
     
     /** Creates new CloneableEditorSupport attached to given environment.
     *

--- a/platform/openide.util.ui/src/org/openide/ErrorManager.java
+++ b/platform/openide.util.ui/src/org/openide/ErrorManager.java
@@ -25,6 +25,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -41,7 +42,6 @@ import org.openide.util.Enumerations;
 import org.openide.util.Lookup;
 import org.openide.util.LookupEvent;
 import org.openide.util.LookupListener;
-import org.openide.util.WeakSet;
 
 /**
  * A more or less <em>deprecated</em> system of managing, annotating, and classifying errors
@@ -531,7 +531,7 @@ public abstract class ErrorManager extends Object {
          * A set that has to be updated when the list of delegates
          * changes. All instances created by getInstance are held here.
          */
-        private WeakSet<DelegatingErrorManager> createdByMe = new WeakSet<DelegatingErrorManager>();
+        private Set<DelegatingErrorManager> createdByMe = Collections.newSetFromMap(new WeakHashMap<>());
 
         /** If we are the "central" delagate this is not null and
          * we listen on the result. On newly created delegates this

--- a/platform/openide.util.ui/src/org/openide/util/actions/CallableSystemAction.java
+++ b/platform/openide.util.ui/src/org/openide/util/actions/CallableSystemAction.java
@@ -21,10 +21,11 @@ package org.openide.util.actions;
 
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
+import java.util.Collections;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Logger;
 import org.openide.util.Utilities;
-import org.openide.util.WeakSet;
 
 /** Not preferred anymore, use <a href="@org-openide-awt@/org/openide/awt/Actions.html#alwaysEnabled(java.awt.event.ActionListener,java.lang.String,java.lang.String,boolean)">Actions.alwaysEnabled</a>
 * instead. To migrate your
@@ -54,7 +55,7 @@ public abstract class CallableSystemAction extends SystemAction implements Prese
      * Set of action classes for which we have already issued a warning that
      * {@link #asynchronous} was not overridden to return false.
      */
-    private static final Set<Class> warnedAsynchronousActions = new WeakSet<Class>(); 
+    private static final Set<Class> warnedAsynchronousActions = Collections.newSetFromMap(new WeakHashMap<>()); 
     private static final boolean DEFAULT_ASYNCH = !Boolean.getBoolean(
             "org.openide.util.actions.CallableSystemAction.synchronousByDefault"
         );

--- a/platform/openide.util.ui/src/org/openide/util/actions/CallbackSystemAction.java
+++ b/platform/openide.util.ui/src/org/openide/util/actions/CallbackSystemAction.java
@@ -20,7 +20,6 @@
 package org.openide.util.actions;
 
 import java.awt.Component;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -32,6 +31,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.Action;
@@ -42,7 +43,6 @@ import org.openide.util.LookupListener;
 import org.openide.util.Mutex;
 import org.openide.util.Utilities;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 
 /** Not preferred anymore, the replacement is
 * <a href="@org-openide-awt@/org/openide/awt/Actions.html#callback(java.lang.String,javax.swing.Action,boolean,java.lang.String,java.lang.String,boolean)">Actions.callback</a> factory method.
@@ -69,10 +69,10 @@ public abstract class CallbackSystemAction extends CallableSystemAction implemen
     private static final String PROP_ACTION_PERFORMER = "actionPerformer"; // NOI18N
 
     /** a list of all actions that has survive focus change set to false */
-    private static final WeakSet<Class<? extends CallbackSystemAction>> notSurviving = new WeakSet<Class<? extends CallbackSystemAction>>(37);
+    private static final Set<Class<? extends CallbackSystemAction>> notSurviving = Collections.newSetFromMap(new WeakHashMap<>(37));
 
     /** a list of actions surviving focus change */
-    private static final WeakSet<Class<? extends CallbackSystemAction>> surviving = new WeakSet<Class<? extends CallbackSystemAction>>(37);
+    private static final Set<Class<? extends CallbackSystemAction>> surviving = Collections.newSetFromMap(new WeakHashMap<>(37));
 
     /** key to access listener */
     private static final Object LISTENER = new Object();

--- a/platform/openide.util/nbproject/project.properties
+++ b/platform/openide.util/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=11
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 module.jar.dir=lib

--- a/platform/openide.util/src/org/openide/util/WeakSet.java
+++ b/platform/openide.util/src/org/openide/util/WeakSet.java
@@ -45,6 +45,8 @@ import java.util.Set;
  * It also provides method <code>resize</code> for changing capacity of internal hash table
  * (can be used for reducing memory occupied by empty set which previously had big number of objects, but they were GCed)
  * Access to set is not thread safe.
+ * 
+ * @deprecated Use {@link java.util.WeakHashMap} and {@link java.util.Collections#newSetFromMap(java.util.Map)} instead.
  *
  * @param <E> the type of elements maintained by this set
  * @see #putIfAbsent(Object)
@@ -52,6 +54,7 @@ import java.util.Set;
  * @author Vladimir Voskresensky
  */
 @SuppressWarnings("unchecked")
+@Deprecated(forRemoval = true)
 public class WeakSet <E> extends AbstractSet<E> implements Cloneable, Serializable {
     private transient SharedKeyWeakHashMap<E, Boolean> m;  // The backing map
     private transient Set<E> s;       // Its keySet

--- a/platform/openide.util/src/org/openide/util/io/NbObjectOutputStream.java
+++ b/platform/openide.util/src/org/openide/util/io/NbObjectOutputStream.java
@@ -26,6 +26,7 @@ import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -33,7 +34,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.logging.Logger;
-import org.openide.util.WeakSet;
 
 // note: keep method NbObjectInputStream.resolveObject
 // consistent with replaceObject method
@@ -43,7 +43,7 @@ import org.openide.util.WeakSet;
 */
 public class NbObjectOutputStream extends ObjectOutputStream {
     private static final String SVUID = "serialVersionUID"; // NOI18N
-    private static final Set<String> alreadyReported = new WeakSet<String>();
+    private static final Set<String> alreadyReported = Collections.newSetFromMap(new WeakHashMap<>());
 
     static {
         // See below.

--- a/platform/openide.windows/src/org/openide/windows/TopComponent.java
+++ b/platform/openide.windows/src/org/openide/windows/TopComponent.java
@@ -46,10 +46,12 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Objects;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -127,10 +129,10 @@ public class TopComponent extends JComponent implements Externalizable, Accessib
     private static Object defaultLookupLock = new Object();
 
     /** Classes that have been warned about overriding preferredID() */
-    private static final Set<Class> warnedTCPIClasses = new WeakSet<Class>();
+    private static final Set<Class> warnedTCPIClasses = Collections.newSetFromMap(new WeakHashMap<>());
 
     /** Used to print warning about getPersistenceType */
-    private static final Set<Class> warnedClasses = new WeakSet<Class>();
+    private static final Set<Class> warnedClasses = Collections.newSetFromMap(new WeakHashMap<>());
 
     /** reference to Lookup with default implementation for the
      * component or the lookup associated with the component itself

--- a/profiler/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/views/InstancesView.java
+++ b/profiler/debugger.jpda.heapwalk/src/org/netbeans/modules/debugger/jpda/heapwalk/views/InstancesView.java
@@ -25,8 +25,10 @@ import java.awt.GridBagConstraints;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.WeakHashMap;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -41,7 +43,6 @@ import org.netbeans.api.debugger.jpda.JPDAThread;
 import org.netbeans.modules.profiler.heapwalk.HeapFragmentWalker;
 import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
-import org.openide.util.WeakSet;
 import org.openide.windows.TopComponent;
 import org.openide.windows.WindowManager;
 
@@ -188,7 +189,7 @@ public class InstancesView extends TopComponent {
     
     private class DebuggerSessionListener extends DebuggerManagerAdapter {
         
-        private Set<JPDADebugger> attachedTo = new WeakSet<JPDADebugger>();
+        private Set<JPDADebugger> attachedTo = Collections.newSetFromMap(new WeakHashMap<>());
         private int lastState = -1;
         
         public int getState() {

--- a/webcommon/javascript.v8debug.ui/src/org/netbeans/modules/javascript/v8debug/ui/vars/models/VariablesModel.java
+++ b/webcommon/javascript.v8debug.ui/src/org/netbeans/modules/javascript/v8debug/ui/vars/models/VariablesModel.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import org.netbeans.api.annotations.common.StaticResource;
 import org.netbeans.lib.v8debug.PropertyLong;
 import org.netbeans.lib.v8debug.V8Command;
@@ -63,7 +64,6 @@ import org.netbeans.spi.viewmodel.UnknownTypeException;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.util.NbBundle;
-import org.openide.util.WeakSet;
 import org.openide.util.datatransfer.PasteType;
 
 /**
@@ -89,7 +89,7 @@ public class VariablesModel extends ViewModelSupport implements TreeModel,
     protected final V8Debugger dbg;
     private final VarValuesLoader vvl;
     private volatile boolean topFrameRefreshed;
-    private final Set<Variable> refreshWhenLoaded = Collections.synchronizedSet(new WeakSet<Variable>());
+    private final Set<Variable> refreshWhenLoaded = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
 
     public VariablesModel(ContextProvider contextProvider) {
         dbg = contextProvider.lookupFirst(null, V8Debugger.class);

--- a/webcommon/javascript.v8debug/src/org/netbeans/modules/javascript/v8debug/breakpoints/BreakpointsHandler.java
+++ b/webcommon/javascript.v8debug/src/org/netbeans/modules/javascript/v8debug/breakpoints/BreakpointsHandler.java
@@ -22,11 +22,13 @@ package org.netbeans.modules.javascript.v8debug.breakpoints;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -51,7 +53,6 @@ import org.netbeans.modules.web.common.sourcemap.SourceMapsTranslator.Location;
 import org.openide.filesystems.FileObject;
 import org.openide.util.NbBundle;
 import org.openide.util.Pair;
-import org.openide.util.WeakSet;
 
 /**
  *
@@ -64,7 +65,7 @@ public class BreakpointsHandler implements V8Debugger.Listener {
     private final V8Debugger dbg;
     private final Map<JSLineBreakpoint, SubmittedBreakpoint> submittedBreakpoints = new HashMap<>();
     private final Map<Long, SubmittedBreakpoint> breakpointsById = new HashMap<>();
-    private final Set<JSLineBreakpoint> removeAfterSubmit = new WeakSet<>();
+    private final Set<JSLineBreakpoint> removeAfterSubmit = Collections.newSetFromMap(new WeakHashMap<>());
     private final List<ActiveBreakpointListener> abListeners = new CopyOnWriteArrayList<ActiveBreakpointListener>();
     private volatile JSLineBreakpoint activeBreakpoint;
     private final List<BreakpointsActiveListener> acListeners = new CopyOnWriteArrayList<>();

--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ant/AntProjectHelperImpl.java
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ant/AntProjectHelperImpl.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.WeakHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.netbeans.modules.web.clientproject.env.CommonProjectHelper;
 import org.netbeans.modules.web.clientproject.env.Values;
@@ -36,7 +37,6 @@ import org.netbeans.spi.project.support.ant.EditableProperties;
 import org.netbeans.spi.project.support.ant.ProjectXmlSavedHook;
 import org.netbeans.spi.queries.SharabilityQueryImplementation2;
 import org.openide.filesystems.FileObject;
-import org.openide.util.WeakSet;
 import org.w3c.dom.Element;
 
 /**
@@ -50,7 +50,7 @@ final class AntProjectHelperImpl extends CommonProjectHelper {
         this.delegate = delegate;
         this.listener = new L();
         this.delegate.addAntProjectListener(listener);
-        this.antListeners = Collections.synchronizedSet(new WeakSet<Callback>());
+        this.antListeners = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
     }
 
     @Override

--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ui/ClientSideProjectLogicalView.java
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ui/ClientSideProjectLogicalView.java
@@ -33,6 +33,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.Action;
@@ -90,7 +91,6 @@ import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.util.WeakListeners;
-import org.openide.util.WeakSet;
 import org.openide.util.actions.SystemAction;
 import org.openide.util.lookup.AbstractLookup;
 import org.openide.util.lookup.InstanceContent;
@@ -872,7 +872,7 @@ public class ClientSideProjectLogicalView implements LogicalViewProvider {
 
     private static class FolderFilterChildren extends FilterNode.Children implements ChangeListener {
 
-        private final Set<File> ignoreList = new WeakSet<File>();
+        private final Set<File> ignoreList = Collections.newSetFromMap(new WeakHashMap<>());
         private final ClientSideProject project;
 
 

--- a/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/locals/VariablesTreeExpansionModel.java
+++ b/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/locals/VariablesTreeExpansionModel.java
@@ -19,14 +19,15 @@
 
 package org.netbeans.modules.web.javascript.debugger.locals;
 
+import java.util.Collections;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.spi.debugger.DebuggerServiceRegistration;
 import org.netbeans.spi.debugger.DebuggerServiceRegistrations;
 import org.netbeans.spi.viewmodel.TreeExpansionModel;
 import org.netbeans.spi.viewmodel.UnknownTypeException;
-import org.openide.util.WeakSet;
 
 
 /**
@@ -44,8 +45,8 @@ public class VariablesTreeExpansionModel implements TreeExpansionModel {
     
     private static final Logger LOGGER = Logger.getLogger(VariablesTreeExpansionModel.class.getName());
 
-    private Set<Object> expandedNodes = new WeakSet<>();
-    private Set<Object> collapsedNodes = new WeakSet<>();
+    private Set<Object> expandedNodes = Collections.newSetFromMap(new WeakHashMap<>());
+    private Set<Object> collapsedNodes = Collections.newSetFromMap(new WeakHashMap<>());
 
     /**
      * Defines default state (collapsed, expanded) of given node.


### PR DESCRIPTION
Instead of updating `WeakSet` (https://github.com/apache/netbeans/pull/8380) we deprecate it for removal and replace all usage.
Once the build starts failing we can still decide what to do with it.

 - `WeakSet` is now deprecated for removal
 - usage can be replaced with `WeakHashMap` and `Collections.newSetFromMap()`

part of https://github.com/apache/netbeans/issues/8257

have to take a good look at all usages which used `putifAbsent`, some might need tweaks
 - `ElementHandle` deduplicaiton mechanism can be replicated using a WeakHashMap and storing the handle as key and as WeakReference-wrapped value. This way the old element can be extracted if there is a match, while allowing the map to shring if the handles aren't used anymore. Not 100% sure yet what overhead this is supposed to avoid though since the `ElementHandle` is created in all paths, but an old handle is returned on hit while discarding the new one.
 - `WebLogicConfiguration` removed the cache since it was redundant. The caller is cached. Someone liked caches.

main difference is that all calls to `WeakSet#add` were implemented via `putIfAbsent`. This is not the case in WeakHashMap, however, during the typical use case (e.g listener storage) this should not make a difference.