### PR TITLE
[GH 8420] PHP Constructor code completion should not add [#Override]

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/codegen/SinglePropertyMethodCreator.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/codegen/SinglePropertyMethodCreator.java
@@ -79,6 +79,9 @@ public interface SinglePropertyMethodCreator<T extends Property> {
         }
 
         private String getOverrideAttribute(MethodElement method) {
+            if (method.isConstructor()) {
+                return CodeUtils.EMPTY_STRING;
+            }
             if (!method.isMagic()
                     && (!method.getType().isTrait() || ElementUtils.isAbstractTraitMethod(method))
                     && cgsInfo.getPhpVersion().hasOverrideAttribute()) {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCompletionItem.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCompletionItem.java
@@ -1419,6 +1419,9 @@ public abstract class PHPCompletionItem implements CompletionProposal {
 
         private String getOverrideAttribute() {
             MethodElement method = (MethodElement) getBaseFunctionElement();
+            if (method.isConstructor()) {
+                return CodeUtils.EMPTY_STRING;
+            }
             TypeElement type = method.getType();
             if (!isMagic()
                     && (!type.isTrait() || ElementUtils.isAbstractTraitMethod(method))

--- a/php/php.editor/test/unit/data/testfiles/codegen/testInstanceOverrideMethod/testInstanceOverrideMethod.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testInstanceOverrideMethod/testInstanceOverrideMethod.php
@@ -1,6 +1,11 @@
 <?php
 
 class Foo {
+
+    function __construct() {
+
+    }
+
     function myFoo(): Foo;
 }
 

--- a/php/php.editor/test/unit/data/testfiles/codegen/testInstanceOverrideMethod/testInstanceOverrideMethod.php.testInstanceOverrideMethod_03.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testInstanceOverrideMethod/testInstanceOverrideMethod.php.testInstanceOverrideMethod_03.codegen
@@ -1,0 +1,3 @@
+public function __construct(){
+parent::__construct();
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodOverride/Override.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodOverride/Override.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class base {
+
+    public function __construct() {
+    }
+
+    public function __call(string $name, array $arguments): mixed {
+    }
+
+    public static function __callStatic(string $name, array $arguments): mixed {
+    }
+
+    public function __clone(): void {
+    }
+
+    public function __debugInfo(): array {
+    }
+
+    public function __destruct() {
+    }
+
+    public function __get(string $name): mixed {
+    }
+
+    public function __invoke(): mixed {
+    }
+
+    public function __isset(string $name): bool {
+    }
+
+    public function __serialize(): array {
+    }
+
+    public function __set(string $name, mixed $value): void {
+    }
+
+    public static function __set_state(array $properties): object {
+    }
+
+    public function __sleep(): array {
+    }
+
+    public function __toString(): string {
+        return "Test";
+    }
+
+    public function __unserialize(array $data): void {
+    }
+
+    public function __unset(string $name): void {
+    }
+
+    public function __wakeup(): void {
+    }
+}
+
+class TestOverride extends base {
+    __
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodOverride/Override.php.testMagicMethodOverride_01_PHP83.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/magicMethods/testMagicMethodOverride/Override.php.testMagicMethodOverride_01_PHP83.cccustomtpl
@@ -1,0 +1,185 @@
+Name: __call
+#[\Override]
+public function __call(string $name, array $arguments): mixed {
+${cursor}return parent::__call($name, $arguments);
+}
+
+Name: __call
+public function __call(string $name, array $arguments): mixed {
+${cursor};
+}
+
+Name: __callStatic
+#[\Override]
+public static function __callStatic(string $name, array $arguments): mixed {
+${cursor}return parent::__callStatic($name, $arguments);
+}
+
+Name: __callStatic
+public static function __callStatic(string $name, array $arguments): mixed {
+${cursor};
+}
+
+Name: __clone
+#[\Override]
+public function __clone(): void {
+${cursor};
+}
+
+Name: __clone
+public function __clone(): void {
+${cursor};
+}
+
+Name: __construct
+public function __construct() {
+${cursor}parent::__construct();
+}
+
+Name: __construct
+public function __construct() {
+${cursor};
+}
+
+Name: __debugInfo
+#[\Override]
+public function __debugInfo(): array {
+${cursor}return parent::__debugInfo();
+}
+
+Name: __debugInfo
+public function __debugInfo(): array {
+${cursor};
+}
+
+Name: __destruct
+#[\Override]
+public function __destruct() {
+${cursor}parent::__destruct();
+}
+
+Name: __destruct
+public function __destruct() {
+${cursor};
+}
+
+Name: __get
+#[\Override]
+public function __get(string $name): mixed {
+${cursor}return parent::__get($name);
+}
+
+Name: __get
+public function __get(string $name): mixed {
+${cursor};
+}
+
+Name: __invoke
+#[\Override]
+public function __invoke(): mixed {
+${cursor}return parent::__invoke();
+}
+
+Name: __invoke
+public function __invoke(): mixed {
+${cursor};
+}
+
+Name: __isset
+#[\Override]
+public function __isset(string $name): bool {
+${cursor}return parent::__isset($name);
+}
+
+Name: __isset
+public function __isset(string $name): bool {
+${cursor};
+}
+
+Name: __serialize
+#[\Override]
+public function __serialize(): array {
+${cursor}return parent::__serialize();
+}
+
+Name: __serialize
+public function __serialize(): array {
+${cursor};
+}
+
+Name: __set
+#[\Override]
+public function __set(string $name, mixed $value): void {
+${cursor};
+}
+
+Name: __set
+public function __set(string $name, mixed $value): void {
+${cursor};
+}
+
+Name: __set_state
+#[\Override]
+public static function __set_state(array $properties): object {
+${cursor}return parent::__set_state($properties);
+}
+
+Name: __set_state
+public static function __set_state(array $properties): object {
+${cursor};
+}
+
+Name: __sleep
+#[\Override]
+public function __sleep(): array {
+${cursor}return parent::__sleep();
+}
+
+Name: __sleep
+public function __sleep(): array {
+${cursor};
+}
+
+Name: __toString
+#[\Override]
+public function __toString(): string {
+return "base[]";${cursor}
+}
+
+Name: __toString
+public function __toString(): string {
+return "TestOverride[]";${cursor}
+}
+
+Name: __unserialize
+#[\Override]
+public function __unserialize(array $data): void {
+${cursor};
+}
+
+Name: __unserialize
+public function __unserialize(array $data): void {
+${cursor};
+}
+
+Name: __unset
+#[\Override]
+public function __unset(string $name): void {
+${cursor};
+}
+
+Name: __unset
+public function __unset(string $name): void {
+${cursor};
+}
+
+Name: __wakeup
+#[\Override]
+public function __wakeup(): void {
+${cursor};
+}
+
+Name: __wakeup
+public function __wakeup(): void {
+${cursor};
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
@@ -197,6 +197,12 @@ public class SelectedPropertyMethodsCreatorTest extends PHPTestBase {
                 selectProperties(cgsInfo.getPossibleMethods(), "myFoo"), new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)));
     }
 
+    public void testInstanceOverrideMethod_03() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class Bar extends Foo {^", PhpVersion.PHP_83);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "__construct"), new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)));
+    }
+
     // #270237
     public void testInstanceOverrideMethodWithNullableType_01() throws Exception {
         CGSInfo cgsInfo = getCgsInfo("class Bar extends Foo {^", PhpVersion.PHP_71);

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionMagicMethodTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionMagicMethodTest.java
@@ -94,6 +94,11 @@ public class PHPCodeCompletionMagicMethodTest extends PHPCodeCompletionTestBase 
                 new DefaultFilter(PhpVersion.PHP_83, "__toString"), true);
     }
 
+    public void testMagicMethodOverride_01_PHP83() throws Exception {
+        checkCompletionCustomTemplateResult(getTestPath("Override"), "    __^",
+                new DefaultFilter(PhpVersion.PHP_83, "__"), true);
+    }
+
     @Override
     protected Map<String, ClassPath> createClassPathsForTest() {
         return Collections.singletonMap(


### PR DESCRIPTION
Override Attribute on constructors in PHP leads to compile errors (See also #8334)

- No longer add override on constructors

before:
![before_01](https://github.com/user-attachments/assets/4e6d0257-16fd-4166-b66c-6081e1e22bb9)

after:
![after_01](https://github.com/user-attachments/assets/264dcae6-240b-408e-9964-6fb3e4608aa5)

---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>