### PR TITLE
ComputeOverrides: move ClasspathInfo creation out of inner loops

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/java/editor/overridden/ComputeOverriders.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/overridden/ComputeOverriders.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -46,12 +47,10 @@ import org.netbeans.api.java.source.ClassIndex;
 import org.netbeans.api.java.source.ClassIndex.SearchKind;
 import org.netbeans.api.java.source.ClassIndex.SearchScope;
 import org.netbeans.api.java.source.ClasspathInfo;
-import org.netbeans.api.java.source.CompilationController;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.java.source.ElementHandle;
 import org.netbeans.api.java.source.JavaSource;
 import org.netbeans.api.java.source.SourceUtils;
-import org.netbeans.api.java.source.Task;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
@@ -83,22 +82,16 @@ public class ComputeOverriders {
         try {
             //TODO: from SourceUtils (which filters out source roots that do not belong to open projects):
             //Create inverse dependencies
-            final Map<URL, List<URL>> inverseDeps = new HashMap<URL, List<URL>> ();
-            for (Map.Entry<URL,List<URL>> entry : sourceDeps.entrySet()) {
-                final URL u1 = entry.getKey();
-                final List<URL> l1 = entry.getValue();
-                for (URL u2 : l1) {
-                    List<URL> l2 = inverseDeps.get(u2);
-                    if (l2 == null) {
-                        l2 = new ArrayList<URL>();
-                        inverseDeps.put (u2,l2);
-                    }
-                    l2.add (u1);
+            final Map<URL, List<URL>> inverseDeps = new HashMap<>();
+            for (Map.Entry<URL, List<URL>> entry : sourceDeps.entrySet()) {
+                for (URL url : entry.getValue()) {
+                    inverseDeps.computeIfAbsent(url, k -> new ArrayList<>())
+                               .add(entry.getKey());
                 }
             }
             //Collect dependencies
-            final Set<URL> result = new HashSet<URL>();
-            final LinkedList<URL> todo = new LinkedList<URL> ();
+            final Set<URL> result = new HashSet<>();
+            final LinkedList<URL> todo = new LinkedList<>();
             todo.add (thisSourceRoot);
             List<URL> peers = rootPeers != null ? rootPeers.get(thisSourceRoot) : null;
             if (peers != null)
@@ -130,7 +123,7 @@ public class ComputeOverriders {
 
     private Set<URL> findBinaryRootsForSourceRoot(FileObject sourceRoot, Map<URL, List<URL>> binaryDeps) {
 //      BinaryForSourceQuery.findBinaryRoots(thisSourceRoot).getRoots();
-        Set<URL> result = new HashSet<URL>();
+        Set<URL> result = new HashSet<>();
 
         for (URL bin : binaryDeps.keySet()) {
             if (cancel.get()) return Collections.emptySet();
@@ -179,21 +172,20 @@ public class ComputeOverriders {
 //                }
 
 
-        final Map<ElementHandle<TypeElement>, List<ElementHandle<ExecutableElement>>> methods = new HashMap<ElementHandle<TypeElement>, List<ElementHandle<ExecutableElement>>>();
+        final Map<ElementHandle<TypeElement>, List<ElementHandle<ExecutableElement>>> methods = new HashMap<>();
 
         if (ee == null) {
             if (te == null) {
                 fillInMethods(info.getTopLevelElements(), methods);
             } else {
-                methods.put(ElementHandle.create(te), Collections.<ElementHandle<ExecutableElement>>emptyList());
+                methods.put(ElementHandle.create(te), Collections.emptyList());
             }
         } else {
             TypeElement owner = (TypeElement) ee.getEnclosingElement();
-
-            methods.put(ElementHandle.create(owner), Collections.singletonList(ElementHandle.create(ee)));
+            methods.put(ElementHandle.create(owner), List.of(ElementHandle.create(ee)));
         }
 
-        final Map<ElementHandle<? extends Element>, List<ElementDescription>> overriding = new HashMap<ElementHandle<? extends Element>, List<ElementDescription>>();
+        final Map<ElementHandle<? extends Element>, List<ElementDescription>> overriding = new HashMap<>();
 
         long startTime = System.currentTimeMillis();
         long[] classIndexTime = new long[1];
@@ -241,7 +233,7 @@ public class ComputeOverriders {
 
     private static void fillInMethods(Iterable<? extends TypeElement> types, Map<ElementHandle<TypeElement>, List<ElementHandle<ExecutableElement>>> methods) {
         for (TypeElement te : types) {
-            List<ElementHandle<ExecutableElement>> l = new LinkedList<ElementHandle<ExecutableElement>>();
+            List<ElementHandle<ExecutableElement>> l = new LinkedList<>();
 
             for (ExecutableElement ee : ElementFilter.methodsIn(te.getEnclosedElements())) {
                 l.add(ElementHandle.create(ee));
@@ -262,20 +254,20 @@ public class ComputeOverriders {
         long startTime = System.currentTimeMillis();
 
         try {
-            List<ElementHandle<TypeElement>> l = new LinkedList<ElementHandle<TypeElement>>(base);
-            Set<ElementHandle<TypeElement>> result = new HashSet<ElementHandle<TypeElement>>();
-            Set<ElementHandle<TypeElement>> seen = new HashSet<ElementHandle<TypeElement>>();
+            Deque<ElementHandle<TypeElement>> l = new LinkedList<>(base);
+            Set<ElementHandle<TypeElement>> result = new HashSet<>();
+            Set<ElementHandle<TypeElement>> seen = new HashSet<>();
 
             while (!l.isEmpty()) {
                 if (cancel.get()) return null;
                 
-                ElementHandle<TypeElement> eh = l.remove(0);
+                ElementHandle<TypeElement> eh = l.removeFirst();
 
                 if (!seen.add(eh)) continue;
 
                 result.add(eh);
-                Set<ElementHandle<TypeElement>> typeElements = cpinfo.getClassIndex().getElements(eh, Collections.singleton(SearchKind.IMPLEMENTORS), EnumSet.of(scope));
-                //XXX: Canceling
+                ClassIndex index = cpinfo.getClassIndex();
+                Set<ElementHandle<TypeElement>> typeElements = index.getElements(eh, Set.of(SearchKind.IMPLEMENTORS), EnumSet.of(scope));
                 if (typeElements != null) {
                     l.addAll(typeElements);
                 }
@@ -306,7 +298,7 @@ public class ComputeOverriders {
         }
         List<URL> sourceRoots;
         try {
-            sourceRoots = new LinkedList<URL>(Utilities.topologicalSort(sourceDeps.keySet(), sourceDeps));
+            sourceRoots = new LinkedList<>(Utilities.topologicalSort(sourceDeps.keySet(), sourceDeps));
         } catch (TopologicalSortException ex) {
             if (interactive) {
                 Exceptions.attachLocalizedMessage(ex,NbBundle.getMessage(GoToImplementation.class, "ERR_CycleInDependencies"));
@@ -349,7 +341,7 @@ public class ComputeOverriders {
             return null;
         }
 
-        baseHandles = new HashSet<ElementHandle<TypeElement>>(baseHandles);
+        baseHandles = new HashSet<>(baseHandles);
 
         for (Iterator<ElementHandle<TypeElement>> it = baseHandles.iterator(); it.hasNext(); ) {
             if (cancel.get()) return null;
@@ -359,10 +351,10 @@ public class ComputeOverriders {
             }
         }
 
-        Map<ElementHandle<TypeElement>, Set<ElementHandle<TypeElement>>> auxHandles = new HashMap<ElementHandle<TypeElement>, Set<ElementHandle<TypeElement>>>();
+        Map<ElementHandle<TypeElement>, Set<ElementHandle<TypeElement>>> auxHandles = new HashMap<>();
 
         if (!sourceDeps.containsKey(thisSourceRootURL)) {
-            Set<URL> binaryRoots = new HashSet<URL>();
+            Set<URL> binaryRoots = new HashSet<>();
             
             for (URL sr : sourceRoots) {
                 List<URL> deps = sourceDeps.get(sr);
@@ -375,7 +367,7 @@ public class ComputeOverriders {
             binaryRoots.retainAll(binaryDeps.keySet());
 
             for (ElementHandle<TypeElement> handle : baseHandles) {
-                Set<ElementHandle<TypeElement>> types = computeUsers(ClasspathInfo.create(ClassPath.EMPTY, ClassPathSupport.createClassPath(binaryRoots.toArray(new URL[0])), ClassPath.EMPTY), SearchScope.DEPENDENCIES, Collections.singleton(handle), classIndexCumulative);
+                Set<ElementHandle<TypeElement>> types = computeUsers(ClasspathInfo.create(ClassPath.EMPTY, ClassPathSupport.createClassPath(binaryRoots.toArray(URL[]::new)), ClassPath.EMPTY), SearchScope.DEPENDENCIES, Set.of(handle), classIndexCumulative);
 
                 if (types == null/*canceled*/ || cancel.get()) {
                     return null;
@@ -385,13 +377,13 @@ public class ComputeOverriders {
             }
         }
         
-        Map<URL, Map<ElementHandle<TypeElement>, Set<ElementHandle<TypeElement>>>> result = new LinkedHashMap<URL, Map<ElementHandle<TypeElement>, Set<ElementHandle<TypeElement>>>>();
+        Map<URL, Map<ElementHandle<TypeElement>, Set<ElementHandle<TypeElement>>>> result = new LinkedHashMap<>();
 
         for (URL file : sourceRoots) {
             for (ElementHandle<TypeElement> base : baseHandles) {
                 if (cancel.get()) return null;
                 
-                Set<ElementHandle<TypeElement>> baseTypes = new HashSet<ElementHandle<TypeElement>>();
+                Set<ElementHandle<TypeElement>> baseTypes = new HashSet<>();
 
                 baseTypes.add(base);
 
@@ -417,14 +409,8 @@ public class ComputeOverriders {
                 }
                 
                 types.removeAll(baseTypes);
-
-                Map<ElementHandle<TypeElement>, Set<ElementHandle<TypeElement>>> currentUsers = result.get(file);
-
-                if (currentUsers == null) {
-                    result.put(file, currentUsers = new LinkedHashMap<ElementHandle<TypeElement>, Set<ElementHandle<TypeElement>>>());
-                }
-
-                currentUsers.put(base, types);
+                result.computeIfAbsent(file, k -> new LinkedHashMap<>())
+                      .put(base, types);
             }
         }
 
@@ -444,55 +430,43 @@ public class ComputeOverriders {
             JavaSource js = JavaSource.create(cpinfo);
 
             try {
-                js.runUserActionTask(new Task<CompilationController>() {
-                    public void run(CompilationController controller) throws Exception {
-                        controller.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
-                        Set<Element> seenElements = new HashSet<Element>();
-                        Element resolvedOriginalType = originalType.resolve(controller);
+                js.runUserActionTask(controller -> {
+                    controller.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
+                    Set<Element> seenElements = new HashSet<>();
+                    Element resolvedOriginalType = originalType.resolve(controller);
 
-                        if (resolvedOriginalType == null) {
-                            return ;
+                    if (resolvedOriginalType == null) {
+                        return ;
+                    }
+
+                    for (ElementHandle<TypeElement> typeHandle : users) {
+                        if (cancel.get()) return ;
+                        TypeElement type = typeHandle.resolve(controller);
+
+                        if (type == null || !seenElements.add(type)) {
+                            continue;
                         }
-                        
-                        for (ElementHandle<TypeElement> typeHandle : users) {
-                            if (cancel.get()) return ;
-                            TypeElement type = typeHandle.resolve(controller);
 
-                            if (type == null || !seenElements.add(type)) {
-                                continue;
-                            }
+                        Types types = controller.getTypes();
 
-                            Types types = controller.getTypes();
+                        if (types.isSubtype(types.erasure(type.asType()), types.erasure(resolvedOriginalType.asType()))) {
+                            overriding.computeIfAbsent(originalType, k -> new LinkedList<>())
+                                      .add(new ElementDescription(controller, type, true));
 
-                            if (types.isSubtype(types.erasure(type.asType()), types.erasure(resolvedOriginalType.asType()))) {
-                                List<ElementDescription> classOverriders = overriding.get(originalType);
+                            for (ElementHandle<ExecutableElement> originalMethodHandle : methods) {
+                                ExecutableElement originalMethod = originalMethodHandle.resolve(controller);
 
-                                if (classOverriders == null) {
-                                    overriding.put(originalType, classOverriders = new LinkedList<ElementDescription>());
-                                }
+                                if (originalMethod != null) {
+                                    ExecutableElement overrider = getImplementationOf(controller, originalMethod, type);
 
-                                classOverriders.add(new ElementDescription(controller, type, true));
-
-                                for (ElementHandle<ExecutableElement> originalMethodHandle : methods) {
-                                    ExecutableElement originalMethod = originalMethodHandle.resolve(controller);
-
-                                    if (originalMethod != null) {
-                                        ExecutableElement overrider = getImplementationOf(controller, originalMethod, type);
-
-                                        if (overrider == null) {
-                                            continue;
-                                        }
-
-                                        List<ElementDescription> overriddingMethods = overriding.get(originalMethodHandle);
-
-                                        if (overriddingMethods == null) {
-                                            overriding.put(originalMethodHandle, overriddingMethods = new ArrayList<ElementDescription>());
-                                        }
-
-                                        overriddingMethods.add(new ElementDescription(controller, overrider, true));
-                                    } else {
-                                        Logger.getLogger("global").log(Level.SEVERE, "IsOverriddenAnnotationHandler: originalMethod == null!"); //NOI18N
+                                    if (overrider == null) {
+                                        continue;
                                     }
+
+                                    overriding.computeIfAbsent(originalMethodHandle, k -> new ArrayList<>())
+                                              .add(new ElementDescription(controller, overrider, true));
+                                } else {
+                                    Logger.getLogger("global").log(Level.SEVERE, "IsOverriddenAnnotationHandler: originalMethod == null!"); //NOI18N
                                 }
                             }
                         }
@@ -527,8 +501,8 @@ public class ComputeOverriders {
             return null;
         }
 
-        Class<?> clazz = null;
-        String method = null;
+        Class<?> clazz;
+        String method;
 
         try {
             clazz = l.loadClass("org.netbeans.modules.parsing.impl.indexing.friendapi.IndexingController");
@@ -569,8 +543,8 @@ public class ComputeOverriders {
             return null;
         }
 
-        Class<?> clazz = null;
-        String method = null;
+        Class<?> clazz;
+        String method;
 
         try {
             clazz = l.loadClass("org.netbeans.modules.parsing.impl.indexing.friendapi.IndexingController");

--- a/java/java.editor/src/org/netbeans/modules/java/editor/overridden/ComputeOverriding.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/overridden/ComputeOverriding.java
@@ -98,7 +98,7 @@ public class ComputeOverriding {
         Logger.getLogger("TIMER").log(Level.FINE, "Overridden Scanner", //NOI18N
                     new Object[] {info.getFileObject(), endTime1 - startTime1});
         
-        Map<ElementHandle<? extends Element>, List<ElementDescription>> result = new HashMap<ElementHandle<? extends Element>, List<ElementDescription>>();
+        Map<ElementHandle<? extends Element>, List<ElementDescription>> result = new HashMap<>();
         
         for (ElementHandle<TypeElement> td : v.type2Declaration.keySet()) {
             if (isCanceled())
@@ -111,10 +111,7 @@ public class ComputeOverriding {
             }
         }
         
-        if (isCanceled())
-            return null;
-        else
-            return result;
+        return isCanceled() ? null : result;
     }
     
     private synchronized boolean isCanceled() {
@@ -123,7 +120,7 @@ public class ComputeOverriding {
     
     private static void sortOutMethods(CompilationInfo info, Map<Name, List<ExecutableElement>> where, Element td, boolean current) {
         if (current) {
-            Map<Name, List<ExecutableElement>> newlyAdded = new HashMap<Name, List<ExecutableElement>>();
+            Map<Name, List<ExecutableElement>> newlyAdded = new HashMap<>();
             
             OUTTER: for (ExecutableElement ee : ElementFilter.methodsIn(td.getEnclosedElements())) {
                 Name name = ee.getSimpleName();
@@ -137,13 +134,8 @@ public class ComputeOverriding {
                     }
                 }
                 
-                List<ExecutableElement> lee = newlyAdded.get(name);
-                
-                if (lee == null) {
-                    newlyAdded.put(name, lee = new ArrayList<ExecutableElement>());
-                }
-                
-                lee.add(ee);
+                newlyAdded.computeIfAbsent(name, k -> new ArrayList<ExecutableElement>())
+                          .add(ee);
             }
             
             for (Map.Entry<Name, List<ExecutableElement>> e : newlyAdded.entrySet()) {
@@ -169,14 +161,15 @@ public class ComputeOverriding {
         Map<ElementHandle<ExecutableElement>, List<ElementDescription>> result = data.data.get(forType);
 
         if (result == null) {
-            data.data.put(forType, result = new HashMap<ElementHandle<ExecutableElement>, List<ElementDescription>>());
+            result = new HashMap<>();
+            data.data.put(forType, result);
             
             if (cancel.get())
                 return null;
 
             LOG.log(Level.FINE, "type: {0}", forType.getQualifiedName()); //NOI18N
 
-            final Map<Name, List<ExecutableElement>> name2Method = new HashMap<Name, List<ExecutableElement>>();
+            final Map<Name, List<ExecutableElement>> name2Method = new HashMap<>();
 
             TypeElement resolvedType = forType.resolve(info);
 
@@ -199,8 +192,8 @@ public class ComputeOverriding {
                     continue;
                 }
 
-                Set<ExecutableElement> seenMethods = new HashSet<ExecutableElement>();
-                List<ElementDescription> descriptions = new LinkedList<ElementDescription>();
+                Set<ExecutableElement> seenMethods = new HashSet<>();
+                List<ElementDescription> descriptions = new LinkedList<>();
 
                 for (ExecutableElement overridee : lee) {
                     if (info.getElements().overrides(ee, overridee, SourceUtils.getEnclosingTypeElement(ee))) {
@@ -219,7 +212,7 @@ public class ComputeOverriding {
         return result;
     }
     
-    private static final Map<Reference<Elements>, DataHolder> CACHE = new HashMap<Reference<Elements>, DataHolder>();
+    private static final Map<Reference<Elements>, DataHolder> CACHE = new HashMap<>();
 
     private static DataHolder getDataFromCache(CompilationInfo info) {
         Elements elements = info.getElements();
@@ -246,7 +239,7 @@ public class ComputeOverriding {
     private static final class DataHolder {
         private final Map<ElementHandle<TypeElement>, Map<ElementHandle<ExecutableElement>, List<ElementDescription>>> data;
         public DataHolder() {
-            data = new HashMap<ElementHandle<TypeElement>, Map<ElementHandle<ExecutableElement>, List<ElementDescription>>>();
+            data = new HashMap<>();
         }
     }
 
@@ -254,6 +247,7 @@ public class ComputeOverriding {
         public CleaningWR(Elements el) {
             super(el, Utilities.activeReferenceQueue());
         }
+        @Override
         public void run() {
             synchronized(CACHE) {
                 CACHE.remove(this);

--- a/java/java.editor/src/org/netbeans/modules/java/editor/overridden/ElementDescription.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/overridden/ElementDescription.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.java.editor.overridden;
 
-import java.awt.Image;
 import java.awt.Toolkit;
 import java.util.Collection;
 import javax.lang.model.element.Element;
@@ -48,12 +47,12 @@ public class ElementDescription {
     private static final String PKG_COLOR = Utilities.getHTMLColor(192, 192, 192);
     private final ElementKind imageKind;
 
-    private ClasspathInfo originalCPInfo;
+    private final ClasspathInfo originalCPInfo;
     
-    private ElementHandle<Element> handle;
-    private ElementHandle<TypeElement> outtermostElement;
-    private Collection<Modifier> modifiers;
-    private String displayName;
+    private final ElementHandle<Element> handle;
+    private final ElementHandle<TypeElement> outtermostElement;
+    private final Collection<Modifier> modifiers;
+    private final String displayName;
     private final boolean overriddenFlag;
 
     public ElementDescription(CompilationInfo info, Element element, boolean overriddenFlag) {

--- a/java/java.editor/src/org/netbeans/modules/java/editor/overridden/IsOverriddenAnnotation.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/overridden/IsOverriddenAnnotation.java
@@ -49,28 +49,20 @@ public class IsOverriddenAnnotation extends Annotation {
         this.declarations = declarations;
     }
     
+    @Override
     public String getShortDescription() {
         return shortDescription;
     }
 
+    @Override
     public String getAnnotationType() {
-        switch(type) {
-            case IS_OVERRIDDEN:
-
-                return "org-netbeans-modules-editor-annotations-is_overridden"; //NOI18N
-            case HAS_IMPLEMENTATION:
-
-                return "org-netbeans-modules-editor-annotations-has_implementations"; //NOI18N
-            case IMPLEMENTS:
-
-                return "org-netbeans-modules-editor-annotations-implements"; //NOI18N
-            case OVERRIDES:
-
-                return "org-netbeans-modules-editor-annotations-overrides"; //NOI18N
-            default:
-
-                throw new IllegalStateException("Currently not implemented: " + type); //NOI18N
-        }
+        return switch(type) {
+            case IS_OVERRIDDEN -> "org-netbeans-modules-editor-annotations-is_overridden"; //NOI18N
+            case HAS_IMPLEMENTATION -> "org-netbeans-modules-editor-annotations-has_implementations"; //NOI18N
+            case IMPLEMENTS -> "org-netbeans-modules-editor-annotations-implements"; //NOI18N
+            case OVERRIDES -> "org-netbeans-modules-editor-annotations-overrides"; //NOI18N
+            default -> throw new IllegalStateException("Currently not implemented: " + type); //NOI18N
+        };
     }
     
     public void attach() {
@@ -81,6 +73,7 @@ public class IsOverriddenAnnotation extends Annotation {
         NbDocument.removeAnnotation(document, this);
     }
     
+    @Override
     public String toString() {
         return "[IsOverriddenAnnotation: " + shortDescription + "]"; //NOI18N
     }
@@ -90,7 +83,7 @@ public class IsOverriddenAnnotation extends Annotation {
     }
     
     public String debugDump(boolean includePosition) {
-        List<String> elementNames = new ArrayList<String>();
+        List<String> elementNames = new ArrayList<>();
         
         for(ElementDescription desc : declarations) {
             elementNames.add(desc.getDisplayName());

--- a/java/java.editor/src/org/netbeans/modules/java/editor/overridden/IsOverriddenPopup.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/overridden/IsOverriddenPopup.java
@@ -26,7 +26,6 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
-import java.util.Comparator;
 import java.util.List;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.DefaultListModel;
@@ -51,18 +50,14 @@ public class IsOverriddenPopup extends JPanel implements FocusListener {
         this.caption = caption;
         this.declarations = declarations;
 
-        declarations.sort(new Comparator<ElementDescription>() {
-            public int compare(ElementDescription o1, ElementDescription o2) {
-                if (o1.isOverridden() == o2.isOverridden()) {
-                    return o1.getDisplayName().compareTo(o2.getDisplayName());
-                }
-                
-                if (o1.isOverridden()) {
-                    return 1;
-                }
-                
-                return -1;
+        declarations.sort((o1, o2) -> {
+            if (o1.isOverridden() == o2.isOverridden()) {
+                return o1.getDisplayName().compareTo(o2.getDisplayName());
             }
+            if (o1.isOverridden()) {
+                return 1;
+            }
+            return -1;
         });
         
         initComponents();
@@ -131,7 +126,7 @@ public class IsOverriddenPopup extends JPanel implements FocusListener {
     
     private void jList1KeyPressed(java.awt.event.KeyEvent evt) {//GEN-FIRST:event_jList1KeyPressed
         // TODO add your handling code here:
-        if (evt.getKeyCode() == KeyEvent.VK_ENTER && evt.getModifiers() == 0) {
+        if (evt.getKeyCode() == KeyEvent.VK_ENTER && evt.getModifiersEx()== 0) {
             openSelected();
         }
     }//GEN-LAST:event_jList1KeyPressed
@@ -168,6 +163,7 @@ public class IsOverriddenPopup extends JPanel implements FocusListener {
         private static final int DARKER_COLOR_COMPONENT = 5;
         private boolean selected;
 
+        @Override
         public Component getListCellRendererComponent(
                 JList list,
                 Object value,
@@ -175,9 +171,7 @@ public class IsOverriddenPopup extends JPanel implements FocusListener {
                 boolean isSelected,
                 boolean cellHasFocus) {
             super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);            
-            if (value instanceof ElementDescription) {
-                ElementDescription desc = (ElementDescription) value;
-                
+            if (value instanceof ElementDescription desc) {
                 setIcon(desc.getIcon());
                 setText(desc.getDisplayName());
             }
@@ -214,11 +208,13 @@ public class IsOverriddenPopup extends JPanel implements FocusListener {
         }
     }
     
+    @Override
     public void focusGained(FocusEvent arg0) {
         jList1.requestFocus();
         jList1.requestFocusInWindow();
     }
     
+    @Override
     public void focusLost(FocusEvent arg0) {
     }
     

--- a/java/java.editor/src/org/netbeans/modules/java/editor/overridden/PopupUtil.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/overridden/PopupUtil.java
@@ -28,7 +28,6 @@ import java.awt.Toolkit;
 import java.awt.event.AWTEventListener;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
-import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowEvent;
@@ -47,15 +46,13 @@ import org.openide.windows.WindowManager;
  */
 public final class PopupUtil  {
     
-    // private static MyFocusListener mfl = new MyFocusListener();
-    
     private static final String CLOSE_KEY = "CloseKey"; //NOI18N
     private static final Action CLOSE_ACTION = new CloseAction();
     private static final KeyStroke ESC_KEY_STROKE = KeyStroke.getKeyStroke( KeyEvent.VK_ESCAPE, 0 ); 
         
     private static final String POPUP_NAME = "popupComponent"; //NOI18N
     private static JDialog popupWindow;
-    private static HideAWTListener hideListener = new HideAWTListener();
+    private static final HideAWTListener hideListener = new HideAWTListener();
     
     // Singleton
     private PopupUtil() {
@@ -100,8 +97,6 @@ public final class PopupUtil  {
         }
         // popupWindow.setAlwaysOnTop( true );
         popupWindow.getContentPane().add(content);
-        // popupWindow.addFocusListener( mfl );                        
-        // content.addFocusListener( mfl );                        
                 
         WindowManager.getDefault().getMainWindow().addWindowStateListener(hideListener);
         WindowManager.getDefault().getMainWindow().addComponentListener(hideListener);
@@ -149,8 +144,7 @@ public final class PopupUtil  {
                                  point.y + (getMainWindow().getHeight() - popupWindow.getHeight()) / 3);
     }
     
-    private static final int X_INSET = 10;
-    private static final int Y_INSET = X_INSET;
+    private static final int INSET = 10;
     
     private static Point fitToScreen( int x, int y, int altHeight ) {
         
@@ -159,12 +153,12 @@ public final class PopupUtil  {
         Point p = new Point( x, y );
         
         // Adjust the x postition if necessary
-        if ( ( p.x + popupWindow.getWidth() ) > ( screen.x + screen.width - X_INSET ) ) {
-            p.x = screen.x + screen.width - X_INSET - popupWindow.getWidth(); 
+        if ( ( p.x + popupWindow.getWidth() ) > ( screen.x + screen.width - INSET ) ) {
+            p.x = screen.x + screen.width - INSET - popupWindow.getWidth(); 
         }
         
         // Adjust the y position if necessary
-        if ( ( p.y + popupWindow.getHeight() ) > ( screen.y + screen.height - X_INSET ) ) {
+        if ( ( p.y + popupWindow.getHeight() ) > ( screen.y + screen.height - INSET ) ) {
             p.y = p.y - popupWindow.getHeight() - altHeight;
         }
         
@@ -180,9 +174,9 @@ public final class PopupUtil  {
     
     private static class HideAWTListener extends ComponentAdapter implements  AWTEventListener, WindowStateListener {
         
+        @Override
         public void eventDispatched(java.awt.AWTEvent aWTEvent) {
-            if (aWTEvent instanceof MouseEvent) {
-                MouseEvent mv = (MouseEvent)aWTEvent;
+            if (aWTEvent instanceof MouseEvent mv) {
                 if (mv.getID() == MouseEvent.MOUSE_CLICKED && mv.getClickCount() > 0) {
                     //#118828
                     if (! (aWTEvent.getSource() instanceof Component)) {
@@ -201,6 +195,7 @@ public final class PopupUtil  {
             }
         }
 
+        @Override
         public void windowStateChanged(WindowEvent windowEvent) {
             if (popupWindow != null ) {
                 int oldState = windowEvent.getOldState();
@@ -217,12 +212,14 @@ public final class PopupUtil  {
 
         }
         
+        @Override
         public void componentResized(ComponentEvent evt) {
             if (popupWindow != null) {
                 resizePopup();
             }
         }
         
+        @Override
         public void componentMoved(ComponentEvent evt) {
             if (popupWindow!= null) {
                 resizePopup();
@@ -230,26 +227,13 @@ public final class PopupUtil  {
         }        
         
     }
-    
-    private static class MyFocusListener implements FocusListener {
-        
-        public void focusLost(java.awt.event.FocusEvent e) {
-            System.out.println( e );
-        }
 
-        public void focusGained(java.awt.event.FocusEvent e) {
-            System.out.println( e );
-        }
-                        
-    }
-    
     private static class CloseAction extends AbstractAction {
         
+        @Override
         public void actionPerformed(java.awt.event.ActionEvent e) {
             hidePopup();
         }
-                
-                
     }
     
 }


### PR DESCRIPTION
improves the performance of the phase in which the overrides editor annotations are computed (similar to https://github.com/apache/netbeans/pull/8437 but no cache is needed here).

691e6cae83fcb0bd7427f8e02ffcb2c68905142b has the perf enhancement
93dcd634584a92a7e7ac16ca7e3352de1f4d6325 JDK 17 lang level cleanup in the containing `java.editor.overridden` package

 - `ClassIndex` creation is expensive, `ClasspahInfo` initializes it lazily
 - this moves `ClasspahInfo` out of inner loops to reduce creation overhead of `ClasspahInfo` and its internal `ClassIndex` instance

running a synthetic [test file](https://github.com/mbien/nb-reprorepo/blob/54003b76bc25116e2f563940836709f02d125b19/performance/classes/src/main/java/test/classes/InnerClasses10k.java#L3) with 10k package private elements

before:
![ComputeOverrrides0](https://github.com/user-attachments/assets/f7ca1b01-88ef-4f6b-8d25-272c623b9eb5)

after:
![ComputeOverrrides1](https://github.com/user-attachments/assets/fbf795f6-2115-4e61-9a61-281cdcce7ce6)



before:
```
ComputeAnnotations_delta: 8853
```
after:
```
ComputeAnnotations_delta: 4256
```

another hotspot with great potential for improvements is `ElementUtils#getTypeElementByBinaryName`, but this has to be addressed separately.