### PR TITLE
Specify displayName to avoid NPE

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
@@ -108,6 +108,7 @@ import org.openide.util.lookup.ProxyLookup;
     "ERR_LaunchDefaultConfiguration=the default one.",
     "# {0} - the recommended configuration",
     "ERR_LaunchSupportiveConfigName=\"{0}\"",
+    "CTL_NativeImageDebugger=Native Image Debugger"
 })
 public abstract class NbLaunchDelegate {
 
@@ -460,6 +461,7 @@ public abstract class NbLaunchDelegate {
         StartDebugParameters.Builder parametersBuilder = StartDebugParameters.newBuilder(command)
                 .debugger(miDebugger)
                 .debuggerDisplayObjects(false)
+                .displayName(Bundle.CTL_NativeImageDebugger())
                 .executionDescriptor(executionDescriptor)
                 .lookup(contextLookup);
         StartDebugParameters parameters = parametersBuilder.build();

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractLspInputOutputProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractLspInputOutputProvider.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.util.Objects;
 import java.util.Set;
 import org.netbeans.api.io.Hyperlink;
 import org.netbeans.api.io.OutputColor;
@@ -153,6 +154,9 @@ public abstract class AbstractLspInputOutputProvider implements InputOutputProvi
         final LspWriter err;
 
         LspIO(String name, IOContext ioCtx, Lookup lookup) {
+            Objects.requireNonNull(name);
+            Objects.requireNonNull(ioCtx);
+            Objects.requireNonNull(lookup);
             this.name = name;
             this.ctx = ioCtx;
             this.lookup = lookup;


### PR DESCRIPTION
I am trying to use VSCode extension to debug _native image_ and I am getting:
```
java.lang.NullPointerException: Cannot invoke "String.startsWith(String)" because "name" is null
	at org.netbeans.modules.java.lsp.server.ui.AbstractLspInputOutputProvider$LspIO.<init>(AbstractLspInputOutputProvider.java:184)
	at org.netbeans.modules.java.lsp.server.ui.AbstractLspInputOutputProvider.getIO(AbstractLspInputOutputProvider.java:54)
	at org.netbeans.modules.java.lsp.server.ui.AbstractLspInputOutputProvider.getIO(AbstractLspInputOutputProvider.java:39)
	at org.openide.io.BridgingIOProvider.getIO(BridgingIOProvider.java:83)
	at org.netbeans.modules.extexecution.InputOutputManager.createInputOutput(InputOutputManager.java:163)
	at org.netbeans.api.extexecution.ExecutionService.getInputOutput(ExecutionService.java:336)
	at org.netbeans.api.extexecution.ExecutionService.run(ExecutionService.java:160)
	at org.netbeans.api.extexecution.ExecutionService.run(ExecutionService.java:156)
	at org.netbeans.modules.cpplite.debugger.ni.NIDebuggerProviderImpl.start(NIDebuggerProviderImpl.java:156)
	at org.netbeans.modules.nativeimage.api.debug.NIDebugger.start(NIDebugger.java:129)
	at org.netbeans.modules.java.nativeimage.debugger.api.NIDebugRunner.start(NIDebugRunner.java:107)
	at org.netbeans.modules.java.lsp.server.debugging.launch.NbLaunchDelegate.startNativeDebug(NbLaunchDelegate.java:468)
	at org.netbeans.modules.java.lsp.server.debugging.launch.NbLaunchDelegate.lambda$nbLaunch$6(NbLaunchDelegate.java:364)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
	at org.netbeans.modules.java.lsp.server.debugging.launch.NbLaunchDelegate.lambda$nbLaunch$7(NbLaunchDelegate.java:362)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1403)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
```
after a bit of debugging I have a fix that specifies `displayName` and seems to work fine. Then the debugging of native image gets started. My launch configuration:
```
  {
      "type": "nativeimage",
      "request": "launch",
      "name": "Launch Native Image",
      "nativeImagePath": "${workspaceFolder}/built-distribution/enso-engine-0.0.0-dev-linux-amd64/enso-0.0.0-dev/bin/enso",
      "args": "--jvm /home/devel/bin/graalvm/ --run ${file}"
    }
```
CCing @jlahoda, @entlicher, @MartinBalin 