### PR TITLE
Add relative path preference settings to PhpUnit

### DIFF
--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/commands/PhpUnit.java
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/commands/PhpUnit.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -473,7 +474,7 @@ public final class PhpUnit {
                     params.add(getNbSuite().getAbsolutePath());
                 } else {
                     // GH-5790 we can use NetBeansSuite.php no longer with PHPUnit 10
-                    params.add(FileUtil.toFile(startFiles.get(0)).getAbsolutePath());
+                    params.add(getTestFilePath(phpModule, FileUtil.toFile(startFiles.get(0))));
                 }
                 // #254276
                 //params.add(PARAM_SEPARATOR);
@@ -483,6 +484,16 @@ public final class PhpUnit {
             }
         }
         return new TestParams(params, envVariables);
+    }
+
+    private String getTestFilePath(PhpModule phpModule, File file) {
+        if (PhpUnitPreferences.isRelativePathEnabled(phpModule)) {
+            String basePathText = phpModule.getSourceDirectory().getPath();
+            return Paths.get(basePathText)
+                    .relativize(file.toPath())
+                    .toString();
+        }
+        return file.getAbsolutePath();
     }
 
     private void addBootstrap(PhpModule phpModule, List<String> params) {

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/preferences/PhpUnitPreferences.java
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/preferences/PhpUnitPreferences.java
@@ -49,9 +49,18 @@ public final class PhpUnitPreferences {
     private static final String ASK_FOR_TEST_GROUPS = "test.groups.ask"; // NOI18N
     private static final String TEST_GROUPS = "test.groups"; // NOI18N
     private static final String TEST_GROUPS_DELIMITER = ","; // NOI18N
+    private static final String PHPUNIT_USE_RELATIVE_PATHS = "relativePath.enabled"; // NOI18N
 
 
     private PhpUnitPreferences() {
+    }
+
+    public static void setRelativePathEnabled(PhpModule phpModule, boolean relativePathEnabled) {
+        getPreferences(phpModule).putBoolean(PHPUNIT_USE_RELATIVE_PATHS, relativePathEnabled);
+    }
+
+    public static boolean isRelativePathEnabled(PhpModule phpModule) {
+        return getPreferences(phpModule).getBoolean(PHPUNIT_USE_RELATIVE_PATHS, false);
     }
 
     public static boolean isBootstrapEnabled(PhpModule phpModule) {

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties
@@ -69,3 +69,4 @@ CustomizerPhpUnit.scriptBrowseButton.text=Brow&se...
 CustomizerPhpUnit.runPhpUnitOnlyCheckBox.text=&Test Project Using Just 'phpunit' Command
 CustomizerPhpUnit.versionLabel.text=PHPUnit &Version:
 CustomizerPhpUnit.versionLabel.AccessibleContext.accessibleDescription=PHPUnit version label
+CustomizerPhpUnit.isRelativePathEnabled.text=Use relative paths for test files (uses source directory as base path)

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/CustomizerPhpUnit.form
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/CustomizerPhpUnit.form
@@ -100,6 +100,7 @@
                   <Component id="askForTestGroupsCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="scriptCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="runPhpUnitOnlyCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="isRelativePathEnabled" alignment="0" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="32767" attributes="0"/>
           </Group>
@@ -144,7 +145,7 @@
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="suiteInfoLabel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace type="unrelated" min="-2" max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
               <Component id="scriptCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
@@ -152,7 +153,9 @@
                   <Component id="scriptTextField" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="scriptBrowseButton" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="isRelativePathEnabled" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Component id="runPhpUnitOnlyCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="runTestUsingUnitCheckBox" min="-2" max="-2" attributes="0"/>
@@ -482,9 +485,6 @@
     </Component>
     <Component class="javax.swing.JLabel" name="versionLabel">
       <Properties>
-        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
-          <ComponentRef name="default"/>
-        </Property>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties" key="CustomizerPhpUnit.versionLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
@@ -498,6 +498,13 @@
     <Component class="javax.swing.JLabel" name="versionLineLabel">
       <Properties>
         <Property name="text" type="java.lang.String" value="VERSION" noResource="true"/>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="isRelativePathEnabled">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/php/phpunit/ui/customizer/Bundle.properties" key="CustomizerPhpUnit.isRelativePathEnabled.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
       </Properties>
     </Component>
   </SubComponents>

--- a/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/CustomizerPhpUnit.java
+++ b/php/php.phpunit/src/org/netbeans/modules/php/phpunit/ui/customizer/CustomizerPhpUnit.java
@@ -96,6 +96,7 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
         runPhpUnitOnlyCheckBox.setSelected(PhpUnitPreferences.getRunPhpUnitOnly(phpModule));
         runTestUsingUnitCheckBox.setSelected(PhpUnitPreferences.getRunAllTestFiles(phpModule));
         askForTestGroupsCheckBox.setSelected(PhpUnitPreferences.getAskForTestGroups(phpModule));
+        isRelativePathEnabled.setSelected(PhpUnitPreferences.isRelativePathEnabled(phpModule));
         initPhpUnitVersion();
 
         enableFile(bootstrapCheckBox.isSelected(), bootstrapLabel, bootstrapTextField, bootstrapGenerateButton, bootstrapBrowseButton, bootstrapForCreateTestsCheckBox);
@@ -180,6 +181,7 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
         PhpUnitPreferences.setRunPhpUnitOnly(phpModule, runPhpUnitOnlyCheckBox.isSelected());
         PhpUnitPreferences.setRunAllTestFiles(phpModule, runTestUsingUnitCheckBox.isSelected());
         PhpUnitPreferences.setAskForTestGroups(phpModule, askForTestGroupsCheckBox.isSelected());
+        PhpUnitPreferences.setRelativePathEnabled(phpModule, isRelativePathEnabled.isSelected());
     }
 
     private void initFile(boolean enabled, String file, JCheckBox checkBox, JTextField textField) {
@@ -329,6 +331,7 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
         askForTestGroupsCheckBox = new JCheckBox();
         versionLabel = new JLabel();
         versionLineLabel = new JLabel();
+        isRelativePathEnabled = new JCheckBox();
 
         bootstrapLabel.setLabelFor(bootstrapTextField);
         Mnemonics.setLocalizedText(bootstrapLabel, NbBundle.getMessage(CustomizerPhpUnit.class, "CustomizerPhpUnit.bootstrapLabel.text")); // NOI18N
@@ -414,6 +417,8 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
 
         Mnemonics.setLocalizedText(versionLineLabel, "VERSION"); // NOI18N
 
+        Mnemonics.setLocalizedText(isRelativePathEnabled, NbBundle.getMessage(CustomizerPhpUnit.class, "CustomizerPhpUnit.isRelativePathEnabled.text")); // NOI18N
+
         GroupLayout layout = new GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
@@ -464,7 +469,8 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
                     .addComponent(runTestUsingUnitCheckBox)
                     .addComponent(askForTestGroupsCheckBox)
                     .addComponent(scriptCheckBox)
-                    .addComponent(runPhpUnitOnlyCheckBox))
+                    .addComponent(runPhpUnitOnlyCheckBox)
+                    .addComponent(isRelativePathEnabled))
                 .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
             .addGroup(layout.createSequentialGroup()
                 .addComponent(versionLabel)
@@ -504,14 +510,16 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
                     .addComponent(suiteBrowseButton))
                 .addPreferredGap(ComponentPlacement.RELATED)
                 .addComponent(suiteInfoLabel)
-                .addPreferredGap(ComponentPlacement.UNRELATED)
+                .addPreferredGap(ComponentPlacement.RELATED)
                 .addComponent(scriptCheckBox)
                 .addPreferredGap(ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(Alignment.BASELINE)
                     .addComponent(scriptLabel)
                     .addComponent(scriptTextField, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
                     .addComponent(scriptBrowseButton))
-                .addPreferredGap(ComponentPlacement.UNRELATED)
+                .addPreferredGap(ComponentPlacement.RELATED)
+                .addComponent(isRelativePathEnabled)
+                .addPreferredGap(ComponentPlacement.RELATED)
                 .addComponent(runPhpUnitOnlyCheckBox)
                 .addPreferredGap(ComponentPlacement.RELATED)
                 .addComponent(runTestUsingUnitCheckBox)
@@ -645,6 +653,7 @@ public final class CustomizerPhpUnit extends JPanel implements HelpCtx.Provider 
     private JButton configurationGenerateButton;
     private JLabel configurationLabel;
     private JTextField configurationTextField;
+    private JCheckBox isRelativePathEnabled;
     private JCheckBox runPhpUnitOnlyCheckBox;
     private JCheckBox runTestUsingUnitCheckBox;
     private JButton scriptBrowseButton;


### PR DESCRIPTION
This checkbox gives boolean setting switching between two behaviour of passing test file paths to the PhpUnit command:

 FALSE/Unchecked = Use absolute paths [Current behaviour]
 TRUE/Checked = Use relative paths

![kép](https://github.com/user-attachments/assets/45eebf0b-611a-48a0-9bc2-23c375b8070f)

![tests](https://github.com/user-attachments/assets/2764f1dd-c0b2-4ac4-bb4c-7a95296b7b76)

[Edit]
Motivation:

I develop PHP projects in a completely containerized setup. This setting would allow me to use all the functionality with a custom runner script, without dealing with path mapping, or any kind of more robust runner configuration.

---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>