### PR TITLE
CI: run more steps with retry script

### DIFF
--- a/.github/retry.sh
+++ b/.github/retry.sh
@@ -22,8 +22,12 @@ TEST=$(getopt -q -a "f:" $@ | cut -d ' ' -f3)
     $@
 } || {
     echo "::warning::$TEST failed: starting retry 1"
-    $@
+    echo "::group::retry 1" && $@ && echo "::endgroup::"
 } || {
+    echo "::endgroup::"
     echo "::warning::$TEST failed: starting retry 2"
-    $@
+    echo "::group::retry 2" && $@ && echo "::endgroup::"
+} || {
+    echo "::endgroup::"
+    exit 1
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1481,6 +1481,10 @@ jobs:
       - name: Extract
         run: tar --zstd -xf build.tar.zst
 
+      - name: java.hints (unreliable tests)
+        if: ${{ (matrix.config == 'batch2') && success() }}
+        run: .github/retry.sh ant $OPTS -Dtest.config=unreliable -f java/java.hints test
+
       - name: java.hints ${{ matrix.config }}
         run: ant $OPTS -Dtest.config=${{ matrix.config }} -f java/java.hints test
 
@@ -1645,7 +1649,7 @@ jobs:
         run: ant $OPTS -f ide/csl.types test
 
       - name: ide/css.editor
-        run: ant $OPTS -f ide/css.editor test
+        run: .github/retry.sh ant $OPTS -f ide/css.editor test
 
       - name: ide/css.lib
         run: ant $OPTS -f ide/css.lib test
@@ -1681,7 +1685,7 @@ jobs:
         run: ant $OPTS -f webcommon/html.angular test-unit
 
       - name: webcommon/html.knockout
-        run: ant $OPTS -f webcommon/html.knockout test-unit
+        run: .github/retry.sh ant $OPTS -f webcommon/html.knockout test-unit
 
       - name: webcommon/javascript.bower
         run: ant $OPTS -f webcommon/javascript.bower test

--- a/java/java.hints/nbproject/project.properties
+++ b/java/java.hints/nbproject/project.properties
@@ -66,11 +66,21 @@ test.config.batch1.includes=\
     **/*Test.class
 test.config.batch1.excludes=\
     **/errors/*Test.class,\
-    **/jdk/*Test.class
+    **/jdk/*Test.class,\
+    ${test.config.unreliable.includes}
 
 test.config.batch2.includes=\
     **/errors/*Test.class,\
     **/jdk/*Test.class
+test.config.batch2.excludes=\
+    ${test.config.unreliable.includes}
+
+# frequent failures
+test.config.unreliable.includes=\
+    **/FieldForUnusedParamTest.class,\
+    **/RenameConstructorTest.class,\
+    **/ConvertInvalidVarToExplicitArrayTypeTest.class
+test.config.unreliable.excludes=
 
 test.jms.flags=\
  --add-opens=java.base/java.net=ALL-UNNAMED \


### PR DESCRIPTION
another attempt to get the failure rate under control before we have to start to disable tests

 - selected tests from `java.hints` module since the job is too long for the retry script
 - `html.knockout` and `css.editor` tests
 - group retry attempts in collapsable sections in github log

current stats:
![image](https://github.com/user-attachments/assets/705f138e-a22b-42ac-aa54-93f9849879b2)

the added log groups for retry runs would produce this output:
![image](https://github.com/user-attachments/assets/aeb89f18-06d9-433e-8aaa-f8c9dffb3f29)


The example above passed after 2 attempts. The idea is to be able to find the first failure easier when multiple attempts ran.


part of https://github.com/apache/netbeans/issues/8183