### PR TITLE
Revert "Restore clipboard history for editor by using ExClipboard instead of directly accessing system clipboard"

### DIFF
--- a/platform/openide.text/src/org/openide/text/QuietEditorPane.java
+++ b/platform/openide.text/src/org/openide/text/QuietEditorPane.java
@@ -59,7 +59,6 @@ import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
-import org.openide.util.datatransfer.ExClipboard;
 import org.openide.windows.ExternalDropHandler;
 import org.openide.windows.TopComponent;
 
@@ -352,8 +351,7 @@ final class QuietEditorPane extends JEditorPane {
 
         @Override
         public void exportToClipboard(JComponent comp, Clipboard clip, int action) {
-            ExClipboard clipboard = Lookup.getDefault().lookup(ExClipboard.class);
-            delegator.exportToClipboard(comp, clipboard != null ? clipboard : clip, action);
+            delegator.exportToClipboard(comp, clip, action);
         }
 
         @Override


### PR DESCRIPTION
Reverts apache/netbeans#8462

Unfortunately looks like we might have to back this out of NB26 and also take more time to consider how to integrate this change into NB27.  This currently causes a test failure because it routes copy through NbClipboard, but not paste.  Setting clipboard contents in NbClipboard is asynchronous - getting contents from it waits for the setting task, but this is not happening because paste is bypassing it.