### PR TITLE
Add Code Template for slf4j to DefaultAbbrevs.xml

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/java/editor/resources/DefaultAbbrevs.xml
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/resources/DefaultAbbrevs.xml
@@ -567,6 +567,12 @@ ${cursor}]]></code>
 <![CDATA[private static final ${loggerType type="java.util.logging.Logger" default="Logger" editable="false"} logger = ${loggerType}.getLogger(${classVar editable="false" currClassName default="getClass()"}.class.getName());]]>
         </code>
     </codetemplate>
+
+    <codetemplate abbreviation="logs">
+        <code>
+<![CDATA[private static final ${LOGGER_TYPE type="org.slf4j.Logger" default="Logger" editable=false} log = ${LOGGER_FACTORY type="org.slf4j.LoggerFactory" default="LoggerFactory" editable=false}.getLogger(${CLASS editable="false" currClassName}.class);]]>
+        </code>
+    </codetemplate>
     
     <codetemplate abbreviation="logrb">
         <code>


### PR DESCRIPTION
Added a code template for slf4j which inserts the following code with using `logs` (tab):

```java
import org.slf4j.Logger;
import org.slf4j.LoggerFactory;
private static final Logger log = LoggerFactory.getLogger(Support.class);
```

