### PR TITLE
JS: Improve handling of const keyword

### DIFF
--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsSemanticAnalyzer.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsSemanticAnalyzer.java
@@ -402,11 +402,11 @@ public class JsSemanticAnalyzer extends SemanticAnalyzer<JsParserResult> {
 
             @Override
             public boolean enterVarNode(VarNode varNode) {
-                if (varNode.isLet()) {
+                if (varNode.isLet() || varNode.isConst()) {
                     TokenSequence<? extends JsTokenId> ts = LexUtilities.getJsPositionedSequence(result.getSnapshot(), varNode.getStart() - 1);
                     if (ts != null) {
                         Token<? extends JsTokenId> token = LexUtilities.findPreviousNonWsNonComment(ts);
-                        if (token != null && token.id() == JsTokenId.RESERVED_LET) {
+                        if (token != null && (token.id() == JsTokenId.RESERVED_LET || token.id() == JsTokenId.KEYWORD_CONST)) {
                             highlights.put(LexUtilities.getLexerOffsets(result,
                                     new OffsetRange(ts.offset(), ts.offset() + token.length())), SEMANTIC_KEYWORD);
                         }

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/coloring/await.js.semantic
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/coloring/await.js.semantic
@@ -1,1 +1,1 @@
-for |>CUSTOM2:await<| (const i of num()) {}
+for |>CUSTOM2:await<| (|>CUSTOM2:const<| i of num()) {}

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/coloring/semanticalKeywords.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/coloring/semanticalKeywords.js
@@ -47,3 +47,4 @@ class Test {
     }
 }
 
+const test2 = 7;

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/coloring/semanticalKeywords.js.semantic
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/coloring/semanticalKeywords.js.semantic
@@ -47,3 +47,4 @@ class |>CLASS,GLOBAL:Test<| {
     }
 }
 
+|>CUSTOM2:const<| test2 = 7;

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/blockscope/arrayLiteral01.js.semantic
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/blockscope/arrayLiteral01.js.semantic
@@ -2,13 +2,13 @@
 
 function |>METHOD:_getFileList<|(buildType, fileList, theme) {
   |>CUSTOM2:let<| |>LOCAL_VARIABLE_DECLARATION:result<| = [];
-  for (const file of fileList) {
+  for (|>CUSTOM2:const<| file of fileList) {
     if (file.buildType === buildType || !file.buildType) {
       |>CUSTOM2:let<| |>LOCAL_VARIABLE_DECLARATION:matches<| = [];
       |>CUSTOM2:let<| |>LOCAL_VARIABLE_DECLARATION:dest<|;
       |>CUSTOM2:let<| |>LOCAL_VARIABLE_DECLARATION:cwd<|;
       for (|>CUSTOM2:let<| |>CLASS:src<| of file.src) {
-        const exclusion = src.indexOf('!') === 0;
+        |>CUSTOM2:const<| exclusion = src.indexOf('!') === 0;
         |>LOCAL_VARIABLE:cwd<| = file.cwd;
         |>LOCAL_VARIABLE:dest<| = file.dest;
         |>LOCAL_VARIABLE:cwd<| = (_isFunction(file.cwd) ? |>LOCAL_VARIABLE:cwd<|(theme) : |>LOCAL_VARIABLE:cwd<|) || '';
@@ -23,7 +23,7 @@ function |>METHOD:_getFileList<|(buildType, fileList, theme) {
           |>LOCAL_VARIABLE:matches<| = _union(|>LOCAL_VARIABLE:matches<|, |>LOCAL_VARIABLE:match<|);
         }
       }
-      const prefixedPaths = _addFileListPathPrefix(|>LOCAL_VARIABLE:matches<|, |>LOCAL_VARIABLE:dest<|, |>GLOBAL:util<|.destPath(|>LOCAL_VARIABLE:cwd<|));
+      |>CUSTOM2:const<| prefixedPaths = _addFileListPathPrefix(|>LOCAL_VARIABLE:matches<|, |>LOCAL_VARIABLE:dest<|, |>GLOBAL:util<|.destPath(|>LOCAL_VARIABLE:cwd<|));
       |>LOCAL_VARIABLE:result<| = |>LOCAL_VARIABLE:result<|.concat(prefixedPaths);
     }
   }

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/classes/class04.js.semantic
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/markoccurences/classes/class04.js.semantic
@@ -12,14 +12,14 @@ class |>CLASS,GLOBAL:Point<| {
      * @param {Point} b 
      */
     |>CUSTOM2:static<| |>METHOD:distance<|(a, b) {
-        const dx = a.|>FIELD:x<| - b.|>FIELD:x<|;
-        const dy = a.|>FIELD:y<| - b.|>FIELD:y<|;
+        |>CUSTOM2:const<| dx = a.|>FIELD:x<| - b.|>FIELD:x<|;
+        |>CUSTOM2:const<| dy = a.|>FIELD:y<| - b.|>FIELD:y<|;
 
         return |>GLOBAL:Math<|.sqrt(dx*dx + dy*dy);
     }
 }
   
-const p1 = new |>GLOBAL:Point<|(5, 5);
-const p2 = new |>GLOBAL:Point<|(10, 10);
+|>CUSTOM2:const<| p1 = new |>GLOBAL:Point<|(5, 5);
+|>CUSTOM2:const<| p2 = new |>GLOBAL:Point<|(10, 10);
 
 |>GLOBAL:console<|.log(|>GLOBAL:Point<|.distance(p1, p2)); 

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/parser/asyncFunctions/asyncFunctions1.js.semantic
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/parser/asyncFunctions/asyncFunctions1.js.semantic
@@ -3,7 +3,7 @@ export default {
   |>FIELD:path<|: '/',
 
   |>CUSTOM2:async<| |>METHOD:action<|() {
-    const component = |>CUSTOM2:await<| next();
+    |>CUSTOM2:const<| component = |>CUSTOM2:await<| next();
 
   },
 

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/parser/asyncFunctions/asyncFunctions2.js.semantic
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/parser/asyncFunctions/asyncFunctions2.js.semantic
@@ -1,5 +1,5 @@
-const |>METHOD:fooBar<| = |>CUSTOM2:async<| () => {
+|>CUSTOM2:const<| |>METHOD:fooBar<| = |>CUSTOM2:async<| () => {
     if (|>GLOBAL:user<|) {
-      const userLogin = |>CUSTOM2:await<| test();
+      |>CUSTOM2:const<| userLogin = |>CUSTOM2:await<| test();
     }
 }

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/parser/topLevelAwait.js.semantic
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/parser/topLevelAwait.js.semantic
@@ -19,4 +19,4 @@
 
 import |>GLOBAL:dummy<| |>CUSTOM2:from<| './dummy.mjs';
 
-const demo = |>CUSTOM2:await<| |>GLOBAL:dummy<|();
+|>CUSTOM2:const<| demo = |>CUSTOM2:await<| |>GLOBAL:dummy<|();

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
@@ -1512,7 +1512,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
                         handleDeclaredFunction(currentBlockScope, parentFn, fnNode);
                     }
                     for (VarNode varNode : declaredVars) {
-                        if (varNode.isLet()) {
+                        if (varNode.isBlockScoped()) {
                             // block scope variable
                             handleDeclaredVariable(currentBlockScope, parentFn, varNode, docHolder);
                         } else {
@@ -1779,10 +1779,15 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
                 pathIndex++;
                 lastVisited = getPath().get(pathSize - pathIndex);
             }
-            if ( lastVisited instanceof VarNode) {
+            if (lastVisited instanceof VarNode) {
                 fqName = getName((VarNode)lastVisited);
                 isDeclaredInParent = true;
-                JsObject declarationScope = ((VarNode)lastVisited).isLet() ? modelBuilder.getCurrentDeclarationScope() : modelBuilder.getCurrentDeclarationFunction();
+                JsObject declarationScope;
+                if (((VarNode) lastVisited).isBlockScoped()) {
+                    declarationScope = modelBuilder.getCurrentDeclarationScope();
+                } else {
+                    declarationScope = modelBuilder.getCurrentDeclarationFunction();
+                }
                 parent = declarationScope;
                 if (fqName.size() == 1 && !ModelUtils.isGlobal(declarationScope)) {
                     isPrivate = true;

--- a/webcommon/javascript2.model/test/unit/data/testfiles/markoccurences/issueGH8299.js
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/markoccurences/issueGH8299.js
@@ -1,0 +1,8 @@
+'use strict';
+
+function testX(a = true) {
+    const x = 1; // caret on x here does not highlight usage of x in next line
+    x; // caret on x here highlights both x
+    function () {
+    }
+}

--- a/webcommon/javascript2.model/test/unit/data/testfiles/markoccurences/issueGH8299.js.model
+++ b/webcommon/javascript2.model/test/unit/data/testfiles/markoccurences/issueGH8299.js.model
@@ -1,0 +1,19 @@
+FUNCTION issueGH8299 [ANONYMOUS: false, DECLARED: true - issueGH8299, MODIFIERS: PUBLIC, FILE]
+# RETURN TYPES
+undefined, RESOLVED: true
+# PROPERTIES
+testX : FUNCTION testX [ANONYMOUS: false, DECLARED: true - testX, MODIFIERS: PUBLIC, FUNCTION]
+      # RETURN TYPES
+      undefined, RESOLVED: true
+      # PARAMETERS
+      OBJECT a [ANONYMOUS: false, DECLARED: true - a, MODIFIERS: PUBLIC, PARAMETER]
+      # PROPERTIES
+      arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]
+      block-40  : OBJECT block-40 [ANONYMOUS: false, DECLARED: false - block-40, MODIFIERS: PUBLIC, BLOCK]
+                # PROPERTIES
+                issueGH8299testX#L#6 : FUNCTION issueGH8299testX#L#6 [ANONYMOUS: true, DECLARED: true - issueGH8299testX#L#6, MODIFIERS: PRIVATE, METHOD]
+                                     # RETURN TYPES
+                                     undefined, RESOLVED: true
+                                     # PROPERTIES
+                                     arguments : OBJECT arguments [ANONYMOUS: false, DECLARED: false - arguments, MODIFIERS: PRIVATE, VARIABLE]
+                x                    : OBJECT x [ANONYMOUS: false, DECLARED: true - x, MODIFIERS: PRIVATE, CONSTANT]

--- a/webcommon/javascript2.model/test/unit/src/org/netbeans/modules/javascript2/model/ModelTest.java
+++ b/webcommon/javascript2.model/test/unit/src/org/netbeans/modules/javascript2/model/ModelTest.java
@@ -278,6 +278,10 @@ public class ModelTest extends ModelTestBase {
         checkModel("testfiles/markoccurences/issue252135.js");
     }
 
+    public void testGH8299() throws Exception {
+        checkModel("testfiles/markoccurences/issueGH8299.js");
+    }
+
     public void testIssue231530() throws Exception {
         checkModel("testfiles/model/issue231530.js");
     }


### PR DESCRIPTION
- `const` declared variables must be treated as block scoped declarations, as `let` declared variables are already
- Highlighting of `const` is aligned with `let`

Closes: #8299





---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [ ] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [ ] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [ ] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [ ] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>