### PR TITLE
Update JSVG from 1.6.1 to 1.7.1

### DIFF
--- a/platform/libs.jsvg/external/binaries-list
+++ b/platform/libs.jsvg/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-A84D34480044DB51A1448E9C0E32BD284B797288 com.github.weisj:jsvg:1.6.1
+2B5F6F42F2B26EE72F6405F66F839DEF459CCA3C com.github.weisj:jsvg:1.7.1

--- a/platform/libs.jsvg/external/jsvg-1.7.1-license.txt
+++ b/platform/libs.jsvg/external/jsvg-1.7.1-license.txt
@@ -1,10 +1,10 @@
 Name: JSVG
-Version: 1.6.1
+Version: 1.7.1
 Description: JSVG - A Java SVG implementation
 License: MIT-jsvg
 Origin: JSVG
 URL: https://github.com/weisJ/jsvg
-Files: jsvg-1.6.1.jar
+Files: jsvg-1.7.1.jar
 
 MIT License
 

--- a/platform/libs.jsvg/manifest.mf
+++ b/platform/libs.jsvg/manifest.mf
@@ -1,5 +1,6 @@
 Manifest-Version: 1.0
-OpenIDE-Module: org.netbeans.libs.jsvg
-OpenIDE-Module-Implementation-Version: 1
+OpenIDE-Module: org.netbeans.libs.jsvg/2
+OpenIDE-Module-Implementation-Version: 1.7.1
+OpenIDE-Module-Specification-Version: 2.0
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/jsvg/Bundle.properties
 AutoUpdate-Show-In-Client: false

--- a/platform/libs.jsvg/nbproject/project.properties
+++ b/platform/libs.jsvg/nbproject/project.properties
@@ -15,12 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-file.reference.jsvg-1.6.1.jar=external/jsvg-1.6.1.jar
-release.external/jsvg-1.6.1.jar=modules/ext/jsvg-1.6.1.jar
+file.reference.jsvg-1.7.1.jar=external/jsvg-1.7.1.jar
+release.external/jsvg-1.7.1.jar=modules/ext/jsvg-1.7.1.jar
 
 is.autoload=true
 javac.source=1.8
 
 nbm.homepage=https://github.com/weisJ/jsvg
+
 sigtest.gen.fail.on.error=false
-spec.version.base=1.23.0
+spec.version.base.fatal.warning=false

--- a/platform/libs.jsvg/nbproject/project.xml
+++ b/platform/libs.jsvg/nbproject/project.xml
@@ -56,8 +56,8 @@
                 <package>com.github.weisj.jsvg.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/jsvg-1.6.1.jar</runtime-relative-path>
-                <binary-origin>external/jsvg-1.6.1.jar</binary-origin>
+                <runtime-relative-path>ext/jsvg-1.7.1.jar</runtime-relative-path>
+                <binary-origin>external/jsvg-1.7.1.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/platform/openide.util.ui.svg/nbproject/project.xml
+++ b/platform/openide.util.ui.svg/nbproject/project.xml
@@ -30,7 +30,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.0</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/openide.util.ui.svg/src/org/openide/util/svg/SVGIcon.java
+++ b/platform/openide.util.ui.svg/src/org/openide/util/svg/SVGIcon.java
@@ -37,6 +37,7 @@ import javax.swing.Icon;
 import com.github.weisj.jsvg.SVGDocument;
 import com.github.weisj.jsvg.geometry.size.FloatSize;
 import com.github.weisj.jsvg.parser.LoaderContext;
+import com.github.weisj.jsvg.parser.ParsedDocument;
 import com.github.weisj.jsvg.parser.ResourceLoader;
 import com.github.weisj.jsvg.parser.SVGLoader;
 import com.github.weisj.jsvg.renderer.awt.NullPlatformSupport;
@@ -128,14 +129,13 @@ final class SVGIcon extends CachedHiDPIIcon {
 
         final SVGDocument svgDocument;
         FloatSize documentSize;
-        InputStream is = url.openStream();
-        try {
+        try (InputStream is = url.openStream()) {
             // Explicitly deny loading of external URLs.
 
             /* Handle e.g. <image href="https://example.com/image.png"> elements. Tested in
             testLoadImageWithExternalImageHref. */
             List<IOException> externalResourceExceptions = new ArrayList<>();
-            ResourceLoader resourceLoader = (URI nnuri) -> {
+            ResourceLoader resourceLoader = (ParsedDocument nnpd, URI nnuri) -> {
               IOException e = new IOException("External resource loading from SVG file not permitted ("+
                   nnuri + " from " + url + ")");
               externalResourceExceptions.add(e);
@@ -168,8 +168,6 @@ final class SVGIcon extends CachedHiDPIIcon {
         } catch (RuntimeException e) {
             /* Rethrow any uncaught exceptions that could be thrown when parsing invalid SVG files. */
             throw new IOException("Error parsing SVG file", e);
-        } finally {
-            is.close();
         }
         if (toSize != null) {
             int width = (int) Math.ceil(documentSize.getWidth());


### PR DESCRIPTION
 - changes since last update
   -  https://github.com/weisJ/jsvg/releases/tag/v1.7.0-rc1
   -  https://github.com/weisJ/jsvg/releases/tag/v1.7.1-rc1
 - bumped spec version due to API change
 - extracted from https://github.com/apache/netbeans/pull/8382

quick test run rendered all icons I checked correctly