### PR TITLE
CI: start testing on JDK 25

### DIFF
--- a/.github/scripts/CommitHeaderChecker.java
+++ b/.github/scripts/CommitHeaderChecker.java
@@ -36,18 +36,18 @@ record Result(int total, boolean green) {}
 // checks commit headers for valid author, email and commit msg formatting
 // its main purpose is to prevent common merge mistakes
 
-// Java 23+, may require preview flag
+// Java 25+
 // java CommitHeaderChecker.java https://github.com/apache/netbeans/pull/${{ github.event.pull_request.number }}
 
 // green tests:
-// java --enable-preview CommitHeaderChecker.java https://github.com/apache/netbeans/pull/66
-// java --enable-preview CommitHeaderChecker.java https://github.com/apache/netbeans/pull/7641
-// java --enable-preview CommitHeaderChecker.java https://github.com/apache/netbeans/pull/4138
-// java --enable-preview CommitHeaderChecker.java https://github.com/apache/netbeans/pull/4692
+// java CommitHeaderChecker.java https://github.com/apache/netbeans/pull/66
+// java CommitHeaderChecker.java https://github.com/apache/netbeans/pull/7641
+// java CommitHeaderChecker.java https://github.com/apache/netbeans/pull/4138
+// java CommitHeaderChecker.java https://github.com/apache/netbeans/pull/4692
 
 // red tests:
-// java --enable-preview CommitHeaderChecker.java https://github.com/apache/netbeans/pull/7776
-// java --enable-preview CommitHeaderChecker.java https://github.com/apache/netbeans/pull/5567
+// java CommitHeaderChecker.java https://github.com/apache/netbeans/pull/7776
+// java CommitHeaderChecker.java https://github.com/apache/netbeans/pull/5567
 
 void main(String[] args) throws IOException, InterruptedException {
 
@@ -60,7 +60,7 @@ void main(String[] args) throws IOException, InterruptedException {
             .timeout(Duration.ofSeconds(10))
             .build();
 
-    println("checking PR patch file...");
+    log("checking PR patch file...");
     Result result;
     try (HttpClient client = HttpClient.newBuilder()
             .followRedirects(Redirect.NORMAL).build()) {
@@ -81,7 +81,7 @@ void main(String[] args) throws IOException, InterruptedException {
             .orElseThrow();
     }
 
-    println(result.total + " commit(s) checked");
+    log(result.total + " commit(s) checked");
     System.exit(result.green ? 0 : 1);
 }
 
@@ -124,7 +124,7 @@ boolean checkNameAndEmail(int i, String from) {
 
     boolean green = true;
     if (mail.isBlank() || !mail.contains("@") || mail.contains("noreply") || mail.contains("localhost")) {
-        println("::error::invalid email in commit " + i + " '" + from + "'");
+        log("::error::invalid email in commit " + i + " '" + from + "'");
         green = false;
     }
 
@@ -133,7 +133,7 @@ boolean checkNameAndEmail(int i, String from) {
 
     // single word author -> probably the nickname/account name/root etc
     if (author.isBlank() || (!encoded && !author.contains(" ") && !author.contains("-"))) {
-        println("::error::invalid author in commit " + i + " '" + author + "' (full name?)");
+        log("::error::invalid author in commit " + i + " '" + author + "' (full name?)");
         green = false;
     }
     return green;
@@ -145,7 +145,7 @@ boolean checkSubject(int i, String subject) {
     subject = subject.substring(subject.indexOf(']')+1).strip();
     // single word subjects are likely not intended or should be squashed before merge
     if (!subject.contains(" ")) {
-        println("::error::invalid subject in commit " + i + " '" + subject + "'");
+        log("::error::invalid subject in commit " + i + " '" + subject + "'");
         return false;
     }
     return true;
@@ -155,8 +155,12 @@ boolean checkSubject(int i, String subject) {
 boolean checkBlankLineAfterSubject(int i, String blank) {
 // disabled since this would produce too many warnings due to overflowing subject lines
 //    if (!blank.isBlank()) {
-//        println("::warning::blank line after subject recommended in commit " + i + " (is subject over 50 char limit?)");
-////        return false;
+//        log("::warning::blank line after subject recommended in commit " + i + " (is subject over 50 char limit?)");
+// //       return false;
 //    }
     return true;
+}
+
+void log(String msg) {
+    System.out.println(msg);
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,9 +60,16 @@ env:
   # what to build and test, see nbbuild/cluster.properties
   CLUSTER_CONFIG: 'full'
   
-  # default java distribution used by the setup-java action
+  # default java distribution used by the setup-java action across jobs
   # see https://github.com/actions/setup-java#supported-distributions
-  DEFAULT_JAVA_DISTRIBUTION: 'zulu'
+  # CI requirements:
+  #  - timely GA releases (no delays if possible)
+  #  - EA builds must be available for the upcoming release (note: some vendors skip builds)
+  #  - linux, win, mac (arm)
+  #  - reliable / no extra sauce
+  DEFAULT_JAVA_DISTRIBUTION: 'temurin'
+#  DEFAULT_JAVA_DISTRIBUTION: 'sapmachine'
+#  DEFAULT_JAVA_DISTRIBUTION: 'zulu'
 
   # labels are mapped to env vars for pipeline customization. If this is not a PR, (almost) everything will run, but with a reduced matrix.
   # note: env vars don't work in the job's 'if' field but do work within jobs ( https://github.com/actions/runner/issues/1189 ), the whole expression must be duplicated
@@ -133,7 +140,7 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        java: [ '17', '21', '24' ]
+        java: [ '17', '21', '25-ea' ]
         exclude:
           - java: ${{ github.event_name == 'pull_request' && 'nothing' || '21' }}
       fail-fast: false
@@ -238,7 +245,7 @@ jobs:
         java: [ 17 ]
         include:
           - os: ubuntu-latest
-            java: 24
+            java: 25-ea
       fail-fast: false
     steps:
 
@@ -314,16 +321,16 @@ jobs:
           submodules: false
           show-progress: false
 
-      - name: Set up JDK 24 for scripts
+      - name: Set up JDK 25 for scripts
         if: ${{ github.event_name == 'pull_request' && !cancelled() }}
         uses: actions/setup-java@v4
         with:
-          java-version: 24
+          java-version: 25-ea
           distribution: ${{ env.DEFAULT_JAVA_DISTRIBUTION }}
 
       - name: Check Commit Headers
         if: ${{ github.event_name == 'pull_request' && !cancelled() }}
-        run: java --enable-preview .github/scripts/CommitHeaderChecker.java ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+        run: java .github/scripts/CommitHeaderChecker.java ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 
       - name: Set up JDK ${{ matrix.java }} 
         if: ${{ !cancelled() }}
@@ -848,7 +855,7 @@ jobs:
     timeout-minutes: 50
     strategy:
       matrix:
-        java: [ '17', '21', '24' ]
+        java: [ '17', '21', '25-ea' ]
         exclude:
           - java: ${{ github.event_name == 'pull_request' && 'nothing' || '21' }}
       fail-fast: false
@@ -1455,6 +1462,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
+        # TODO bump together with nb-javac 25 update
         java: [ '17', '24' ]
         config: [ 'batch1', 'batch2' ]
         exclude:
@@ -1512,7 +1520,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '17', '21', '24' ]
+        java: [ '17', '21', '25-ea' ]
         exclude:
           - java: ${{ github.event_name == 'pull_request' && 'nothing' || '21' }}
       fail-fast: false

--- a/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/EvaluatorApp.java
+++ b/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/EvaluatorApp.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Vector;
 
 /**
@@ -727,15 +728,15 @@ public class EvaluatorApp extends BaseClass {
     }
     
     public static boolean testOp36c() {
-        return (Runtime.getRuntime() instanceof java.lang.Iterable);
+        return (System.getProperties() instanceof java.lang.AutoCloseable);
     }
     
     public static boolean testOp36d() {
-        return (Runtime.getRuntime() instanceof Runtime);
+        return (System.getProperties() instanceof Properties);
     }
     
     public static boolean testOp36e() {
-        return (Runtime.getRuntime() instanceof Object);
+        return (System.getProperties() instanceof Object);
     }
     
     public static int testOp37a() {


### PR DESCRIPTION
 - bump upper bound from JDK 24 to 25ea
 - switch to temurin due to EA build availability (fails below b22, also see brute forced [JDK matrix](https://gist.github.com/mbien/7911a1272e2bc77234cd7ffca35cdcb4)) 
 - `--enable-preview` can be removed from a build script since "compact source files" are going final ([JEP 512](https://openjdk.org/jeps/512))
 - java hints job (and javadoc build) remains on JDK 24 until new nb-javac is integrated
 - `EvaluatorTest`: updated test data since `java.lang.Runtime` is now final (see below)

a test file seems to hit a JDK 25 ~compiler regression~ API change, `Runtime` is now final (https://github.com/openjdk/jdk/pull/22389):
```
 [nb-javac] /home/runner/work/netbeans/netbeans/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/testapps/EvaluatorApp.java:730: error: incompatible types: Runtime cannot be converted to Iterable
 [nb-javac]         return (Runtime.getRuntime() instanceof java.lang.Iterable);
```
