### PR TITLE
fixing formatter issues

### DIFF
--- a/ide/editor.document/src/org/netbeans/api/editor/document/LineDocumentUtils.java
+++ b/ide/editor.document/src/org/netbeans/api/editor/document/LineDocumentUtils.java
@@ -30,7 +30,6 @@ import org.netbeans.lib.editor.util.swing.DocumentUtilities;
 import org.netbeans.modules.editor.document.DocumentServices;
 import org.netbeans.modules.editor.document.TextSearchUtils;
 import org.netbeans.modules.editor.document.implspi.CharClassifier;
-import org.netbeans.modules.editor.lib2.AcceptorFactory;
 import org.netbeans.spi.editor.document.DocumentFactory;
 import org.openide.util.Lookup;
 

--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
@@ -2565,7 +2565,39 @@ public class Reformatter implements ReformatTask {
             StatementTree elseStat = node.getElseStatement();
             CodeStyle.BracesGenerationStyle redundantIfBraces = cs.redundantIfBraces();
             int eoln = findNewlineAfterStatement(node);
-            if ((elseStat != null && redundantIfBraces == CodeStyle.BracesGenerationStyle.ELIMINATE && danglingElseChecker.hasDanglingElse(node.getThenStatement())) ||
+            Boolean hasErrThenStatement = Optional.ofNullable(node.getThenStatement())
+                    .filter(it-> it instanceof ExpressionStatementTree)
+                    .map(it -> ((ExpressionStatementTree)it).getExpression())
+                    .map(it->  (it instanceof ErroneousTree))
+                    .orElse(false);
+            if (hasErrThenStatement) {
+                if (getCurrentPath().getParentPath().getLeaf() instanceof BlockTree parentStTree) {
+                    var isPreviousIfTree = false;
+                    var endPositionOfErrThenStatement = endPos;
+                    for (var statment : parentStTree.getStatements()) {
+                        if (isPreviousIfTree) {
+                            var startPositionOfNextErrorStatement = (int) sp.getStartPosition(getCurrentPath().getCompilationUnit(), statment);
+                            endPositionOfErrThenStatement = startPositionOfNextErrorStatement;
+                            break;
+                        } else if (statment == node) {
+                            isPreviousIfTree = true;
+                            endPositionOfErrThenStatement = (int) sp.getEndPosition(getCurrentPath().getCompilationUnit(), parentStTree) - 1;
+                        }
+
+                    }
+                    if (isPreviousIfTree) {
+                        while (tokens.offset() <= endPositionOfErrThenStatement && endPositionOfErrThenStatement != -1) {
+                            tokens.moveNext();
+                        }
+                        tokens.movePrevious();
+                        if (endPositionOfErrThenStatement != -1) {
+                            endPos = endPositionOfErrThenStatement;
+                        }
+                    }
+                }
+            }
+            
+            if (hasErrThenStatement || (elseStat != null && redundantIfBraces == CodeStyle.BracesGenerationStyle.ELIMINATE && danglingElseChecker.hasDanglingElse(node.getThenStatement())) ||
                     (redundantIfBraces == CodeStyle.BracesGenerationStyle.GENERATE && (startOffset > sp.getStartPosition(root, node) || endOffset < eoln || node.getCondition().getKind() == Tree.Kind.ERRONEOUS))) {
                 redundantIfBraces = CodeStyle.BracesGenerationStyle.LEAVE_ALONE;
             }

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
@@ -1556,6 +1556,76 @@ public class FormatingTest extends NbTestCase {
         preferences.putBoolean("specialElseIf", false);
         reformat(doc, content, golden);
         preferences.putBoolean("specialElseIf", true);
+        
+       content = """
+                  package hierbas.del.litoral;
+                  class Test extends Integer implements Runnable, Serializable{
+                  public void run(){
+                     if ("foo".contains("bar"))))) )))  {
+                                System.out.println("bar");
+                    }
+                  }
+                  }
+                 """;
+        golden = """
+                 package hierbas.del.litoral;
+                 
+                 class Test extends Integer implements Runnable, Serializable {
+                 
+                     public void run() {
+                         if ("foo".contains("bar"))))) )))  {
+                             System.out.println("bar");
+                         }
+                     }
+                 }
+                 """;
+       reformat(doc, content, golden);
+       
+       content = """
+                  package hierbas.del.litoral;
+                  class Test extends Integer implements Runnable, Serializable{
+                  public void run(){
+                     if ("foo".contains("bar"))))) ))) 
+                  }
+                  }
+                 """;
+        golden = """
+                 package hierbas.del.litoral;
+                 
+                 class Test extends Integer implements Runnable, Serializable {
+                 
+                     public void run() {
+                         if ("foo".contains("bar"))))) )))
+                     }
+                 }
+                 """;
+       reformat(doc, content, golden);
+       
+       content = """
+                  package hierbas.del.litoral;
+                  class Test extends Integer implements Runnable, Serializable{
+                  public void run(){
+                     if ("foo".contains("bar"))))) ))) 
+                 else {
+                       System.out.println("bar2")
+                    }
+                  }
+                  }
+                 """;
+        golden = """
+                 package hierbas.del.litoral;
+                 
+                 class Test extends Integer implements Runnable, Serializable {
+                 
+                     public void run() {
+                         if ("foo".contains("bar"))))) )))
+                 else {
+                                     System.out.println("bar2")
+                                 }
+                     }
+                 }
+                 """;
+       reformat(doc, content, golden);
     }
 
     public void testWhile() throws Exception {


### PR DESCRIPTION
providing fix for [issue](https://github.com/apache/netbeans/issues/8483)

- **root cause**:
	- a pair of `{}` of braces are injected at the erroneous then part in IfTree
	- improper end position of erroneous block as `sp.getStartPosition` and `sp.getEndPosition` always returns begining index for erroneous then statement
	- due to above issues new braces were injected,  new lines and indentation has issues which was causing more problems in user experience while formatting long files