### PR TITLE
Fix occasional ClassCastException when parsing Maven pom.xml files

### DIFF
--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/MavenPOMParser.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/pom/MavenPOMParser.java
@@ -23,6 +23,7 @@ import java.util.prefs.PreferenceChangeEvent;
 import java.util.prefs.PreferenceChangeListener;
 import java.util.prefs.Preferences;
 import javax.swing.event.ChangeListener;
+import javax.swing.text.Document;
 import org.netbeans.api.editor.mimelookup.MimeRegistration;
 import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.maven.embedder.EmbedderFactory;
@@ -76,9 +77,9 @@ public class MavenPOMParser extends Parser implements PreferenceChangeListener {
             return;
         }
         //#236116 passing document protects from looking it up later and causing a deadlock.
-        final BaseDocument document = (BaseDocument)snapshot.getSource().getDocument(false);
+        final Document document = snapshot.getSource().getDocument(false);
         final DataObject d = sFile.getLookup().lookup(DataObject.class);
-        ModelSource ms = Utilities.createModelSource(sFile, d, document);
+        ModelSource ms = Utilities.createModelSource(sFile, d, document instanceof BaseDocument bd ? bd : null);
         synchronized (this) {
             theModel = POMModelFactory.getDefault().getModel(ms);
             lastSnapshot = snapshot;


### PR DESCRIPTION
When you open any Maven project, when Netbeans tries to parse `pom.xml` sometimes it shows the class cast exception as seen in issue https://github.com/oracle/javavscode/issues/378 and https://github.com/oracle/javavscode/issues/185. The root cause is if some of the modules are not included like `org.netbeans.modules.editor.structure` and `org.netbeans.modules.editor.deprecated.pre65formatting`, then `LspMavenErrorProvider` class sends document as `FilterDocument` instead of `NbEditorDocument` which causes this class cast exception. Since, `FilterDocument` extends `StyledDocument` and not `LineDocument` which is required by the `BaseDocument`.

This PR addresses above mentioned issue by introducing a new utility method that accepts a `Document` and ensures it is returned as a `BaseDocument`. If the given `Document` is already an instance of `BaseDocument`, it is returned as-is; otherwise, it is converted accordingly.  
This approach ensures that the implementation remains agnostic to the available modules, providing a consistent and reliable way to work with `BaseDocument` regardless of the module configuration.