### PR TITLE
add new PrimeFaces and OmniFaces namespaces

### DIFF
--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/facelets/FaceletsLibrarySupport.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/facelets/FaceletsLibrarySupport.java
@@ -404,7 +404,13 @@ public class FaceletsLibrarySupport {
 
             Map<String, Library> libsMap = new HashMap<>();
             for (Library lib : processor.compiler.libraries) {
-                lib.getValidNamespaces().forEach(namespace -> libsMap.put(namespace, lib));
+                for (String namespace : lib.getValidNamespaces()) {
+                    Library currentLibrary = libsMap.get(namespace);
+                    // replace the current library only if the new one supports more namespaces
+                    if (currentLibrary == null || currentLibrary.getValidNamespaces().size() < lib.getValidNamespaces().size()) {
+                        libsMap.put(namespace, lib);
+                    }
+                }
             }
 
             //4. in case of JSF2.2 include pseudo-libraries (http://java.sun.com/jsf/passthrough, http://java.sun.com/jsf)

--- a/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/api/DefaultLibraryInfo.java
+++ b/enterprise/web.jsfapi/src/org/netbeans/modules/web/jsfapi/api/DefaultLibraryInfo.java
@@ -84,6 +84,7 @@ public enum DefaultLibraryInfo implements LibraryInfo {
     // PrimeFaces
     PRIMEFACES(
             sortedSet(
+                    "primefaces",
                     "http://primefaces.org/ui"
             ),
             "PrimeFaces",
@@ -95,6 +96,14 @@ public enum DefaultLibraryInfo implements LibraryInfo {
             ),
             "PrimeFaces Mobile",
             "pm"
+    ), //NOI18N
+    PRIMEFACES_EXTENSIONS(
+            sortedSet(
+                    "primefaces.extensions",
+                    "http://primefaces.org/ui/extensions"
+            ),
+            "PrimeFaces Extensions",
+            "pe"
     ), //NOI18N
 
     // JSF 2.2+
@@ -113,6 +122,16 @@ public enum DefaultLibraryInfo implements LibraryInfo {
             ),
             "Passthrough",
             "p"
+    ), //NOI18N
+
+    // OmniFaces
+    OMNIFACES(
+            sortedSet(
+                    "omnifaces",
+                    "http://omnifaces.org/ui"
+            ),
+            "OmniFaces",
+            "o"
     ); //NOI18N
 
     private final Set<String> allValidNamespaces;


### PR DESCRIPTION
Add new namespaces support.

For reference:
https://github.com/primefaces/primefaces/pull/11923
https://github.com/primefaces/primefaces/issues/11914
https://github.com/primefaces-extensions/primefaces-extensions/pull/1548

With the PR, primefaces 15 (supports both the old `http://primefaces.org/ui` and the new `primefaces` namespace, see the "Library" line):
![image](https://github.com/user-attachments/assets/1be98256-b762-415d-8a2d-f37df8587461)

With the PR, primefaces 13 (supports only `http://primefaces.org/ui`)
![image](https://github.com/user-attachments/assets/e901cb9f-8964-4ab8-996e-303d4c6be6ae)