### PR TITLE
Restore clipboard history for editor by using ExClipboard instead of directly accessing system clipboard

### DIFF
--- a/platform/openide.text/src/org/openide/text/QuietEditorPane.java
+++ b/platform/openide.text/src/org/openide/text/QuietEditorPane.java
@@ -59,6 +59,7 @@ import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
+import org.openide.util.datatransfer.ExClipboard;
 import org.openide.windows.ExternalDropHandler;
 import org.openide.windows.TopComponent;
 
@@ -351,7 +352,8 @@ final class QuietEditorPane extends JEditorPane {
 
         @Override
         public void exportToClipboard(JComponent comp, Clipboard clip, int action) {
-            delegator.exportToClipboard(comp, clip, action);
+            ExClipboard clipboard = Lookup.getDefault().lookup(ExClipboard.class);
+            delegator.exportToClipboard(comp, clipboard != null ? clipboard : clip, action);
         }
 
         @Override


### PR DESCRIPTION
Restore clipboard history for editor:

![Bildschirmfoto vom 2025-04-27 12-29-39](https://github.com/user-attachments/assets/58ca501b-0160-40ee-a745-f1f28395cca9)