### PR TITLE
Cache ClassIndex during UnusedDetector search

### DIFF
--- a/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/SemanticHighlighterBase.java
+++ b/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/SemanticHighlighterBase.java
@@ -91,7 +91,7 @@ import org.openide.util.Pair;
  *
  * @author Jan Lahoda
  */
-public abstract class SemanticHighlighterBase extends JavaParserResultTask {
+public abstract class SemanticHighlighterBase extends JavaParserResultTask<Result> {
 
     public static final String JAVA_INLINE_HINT_PARAMETER_NAME = "javaInlineHintParameterName"; //NOI18N
     public static final String JAVA_INLINE_HINT_CHAINED_TYPES = "javaInlineHintChainedTypes"; //NOI18N
@@ -197,7 +197,7 @@ public abstract class SemanticHighlighterBase extends JavaParserResultTask {
         
         Map<Element, List<UnusedDescription>> element2Unused = UnusedDetector.findUnused(info, () -> cancel.get()) //XXX: unnecessarily ugly
                                                                              .stream()
-                                                                             .collect(Collectors.groupingBy(ud -> ud.unusedElement));
+                                                                             .collect(Collectors.groupingBy(ud -> ud.unusedElement()));
         for (Map.Entry<Element, List<Use>> entry : v.type2Uses.entrySet()) {
             if (cancel.get())
                 return true;

--- a/java/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/UnusedDetectorTest.java
+++ b/java/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/UnusedDetectorTest.java
@@ -593,7 +593,7 @@ public class UnusedDetectorTest extends NbTestCase {
 
                     Set<String> result = UnusedDetector.findUnused(parameter, () -> false)
                                                        .stream()
-                                                       .map(ud -> parameter.getCompilationUnit().getLineMap().getLineNumber(parameter.getTrees().getSourcePositions().getStartPosition(ud.unusedElementPath.getCompilationUnit(), ud.unusedElementPath.getLeaf())) + ":" + ud.unusedElement.getSimpleName() + ":" + ud.reason.name())
+                                                       .map(ud -> parameter.getCompilationUnit().getLineMap().getLineNumber(parameter.getTrees().getSourcePositions().getStartPosition(ud.unusedElementPath().getCompilationUnit(), ud.unusedElementPath().getLeaf())) + ":" + ud.unusedElement().getSimpleName() + ":" + ud.reason().name())
                                                        .collect(Collectors.toSet());
                     assertEquals(new HashSet<>(Arrays.asList(expected)), result);
                 } catch (IOException e) {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unused.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unused.java
@@ -67,10 +67,10 @@ public class Unused {
             if (ctx.isCanceled()) {
                 break;
             }
-            if (ud.unusedElementPath.getLeaf() != ctx.getPath().getLeaf()) {
+            if (ud.unusedElementPath().getLeaf() != ctx.getPath().getLeaf()) {
                 continue;
             }
-            if (!detectUnusedPackagePrivate && ud.packagePrivate) {
+            if (!detectUnusedPackagePrivate && ud.packagePrivate()) {
                 continue;
             }
             ErrorDescription err = convertUnused(ctx, ud);
@@ -98,34 +98,34 @@ public class Unused {
     })
     private static ErrorDescription convertUnused(HintContext ctx, UnusedDescription ud) {
         //TODO: switch expression candidate!
-        String name = ud.unusedElement.getSimpleName().toString();
+        String name = ud.unusedElement().getSimpleName().toString();
         String message;
         Fix fix = null;
-        switch (ud.reason) {
+        switch (ud.reason()) {
             case NOT_WRITTEN_READ: message = Bundle.ERR_NeitherReadOrWritten(name);
-                fix = JavaFixUtilities.removeFromParent(ctx, Bundle.FIX_RemoveUsedElement(name), ud.unusedElementPath);
+                fix = JavaFixUtilities.removeFromParent(ctx, Bundle.FIX_RemoveUsedElement(name), ud.unusedElementPath());
                 break;
             case NOT_WRITTEN: message = Bundle.ERR_NotWritten(name);
                 break;
             case NOT_READ: message = Bundle.ERR_NotRead(name);
                 //unclear what can be done with unused binding variables currently (before "_"):
-                if (ud.unusedElementPath.getParentPath().getLeaf().getKind() != Kind.BINDING_PATTERN) {
-                    fix = JavaFixUtilities.safelyRemoveFromParent(ctx, Bundle.FIX_RemoveUsedElement(name), ud.unusedElementPath);
+                if (ud.unusedElementPath().getParentPath().getLeaf().getKind() != Kind.BINDING_PATTERN) {
+                    fix = JavaFixUtilities.safelyRemoveFromParent(ctx, Bundle.FIX_RemoveUsedElement(name), ud.unusedElementPath());
                 }
                 break;
             case NOT_USED:
-                if (ud.unusedElement.getKind() == ElementKind.CONSTRUCTOR) {
+                if (ud.unusedElement().getKind() == ElementKind.CONSTRUCTOR) {
                     message = Bundle.ERR_NotUsedConstructor();
-                    fix = JavaFixUtilities.removeFromParent(ctx, Bundle.FIX_RemoveUsedConstructor(), ud.unusedElementPath);
+                    fix = JavaFixUtilities.removeFromParent(ctx, Bundle.FIX_RemoveUsedConstructor(), ud.unusedElementPath());
                 } else {
                     message = Bundle.ERR_NotUsed(name);
-                    fix = JavaFixUtilities.removeFromParent(ctx, Bundle.FIX_RemoveUsedElement(name), ud.unusedElementPath);
+                    fix = JavaFixUtilities.removeFromParent(ctx, Bundle.FIX_RemoveUsedElement(name), ud.unusedElementPath());
                 }
                 break;
             default:
-                throw new IllegalStateException("Unknown unused type: " + ud.reason);
+                throw new IllegalStateException("Unknown unused type: " + ud.reason());
         }
-        return fix != null ? ErrorDescriptionFactory.forName(ctx, ud.unusedElementPath, message, fix)
-                           : ErrorDescriptionFactory.forName(ctx, ud.unusedElementPath, message);
+        return fix != null ? ErrorDescriptionFactory.forName(ctx, ud.unusedElementPath(), message, fix)
+                           : ErrorDescriptionFactory.forName(ctx, ud.unusedElementPath(), message);
     }
 }


### PR DESCRIPTION
 - optimizes the `isUnusedInPkg()` code path
 - one pkg private element comes rarely alone, getting the `ClassIndex` for the `FileObject` can be expensive
 - compute it only once

running a synthetic [test file](https://github.com/mbien/nb-reprorepo/blob/54003b76bc25116e2f563940836709f02d125b19/performance/classes/src/main/java/test/classes/InnerClasses10k.java#L3) with 10k package private elements

`findUnused()` without caching (in ms):
```
time: 8289
time: 9288
```

`ClassIndex` computed once:
```
time: 262
time: 1818
```
note: the method is called twice on first file open, both measurements are shown since the code paths are different.

This might be potentially solvable without putting anything into the cache and making `UnusedDetector` an instance object.