### PR TITLE
solves issue7044, refactoring inner to outer and pullup for record.

### DIFF
--- a/harness/nbjunit/nbproject/project.properties
+++ b/harness/nbjunit/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.source=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/harness/nbjunit/src/org/netbeans/junit/AssertLinesEqualHelpers.java
+++ b/harness/nbjunit/src/org/netbeans/junit/AssertLinesEqualHelpers.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.junit;
+
+import java.io.PrintStream;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.fail;
+import static org.netbeans.junit.AssertLinesEqualHelpers.StringsCompareMode.EXACT;
+
+/**
+ *
+ * @author homberghp
+ */
+public class AssertLinesEqualHelpers {
+
+    public enum StringsCompareMode {
+        EXACT, IGNORE_DUP_SPACES, IGNORE_INDENTATION, IGNORE_WHITESPACE_DIFF
+    }
+    private static StringsCompareMode stringsCompareMode = EXACT;
+    private static Function<String, String> linePreprocessor = s -> s;
+    public static boolean showOutputOnPass = false;
+
+    /**
+     * Sets the string compare mode.
+     * <ul>
+     * <li>EXACT: exact line by line, including empty lines.
+     * <li>IGNORE_DUP_SPACES: ignore duplicate (inner) spacing
+     * </li>INGNORE_INDENTATION ignore difference in leading and trailing white
+     * space
+     * </li>INGNORE_WHITE_SPACE_DIFF ignore difference in any white space
+     * </ul>
+     *
+     * @param mode
+     */
+    public static void setStringCompareMode(StringsCompareMode mode) {
+        stringsCompareMode = mode;
+        linePreprocessor = switch (mode) {
+            case EXACT ->
+                s -> s;
+            case IGNORE_DUP_SPACES ->
+                s -> s.replaceAll("\\s{2,}", " ");
+            case IGNORE_INDENTATION ->
+                s -> s.trim();
+            case IGNORE_WHITESPACE_DIFF ->
+                s -> s.trim().replaceAll("\\s{2,}", " ");
+        };
+
+    }
+
+    /**
+     * Prints a source by splitting on the line breaks and prefixing with name
+     * and line number.
+     *
+     * @param out the stream to print to
+     * @param name the name as prefix to each line
+     * @param source the source code to print to the out stream.
+     */
+    public static void printNumbered(final PrintStream out, final String name, String source) {
+        AtomicInteger c = new AtomicInteger(1);
+        source.trim().lines().forEach(l -> out.println("%s [%4d] %s".formatted(name, c.getAndIncrement(), l)));
+    }
+
+    /**
+     * Compare strings by replacing all multiples of white space([ \t\n\r]) with
+     * a space.
+     *
+     * The test programmer chooses this to make it easier to write the input and
+     * the expected strings.
+     *
+     * @param expected to compare
+     * @param actual to compare
+     */
+    public static void assertLinesEqual1(String name, String expected, String actual) {
+        try {
+            assertEquals(name, expected.replaceAll("[ \t\r\n\n]+", " "), actual.replaceAll("[ \t\r\n\n]+", " "));
+        } catch (Throwable t) {
+            System.err.println("expected:");
+            System.err.println(expected);
+            System.err.println("actual:");
+            System.err.println(actual);
+            throw t;
+        }
+    }
+
+    /**
+     * Compare strings by splitting them into lines, remove empty lines, and
+     * trim white space.Only when any of the lines differ, all lines are printed
+     * with the unequal lines flagged.
+     *
+     * Before the lines are compared, they are trimmed and the white space is
+     * normalized by collapsing multiple white space characters into one. This
+     * should make the tests less brittle.
+     *
+     * If any of the compared lines are unequal, this test fails and the
+     * comparison result is shown on stderr in a simplified diff format.
+     *
+     * @param testName to print before comparison result.
+     * @param fileName to print before each compared line.
+     * @param expected to compare
+     * @param actual to compare
+     */
+    public static void assertLinesEqual2(String testName,String fileName, String expected, String actual) {
+        if (stringsCompareMode != EXACT) {
+            expected = expected.trim().replaceAll("([\t\r\n])\\1+", "$1");
+            actual = actual.trim().replaceAll("([\t\r\n])\\1+", "$1");
+        }
+        String[] linesExpected;
+        String[] linesActual;
+        linesExpected = expected.lines().toArray(String[]::new);
+        linesActual = actual.lines().toArray(String[]::new);
+        int limit = Math.max(linesExpected.length, linesActual.length);
+        StringBuilder sb = new StringBuilder();
+        boolean equals = true;
+        for (int i = 0; i < limit; i++) {
+            String oe = (i < linesExpected.length ? linesExpected[i] : "");
+            String oa = (i < linesActual.length ? linesActual[i] : "");
+            String e = linePreprocessor.apply(oe);
+            String a = linePreprocessor.apply(oa);
+            // somehow my user is inserted, so avoid to test those lines.
+            if (e.contains("@author") && a.contains("@author")) {
+                e = a = "* @author goes here";
+                oa = oe;
+            }
+            boolean same = e.equals(a);
+            String sep = same ? "   " : " | ";
+            equals &= same;
+            sb.append(String.format(fileName + " [%3d] %-80s%s%-80s%n", i, oe, sep, oa));
+        }
+        if (!equals || showOutputOnPass) {
+            System.err.println("test " + testName + (equals ? " PASSED" : " FAILED") + " with compare mode = " + stringsCompareMode);
+            System.err.print(String.format(fileName + "       %-80s%s%-80s%n", "expected", " + ", "actual"));
+            System.err.println(sb.toString());
+            System.err.flush();
+            if (!equals) {
+                fail("lines differ, see stderr for more details.");
+            }
+        }
+    }
+
+}

--- a/java/java.source.base/src/org/netbeans/api/java/source/AssignComments.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/AssignComments.java
@@ -69,6 +69,7 @@ class AssignComments extends ErrorAwareTreeScanner<Void, Void> {
             Tree.Kind.CLASS,
             Tree.Kind.INTERFACE,
             Tree.Kind.ENUM,
+            Tree.Kind.RECORD,
 
             Tree.Kind.METHOD,
             Tree.Kind.VARIABLE

--- a/java/java.source.base/src/org/netbeans/api/java/source/ClassIndex.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ClassIndex.java
@@ -862,6 +862,7 @@ public final class ClassIndex {
                             result.add(ClassIndexImpl.UsageType.SUPER_CLASS);
                             break;
                         case ENUM:
+                        case RECORD:
                             result.add(ClassIndexImpl.UsageType.SUPER_CLASS);
                             break;
                         case OTHER:

--- a/java/java.source.base/src/org/netbeans/api/java/source/CodeStyle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/CodeStyle.java
@@ -1382,7 +1382,7 @@ public final class CodeStyle {
         public int getGroupId(Element element) {
             for (Info info : infos) {
                 ElementKind kind = element.getKind();
-                if (kind == ElementKind.ANNOTATION_TYPE || kind == ElementKind.ENUM || kind == ElementKind.INSTANCE_INIT)
+                if (kind == ElementKind.ANNOTATION_TYPE || kind == ElementKind.ENUM || kind == ElementKind.RECORD || kind == ElementKind.INSTANCE_INIT)
                     kind = ElementKind.CLASS;
                 if (info.check(kind, element.getModifiers()));
                     return info.groupId;

--- a/java/java.source.base/src/org/netbeans/api/java/source/ElementHandle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ElementHandle.java
@@ -156,6 +156,7 @@ public final class ElementHandle<T extends Element> {
             case CLASS:
             case INTERFACE:
             case ENUM:
+            case RECORD:
             case ANNOTATION_TYPE: {
                 assert signatures.length == 1;
                 final Element type = getTypeElementByBinaryName (module, signatures[0], jt);

--- a/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
@@ -632,7 +632,7 @@ public final class GeneratorUtilities {
             // ignore type
             Tree parent = getCurrentPath().getParentPath().getLeaf();
             Tree.Kind k = parent.getKind();
-            if (k == Tree.Kind.CLASS || k == Tree.Kind.INTERFACE || k == Tree.Kind.ENUM) {
+            if (k == Tree.Kind.CLASS || k == Tree.Kind.INTERFACE || k == Tree.Kind.ENUM || k == Tree.Kind.RECORD) {
                 member = node;
             }
             Object o = scan(node.getInitializer(), p);
@@ -643,7 +643,7 @@ public final class GeneratorUtilities {
         @Override public Object visitBlock(BlockTree node, Object p) { 
             Tree parent = getCurrentPath().getParentPath().getLeaf();
             Tree.Kind k = parent.getKind();
-            if (k == Tree.Kind.CLASS || k == Tree.Kind.INTERFACE || k == Tree.Kind.ENUM) {
+            if (k == Tree.Kind.CLASS || k == Tree.Kind.INTERFACE || k == Tree.Kind.ENUM || k == Tree.Kind.RECORD) {
                 member = node;
                 return super.visitBlock(node, p);
             }

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeMaker.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeMaker.java
@@ -480,6 +480,26 @@ public final class TreeMaker {
     }
     
     /**
+     * Creates a new ClassTree representing enum.
+     *
+     * @param modifiers the modifiers declaration
+     * @param simpleName        the name of the class without its package, such
+     *                          as "String" for the class "java.lang.String".
+     * @param implementsClauses the list of the interfaces this class
+     *                          implements, or an empty list.
+     * @param memberDecls       the list of fields defined by this class, or an
+     *                          empty list.
+     * @see com.sun.source.tree.ClassTree
+     */
+    public ClassTree Record(ModifiersTree modifiers,
+             CharSequence simpleName,
+             List<? extends TypeParameterTree> typeParameters,
+             List<? extends Tree> implementsClauses,
+             List<? extends Tree> memberDecls) {
+        return delegate.Record(modifiers, simpleName, typeParameters, implementsClauses, memberDecls);
+    }
+
+    /**
      * Creates a new CompilationUnitTree.
      *
      * @param packageName        a tree representing the package name.

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -125,7 +125,7 @@ public final class TreeUtilities {
      */
     @Deprecated
     public boolean isClass(ClassTree tree) {
-        return (((JCTree.JCModifiers)tree.getModifiers()).flags & (Flags.INTERFACE | Flags.ENUM | Flags.ANNOTATION)) == 0;
+        return (((JCTree.JCModifiers)tree.getModifiers()).flags & (Flags.INTERFACE | Flags.ENUM | Flags.RECORD | Flags.ANNOTATION)) == 0;
     }
     
     /**Checks whether the given tree represents an interface.

--- a/java/java.source.base/src/org/netbeans/api/java/source/WorkingCopy.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/WorkingCopy.java
@@ -549,6 +549,7 @@ public class WorkingCopy extends CompilationController {
             case ANNOTATION_TYPE:
             case CLASS:
             case ENUM:
+            case RECORD:
             case INTERFACE:
                 children = ((ClassTree) parentPath.getLeaf()).getMembers(); break;
             case CASE:  children = ((CaseTree) parentPath.getLeaf()).getStatements(); break;
@@ -1221,7 +1222,9 @@ public class WorkingCopy extends CompilationController {
             case INTERFACE: return "Templates/Classes/Interface.java"; // NOI18N
             case ANNOTATION_TYPE: return "Templates/Classes/AnnotationType.java"; // NOI18N
             case ENUM: return "Templates/Classes/Enum.java"; // NOI18N
+            case RECORD: return "Templates/Classes/Record.java"; // NOI18N
             case PACKAGE: return "Templates/Classes/package-info.java"; // NOI18N
+            case MODULE: return "Templates/Classes/module-info.java"; // NOI18N
             default:
                 Logger.getLogger(WorkingCopy.class.getName()).log(Level.SEVERE, "Cannot resolve template for {0}", kind);
                 return "Templates/Classes/Empty.java"; // NOI18N
@@ -1247,6 +1250,9 @@ public class WorkingCopy extends CompilationController {
                     break;
                 case ENUM:
                     kind = ElementKind.ENUM;
+                    break;
+                case RECORD:
+                    kind = ElementKind.RECORD;
                     break;
                 default:
                     Logger.getLogger(WorkingCopy.class.getName()).log(Level.SEVERE, "Cannot resolve template for {0}", cut.getTypeDecls().get(0).getKind());

--- a/java/java.source.base/src/org/netbeans/modules/java/source/builder/ASTService.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/builder/ASTService.java
@@ -70,6 +70,7 @@ public final class ASTService {
             case ANNOTATION_TYPE:
             case CLASS:
             case ENUM:
+            case RECORD:
             case INTERFACE:
                 return ((JCClassDecl)tree).sym;
             case METHOD:           return ((JCMethodDecl)tree).sym;

--- a/java/java.source.base/src/org/netbeans/modules/java/source/builder/TreeFactory.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/builder/TreeFactory.java
@@ -329,6 +329,15 @@ public class TreeFactory {
         long flags = getBitFlags(modifiers.getFlags()) | Flags.ENUM;
         return Class(flags, (com.sun.tools.javac.util.List<JCAnnotation>) modifiers.getAnnotations(), simpleName, Collections.<TypeParameterTree>emptyList(), null, implementsClauses, Collections.emptyList(), memberDecls);
     }
+
+    public ClassTree Record(ModifiersTree modifiers,
+             CharSequence simpleName,
+             List<? extends TypeParameterTree> typeParameters,
+             List<? extends Tree> implementsClauses,
+             List<? extends Tree> memberDecls) {
+        long flags = getBitFlags(modifiers.getFlags()) | Flags.RECORD;
+        return Class(flags, (com.sun.tools.javac.util.List<JCAnnotation>) modifiers.getAnnotations(), simpleName, typeParameters, null, implementsClauses, Collections.emptyList(), memberDecls);
+    }
     
     public CompilationUnitTree CompilationUnit(PackageTree packageDecl,
                                                List<? extends ImportTree> importDecls, 

--- a/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
@@ -952,7 +952,6 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
      * @return the canonical parameters for the record
      */
     private List<JCVariableDecl> getRecordComponents(JCClassDecl tree) {
-        System.err.println("VP getRecordComponents");
         List<JCVariableDecl> components
                 = List.from(tree.defs
                         .stream()

--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/Reindenter.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/Reindenter.java
@@ -372,7 +372,7 @@ public class Reindenter implements IndentTask {
                 break;
             case CLASS:
             case INTERFACE:
-            case ENUM:
+            case ENUM: // RECORD is at the end
             case ANNOTATION_TYPE:
                 token = findFirstNonWhitespaceToken(startOffset, endOffset);
                 nextTokenId = token != null ? token.token().id() : null;
@@ -1236,6 +1236,7 @@ public class Reindenter implements IndentTask {
                 case CLASS:
                 case INTERFACE:
                 case ENUM:
+                case RECORD:
                 case ANNOTATION_TYPE:
                 case VARIABLE:
                 case METHOD:

--- a/java/java.source.base/src/org/netbeans/modules/java/source/usages/DocumentUtil.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/usages/DocumentUtil.java
@@ -391,6 +391,8 @@ public class DocumentUtil {
                 return isLocal ? EK_LOCAL_INTERFACE : EK_INTERFACE;
             case ENUM:
                 return isLocal ? EK_LOCAL_ENUM : EK_ENUM;
+            case RECORD:
+                return isLocal ? EK_LOCAL_RECORD : EK_RECORD;
             case ANNOTATION_TYPE:
                 return isLocal ? EK_LOCAL_ANNOTATION : EK_ANNOTATION;
             case MODULE:

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/APIIsSelfContainedTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/APIIsSelfContainedTest.java
@@ -166,6 +166,7 @@ public class APIIsSelfContainedTest extends NbTestCase {
             case CLASS:
             case INTERFACE:
             case ENUM:
+            case RECORD:
                 verifySelfContainedAPI((TypeElement) e);
                 break;
             case CONSTRUCTOR:

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/GeneratorUtilitiesTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/GeneratorUtilitiesTest.java
@@ -745,6 +745,7 @@ public class GeneratorUtilitiesTest extends NbTestCase {
                 case ANNOTATION_TYPE:
                 case CLASS:
                 case ENUM:
+                case RECORD:
                 case INTERFACE:
                     name = ((ClassTree)t).getSimpleName();
                     break;

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/RewriteOccasionalStatements.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/RewriteOccasionalStatements.java
@@ -252,6 +252,13 @@ public class RewriteOccasionalStatements extends GeneratorTestBase {
                             classTree.getSimpleName(),
                             impls2Add,
                             members2Add);
+                } else if (clazz.getKind() == ElementKind.RECORD) {
+                    nc = maker.Record(
+                            classTree.getModifiers(),
+                            classTree.getSimpleName(),
+                            classTree.getTypeParameters(),
+                            impls2Add,
+                            members2Add);
                 } else {
                     throw new IllegalStateException(classTree.toString());
                 }
@@ -316,6 +323,13 @@ public class RewriteOccasionalStatements extends GeneratorTestBase {
                             classTree.getSimpleName(),
                             impls2Add,
                             members2Add);
+                } else if (clazz.getKind() == ElementKind.RECORD) {
+                    nc = maker.Record(
+                            classTree.getModifiers(),
+                            classTree.getSimpleName(),
+                            classTree.getTypeParameters(),
+                            impls2Add,
+                            members2Add);
                 } else {
                     throw new IllegalStateException(classTree.toString());
                 }
@@ -378,6 +392,13 @@ public class RewriteOccasionalStatements extends GeneratorTestBase {
                     nc = maker.Enum(
                             classTree.getModifiers(),
                             classTree.getSimpleName(),
+                            impls2Add,
+                            members2Add);
+                } else if (clazz.getKind() == ElementKind.RECORD) {
+                    nc = maker.Record(
+                            classTree.getModifiers(),
+                            classTree.getSimpleName(),
+                            classTree.getTypeParameters(),
                             impls2Add,
                             members2Add);
                 } else {

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TreeMakerDemo.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TreeMakerDemo.java
@@ -170,6 +170,7 @@ public class TreeMakerDemo extends GeneratorTestMDRCompat {
             case ANNOTATION_TYPE:
             case CLASS:
             case ENUM:
+            case RECORD:
             case INTERFACE:
                 builder.append("make.Class(");
                 ClassTree classTree = (ClassTree) tree;

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PartialReparseTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PartialReparseTest.java
@@ -518,7 +518,7 @@ public class PartialReparseTest extends NbTestCase {
     private static final Set<ElementKind> SUPPORTED_ELEMENTS = EnumSet.of(
             ElementKind.PACKAGE, ElementKind.CLASS, ElementKind.INTERFACE,
             ElementKind.ENUM, ElementKind.ANNOTATION_TYPE, ElementKind.METHOD,
-            ElementKind.CONSTRUCTOR, ElementKind.INSTANCE_INIT,
+            ElementKind.CONSTRUCTOR, ElementKind.INSTANCE_INIT,ElementKind.RECORD,
             ElementKind.STATIC_INIT, ElementKind.FIELD, ElementKind.ENUM_CONSTANT);
 
     private static List<DiagnosticDescription> dumpDiagnostics(CompilationInfo info) {

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/CreateElementUtilities.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/CreateElementUtilities.java
@@ -136,6 +136,7 @@ public final class CreateElementUtilities {
             case ANNOTATION_TYPE:
             case CLASS:
             case ENUM:
+            case RECORD:
             case INTERFACE:
                 return computeClass(types, info, currentPath, unresolved, offset);
                 

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/LspCallHierarchyProvider.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/LspCallHierarchyProvider.java
@@ -84,6 +84,7 @@ public class LspCallHierarchyProvider implements CallHierarchyProvider {
                     return tp;
                 case CLASS:
                 case ENUM:
+                case RECORD:
                 case INTERFACE:
                     return null;
                     

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/EncapsulateFieldRefactoringPlugin.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/EncapsulateFieldRefactoringPlugin.java
@@ -1174,7 +1174,7 @@ public final class EncapsulateFieldRefactoringPlugin extends JavaRefactoringPlug
                     case COMPILATION_UNIT:
                     case ANNOTATION_TYPE:
                     case CLASS:
-                    case ENUM:
+                    case RECORD:
                     case INTERFACE:
                     case NEW_CLASS:
                         return false;
@@ -1209,6 +1209,7 @@ public final class EncapsulateFieldRefactoringPlugin extends JavaRefactoringPlug
                     case ANNOTATION_TYPE:
                     case CLASS:
                     case ENUM:
+                    case RECORD:
                     case INTERFACE:
                     case NEW_CLASS:
                         return false;

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/FindLocalUsagesQuery.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/FindLocalUsagesQuery.java
@@ -109,6 +109,7 @@ public class FindLocalUsagesQuery extends CancellableTreePathScanner<Void, Void>
                 case ANNOTATION_TYPE:
                 case CLASS:
                 case ENUM:
+                case RECORD:
                 case INTERFACE:
                 case VARIABLE:
                     DocCommentTree docCommentTree = info.getDocTrees().getDocCommentTree(el);

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveClassTransformer.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveClassTransformer.java
@@ -244,6 +244,14 @@ public class MoveClassTransformer extends RefactoringVisitor {
                                     newClass.getImplementsClause(),
                                     newClass.getMembers());
                             break;
+                        case RECORD:
+                            newClass = make.Record(
+                                    make.Modifiers(flags, modifiers.getAnnotations()),
+                                    newClass.getSimpleName(),
+                                    newClass.getTypeParameters(),
+                                    newClass.getImplementsClause(),
+                                    newClass.getMembers());
+                            break;
                         case ANNOTATION_TYPE:
                             newClass = make.AnnotationType(
                                     make.Modifiers(flags, modifiers.getAnnotations()),

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveFileRefactoringPlugin.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveFileRefactoringPlugin.java
@@ -332,6 +332,7 @@ public class MoveFileRefactoringPlugin extends JavaRefactoringPlugin {
                 for (Element element : enclosedElements) {
                     switch (element.getKind()) {
                         case ENUM:
+                        case RECORD:
                         case CLASS:
                         case ANNOTATION_TYPE:
                         case INTERFACE:

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/PullUpTransformer.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/PullUpTransformer.java
@@ -266,6 +266,14 @@ public class PullUpTransformer extends RefactoringVisitor {
                                 oldOne.getImplementsClause(),
                                 oldOne.getMembers());
                         break;
+                    case RECORD:
+                        newMemberTree = make.Record(
+                                make.addModifiersModifier(make.removeModifiersModifier(oldOne.getModifiers(), Modifier.PRIVATE), Modifier.PROTECTED),
+                                oldOne.getSimpleName(),
+                                oldOne.getTypeParameters(),
+                                oldOne.getImplementsClause(),
+                                oldOne.getMembers());
+                        break;
                 }
             }
             if (newMemberTree != null) {

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/TreeDuplicator.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/TreeDuplicator.java
@@ -97,6 +97,7 @@ public class TreeDuplicator {
             case CLASS:
             case INTERFACE:
             case ENUM:
+            case RECORD:
             case ANNOTATION_TYPE:{
                 ClassTree t = (ClassTree) tree;
                 result = make.setLabel(tree, t.getSimpleName());

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/RefactoringVisitor.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/RefactoringVisitor.java
@@ -182,6 +182,7 @@ public class RefactoringVisitor extends ErrorAwareTreePathScanner<Tree, Element>
                 case ANNOTATION_TYPE:
                 case CLASS:
                 case ENUM:
+                case RECORD:
                 case INTERFACE:
                 case VARIABLE:
                     TreePath path = new TreePath(currentPath, tree);

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PullUpRefactoringUI.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/PullUpRefactoringUI.java
@@ -314,6 +314,7 @@ public class PullUpRefactoringUI implements RefactoringUI, JavaRefactoringUIFact
                 case ANNOTATION_TYPE:
                 case CLASS:
                 case ENUM:
+                case RECORD:
                 case INTERFACE:
                 case NEW_CLASS:
                 case METHOD:

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/UIUtilities.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/UIUtilities.java
@@ -335,6 +335,9 @@ public final class UIUtilities {
                     case ENUM:
                         stringBuilder.append("enum "); // NOI18N
                         break;
+                    case RECORD:
+                        stringBuilder.append("record "); // NOI18N
+                        break;
                     case ANNOTATION_TYPE:
                         stringBuilder.append("@interface "); // NOI18N
                         break;

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedPanel.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/WhereUsedPanel.java
@@ -74,6 +74,7 @@ public class WhereUsedPanel extends JPanel implements CustomRefactoringPanel {
             }
             case CLASS:
             case ENUM:
+            case RECORD:
             case INTERFACE:
             case ANNOTATION_TYPE: {
                 panel = new WhereUsedPanelClass(parent);

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/ElementNode.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/elements/ElementNode.java
@@ -561,6 +561,7 @@ public class ElementNode extends AbstractNode {
                     case CLASS:
                     case INTERFACE:
                     case ENUM:
+                    case RECORD:
                     case ANNOTATION_TYPE:
                         return 4;
                     default:

--- a/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ExtractSuperclassTest.java
+++ b/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ExtractSuperclassTest.java
@@ -48,6 +48,8 @@ public class ExtractSuperclassTest extends RefactoringTestBase {
 
     public ExtractSuperclassTest(String name) {
         super(name);
+        RETRIES=1;
+//        show
     }
 
     public void test235246() throws Exception {

--- a/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InnerOuterRecordTest.java
+++ b/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InnerOuterRecordTest.java
@@ -1,0 +1,943 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.refactoring.java.test;
+
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreePath;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Name;
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+import org.netbeans.api.java.source.CompilationController;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.Task;
+import org.netbeans.api.java.source.TreePathHandle;
+import org.netbeans.junit.AssertLinesEqualHelpers;
+import org.netbeans.modules.refactoring.api.Problem;
+import org.netbeans.modules.refactoring.api.RefactoringSession;
+import org.netbeans.modules.refactoring.java.api.InnerToOuterRefactoring;
+import static org.netbeans.modules.refactoring.java.test.RefactoringTestBase.addAllProblems;
+import static org.netbeans.junit.AssertLinesEqualHelpers.*;
+import org.openide.util.Exceptions;
+
+/**
+ * Test inner to outer refactoring for test.
+ *
+ * In the input files, and the expected outcomes, the indentation does not
+ * really matter as far as the tests are concerned because the indentation is
+ * stripped away before the remaining source lines are compared to the expected
+ * lines.
+ *
+ * @author homberghp {@code <pieter.van.den.hombergh@gmail.com)>}
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class InnerOuterRecordTest extends RefactoringTestBase {
+
+    public InnerOuterRecordTest(String name) {
+        super(name, "16");
+        //ensure we are running on at least 16.
+        try {
+            SourceVersion.valueOf("RELEASE_16"); //NOI18N
+        } catch (IllegalArgumentException ex) {
+            //OK, no RELEASE_16, skip test
+            throw new RuntimeException("need at least Java 16 for record");
+        }
+        sideBySideCompare = true;
+        showOutputOnPass=true;
+
+        RETRIES=1;
+    }
+
+    public void test9ApacheNetbeans7044() throws Exception {
+        // initial outer has record with meaningful canonical constructor.
+        // note that Inner class should be in last member for assumptions in the test.
+        String source
+                = """
+                package t;
+
+                import java.time.LocalDate;
+                import java.util.Objects;
+
+                public class A {
+
+                    void useStudent() {
+                        F s = new F(42,"Jan Klaassen", LocalDate.now().minusDays(1));
+                        System.out.println("student = " + s);
+                    }
+                    record F(int id, String name, LocalDate dob) {
+
+                        /**
+                          * Validate stuff.
+                          */
+                        public F {
+                            Objects.requireNonNull(id);
+                            Objects.requireNonNull(name);
+                            Objects.requireNonNull(dob);
+                            assert !name.isEmpty() && !name.isBlank();
+                            assert dob.isAfter(LocalDate.EPOCH);
+                        }
+
+                        public void method() {
+                        }
+                    }
+
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+
+                import java.time.LocalDate;
+                import java.util.Objects;
+
+                public class A {
+
+                    void useStudent() {
+                        F s = new F(42,"Jan Klaassen", LocalDate.now().minusDays(1));
+                        System.out.println("student = " + s);
+                    }
+
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.time.LocalDate;
+                import java.util.Objects;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                 record F(int id, String name, LocalDate dob) {
+
+                    /**
+                     * Validate stuff.
+                     */
+                    public F {
+                        Objects.requireNonNull(id);
+                        Objects.requireNonNull(name);
+                        Objects.requireNonNull(dob);
+                        assert !name.isEmpty() && !name.isBlank();
+                        assert dob.isAfter(LocalDate.EPOCH);
+                    }
+
+                    public void method() {
+                    }
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    public void test1BasicClassInClass() throws Exception {
+        // initial outer has record with meaningful canonical constructor.
+        String source
+                = """
+            package t;
+            import java.time.LocalDate;
+            import java.util.Objects;
+            public class A {
+                void useStudent() {
+                    F s = new F(42, "Jan Klaassen", LocalDate.now().minusDays(1));
+                    System.out.println("student = " + s);
+                }
+                public static class F {
+                    int id;
+                    String name;
+                    LocalDate dob
+                    public Student(int id, String name, LocalDate dob) {
+                        Objects.requireNonNull(id);
+                        Objects.requireNonNull(name);
+                        Objects.requireNonNull(dob);
+                        assert !name.isEmpty() && !name.isBlank();
+                        assert dob.isAfter(LocalDate.EPOCH);
+                        this.id=id;
+                        this.name=name;
+                        this.dob=dob;
+                    }
+                }
+            }
+            """;
+        String newOuter
+                = """
+                package t;
+                import java.time.LocalDate;
+                import java.util.Objects;
+                public class A {
+                    void useStudent() {
+                        F s = new F(42, "Jan Klaassen", LocalDate.now().minusDays(1));
+                        System.out.println("student = " + s);
+                    }
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.time.LocalDate;
+                import java.util.Objects;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                public class F {
+
+                    int id;
+                    String name;
+                    LocalDate dob;
+
+                    public F(int id, String name, LocalDate dob) {
+                        Objects.requireNonNull(id);
+                        Objects.requireNonNull(name);
+                        Objects.requireNonNull(dob);
+                        assert !name.isEmpty() && !name.isBlank();
+                        assert dob.isAfter(LocalDate.EPOCH);
+                        this.id = id;
+                        this.name = name;
+                        this.dob = dob;
+                    }
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    public void test2BasicRecordInRecord() throws Exception {
+        String source
+                = """
+                package t;
+                import java.time.LocalDate;
+                record A(int id, String name, LocalDate dob) {
+                   static F f;
+                   record F(int x, int y){
+                      /** I should be back. */
+                      static String code = "nix";
+                   }
+                }
+                """;
+        String newOuter
+                =
+                """
+                package t;
+                import java.time.LocalDate;
+                record A(int id, String name, LocalDate dob) {
+                   static F f;
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                /**
+                 *
+                 * @author hom
+                 */
+                 record F(int x, int y) {
+                    /** I should be back. */
+                    static String code = "nix";
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    /**
+     * Test to verify what happens to the compact constructor in the outer
+     * record. It appears to survive the refactoring.
+     *
+     * @throws Exception
+     */
+    public void test3OuterWithCompact() throws Exception {
+        String source
+                = """
+                package t;
+
+                import java.time.LocalDate;
+
+                /** Record with compact ctor. */
+                record A(F f) {
+                    public A{
+                        assert f!=null;
+                    }
+                    record F(int id, String name, LocalDate dob){}
+
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+
+                import java.time.LocalDate;
+
+                /** Record with compact ctor. */
+                record A(F f) {
+                    public A{
+                        assert f!=null;
+                    }
+
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.time.LocalDate;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                 record F(int id, String name, LocalDate dob) {}
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    public void test4InnerWithCompact() throws Exception {
+        String source
+                = """
+                package t;
+                import java.time.LocalDate;
+                record A(F f) {
+                    public A {
+                        assert f != null;
+                    }
+                    record F(int id, String name, LocalDate dob) {
+                        public F {
+                            if (dob.isBefore(LocalDate.EPOCH)) {
+                                throw new IllegalArgumentException("to old " + dob);
+                            }
+                        }
+                    }
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+                import java.time.LocalDate;
+                record A(F f) {
+                    public A {
+                        assert f != null;
+                    }
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.time.LocalDate;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                 record F(int id, String name, LocalDate dob) {
+
+                    public F {
+                        if (dob.isBefore(LocalDate.EPOCH)) {
+                            throw new IllegalArgumentException("to old " + dob);
+                        }
+                    }
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    // outer may have effect
+    public void test5ClassWithInnerRecord() throws Exception {
+        String source
+                = """
+                package t;
+
+                import java.time.LocalDate;
+
+                class A {
+
+                    final F f;
+                    public A(F f) {
+                        assert f != null;
+                        this.f=f;
+                    }
+                    record F(int id, String name, LocalDate dob) {
+                        public F   {
+                            if (dob.isBefore(LocalDate.EPOCH)) {
+                                throw new IllegalArgumentException("to old " + dob);
+                            }
+                        }
+                    }
+
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+
+                import java.time.LocalDate;
+
+                class A {
+
+                    final F f;
+                    public A(F f) {
+                        assert f != null;
+                        this.f=f;
+                    }
+
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.time.LocalDate;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                 record F(int id, String name, LocalDate dob) {
+
+                    public F {
+                        if (dob.isBefore(LocalDate.EPOCH)) {
+                            throw new IllegalArgumentException("to old " + dob);
+                        }
+                    }
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    public void test6InnerWithCompactAndMethodAndExtraCtor() throws Exception {
+        AssertLinesEqualHelpers.setStringCompareMode(StringsCompareMode.IGNORE_WHITESPACE_DIFF);
+        String source
+                = """
+                package t;
+
+                import java.time.LocalDate;
+
+                record A(F f) {
+
+                    enum Suite {
+                        SPADE, CLUB, DIAMOND, HEART;
+                    }
+
+                    public A {
+                        assert f != null;
+                    }
+
+                    record F(int id, String name, LocalDate dob) {
+
+                        public F {
+                            if (dob.isBefore(LocalDate.EPOCH)) {
+                                throw new IllegalArgumentException("to old " + dob);
+                            }
+                        }
+
+                        public F(int id, String name){
+                            this(id,name,LocalDate.now());
+                        }
+
+                        boolean bornBefore(LocalDate someDate) {
+                            return dob.isBefore(someDate);
+                        }
+
+                    }
+
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+
+                import java.time.LocalDate;
+
+                record A(F f) {
+
+                    enum Suite {
+                        SPADE, CLUB, DIAMOND, HEART;
+                    }
+
+                    public A {
+                        assert f != null;
+                    }
+
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.time.LocalDate;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                record F(int id, String name, LocalDate dob) {
+
+                    public F {
+                        if (dob.isBefore(LocalDate.EPOCH)) {
+                            throw new IllegalArgumentException("to old " + dob);
+                        }
+                    }
+
+                    public F(int id, String name) {
+                        this(id, name, LocalDate.now());
+                    }
+
+                    boolean bornBefore(LocalDate someDate) {
+                        return dob.isBefore(someDate);
+                    }
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    public void test7Generic() throws Exception {
+        String source
+                = """
+                package t;
+                record A(F f) {
+                    public A {
+                        assert f != null;
+                    }
+                    record F<P, Q>(P first, Q second) {
+                        public F {
+                            assert null != first;
+                            assert null != second;
+                        }
+                    }
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+                record A(F f) {
+                    public A {
+                        assert f != null;
+                    }
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+                package t;
+                /**
+                 *
+                 * @author junit
+                 */
+                record F<P, Q>(P first, Q second) {
+                    public F {
+                        assert null != first;
+                        assert null != second;
+                    }
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    // disable for the time being, varargs not yet implemented
+    public void _test8Varargs() throws Exception {
+        RETRIES = 0;
+//        debug = true;
+        String source =
+                """
+                package t;
+                record A(F f, String... params) {
+                    public A {
+                        assert f != null;
+                    }
+                    record F<P>(P first, String... second) {
+                        public F {
+                            assert null != first;
+                            assert null != second && second.length > 0;
+                        }
+                    }
+                }
+                """;
+        String newOuter =
+                """
+                package t;
+                record A(F f, String... params) {
+                    public A {
+                        assert f != null;
+                    }
+                }
+                """;
+        String newInner =
+                """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                record F<P>(P first, String... second) {
+
+                    public F {
+                        assert null != first;
+                        assert null != second && second.length > 0;
+                    }
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    // disable for the time being, varargs not yet implemented
+    public void _test8VarargsWithGen() throws Exception {
+        RETRIES = 0;
+//        debug = true;
+        String source =
+                """
+                package t;
+                record A<Q>(F f, Q... params) {
+                    public A {
+                        assert f != null;
+                    }
+                    record F<P>(P first, P... second) {
+                        public F {
+                            assert null != first;
+                            assert null != second && second.length > 0;
+                        }
+                    }
+                }
+                """;
+        String newOuter =
+                """
+                package t;
+                record A<Q>(F f, Q... params) {
+                    public A {
+                        assert f != null;
+                    }
+                }
+                """;
+        String newInner =
+                """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                /**
+                 *
+                 * @author junit
+                 */
+                record F<P>(P first, P... second) {
+
+                    public F {
+                        assert null != first;
+                        assert null != second && second.length > 0;
+                    }
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    // show that brace comes too early in inner record.
+    public void test8RecordImplements1() throws Exception {
+//        debug = true;
+        RETRIES = 0;
+        sideBySideCompare = true;
+        String source
+                = """
+                package t;
+                import java.time.LocalDate;
+                import java.io.Serializable;
+                public class A implements Cloneable, Serializable {
+                    static F f;
+                    public record F(int x, int y) implements Cloneable, Serializable {
+                        /** I should be back. */
+                        static String code = "nix";
+                   }
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+                import java.time.LocalDate;
+                import java.io.Serializable;
+                public class A implements Cloneable, Serializable {
+                    static F f;
+                }
+                """;
+        String newInner
+                = """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.io.Serializable;
+
+                /**
+                 *
+                 * @author hom
+                 */
+                public record F(int x, int y) implements Cloneable, Serializable {
+                    /** I should be back. */
+                    static String code = "nix";
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    // show that outer record survives casual diff.
+    public void test8RecordImplements2() throws Exception {
+//        debug = true;
+        RETRIES = 0;
+        sideBySideCompare = true;
+//        showOutputOnPass=true;
+        String source
+                = """
+                package t;
+                import java.time.LocalDate;
+                import java.io.Serializable;
+                public record A(int a, String b) implements Cloneable, Serializable {
+                    static F f;
+                    enum F {
+                        F1, F2;
+                        /** I should be back. */
+                        static String code = "nix";
+                   }
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+                import java.time.LocalDate;
+                import java.io.Serializable;
+                public record A(int a, String b) implements Cloneable, Serializable {
+                    static F f;
+                }
+                """;
+        String newInner
+                =
+                """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                /**
+                 *
+                 * @author hom
+                 */
+                 enum F {
+
+                    F1, F2;
+                    /** I should be back. */
+                    static String code = "nix";
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    // Test shows that inner enum does not have the too early brace problem.
+    public void test8EnumImplements() throws Exception {
+//        debug = true;
+        RETRIES = 0;
+        sideBySideCompare = true;
+        String source
+                = """
+                package t;
+                import java.time.LocalDate;
+                import java.io.Serializable;
+                public class A implements Cloneable, Serializable {
+                    static F f;
+                    enum F implements Cloneable, Serializable {
+                        F1,F2;
+                        /** I should be back. */
+                        static String code = "nix";
+                   }
+                }
+                """;
+        String newOuter
+                = """
+                package t;
+                import java.time.LocalDate;
+                import java.io.Serializable;
+                public class A implements Cloneable, Serializable {
+                    static F f;
+                }
+                """;
+        String newInner
+                =
+                """
+                /*
+                 * Refactoring License
+                 */
+
+                package t;
+
+                import java.io.Serializable;
+
+                /**
+                 *
+                 * @author hom
+                 */
+                 enum F implements Cloneable, Serializable {
+
+                    F1, F2;
+                    /** I should be back. */
+                    static String code = "nix";
+
+                }
+                """;
+        innerOuterSetupAndTest(source, newOuter, newInner);
+    }
+
+    void innerOuterSetupAndTest(String source, String newOuterText, String newInnerText) throws Exception {
+        writeFilesNoIndexing(src, new File("t/A.java", source));
+        performInnerToOuterTest2(null);
+        verifyContent(src, new File("t/A.java", newOuterText), new File("t/F.java", newInnerText));
+    }
+    boolean debug = false;
+
+    // variant for record inner to outer test
+    private void performInnerToOuterTest2(String newOuterName, Problem... expectedProblems) throws Exception {
+        final InnerToOuterRefactoring[] r = new InnerToOuterRefactoring[1];
+        JavaSource.forFileObject(src.getFileObject("t/A.java")).runUserActionTask(new Task<CompilationController>() {
+            @Override
+            public void run(CompilationController parameter) {
+                try {
+                    parameter.toPhase(JavaSource.Phase.RESOLVED);
+                } catch (IOException ex) {
+                    Exceptions.printStackTrace(ex);
+                }
+                CompilationUnitTree cut = parameter.getCompilationUnit();
+                if (debug) {
+                    System.err.println("cut is of type " + cut.getClass().getCanonicalName());
+                }
+                ClassTree outer = (ClassTree) cut.getTypeDecls().get(0);
+                if (debug) {
+                    printNumbered(System.err, "start source " + outer.getKind().toString(), outer.toString());
+                }
+                List<? extends Tree> members = outer.getMembers();
+                int m = 0;
+                if (debug) {
+                    printMembers(members, m);
+                }
+                // selecting the last element assumes that the inner class is the last member in the outer class.
+                Tree lastInnerClass
+                        = outer.getMembers().get(outer.getMembers().size() - 1);
+                if (debug && lastInnerClass instanceof ClassTree lct) {
+//                    String n = "lastInnerClass " + lastInnerClass.getKind().toString();
+//                    printNumbered(System.err, n, lastInnerClass.toString());
+                    printClassTree(lct);
+                }
+                TreePath tp = TreePath.getPath(cut, lastInnerClass);
+                try {
+                    r[0]
+                            = new InnerToOuterRefactoring(TreePathHandle.create(tp, parameter));
+                } catch (Throwable t) {
+                    System.err.println("InnerOuter refatoring failed with exception " + t);
+                    t.printStackTrace(System.out);
+                    throw t;
+                }
+            }
+        }, true);
+        r[0].setClassName("F");
+        if (debug) {
+            printNumbered(System.err, "result ", r[0].toString());
+        }
+        r[0].setReferenceName(newOuterName);
+        RefactoringSession rs = RefactoringSession.create("Session");
+        List<Problem> problems = new LinkedList<Problem>();
+        addAllProblems(problems, r[0].preCheck());
+        addAllProblems(problems, r[0].prepare(rs));
+        addAllProblems(problems, rs.doRefactoring(true));
+        assertProblems(Arrays.asList(expectedProblems), problems);
+    }
+
+    // test helper
+    static void printMembers(List<? extends Tree> members, int m) {
+        printMembers(members, m, "");
+    }
+
+    // test helper
+    static void printMembers(List<? extends Tree> members, int m, String indent) {
+        for (Tree member : members) {
+            printNumbered(System.err, indent + "member %d %15s".formatted(m, member.getKind()), member.toString());
+            String toString = member.toString();
+            if (member instanceof ClassTree ct) {
+                int n = 0;
+                Name simpleName = ct.getSimpleName();
+                List<? extends Tree> members1 = ct.getMembers();
+                printMembers(members1, n, indent + "  " + m + " ");
+            }
+            m++;
+        }
+    }
+
+    // test helper
+    static void printClassTree(ClassTree ct) {
+        printMembers(ct.getMembers(), 0, "class " + ct.getSimpleName() + " type " + ct.getKind() + " ");
+    }
+}

--- a/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InnerOuterRecordTest.java
+++ b/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InnerOuterRecordTest.java
@@ -593,7 +593,7 @@ public class InnerOuterRecordTest extends RefactoringTestBase {
     }
 
     // disable for the time being, varargs not yet implemented
-    public void _test8Varargs() throws Exception {
+    public void test8Varargs() throws Exception {
         RETRIES = 0;
 //        debug = true;
         String source =
@@ -645,7 +645,7 @@ public class InnerOuterRecordTest extends RefactoringTestBase {
     }
 
     // disable for the time being, varargs not yet implemented
-    public void _test8VarargsWithGen() throws Exception {
+    public void test8VarargsWithGen() throws Exception {
         RETRIES = 0;
 //        debug = true;
         String source =

--- a/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InnerOuterRecordTest.java
+++ b/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InnerOuterRecordTest.java
@@ -548,6 +548,7 @@ public class InnerOuterRecordTest extends RefactoringTestBase {
     }
 
     public void test7Generic() throws Exception {
+        AssertLinesEqualHelpers.setStringCompareMode(StringsCompareMode.IGNORE_WHITESPACE_DIFF);
         String source
                 = """
                 package t;
@@ -555,10 +556,15 @@ public class InnerOuterRecordTest extends RefactoringTestBase {
                     public A {
                         assert f != null;
                     }
-                    record F<P, Q>(P first, Q second) {
+                    record F<P, Q extends Comparable<Q>> (P first, Q second) {
                         public F {
                             assert null != first;
                             assert null != second;
+                        }
+
+                        @Override
+                        public int compare(Q o){
+                          return this.second.compareTo(o.second);
                         }
                     }
                 }
@@ -577,16 +583,24 @@ public class InnerOuterRecordTest extends RefactoringTestBase {
                 /*
                  * Refactoring License
                  */
+                  
                 package t;
+                  
                 /**
                  *
                  * @author junit
                  */
-                record F<P, Q>(P first, Q second) {
+                record F<P, Q extends Comparable<Q>>(P first, Q second) {
                     public F {
                         assert null != first;
                         assert null != second;
                     }
+
+                    @Override
+                    public int compare(Q o) {
+                      return this.second.compareTo(o.second);
+                    }
+
                 }
                 """;
         innerOuterSetupAndTest(source, newOuter, newInner);

--- a/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/PullUpTest.java
+++ b/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/PullUpTest.java
@@ -34,6 +34,8 @@ import org.netbeans.api.java.source.ElementHandle;
 import org.netbeans.api.java.source.JavaSource;
 import org.netbeans.api.java.source.Task;
 import org.netbeans.api.java.source.TreePathHandle;
+import org.netbeans.junit.AssertLinesEqualHelpers;
+import static org.netbeans.junit.AssertLinesEqualHelpers.*;
 import org.netbeans.modules.java.source.parsing.JavacParser;
 import org.netbeans.modules.refactoring.api.Problem;
 import org.netbeans.modules.refactoring.api.RefactoringSession;
@@ -51,12 +53,13 @@ public class PullUpTest extends RefactoringTestBase {
 
     public PullUpTest(String name) {
         super(name, "1.8");
+        RETRIES=1;
     }
-    
+
     static {
         JavacParser.DISABLE_SOURCE_LEVEL_DOWNGRADE = true;
     }
-    
+
     public void test241514a() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("pullup/A.java", "package pullup; public interface A { void x(); }"),
@@ -66,7 +69,7 @@ public class PullUpTest extends RefactoringTestBase {
                 new File("pullup/A.java", "package pullup; public interface A { void x(); void y(); }"),
                 new File("pullup/B.java", "package pullup; public interface B extends A { default void y() { } }"));
     }
-    
+
     public void test241514b() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("pullup/A.java", "package pullup; public interface A { void x(); }"),
@@ -76,7 +79,7 @@ public class PullUpTest extends RefactoringTestBase {
                 new File("pullup/A.java", "package pullup; public interface A { void x(); default void y() { } }"),
                 new File("pullup/B.java", "package pullup; public interface B extends A {}"));
     }
-    
+
     public void testPullUpOverridingMethod() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("pullup/A.java", "package pullup; public class A extends B implements C { @Override public void i() { } }"),
@@ -87,7 +90,7 @@ public class PullUpTest extends RefactoringTestBase {
                 new File("pullup/A.java", "package pullup; public class A extends B implements C {}"),
                 new File("pullup/B.java", "package pullup; public class B { public void i() { } }"),
                 new File("pullup/C.java", "package pullup; public interface C { void i(); }"));
-        
+
         writeFilesAndWaitForScan(src,
                 new File("pullup/A.java", "package pullup; public class A extends B  { @Override public void i() { } }"),
                 new File("pullup/B.java", "package pullup; public class B extends C { }"),
@@ -98,7 +101,7 @@ public class PullUpTest extends RefactoringTestBase {
                 new File("pullup/B.java", "package pullup; public class B extends C { @Override public void i() { } }"),
                 new File("pullup/C.java", "package pullup; public class C { public void i() { } }"));
     }
-    
+
     public void test230719() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("pullup/A.java", "package pullup; public interface A {\n"
@@ -127,14 +130,14 @@ public class PullUpTest extends RefactoringTestBase {
                 + "    }\n"
                 + "}"));
     }
-    
+
     public void test230930() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("pullup/A.java", "package pullup; public interface A { }"),
                 new File("pullup/B.java", "package pullup; public class B implements A { static void y(); }"));
         performPullUpIface(src.getFileObject("pullup/B.java"), 0, 0, true);
     }
-    
+
     public void test229061() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("pullup/A.java", "package pullup; public interface A { void x(); }"),
@@ -154,7 +157,7 @@ public class PullUpTest extends RefactoringTestBase {
                 new File("pullup/A.java", "package pullup; public class A { void x() { } void y() { x(); } }"),
                 new File("pullup/B.java", "package pullup; public class B extends A {}"));
     }
-    
+
     public void test212934() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("pullup/A.java", "package pullup; public class A { }"),
@@ -181,7 +184,7 @@ public class PullUpTest extends RefactoringTestBase {
                 new File("pullup/A.java", "package pullup; public class A extends B {}"),
                 new File("pullup/B.java", "package pullup; public class B { public int i; }"));
     }
-    
+
     public void testPullUpGenMethoda() throws Exception { // #147508 - [Pull Up][Push down] Remap generic names
         writeFilesAndWaitForScan(src,
                 new File("pullup/PullUpBaseClass.java", "package pullup;\n"
@@ -303,7 +306,7 @@ public class PullUpTest extends RefactoringTestBase {
                 new File("pullup/B.java", "package pullup; public class B<T, Z> extends C<T> { }"),
                 new File("pullup/C.java", "package pullup; public class C<Y> { void method(String x) { } }"));
     }
-    
+
     public void testPullUpGenMethodc() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("pullup/A.java", "package pullup; public class A<X extends String> extends B<String, X> { X method() { } }"),
@@ -325,7 +328,7 @@ public class PullUpTest extends RefactoringTestBase {
                 new File("pullup/B.java", "package pullup; public class B<T, Z> extends C<T> { }"),
                 new File("pullup/C.java", "package pullup; public class C<Y> { void method(String x) { } }"));
     }
-    
+
     public void testPullUpGenField() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("pullup/A.java", "package pullup; public class A<X extends String> extends B<String, X> { X x; }"),
@@ -447,7 +450,7 @@ public class PullUpTest extends RefactoringTestBase {
                 + "\n"
                 + "}"));
     }
-    
+
     public void testPullUpMethodUndo() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("pullup/PullUpBaseClass.java", "package pullup;\n"
@@ -1166,7 +1169,7 @@ public class PullUpTest extends RefactoringTestBase {
                 new File("pullup/A.java", "package pullup; public class A extends B { public void run() { } }"),
                 new File("pullup/B.java", "package pullup; public class B implements Runnable { }"));
     }
-    
+
     public void testPullUpInterface2() throws Exception {
         writeFilesAndWaitForScan(src,
                 new File("pullup/A.java", "package pullup; public class A implements B { }"),
@@ -1204,6 +1207,247 @@ public class PullUpTest extends RefactoringTestBase {
         verifyContent(src,
                 new File("pullup/A.java", "package pullup; public class A extends B {private void method() { foo() } }"),
                 new File("pullup/B.java", "package pullup; public class B { protected void foo() { } }"));
+    }
+
+    public void testPullUpInnerTypeEnum() throws Exception {
+
+        writeFilesAndWaitForScan(src,
+                new File("pullup/A.java",
+                """
+                package pullup;
+                public class A extends B {
+                    private void foo() {
+                    }
+                    enum Suite implements I{ Heart, Diamond, Club, Spade; }
+                    private void method(Suite s) {
+                        foo();
+                    }
+                }"""
+                ),
+                new File("pullup/B.java",
+                """
+                package pullup;
+                public class B { }
+                """
+                ),
+                new File("pullup/I.java",
+                """
+                package pullup;
+                public interface I{ }
+                """
+                )
+        );
+        performPullUp(src.getFileObject("pullup/A.java"), 2, Boolean.FALSE);
+        verifyContent(src,
+                        new File("pullup/A.java",
+                """
+                package pullup;
+                public class A extends B {
+                    private void foo() {
+                    }
+                    private void method(Suite s) {
+                        foo();
+                    }
+                 }"""
+                ),
+                new File("pullup/B.java",
+                """
+                package pullup;
+                public class B {
+
+                    enum Suite implements I {
+                        Heart, Diamond, Club, Spade
+                    }
+                 }
+                """
+                ) ,
+                new File("pullup/I.java",
+                """
+                package pullup;
+                public interface I{ }
+                """
+                )
+
+        );
+    }
+
+    public void testPullUpInnerSimpleRecord() throws Exception {
+       sideBySideCompare=true;
+       showOutputOnPass=true;
+        setStringCompareMode(StringsCompareMode.IGNORE_INDENTATION);
+        writeFilesAndWaitForScan(src,
+                new File("pullup/A.java",
+                """
+                package pullup;
+                public class A extends B {
+                    record R( int i, String name ) {}
+                    private void foo() {
+                    }
+                    private void method(R r) {
+                        foo();
+                    }
+                }"""
+                ),
+                new File("pullup/B.java",
+                """
+                package pullup;
+                public class B { }
+                """
+                ),
+                new File("pullup/I.java",
+                """
+                package pullup;
+                public interface I{ }
+                """
+                )
+        );
+        performPullUp(src.getFileObject("pullup/A.java"), 1, Boolean.FALSE);
+        verifyContent(src,
+                        new File("pullup/A.java",
+                """
+                package pullup;
+                public class A extends B {
+                    private void foo() {
+                    }
+                    private void method(R r) {
+                        foo();
+                    }
+                }"""
+                ),
+                new File("pullup/B.java",
+                """
+                package pullup;
+                public class B {
+
+                    record R(int i, String name) {
+                    }
+                }
+                """
+                ) ,
+                new File("pullup/I.java",
+                """
+                package pullup;
+                public interface I{ }
+                """
+                )
+
+        );
+    }
+
+    public void testPullUpVarargRecord() throws Exception {
+        sideBySideCompare = true;
+        showOutputOnPass = true;
+        setStringCompareMode(StringsCompareMode.IGNORE_INDENTATION);
+
+        writeFilesAndWaitForScan(src,
+                new File("pullup/A.java",
+                """
+                package pullup;
+                public class A extends B {
+                    record R( int i, String... name ) {}
+                    private void foo() {
+                    }
+                    private void method(R r) {
+                        foo();
+                    }
+                 }"""
+                ),
+                new File("pullup/B.java",
+                """
+                package pullup;
+                public class B { }
+                """
+                ),
+                new File("pullup/I.java",
+                """
+                package pullup;
+                public interface I{ }
+                """
+                )
+        );
+        performPullUp(src.getFileObject("pullup/A.java"), 1, Boolean.FALSE);
+        verifyContent(src,
+                        new File("pullup/A.java",
+                """
+                package pullup;
+                public class A extends B {
+                    private void foo() {
+                    }
+                    private void method(R r) {
+                        foo();
+                    }
+                 }"""
+                ),
+                new File("pullup/B.java",
+                """
+                package pullup;
+                public class B {
+
+                    record R(int i, String... name) {
+                    }
+                }
+                """
+                ) ,
+                new File("pullup/I.java",
+                """
+                package pullup;
+                public interface I{ }
+                """
+                )
+
+        );
+    }
+
+    // disable because implements part is broken
+    public void testPullUpInnerRecord() throws Exception {
+        sideBySideCompare=true;
+        writeFilesAndWaitForScan(src,
+                new File("pullup/A.java",
+                """
+                package pullup;
+                public class A extends B {
+                    record R( int age, String name ) {}
+                    private void foo() {
+                    }
+                    private void method(R r) {
+                        foo();
+                    }
+                }
+                """
+                ),
+                new File("pullup/B.java",
+                """
+                package pullup;
+                public class B {}
+                """
+                )
+        );
+        String asText = src.getFileObject("pullup/A.java").asText();
+//        System.out.println("asText = " + asText);
+        performPullUp(src.getFileObject("pullup/A.java"), 1, Boolean.FALSE);
+        verifyContent(src,
+                new File("pullup/A.java",
+                """
+                package pullup;
+                public class A extends B {
+                    private void foo() {
+                    }
+                    private void method(R r) {
+                        foo();
+                    }
+                }"""
+                ),
+                new File("pullup/B.java",
+                """
+                package pullup;
+                public class B {
+
+                    record R(int age, String name) {
+                    }
+                }
+                """
+                )
+        );
     }
 
     private void performPullUpImplements(FileObject source, final int position, final int supertype, Problem... expectedProblems) throws IOException, IllegalArgumentException, InterruptedException {

--- a/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RenameRecordTest.java
+++ b/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RenameRecordTest.java
@@ -29,6 +29,7 @@ import org.netbeans.api.java.source.Task;
 import org.netbeans.api.java.source.TestUtilities;
 import org.netbeans.api.java.source.TestUtilities.TestInput;
 import org.netbeans.api.java.source.TreePathHandle;
+import static org.netbeans.junit.AssertLinesEqualHelpers.*;
 import org.netbeans.modules.refactoring.api.Problem;
 import org.netbeans.modules.refactoring.api.RefactoringSession;
 import org.netbeans.modules.refactoring.api.RenameRefactoring;
@@ -40,13 +41,16 @@ public class RenameRecordTest extends RefactoringTestBase {
 
     public RenameRecordTest(String name) {
         super(name, "17");
+        sideBySideCompare=true;
+        showOutputOnPass=true;
+        RETRIES=1;
     }
 
     public void testRenameComponent1() throws Exception {
         String testCode = """
-                          package test;
-                          public record Test(int compo|nent) {}
-                          """;
+                        package test;
+                        public record Test(int compo|nent, int y) {}
+                        """;
         TestInput splitCode = TestUtilities.splitCodeAndPos(testCode);
         writeFilesAndWaitForScan(src,
                                  new File("Test.java", splitCode.code()),
@@ -64,7 +68,7 @@ public class RenameRecordTest extends RefactoringTestBase {
         verifyContent(src, new File("Test.java",
                                     """
                                     package test;
-                                    public record Test(int newName) {}
+                                    public record Test(int newName, int y) {}
                                     """),
                            new File("Use.java",
                                     """
@@ -78,21 +82,13 @@ public class RenameRecordTest extends RefactoringTestBase {
 
     }
 
-    public void testRenameComponent2() throws Exception {
+    // changes in refactoring or javs.source.base  breaks rename
+    // when there is somthing before the 'com|ponent'.
+    public void testRenameComponent1a() throws Exception {
         String testCode = """
-                          package test;
-                          public record Test(int compo|nent) {
-                              public Test(int component) {
-                                  component = -1;
-                              }
-                              public int component() {
-                                  return component;
-                              }
-                              public int hashCode() {
-                                  return component;
-                              }
-                          }
-                          """;
+                        package test;
+                        public record Test(int x, int compo|nent) {}
+                        """;
         TestInput splitCode = TestUtilities.splitCodeAndPos(testCode);
         writeFilesAndWaitForScan(src,
                                  new File("Test.java", splitCode.code()),
@@ -110,8 +106,97 @@ public class RenameRecordTest extends RefactoringTestBase {
         verifyContent(src, new File("Test.java",
                                     """
                                     package test;
-                                    public record Test(int newName) {
-                                        public Test(int newName) {
+                                    public record Test(int x, int newName) {}
+                                    """),
+                           new File("Use.java",
+                                    """
+                                    package test;
+                                    public class Use {
+                                        private void test(Test t) {
+                                            int i = t.newName();
+                                        }
+                                    }
+                                    """));
+
+    }
+
+    // disabled, somehow having int x before to be renamed component
+    // breaks list diff
+    public void _testRenameComponent1a() throws Exception {
+        String testCode = """
+                        package test;
+                        public record Test(int x, int compo|nent) {}
+                        """;
+        TestInput splitCode = TestUtilities.splitCodeAndPos(testCode);
+        writeFilesAndWaitForScan(src,
+                                 new File("Test.java", splitCode.code()),
+                                 new File("Use.java",
+                                          """
+                                          package test;
+                                          public class Use {
+                                              private void test(Test t) {
+                                                  int i = t.component();
+                                              }
+                                          }
+                                          """));
+        JavaRenameProperties props = new JavaRenameProperties();
+        performRename(src.getFileObject("Test.java"), splitCode.pos(), "newName", props, true);
+        verifyContent(src, new File("Test.java",
+                                    """
+                                    package test;
+                                    public record Test(int x, int newName) {}
+                                    """),
+                           new File("Use.java",
+                                    """
+                                    package test;
+                                    public class Use {
+                                        private void test(Test t) {
+                                            int i = t.newName();
+                                        }
+                                    }
+                                    """));
+
+    }
+
+    // this test has an explicit accessor.
+    // this appears to break on potential compact constructor not being compact.
+    public void testRenameComponent2() throws Exception {
+        String testCode = """
+                        package test;
+                        public record Test(int compo|nent, int y) {
+                            public Test {
+                                component = -1;
+                            }
+                            public int component() {
+                                return component;
+                            }
+                            public int hashCode() {
+                                return component;
+                            }
+                            public Test(int someInt) {
+                              this(someInt, 0);
+                            }
+                        }
+                        """;
+        TestInput splitCode = TestUtilities.splitCodeAndPos(testCode);
+        writeFilesAndWaitForScan(src,
+                                 new File("Test.java", splitCode.code()),
+                                 new File("Use.java",
+                                          """
+                                          package test;
+                                          public class Use {
+                                              private void test(Test t) {
+                                                  int i = t.component();
+                                              }
+                                          }
+                                          """));
+        JavaRenameProperties props = new JavaRenameProperties();
+        performRename(src.getFileObject("Test.java"), splitCode.pos(), "newName", props, true);
+        verifyContent(src, new File("Test.java",
+                                    """
+                                    package test;
+                                    public record Test(int newName, int y) {
+                                        public Test {
                                             newName = -1;
                                         }
                                         public int newName() {
@@ -120,6 +205,9 @@ public class RenameRecordTest extends RefactoringTestBase {
                                         public int hashCode() {
                                             return newName;
                                         }
+                                        public Test(int someInt) {
+                                          this(someInt, 0);
+                                        }
                                     }
                                     """),
                            new File("Use.java",
@@ -134,11 +222,14 @@ public class RenameRecordTest extends RefactoringTestBase {
 
     }
 
+    /*
+     * Show that with compact constructor behaves.
+     */
     public void testRenameComponent3() throws Exception {
         String testCode = """
                           package test;
-                          public record Test(int compo|nent) {
-                              public Test {
+                          public record Test(int compo|nent, int y) {
+                              public Test { //compact
                                   component = -1;
                               }
                               public int component() {
@@ -166,8 +257,8 @@ public class RenameRecordTest extends RefactoringTestBase {
         verifyContent(src, new File("Test.java",
                                     """
                                     package test;
-                                    public record Test(int newName) {
-                                        public Test {
+                                    public record Test(int newName, int y) {
+                                        public Test { //compact
                                             newName = -1;
                                         }
                                         public int newName() {
@@ -204,7 +295,7 @@ public class RenameRecordTest extends RefactoringTestBase {
                                  new File("Test.java",
                                           """
                                           package test;
-                                          public record Test(int component) {
+                                          public record Test(int component, int y) {
                                               public Test {
                                                   component = -1;
                                               }
@@ -222,7 +313,7 @@ public class RenameRecordTest extends RefactoringTestBase {
         verifyContent(src, new File("Test.java",
                                     """
                                     package test;
-                                    public record Test(int newName) {
+                                    public record Test(int newName, int y) {
                                         public Test {
                                             newName = -1;
                                         }
@@ -260,7 +351,7 @@ public class RenameRecordTest extends RefactoringTestBase {
                                  new File("Test.java",
                                           """
                                           package test;
-                                          public record Test(int component) {
+                                          public record Test(int component, int y) {
                                           }
                                           """),
                                  new File("Use.java", splitCode.code()));
@@ -269,7 +360,7 @@ public class RenameRecordTest extends RefactoringTestBase {
         verifyContent(src, new File("Test.java",
                                     """
                                     package test;
-                                    public record Test(int newName) {
+                                    public record Test(int newName, int y) {
                                     }
                                     """),
                            new File("Use.java",
@@ -287,7 +378,7 @@ public class RenameRecordTest extends RefactoringTestBase {
     public void testRenameComponentStartFromConstructorArg() throws Exception {
         String testCode = """
                           package test;
-                          public record Test(int component) {
+                          public record Test(int component, int y) {
                               public Test {
                                   compo|nent = -1;
                               }
@@ -316,7 +407,7 @@ public class RenameRecordTest extends RefactoringTestBase {
         verifyContent(src, new File("Test.java",
                                     """
                                     package test;
-                                    public record Test(int newName) {
+                                    public record Test(int newName, int y) {
                                         public Test {
                                             newName = -1;
                                         }
@@ -377,6 +468,55 @@ public class RenameRecordTest extends RefactoringTestBase {
                                     public class Use {
                                         private NewName test() {
                                             return new NewName(0);
+                                        }
+                                    }
+                                    """));
+
+    }
+
+    // test fro varargs and generic.
+    public void testRenameRecordGenVar() throws Exception {
+//        RETRIES=1;
+        sideBySideCompare=true;
+        showOutputOnPass=true;
+
+        String testCode = """
+                          package test;
+                          public record Te|st<G extends Number>(G... component) {
+                              public Test {
+                                  assert 0 < component.length;
+                              }
+                          }
+                          """;
+        TestInput splitCode = TestUtilities.splitCodeAndPos(testCode);
+        writeFilesAndWaitForScan(src,
+                                 new File("Test.java", splitCode.code()),
+                                 new File("Use.java",
+                                          """
+                                          package test;
+                                          public class Use {
+                                              private Test<Integer> test() {
+                                                  return new Test(1, 2);
+                                              }
+                                          }
+                                          """));
+        JavaRenameProperties props = new JavaRenameProperties();
+        performRename(src.getFileObject("Test.java"), splitCode.pos(), "NewName", props, true);
+        verifyContent(src, new File("Test.java",
+                                    """
+                                    package test;
+                                    public record NewName<G extends Number>(G... component) {
+                                        public NewName {
+                                            assert 0 < component.length;
+                                        }
+                                    }
+                                    """),
+                           new File("Use.java",
+                                    """
+                                    package test;
+                                    public class Use {
+                                        private NewName<Integer> test() {
+                                            return new NewName(1, 2);
                                         }
                                     }
                                     """));


### PR DESCRIPTION
This PR solves issue #7044 

The issue describes that record info was lost when doing and inner to outer or pull up refactoring.

In this pull request
* tests to show the issue.
* junit test helper to make test output better understandable: AssertLinesEqualHelpers.java
* added RECORD case label where appropriate, for instance where the record template should be used.
* added factory for Record classTree in TreeFactory and TreeMaker
* added/improved methods in CasualDiff and VeryPretty to pick op parameters from record in constructor, so that
 var args are preserved.
