### PR TITLE
Fix race condition in JavaScript TextInterceptorTests

### DIFF
--- a/ide/db.sql.editor/src/org/netbeans/modules/db/sql/editor/OptionsUtils.java
+++ b/ide/db.sql.editor/src/org/netbeans/modules/db/sql/editor/OptionsUtils.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.db.sql.editor;
 
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.prefs.PreferenceChangeEvent;
 import java.util.prefs.PreferenceChangeListener;
 import java.util.prefs.Preferences;
@@ -35,7 +34,6 @@ public final class OptionsUtils {
     public static final String PAIR_CHARACTERS_COMPLETION = "pair-characters-completion"; //NOI18N
     public static final String SQL_AUTO_COMPLETION_SUBWORDS = "sql-completion-subwords"; //NOI18N
     public static final boolean SQL_AUTO_COMPLETION_SUBWORDS_DEFAULT = false;
-    private static final AtomicBoolean INITED = new AtomicBoolean(false);
 
     private static final PreferenceChangeListener PREFERENCES_TRACKER = new PreferenceChangeListener() {
         @Override
@@ -54,8 +52,8 @@ public final class OptionsUtils {
 
     private static Preferences preferences;
 
-    private static boolean pairCharactersCompletion = true;
-    private static boolean sqlCompletionSubwords = SQL_AUTO_COMPLETION_SUBWORDS_DEFAULT;
+    private static volatile boolean pairCharactersCompletion = true;
+    private static volatile boolean sqlCompletionSubwords = SQL_AUTO_COMPLETION_SUBWORDS_DEFAULT;
 
     private OptionsUtils() {
     }
@@ -80,8 +78,8 @@ public final class OptionsUtils {
         return sqlCompletionSubwords;
     }
 
-    private static void lazyInit() {
-        if (INITED.compareAndSet(false, true)) {
+    private synchronized static void lazyInit() {
+        if (preferences == null) {
             preferences = MimeLookup.getLookup(SQLLanguageConfig.mimeType).lookup(Preferences.class);
             preferences.addPreferenceChangeListener(WeakListeners.create(PreferenceChangeListener.class, PREFERENCES_TRACKER, preferences));
             PREFERENCES_TRACKER.preferenceChange(null);

--- a/php/php.editor/src/org/netbeans/modules/php/editor/options/OptionsUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/options/OptionsUtils.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.php.editor.options;
 
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.prefs.PreferenceChangeEvent;
 import java.util.prefs.PreferenceChangeListener;
 import java.util.prefs.Preferences;
@@ -31,7 +30,6 @@ import org.openide.util.WeakListeners;
  * @author Tomas Mysik
  */
 public final class OptionsUtils {
-    private static final AtomicBoolean INITED = new AtomicBoolean(false);
 
     private static final PreferenceChangeListener PREFERENCES_TRACKER = new PreferenceChangeListener() {
         @Override
@@ -145,22 +143,22 @@ public final class OptionsUtils {
 
     private static Preferences preferences;
 
-    private static Boolean autoCompletionFull = null;
-    private static Boolean autoCompletionVariables = null;
-    private static Boolean autoCompletionTypes = null;
-    private static Boolean autoCompletionNamespaces = null;
-    private static Boolean autoCompletionSmartQuotes = null;
-    private static Boolean autoStringConcatination = null;
-    private static Boolean autoCompletionUseLowercaseTrueFalseNull = null;
-    private static Boolean autoCompletionCommentAsterisk = null;
+    private static volatile Boolean autoCompletionFull = null;
+    private static volatile Boolean autoCompletionVariables = null;
+    private static volatile Boolean autoCompletionTypes = null;
+    private static volatile Boolean autoCompletionNamespaces = null;
+    private static volatile Boolean autoCompletionSmartQuotes = null;
+    private static volatile Boolean autoStringConcatination = null;
+    private static volatile Boolean autoCompletionUseLowercaseTrueFalseNull = null;
+    private static volatile Boolean autoCompletionCommentAsterisk = null;
 
-    private static Boolean codeCompletionStaticMethods = null;
-    private static Boolean codeCompletionNonStaticMethods = null;
-    private static Boolean codeCompletionSmartParametersPreFilling = null;
-    private static Boolean codeCompletionFirstClassCallable = null;
-    private static Boolean autoImport = null;
-    private static Boolean autoImportFileScope = null;
-    private static Boolean autoImportNamespaceScope = null;
+    private static volatile Boolean codeCompletionStaticMethods = null;
+    private static volatile Boolean codeCompletionNonStaticMethods = null;
+    private static volatile Boolean codeCompletionSmartParametersPreFilling = null;
+    private static volatile Boolean codeCompletionFirstClassCallable = null;
+    private static volatile Boolean autoImport = null;
+    private static volatile Boolean autoImportFileScope = null;
+    private static volatile Boolean autoImportNamespaceScope = null;
 
     private static CodeCompletionPanel.VariablesScope codeCompletionVariablesScope = null;
 
@@ -363,8 +361,8 @@ public final class OptionsUtils {
         return autoImportNamespaceScope;
     }
 
-    private static void lazyInit() {
-        if (INITED.compareAndSet(false, true)) {
+    private synchronized static void lazyInit() {
+        if (preferences == null) {
             preferences = MimeLookup.getLookup(FileUtils.PHP_MIME_TYPE).lookup(Preferences.class);
             preferences.addPreferenceChangeListener(WeakListeners.create(PreferenceChangeListener.class, PREFERENCES_TRACKER, preferences));
             PREFERENCES_TRACKER.preferenceChange(null);

--- a/php/php.twig/src/org/netbeans/modules/php/twig/editor/ui/options/OptionsUtils.java
+++ b/php/php.twig/src/org/netbeans/modules/php/twig/editor/ui/options/OptionsUtils.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.php.twig.editor.ui.options;
 
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.prefs.PreferenceChangeEvent;
 import java.util.prefs.PreferenceChangeListener;
 import java.util.prefs.Preferences;
@@ -31,13 +30,11 @@ import org.openide.util.WeakListeners;
  */
 public final class OptionsUtils {
 
-    private static final AtomicBoolean INITED = new AtomicBoolean(false);
-
     public static final String AUTO_COMPLETION_SMART_QUOTES = "twigAutoCompletionSmartQuotes"; // NOI18N
     public static final String AUTO_COMPLETION_SMART_DELIMITERS = "twigAutoCompletionSmartDelimiters"; // NOI18N
 
-    private static Boolean autoCompletionSmartQuotes = null;
-    private static Boolean autoCompletionSmartDelimiters = null;
+    private static volatile Boolean autoCompletionSmartQuotes = null;
+    private static volatile Boolean autoCompletionSmartDelimiters = null;
 
     // default values
     public static final boolean AUTO_COMPLETION_SMART_QUOTES_DEFAULT = true;
@@ -78,8 +75,8 @@ public final class OptionsUtils {
         return autoCompletionSmartDelimiters;
     }
 
-    private static void lazyInit() {
-        if (INITED.compareAndSet(false, true)) {
+    private synchronized static void lazyInit() {
+        if (PREFERENCES == null) {
             PREFERENCES = MimeLookup.getLookup(TwigLanguage.TWIG_MIME_TYPE).lookup(Preferences.class);
             PREFERENCES.addPreferenceChangeListener(WeakListeners.create(PreferenceChangeListener.class, PREFERENCES_TRACKER, PREFERENCES));
             PREFERENCES_TRACKER.preferenceChange(null);

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsDeletedTextInterceptorTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsDeletedTextInterceptorTest.java
@@ -47,10 +47,13 @@ public class JsDeletedTextInterceptorTest extends JsTestBase {
         super(testName);
     }
 
-
     @Override
     protected void setUp() throws Exception {
         super.setUp();
+        @SuppressWarnings("unchecked")
+        OptionsUtils options = OptionsUtils.forLanguage(getPreferredLanguage().getLexerLanguage());
+        options.setTestDisablePreferencesTracking();
+        options.setTestCompletionSmartQuotes(OptionsUtils.AUTO_COMPLETION_SMART_QUOTES_DEFAULT);
         MimeLookup.getLookup(JsTokenId.JAVASCRIPT_MIME_TYPE).lookup(Preferences.class).clear();
     }
     
@@ -194,15 +197,15 @@ public class JsDeletedTextInterceptorTest extends JsTestBase {
         }
     }
 
+    @SuppressWarnings("unchecked")
     public void testDisabledSmartQuotes1() throws Exception {
-        MimeLookup.getLookup(JsTokenId.JAVASCRIPT_MIME_TYPE).lookup(Preferences.class)
-                .putBoolean(OptionsUtils.AUTO_COMPLETION_SMART_QUOTES, false);
+        OptionsUtils.forLanguage(getPreferredLanguage().getLexerLanguage()).setTestCompletionSmartQuotes(false);
         deleteChar("x = \"^\"", "x = ^\"");
     }
 
+    @SuppressWarnings("unchecked")
     public void testDisabledSmartQuotes2() throws Exception {
-        MimeLookup.getLookup(JsTokenId.JAVASCRIPT_MIME_TYPE).lookup(Preferences.class)
-                .putBoolean(OptionsUtils.AUTO_COMPLETION_SMART_QUOTES, false);
+        OptionsUtils.forLanguage(getPreferredLanguage().getLexerLanguage()).setTestCompletionSmartQuotes(false);
         deleteChar("x = `^`", "x = ^`");
     }
 

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsTypedTextInterceptorTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsTypedTextInterceptorTest.java
@@ -44,8 +44,12 @@ public class JsTypedTextInterceptorTest extends JsTestBase {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     protected void setUp() throws Exception {
         super.setUp();
+        OptionsUtils options = OptionsUtils.forLanguage(getPreferredLanguage().getLexerLanguage());
+        options.setTestDisablePreferencesTracking();
+        options.setTestCompletionSmartQuotes(OptionsUtils.AUTO_COMPLETION_SMART_QUOTES_DEFAULT);
         MimeLookup.getLookup(JsTokenId.JAVASCRIPT_MIME_TYPE).lookup(Preferences.class).clear();
     }
 
@@ -332,9 +336,9 @@ public class JsTypedTextInterceptorTest extends JsTestBase {
         insertChar("x = ^", '"', "x = \"^\"");
     }
 
+    @SuppressWarnings("unchecked")
     public void testDisabledSmartQuotes() throws Exception {
-        MimeLookup.getLookup(JsTokenId.JAVASCRIPT_MIME_TYPE).lookup(Preferences.class)
-                .putBoolean(OptionsUtils.AUTO_COMPLETION_SMART_QUOTES, false);
+        OptionsUtils.forLanguage(getPreferredLanguage().getLexerLanguage()).setTestCompletionSmartQuotes(false);
         insertChar("x = ^", '"', "x = \"^");
     }
 


### PR DESCRIPTION
(e.g `JsTypedTextInterceptorTest#testDisabledSmartQuotes` had a high failure rate)

situation:
 - `OptionsUtils` caches some Preference values and updates those asynchronously via a listener (`Preferences` event `Thread` is not EDT even though it has a deceivingly similar name when looked at through the debugger)
 - tests expect values to be immediately available after writes to `Preferences` (and also that `clear()` isn't delayed)

fix:
 - disable async preferences tracking during tests, write values manually via `OptionsUtils` instead of preferences.
 - update all `OptionsUtils` copies so that the cached values are made volatile since they are shared between threads and fixed lazy init code which used a CAS block as critical section

part of https://github.com/apache/netbeans/issues/8183