### PR TITLE
Implement Preferences cache for java hints.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unused.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unused.java
@@ -33,8 +33,6 @@ import org.netbeans.spi.java.hints.JavaFixUtilities;
 import org.netbeans.spi.java.hints.TriggerTreeKind;
 import org.openide.util.NbBundle.Messages;
 
-import static org.netbeans.api.java.source.CompilationInfo.CacheClearPolicy.ON_TASK_END;
-
 /**
  *
  * @author lahvac
@@ -64,7 +62,7 @@ public class Unused {
         if (unused.isEmpty()) {
             return null;
         }
-        boolean detectUnusedPackagePrivate = getTaskCachedBoolean(ctx, DETECT_UNUSED_PACKAGE_PRIVATE, DETECT_UNUSED_PACKAGE_PRIVATE_DEFAULT);
+        boolean detectUnusedPackagePrivate = ctx.getPreferences().getBoolean(DETECT_UNUSED_PACKAGE_PRIVATE, DETECT_UNUSED_PACKAGE_PRIVATE_DEFAULT);
         for (UnusedDescription ud : unused) {
             if (ctx.isCanceled()) {
                 break;
@@ -82,17 +80,6 @@ public class Unused {
             break;
         }
         return null;
-    }
-
-    // reading from AuxiliaryConfigBasedPreferences in inner loops is not cheap since it needs a mutex
-    private static boolean getTaskCachedBoolean(HintContext ctx, String key, boolean defaultVal) {
-        Object cached = ctx.getInfo().getCachedValue(key);
-        if (cached instanceof Boolean val) {
-            return val;
-        }
-        boolean fromPrefs = ctx.getPreferences().getBoolean(key, defaultVal);
-        ctx.getInfo().putCachedValue(key, fromPrefs, ON_TASK_END);
-        return fromPrefs;
     }
 
     @Messages({


### PR DESCRIPTION
Some hints are invoked very frequently by the scanner (analog to an inner loop). Querying Preferences from hot code can be expensive.

Preferences were also used outside of the hint implementation, for example for `isEnabled()` or` getSeverity()` queries before invoking the actual hint. This isn't visible in the hint metrics log.

Caching Preferences in the hint context covers both usages. The cache is disposed together with the hint processing task.

pink sections mark Preferences queries during hint computation.

![image](https://github.com/user-attachments/assets/9f7b03df-573c-470d-b392-f40833ec8d59)

with cache enabled they are gone
![image](https://github.com/user-attachments/assets/b6ab1417-4e6e-425c-88b3-bae7423f3655)
