### PR TITLE
Allowing refactorings for java files not part of any project.

### DIFF
--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/RefactoringUtils.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/RefactoringUtils.java
@@ -305,7 +305,7 @@ public class RefactoringUtils {
     public static boolean isOnSourceClasspath(FileObject fo) {
         Project pr = FileOwnerQuery.getOwner(fo);
         if (pr == null) {
-            return false;
+            return SourceLauncher.isSourceLauncherFile(fo);
         }
 
         //workaround for 143542


### PR DESCRIPTION
**Issue** 
Consider a java file not part of any project . Code Refactorings are not available currently as the file is marked as not refactorable by the  `isRefactorable` method when it checks for the  condition of `isOnSourceClasspath`. The method `isOnSourceClasspath` marks the file as not refactorable as the file is not part of any project.
**Fix Done**
If a file is not found to be part of any project then using the `SourceLauncher.isSourceLauncherFile` function we can check if it is a single source file similar to what is already being  done in the `isFileInOpenProject` method .