### PR TITLE
Logging DTD validation error instead of throwing an exception

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
@@ -1044,7 +1044,7 @@ public class MakeNBM extends Task {
                 XMLUtil.write(doc, baos);
                 validateAgainstAUDTDs(new InputSource(new ByteArrayInputStream(baos.toByteArray())), updaterJar, this);
             } catch (Exception x) {
-                throw new BuildException("Could not validate Info.xml before writing: " + x, x, getLocation());
+                log("Could not validate Info.xml before writing: " + x, Project.MSG_ERR);
             }
         } else {
             log("No updater.jar specified, cannot validate Info.xml against DTD", Project.MSG_WARN);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeUpdateDesc.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeUpdateDesc.java
@@ -488,8 +488,7 @@ public class MakeUpdateDesc extends MatchingTask {
             try {
                 MakeNBM.validateAgainstAUDTDs(new InputSource(desc.toURI().toString()), updaterJar, this);
             } catch (Exception x) {
-                desc.delete();
-                throw new BuildException("Could not validate " + desc + " after writing: " + x, x, getLocation());
+                log("Could not validate " + desc + " after writing: " + x, Project.MSG_ERR);
             }
         } else {
             log("No updater.jar specified, cannot validate " + desc + " against DTD", Project.MSG_WARN);


### PR DESCRIPTION
In corporate networks with limited internet access, Netbeans is unable to build modules due to the internet dependency on remote DTDs.

Currently, when `ant nbm` is executed `MakeNBM.validateAgainstAUDTDs()` throws an SSL exception when attempting to download the AutoUpdate DTDs from http://www.netbeans.org/dtds/ (which redirects to https://netbeans.apache.org/dtds/).

This can occur when the corporate JRE used does not have netbeans.apache.org certificate, when internet access is not available or when corporate IT Security is unable to allow-list http://www.netbeans.org and https://netbeans.apache.org. 

This PR proposes a solution with minimal code change: logging a DTD validation error at build time rather than throwing an uncaught exception which prevents Netbeans from continuing with the build.

---
<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [ ] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>