### PR TITLE
Improve/fix handling of XML Catalogs

### DIFF
--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/XCatalogCustomizer.form
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/XCatalogCustomizer.form
@@ -87,7 +87,7 @@
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="0" gridY="1" gridWidth="3" gridHeight="0" fill="1" ipadX="0" ipadY="0" insetsTop="12" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="1.0" weightY="1.0"/>
+          <GridBagConstraints gridX="0" gridY="2" gridWidth="3" gridHeight="2" fill="1" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="1.0" weightY="1.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -103,6 +103,19 @@
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
           <GridBagConstraints gridX="2" gridY="0" gridWidth="0" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+    <Component class="javax.swing.JLabel" name="warningLabel">
+      <Properties>
+        <Property name="foreground" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+          <Color blue="0" green="0" red="ff" type="rgb"/>
+        </Property>
+        <Property name="text" type="java.lang.String" value=" "/>
+      </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="1" gridY="1" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="12" insetsBottom="0" insetsRight="12" anchor="10" weightX="1.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/XCatalogCustomizer.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/XCatalogCustomizer.java
@@ -21,7 +21,7 @@ package org.netbeans.modules.xml.catalog.impl;
 import java.beans.*;
 import java.io.File;
 import java.net.MalformedURLException;
-import org.netbeans.modules.xml.catalog.impl.XCatalog;
+
 import static org.netbeans.modules.xml.catalog.impl.res.Bundle.*;
 
 /**
@@ -44,6 +44,8 @@ public class XCatalogCustomizer extends javax.swing.JPanel implements Customizer
         this.getAccessibleContext().setAccessibleDescription(ACSD_XCatalogCustomizer());
         locationLabel.setDisplayedMnemonic(XCatalogCustomizer_locationLabel_mne().charAt(0));
         locationTextField.getAccessibleContext().setAccessibleDescription(ACSD_locationTextField());
+
+        updateValidity();
     }
 
     /** This method is called from within the constructor to
@@ -59,6 +61,7 @@ public class XCatalogCustomizer extends javax.swing.JPanel implements Customizer
         locationTextField = new javax.swing.JTextField();
         descTextArea = new javax.swing.JTextArea();
         selectButton = new javax.swing.JButton();
+        warningLabel = new javax.swing.JLabel();
 
         setLayout(new java.awt.GridBagLayout());
 
@@ -94,13 +97,13 @@ public class XCatalogCustomizer extends javax.swing.JPanel implements Customizer
         descTextArea.setOpaque(false);
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 1;
+        gridBagConstraints.gridy = 2;
         gridBagConstraints.gridwidth = 3;
-        gridBagConstraints.gridheight = java.awt.GridBagConstraints.REMAINDER;
+        gridBagConstraints.gridheight = 2;
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 1.0;
-        gridBagConstraints.insets = new java.awt.Insets(12, 0, 0, 0);
+        gridBagConstraints.insets = new java.awt.Insets(6, 0, 0, 0);
         add(descTextArea, gridBagConstraints);
 
         java.util.ResourceBundle bundle = java.util.ResourceBundle.getBundle("org/netbeans/modules/xml/catalog/impl/res/Bundle"); // NOI18N
@@ -116,6 +119,17 @@ public class XCatalogCustomizer extends javax.swing.JPanel implements Customizer
         gridBagConstraints.gridwidth = java.awt.GridBagConstraints.REMAINDER;
         gridBagConstraints.insets = new java.awt.Insets(0, 12, 0, 0);
         add(selectButton, gridBagConstraints);
+
+        warningLabel.setForeground(new java.awt.Color(255, 0, 0));
+        warningLabel.setText(" ");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 1;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.insets = new java.awt.Insets(6, 12, 0, 12);
+        add(warningLabel, gridBagConstraints);
     }// </editor-fold>//GEN-END:initComponents
 
     private void selectButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_selectButtonActionPerformed
@@ -125,6 +139,7 @@ public class XCatalogCustomizer extends javax.swing.JPanel implements Customizer
             String location = f.toURL().toExternalForm();
             locationTextField.setText(location);
             model.setSource(location);
+            updateValidity();
         } catch (MalformedURLException ex) {
             // ignore
         }
@@ -135,11 +150,13 @@ public class XCatalogCustomizer extends javax.swing.JPanel implements Customizer
     private void locationTextFieldFocusLost(java.awt.event.FocusEvent evt) {//GEN-FIRST:event_locationTextFieldFocusLost
         //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("FocusLost-setting location: " + locationTextField.getText()); // NOI18N
         model.setSource(locationTextField.getText());
+        updateValidity();
     }//GEN-LAST:event_locationTextFieldFocusLost
 
     private void locationTextFieldActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_locationTextFieldActionPerformed
         //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("ActionPerformed-setting location: " + locationTextField.getText()); // NOI18N
         model.setSource(locationTextField.getText());
+        updateValidity();
     }//GEN-LAST:event_locationTextFieldActionPerformed
 
     /**
@@ -152,6 +169,7 @@ public class XCatalogCustomizer extends javax.swing.JPanel implements Customizer
         
         model = (XCatalog) peer;        
         locationTextField.setText(model.getSource());
+        updateValidity();
     }    
 
     public void addPropertyChangeListener(java.beans.PropertyChangeListener p1) {
@@ -159,12 +177,17 @@ public class XCatalogCustomizer extends javax.swing.JPanel implements Customizer
     
     public void removePropertyChangeListener(java.beans.PropertyChangeListener p1) {
     }
-    
+
+    private void updateValidity() {
+        warningLabel.setText((model != null && ! model.isValid()) ? TEXT_catalog_not_valid() : " ");
+    }
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JTextArea descTextArea;
     private javax.swing.JLabel locationLabel;
     private javax.swing.JTextField locationTextField;
     private javax.swing.JButton selectButton;
+    private javax.swing.JLabel warningLabel;
     // End of variables declaration//GEN-END:variables
 
 }

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/res/Bundle.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/res/Bundle.java
@@ -93,4 +93,8 @@ public class Bundle {
     public static String DESC_xcatalog_fmts() {
         return NbBundle.getMessage(Bundle.class, "DESC_xcatalog_fmts");
     }
+
+    public static String TEXT_catalog_not_valid() {
+        return NbBundle.getMessage(Bundle.class, "TEXT_catalog_not_valid");
+    }
 }

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/res/Bundle.properties
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/res/Bundle.properties
@@ -43,3 +43,5 @@ XCatalogCustomizer.locationLabel.text=XML Catalog URL:
 ACSD_locationTextField=n/a
 
 PROP_choose_file=Browse...
+
+TEXT_catalog_not_valid=Catalog does not seem to be valid.

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/sun/CatalogCustomizer.form
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/sun/CatalogCustomizer.form
@@ -94,7 +94,7 @@
       </Events>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="1" gridY="-1" gridWidth="0" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="12" insetsLeft="12" insetsBottom="0" insetsRight="11" anchor="18" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="1" gridY="-1" gridWidth="0" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="12" insetsBottom="6" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -122,7 +122,20 @@
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="0" gridHeight="0" fill="1" ipadX="0" ipadY="0" insetsTop="12" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="1.0" weightY="1.0"/>
+          <GridBagConstraints gridX="0" gridY="3" gridWidth="0" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="1.0" weightY="1.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+    <Component class="javax.swing.JLabel" name="warningLabel">
+      <Properties>
+        <Property name="foreground" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+          <Color blue="0" green="0" red="ff" type="rgb"/>
+        </Property>
+        <Property name="text" type="java.lang.String" value=" "/>
+      </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="1" gridY="2" gridWidth="2" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="12" insetsBottom="6" insetsRight="12" anchor="10" weightX="1.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/sun/CatalogCustomizer.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/sun/CatalogCustomizer.java
@@ -53,6 +53,8 @@ public class CatalogCustomizer extends javax.swing.JPanel implements Customizer 
         
         selectButton.setMnemonic(MNE_file().charAt(0));
         selectButton.getAccessibleContext().setAccessibleDescription(ACSD_file());
+
+        updateValidity();
     }
 
     /** This method is called from within the constructor to
@@ -69,6 +71,7 @@ public class CatalogCustomizer extends javax.swing.JPanel implements Customizer 
         selectButton = new javax.swing.JButton();
         preferCheckBox = new javax.swing.JCheckBox();
         descTextArea = new javax.swing.JTextArea();
+        warningLabel = new javax.swing.JLabel();
 
         setLayout(new java.awt.GridBagLayout());
 
@@ -117,7 +120,7 @@ public class CatalogCustomizer extends javax.swing.JPanel implements Customizer 
         gridBagConstraints.gridwidth = java.awt.GridBagConstraints.REMAINDER;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
-        gridBagConstraints.insets = new java.awt.Insets(12, 12, 0, 11);
+        gridBagConstraints.insets = new java.awt.Insets(6, 12, 6, 12);
         add(preferCheckBox, gridBagConstraints);
 
         descTextArea.setEditable(false);
@@ -132,13 +135,25 @@ public class CatalogCustomizer extends javax.swing.JPanel implements Customizer 
         descTextArea.setEnabled(false);
         descTextArea.setOpaque(false);
         gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 3;
         gridBagConstraints.gridwidth = java.awt.GridBagConstraints.REMAINDER;
-        gridBagConstraints.gridheight = java.awt.GridBagConstraints.REMAINDER;
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 1.0;
-        gridBagConstraints.insets = new java.awt.Insets(12, 0, 0, 0);
+        gridBagConstraints.insets = new java.awt.Insets(6, 0, 0, 0);
         add(descTextArea, gridBagConstraints);
+
+        warningLabel.setForeground(new java.awt.Color(255, 0, 0));
+        warningLabel.setText(" ");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 2;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.insets = new java.awt.Insets(6, 12, 6, 12);
+        add(warningLabel, gridBagConstraints);
     }// </editor-fold>//GEN-END:initComponents
 
     private void selectButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_selectButtonActionPerformed
@@ -148,6 +163,7 @@ public class CatalogCustomizer extends javax.swing.JPanel implements Customizer 
             String location = f.toURL().toExternalForm();
             locationTextField.setText(location);
             model.setLocation(location);
+            updateValidity();
         } catch (MalformedURLException ex) {
             // ignore
         }
@@ -162,11 +178,13 @@ public class CatalogCustomizer extends javax.swing.JPanel implements Customizer 
     private void locationTextFieldFocusLost(java.awt.event.FocusEvent evt) {//GEN-FIRST:event_locationTextFieldFocusLost
         //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("FocusLost-setting location: " + locationTextField.getText()); // NOI18N
         model.setLocation(locationTextField.getText());
+        updateValidity();
     }//GEN-LAST:event_locationTextFieldFocusLost
 
     private void locationTextFieldActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_locationTextFieldActionPerformed
         //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("ActionPerformed-setting location: " + locationTextField.getText()); // NOI18N
         model.setLocation(locationTextField.getText());
+        updateValidity();
     }//GEN-LAST:event_locationTextFieldActionPerformed
 
     /**
@@ -180,12 +198,17 @@ public class CatalogCustomizer extends javax.swing.JPanel implements Customizer 
         model = (Catalog) peer;        
         locationTextField.setText(model.getLocation());
         preferCheckBox.setSelected(model.isPreferPublic());
+        updateValidity();
     }    
 
     public void addPropertyChangeListener(java.beans.PropertyChangeListener p1) {
     }
     
     public void removePropertyChangeListener(java.beans.PropertyChangeListener p1) {
+    }
+
+    private void updateValidity() {
+        warningLabel.setText((model != null && ! model.isValid()) ? TEXT_catalog_not_valid() : " ");
     }
     
     // Variables declaration - do not modify//GEN-BEGIN:variables
@@ -194,6 +217,7 @@ public class CatalogCustomizer extends javax.swing.JPanel implements Customizer 
     private javax.swing.JTextField locationTextField;
     private javax.swing.JCheckBox preferCheckBox;
     private javax.swing.JButton selectButton;
+    private javax.swing.JLabel warningLabel;
     // End of variables declaration//GEN-END:variables
 
 }

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/sun/res/Bundle.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/sun/res/Bundle.java
@@ -89,4 +89,8 @@ public final class Bundle {
     public static String DESC_catalog_fmts() {
         return NbBundle.getMessage(Bundle.class, "DESC_catalog_fmts");
     }
+
+    public static String TEXT_catalog_not_valid() {
+        return NbBundle.getMessage(Bundle.class, "TEXT_catalog_not_valid");
+    }
 }

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/sun/res/Bundle.properties
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/impl/sun/res/Bundle.properties
@@ -37,3 +37,4 @@ PROP_catalog_name_desc=Name that identifies catalog.
 PROP_catalog_info=Catalog Info
 PROP_catalog_info_desc=Describes actual catalog state.
 
+TEXT_catalog_not_valid=Catalog does not seem to be valid.

--- a/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/XCatalog.java
+++ b/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/XCatalog.java
@@ -524,4 +524,13 @@ public final class XCatalog extends AbstractCatalog
 
     }
 
+    /**
+     * Check validity of the current entry. Only to be used by GUI!
+     */
+    public boolean isValid() {
+        return getPublicMappingKeys().hasNext()
+                || getSystemMappingKeys().hasNext()
+                || getDelegateCatalogKeys().hasMoreElements()
+                || (! extenders.isEmpty());
+    }
 }

--- a/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/XCatalog.java
+++ b/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/XCatalog.java
@@ -18,9 +18,7 @@
  */
 package org.netbeans.modules.xml.catalog.impl;
 
-import java.awt.*;
 import java.io.*;
-import java.beans.*;
 import java.util.*;
 
 import org.xml.sax.*;
@@ -41,42 +39,45 @@ import org.netbeans.modules.xml.catalog.lib.*;
  */
 public final class XCatalog extends AbstractCatalog
        implements CatalogReader, CatalogDescriptor2, Serializable, EntityResolver {
-    
+
     /** Serial Version UID MUST NOT change. */
     private static final long serialVersionUID = 06022001L;
-    
+
 
     // ~~~~~~~~~~~~~~~ 0.4 grammar ~~~~~~~~~~~~~~~~~~
     public static final String DTD_PUBLIC_ID_4 = "-//DTD XMLCatalog//EN"; // NOI18N
-       
+
     /** XCatalog DTD resource name ("xcatalog.dtd"). */
+    @SuppressWarnings("unused")
     static final String DTD = "xcatalog.dtd"; // NOI18N
-    
+
     // tag and attribute names
-    
+
     /** PublicID attribute name ("PublicID"). */
     static final String PUBLICID_ATT_4 = "PublicId"; // NOI18N
-    
+
     /** SystemID attribute name ("SystemID"). */
     static final String SYSTEMID_ATT_4 = "SystemID"; // NOI18N
-    
+
     // ~~~~~~~~~~~~~~~~~~~~ 0.2 grammar ~~~~~~~~~~~~~~~~~~~
 
     public static final String DTD_PUBLIC_ID_2 = "-//DTD XCatalog//EN"; // NOI18N
 
     /** XCatalog element name ("XCatalog"). */
+    @SuppressWarnings("unused")
     static final String XCATALOG_2 = "XMLCatalog"; // NOI18N
 
     /** XML Catalog version */
+    @SuppressWarnings("unused")
     static final String VERSION_2 = "Version"; // NOI18N
-    
-    
+
+
     /** PublicID attribute name ("PublicID"). */
     static final String PUBLICID_ATT_2 = "PublicID"; // NOI18N
-     
+
     /** SystemID attribute name ("SystemID"). */
     static final String SYSTEMID_ATT_2 = "SystemID"; // NOI18N
-    
+
     // ~~~~~~~~~~~~~~~~~~~ 0.X grammar ~~~~~~~~~~~~~~~~~~~~`
 
     static final String MAP = "Map"; // NOI18N
@@ -91,20 +92,20 @@ public final class XCatalog extends AbstractCatalog
 
     static final String HREF_ATT = "HRef"; // NOI18N
 
-    
+
     /**
      * @serial Only catalog location is serialized.
      */
     private String catalogSrc = null;
-    
+
     private transient String shortDescription;
-    
+
     private transient String icon;
-    
-    
+
+
     // INIT ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    
-    
+
+
     /**
      * Constructs an XCatalog instance.
      */
@@ -119,36 +120,36 @@ public final class XCatalog extends AbstractCatalog
         loadCatalog(catalogSrc);  //!!! loading catalog during deserialization. Could be deferred
     }
 
-    
+
     // Catalog loading (and error handling) ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    
-    
+
+
     /**
      * Load catalog from given URL.
      */
+    @SuppressWarnings("ResultOfObjectAllocationIgnored")
     public void loadCatalog(String systemID) {
         try {
 
             clearAll();
-            
-            if (systemID == null) return;  //balk it
-            
-            new CatalogParser(new InputSource(systemID));
-            
-            updateShortDescription(catalogSrc);
-            updateIcon(getDefaultIcon(0));             //!!! icon type should be deffered 
 
-            
-        } catch (SAXException ex) {
-            handleLoadError(ex);
-        } catch (IOException ex) {
+            if (systemID == null) return;  //balk it
+
+            // Side effect is getting the result of parsing
+            new CatalogParser(new InputSource(systemID));
+
+            updateShortDescription(catalogSrc);
+            updateIcon(getDefaultIcon(0));             //!!! icon type should be deffered
+
+
+        } catch (SAXException | IOException ex) {
             handleLoadError(ex);
         } finally {
             notifyInvalidate();
-        }            
+        }
     }
-    
-    
+
+
     private void handleLoadError(Exception ex) {
         updateShortDescription(ex.getLocalizedMessage());
         updateIcon(getDefaultErrorIcon(0));               //!!!
@@ -163,13 +164,13 @@ public final class XCatalog extends AbstractCatalog
         shortDescription = loc;
         firePropertyChange(PROP_CATALOG_DESC, old, shortDescription);
     }
-    
+
     /** Update and fire. */
     private void updateIcon(String newIcon) {
         icon = newIcon;
         firePropertyChange(PROP_CATALOG_ICON, null, null);
     }
-    
+
     // Properties (serialized) ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     /**
@@ -181,9 +182,9 @@ public final class XCatalog extends AbstractCatalog
     public void setSource(String source) {
         catalogSrc = source;
         loadCatalog(source);
-        firePropertyChange(PROP_CATALOG_NAME, null, getDisplayName());        
+        firePropertyChange(PROP_CATALOG_NAME, null, getDisplayName());
     }
-    
+
     /**
      * @return currently catalog location URL, the URL may be invalid
      */
@@ -192,23 +193,25 @@ public final class XCatalog extends AbstractCatalog
     }
 
 
-    // Catalog Reader Interface ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
-        
+    // Catalog Reader Interface ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
     /**
      * Reload the catalog from its original location.
      */
+    @Override
     public void refresh() {
         //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("Refreshing catalog...impl..."); // NOI18N
 
         loadCatalog(getSource());
     }
-    
-    
-    // Catalog Descriptor Interface ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
-    
+
+
+    // Catalog Descriptor Interface ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
     /**
      * Return display name of this reader (e.g. "XCatalog Reader" or "SOCAT Reader"
      */
+    @Override
     public String getDisplayName() {
         String location = catalogSrc;
         if (location == null || "".equals(location.trim())) {
@@ -217,17 +220,20 @@ public final class XCatalog extends AbstractCatalog
             return NbBundle.getMessage(XCatalog.class, "PROP_display_name", catalogSrc);
         }
     }
-        
+
+    @Override
     public String getIconResource(int type) {
         // let the node to get the icon from the BeanInfo
         return icon;
     }
-    
+
+    @Override
     public String getShortDescription() {
         return shortDescription;
     }
-    
 
+
+    @Override
     public String toString() {
         return super.toString() + ":" + catalogSrc; // NOI18N
     }
@@ -241,33 +247,34 @@ public final class XCatalog extends AbstractCatalog
         }
         return false;
     }
-    
+
 
     public int hashCode() {
         return catalogSrc != null ? catalogSrc.hashCode() : 0;
     }
-    
+
 */
-    
+
     // Entity resolver interface ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    
-        
+
+
     /**
      * Resolves external entities using this catalog.
      * @see org.xml.sax.EntityResolver#resolveEntity(String,String)
      */
+    @Override
     public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
-        
+
         //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("resolveEntity(\""+publicId+"\", \""+systemId+"\")"); // NOI18N
-                
+
         // public identifier resolution
         if (publicId != null) {
-            
+
             // direct public id mappings
             String value = getPublicMapping(publicId);
 
             //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("  map: \""+publicId+"\" -> \""+value+"\""); // NOI18N
-            
+
             if (value != null) {
                 InputSource source = resolveEntity(null, value);
                 if (source == null) {
@@ -276,7 +283,7 @@ public final class XCatalog extends AbstractCatalog
                 source.setPublicId(publicId);
                 return source;
             }
-            
+
             // delegates
             Enumeration delegates = getDelegateCatalogKeys();
             while (delegates.hasMoreElements()) {
@@ -293,7 +300,7 @@ public final class XCatalog extends AbstractCatalog
                 }
             }
         }
-        
+
         // system identifier resolution
         String value = getSystemMapping(systemId);
         if (value != null) {
@@ -303,7 +310,7 @@ public final class XCatalog extends AbstractCatalog
             source.setPublicId(publicId);
             return source;
         }
-        
+
 
         // try extenders
         Iterator it = extenders.iterator();
@@ -317,189 +324,187 @@ public final class XCatalog extends AbstractCatalog
         //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("  returning null!"); // NOI18N
 
         return null;
-        
-    }
-    
 
-    
+    }
+
+
+
     // Catalog parsing classes ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    
+
     /**
      * Parser for XML Catalog document instances.
      * SAX 2 is used only to avoid deprecation messages.
      */
     private class CatalogParser extends DefaultHandler {
-                
+
         /** Current base. */
         private String base;
-                
+
         /** Parses the specified input source. */
+        @SuppressWarnings("LeakingThisInConstructor")
         public CatalogParser(InputSource source) throws SAXException, IOException {
-            
+
             XMLReader parser = XMLUtil.createXMLReader(true);
-            
+
             // setup parser
             parser.setEntityResolver(new Resolver());  // overwrite system entity resolver
             parser.setContentHandler(this);
             parser.setErrorHandler(this);
-            
+
             // set initial base and parse
             setBase(source.getSystemId());
             parser.parse(source);
-            
+
         }
-        
-        
+
+
         /**
          * Sets the base from the given system identifier. The base is
          * the same as the system identifier with the least significant
          * part (the filename) removed.
          */
+        @SuppressWarnings("AssignmentToMethodParameter")
         private void setBase(String systemId) throws SAXException {
-            
+
             // normalize system id
             if (systemId == null) {
                 systemId = ""; // NOI18N
             }
-            
+
             // cut off the least significant part
             int index = systemId.lastIndexOf('/');
             if (index != -1) {
                 systemId = systemId.substring(0, index + 1);
             }
-            
+
             // save base
             base = systemId;
-            
+
         }
-        
+
 
         //~~~~~~~~~~~~~~~~~ XCATALOG ATTRIBUTES SCANNER ~~~~~~~~~~~~~~~~~~~~~
-        
+
         /** Stop parsing on fatal error. */
         public void fatalError(SAXException ex) throws SAXException {
             throw ex;
         }
-        
+
         /** Stop parsing on error*/
         public void error(SAXException ex) throws SAXException {
             throw ex;
         }
-        
-        /** 
+
+        /**
           * The start of an element. Parse attributes.
           */
+        @Override
         public void startElement(String ns, String local, String qName, Attributes attrList) throws SAXException {
-            
+
             try {
-                
+
                 // <XCatalog Version="...">
 /*                if (qName.equals(XCATALOG)) {
-                    String version = attrList.getValue(VERSION);
-                    if ("1.0".equals(version))
-                        return;
-                    throw new SAXException("Illeagal XML catalog version");
- 
-                    return;
+                String version = attrList.getValue(VERSION);
+                if ("1.0".equals(version))
+                return;
+                throw new SAXException("Illeagal XML catalog version");
+                return;
                 }
-*/                                
-                if (qName.equals(MAP)) {
-                    
-                    // <Map PublicID="..." HRef="..."/>
-                    String publicId = attrList.getValue(PUBLICID_ATT_4);
-                    if (publicId == null) publicId = attrList.getValue(PUBLICID_ATT_2);
+                 */
+                switch (qName) {
+                    case MAP:
+                        {
+                            // <Map PublicID="..." HRef="..."/>
+                            String publicId = attrList.getValue(PUBLICID_ATT_4);
+                            if (publicId == null) publicId = attrList.getValue(PUBLICID_ATT_2);
+                            String href     = attrList.getValue(HREF_ATT);
+                            //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("MAP \""+publicId+"\" \""+href+"\""); // NOI18N
 
-                    String href     = attrList.getValue(HREF_ATT);
+                            // create mapping
+                            if (Categorizer.isURL(href) == false) {
+                                href = base + href;  // seems to be relative
+                            }       if (publicId != null)
+                                addPublicMapping(publicId, href);
+                            break;
+                        }
+                    case DELEGATE:
+                        {
+                            // <Delegate PublicId="..." HRef="..."/>
+                            String publicId = attrList.getValue(PUBLICID_ATT_4);
+                            if (publicId == null) publicId = attrList.getValue(PUBLICID_ATT_2);
+                            String href     = attrList.getValue(HREF_ATT);
+                            //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("DELEGATE \""+publicId+"\" \""+href+"\""); // NOI18N
 
-                    //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("MAP \""+publicId+"\" \""+href+"\""); // NOI18N
-                    
-                    // create mapping
-                    if (Categorizer.isURL(href) == false) {
-                        href = base + href;  // seems to be relative
-                    }
-                    if (publicId != null)
-                        addPublicMapping(publicId, href);
-                    
-                } else if (qName.equals(DELEGATE)) {
-                    
-                    // <Delegate PublicId="..." HRef="..."/>
-                    String publicId = attrList.getValue(PUBLICID_ATT_4);
-                    if (publicId == null) publicId = attrList.getValue(PUBLICID_ATT_2);
-                    String href     = attrList.getValue(HREF_ATT);
-                    
-                    //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("DELEGATE \""+publicId+"\" \""+href+"\""); // NOI18N
-                    
-                    // expand system id
-                    if (Categorizer.isURL(href) == false) {
-                        href = base + href;
-                    }
-                    String systemId = href; //!!!fEntityHandler.expandSystemId(href);
-                    
-                    // create delegate
-                    XCatalog catalog = new XCatalog();
-                    catalog.loadCatalog(systemId);
-                    addDelegateCatalog(publicId, catalog);
-                    
-                } else if (qName.equals(EXTEND)) {
-                    
-                    // <Extend HRef="..."/>
-                    String href = attrList.getValue(HREF_ATT);
-                    
-                    //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("EXTEND \""+href+"\""); // NOI18N
-                    
-                    // expand system id
-                    if (Categorizer.isURL(href) == false) {
-                        href = base + href;
-                    }
-                    String systemId = href; //!!!fEntityHandler.expandSystemId(href);
-                    
-                    // create "patch/extender" catalog
-                    XCatalog extender = new XCatalog();
-                    extender.loadCatalog(systemId);
-                    extenders.add(extender);
-                    
-                } else if (qName.equals(BASE)) {
-                    
-                    // <Base HRef="..."/>
-                    String href = attrList.getValue(HREF_ATT);
-                    
-                    // set new base  //!!! new specs replaces it with XBase
-                    if (href != null) { 
-                        base = href;
-                    }
-                    //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("BASE \""+href+"\" -> \""+base+"\""); // NOI18N
-                    
-                } else if (qName.equals(REMAP)) {
-                    
-                    // <Remap SystemID="..." HRef="..."/>
-                    
-                    String systemId = attrList.getValue(SYSTEMID_ATT_4);
-                    if (systemId == null) systemId=attrList.getValue(SYSTEMID_ATT_2);
+                            // expand system id
+                            if (Categorizer.isURL(href) == false) {
+                                href = base + href;
+                            }       String systemId = href; //!!!fEntityHandler.expandSystemId(href);
+                            // create delegate
+                            XCatalog catalog = new XCatalog();
+                            catalog.loadCatalog(systemId);
+                            addDelegateCatalog(publicId, catalog);
+                            break;
+                        }
+                    case EXTEND:
+                        {
+                            // <Extend HRef="..."/>
+                            String href = attrList.getValue(HREF_ATT);
+                            //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("EXTEND \""+href+"\""); // NOI18N
 
-                    String href = attrList.getValue(HREF_ATT);
-                    
-                    //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("REMAP \""+systemId+"\" \""+href+"\""); // NOI18N
-                                        
-                    // create mapping
-                    if (Categorizer.isURL(href) == false) {
-                        href = base + href;
-                    }
-                    addSystemMapping(systemId, href);
-                    
+                            // expand system id
+                            if (Categorizer.isURL(href) == false) {
+                                href = base + href;
+                            }       String systemId = href; //!!!fEntityHandler.expandSystemId(href);
+                            // create "patch/extender" catalog
+                            XCatalog extender = new XCatalog();
+                            extender.loadCatalog(systemId);
+                            extenders.add(extender);
+                            break;
+                        }
+                    case BASE:
+                        {
+                            // <Base HRef="..."/>
+                            String href = attrList.getValue(HREF_ATT);
+                            // set new base  //!!! new specs replaces it with XBase
+                            if (href != null) {
+                                base = href;
+                            }
+                            //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("BASE \""+href+"\" -> \""+base+"\""); // NOI18N
+                            break;
+                        }
+                    case REMAP:
+                        {
+                            // <Remap SystemID="..." HRef="..."/>
+
+                            String systemId = attrList.getValue(SYSTEMID_ATT_4);
+                            if (systemId == null) systemId=attrList.getValue(SYSTEMID_ATT_2);
+                            String href = attrList.getValue(HREF_ATT);
+                            //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("REMAP \""+systemId+"\" \""+href+"\""); // NOI18N
+
+                            // create mapping
+                            if (Categorizer.isURL(href) == false) {
+                                href = base + href;
+                            }       addSystemMapping(systemId, href);
+                            break;
+                        }
+                    default:
+                        break;
                 }
-                
+
             } catch (Exception e) {
                 throw new SAXException(e);
             }
-            
+
         }
-        
-        
+
+
         private class Resolver implements EntityResolver {
-            
+
             /** Resolves the XCatalog DTD entity. */
+            @Override
             public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
-                
+
                 // parser does not validate, let skip DTD
                 if (DTD_PUBLIC_ID_2.equals(publicId) || DTD_PUBLIC_ID_4.equals(publicId)) {
                     InputSource src = new InputSource();
@@ -509,14 +514,14 @@ public final class XCatalog extends AbstractCatalog
                     src.setCharacterStream(new InputStreamReader(is, "UTF8")); // NOI18N
                     return src;
                 }
-                
+
                 // no resolution possible
                 return null;
-                
+
             }
-            
+
         }
-        
+
     }
-    
+
 }

--- a/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/XCatalogProvider.java
+++ b/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/XCatalogProvider.java
@@ -29,7 +29,7 @@ import org.openide.util.lookup.ServiceProvider;
  * @author  Petr Kuzel
  * @version
  */
-@ServiceProvider(service = CatalogProvider.class)
+@ServiceProvider(service = CatalogProvider.class, position = 200)
 public class XCatalogProvider implements CatalogProvider {
 
     @Override

--- a/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/XCatalogProvider.java
+++ b/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/XCatalogProvider.java
@@ -32,6 +32,7 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = CatalogProvider.class)
 public class XCatalogProvider implements CatalogProvider {
 
+    @Override
     public Class provideClass() throws IOException, ClassNotFoundException {
         return XCatalog.class;
     }

--- a/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/sun/Catalog.java
+++ b/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/sun/Catalog.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.xml.catalog.impl.sun;
 
-import java.awt.Image;
 import java.io.*;
 import java.beans.*;
 import java.util.*;
@@ -43,29 +42,29 @@ import org.openide.util.NbBundle;
  *
  * @author  Petr Kuzel
  */
-public final class Catalog 
+public final class Catalog
     implements org.netbeans.modules.xml.catalog.spi.CatalogReader, CatalogDescriptorBase, Serializable, EntityResolver{
 
     private static final long serialVersionUID = 123659121L;
-        
+
     private transient PropertyChangeSupport pchs;
 
     private transient EntityResolver peer;
 
     private transient String desc;
-    
+
     // a catalog source location
     private String location;
-    
+
     // a public preference
     private boolean preference = true;
-    
+
     private static final String PROP_LOCATION = "cat-loc";
-    
+
     private static final String PROP_PREF_PUBLIC = "cat-pref";
 
     private static final String PROP_DESC = CatalogDescriptorBase.PROP_CATALOG_DESC;
-    
+
     /** Creates a new instance of Catalog */
     public Catalog() {
     }
@@ -75,19 +74,19 @@ public final class Catalog
      */
     public void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
-        
+
         // lazy init transient fields, see getPCHS() and getPeer() methods
         setShortDescription(NbBundle.getMessage(Catalog.class, "MSG_prepared", location));
     }
-    
+
     /**
      * Set Catalog source (a URL).
      */
     public synchronized void setLocation(String location) {
         String old = this.location;
         this.location = location;
-        peer = null;  // lazy init       
-        getPCHS().firePropertyChange(PROP_LOCATION, old, location);        
+        peer = null;  // lazy init
+        getPCHS().firePropertyChange(PROP_LOCATION, old, location);
         updateDisplayName();
     }
 
@@ -97,14 +96,14 @@ public final class Catalog
     public String getLocation() {
         return location;
     }
-    
+
     /**
      * Set public resolving preference.
      */
     public void setPreferPublic(boolean val) {
         boolean old = preference;
         this.preference = val;
-        getPCHS().firePropertyChange(PROP_LOCATION, old, val);
+        getPCHS().firePropertyChange(PROP_PREF_PUBLIC, old, val);
     }
 
     /**
@@ -113,28 +112,31 @@ public final class Catalog
     public boolean isPreferPublic() {
         return preference;
     }
-    
+
     /**
      * Optional operation allowing to listen at catalog for changes.
      * @throws UnsupportedOpertaionException if not supported by the implementation.
      */
+    @Override
     public void addCatalogListener(CatalogListener l) {
         throw new UnsupportedOperationException();
     }
-    
+
     /** Registers new listener.  */
+    @Override
     public void addPropertyChangeListener(PropertyChangeListener l) {
         getPCHS().addPropertyChangeListener(l);
     }
-    
+
     /**
      * @return I18N display name
      */
+    @Override
     public String getDisplayName() {
         String src = location;
         if (src == null || "".equals(src.trim())) {
             return NbBundle.getMessage(Catalog.class, "PROP_missing_location");
-        } else {        
+        } else {
             return NbBundle.getMessage(Catalog.class, "TITLE_catalog", location);
         }
     }
@@ -142,7 +144,7 @@ public final class Catalog
     public String getName() {
         return getClass() + location + preference;
     }
-    
+
     /**
      * Notify listeners that display name have changed.
      */
@@ -150,7 +152,7 @@ public final class Catalog
         String name = getDisplayName();
         getPCHS().firePropertyChange(CatalogDescriptorBase.PROP_CATALOG_NAME, null, name);
     }
-    
+
     /**
      * Return visuaized state of given catalog.
      * @param type of icon defined by JavaBeans specs
@@ -159,11 +161,12 @@ public final class Catalog
     public String getIconResource(int type) {
         return null;
     }
-    
+
     /**
      * Get String iterator representing all public IDs registered in catalog.
      * @return null if cannot proceed, try later.
      */
+    @Override
     public Iterator getPublicIDs() {
         Object p = getPeer();
         if (p instanceof org.apache.xml.resolver.tools.NbCatalogResolver) {
@@ -172,24 +175,26 @@ public final class Catalog
         }
         return null;
     }
-    
+
     /**
      * @return I18N short description
      */
+    @Override
     public String getShortDescription() {
         return desc;
     }
-    
+
     public void setShortDescription(String desc) {
         String old = this.desc;
         this.desc = desc;
         getPCHS().firePropertyChange(PROP_DESC, old, desc);
     }
-    
+
     /**
      * Get registered systemid for given public Id or null if not registered.
      * @return null if not registered
      */
+    @Override
     public String getSystemID(String publicId) {
         Object p = getPeer();
         if (p instanceof org.apache.xml.resolver.tools.NbCatalogResolver)
@@ -199,23 +204,26 @@ public final class Catalog
               catch (java.io.IOException ex) {}
         return null;
     }
-    
+
     /**
      * Refresh content according to content of mounted catalog.
      */
+    @Override
     public synchronized void refresh() {
         peer = createPeer(location, preference);
     }
-    
+
     /**
      * Optional operation couled with addCatalogListener.
      * @throws UnsupportedOpertaionException if not supported by the implementation.
      */
+    @Override
     public void removeCatalogListener(CatalogListener l) {
         throw new UnsupportedOperationException();
     }
-    
+
     /** Unregister the listener.  */
+    @Override
     public void removePropertyChangeListener(PropertyChangeListener l) {
         getPCHS().removePropertyChangeListener(l);
     }
@@ -223,10 +231,11 @@ public final class Catalog
     /**
      * Delegate entity resution process to peer if exists.
      */
-    public InputSource resolveEntity(String publicID, String systemID) throws SAXException, IOException {        
+    @Override
+    public InputSource resolveEntity(String publicID, String systemID) throws SAXException, IOException {
         return getPeer().resolveEntity(publicID, systemID);
     }
-    
+
 /** We are a key and must retain equals immutability
     public boolean equals(Object obj) {
         if (obj instanceof Catalog) {
@@ -237,17 +246,18 @@ public final class Catalog
         }
         return false;
     }
-    
-    
+
+
     public int hashCode() {
         return (location != null ? location.hashCode() : 0) ^ (preference?13:7);
     }
-*/    
+*/
     /**
      * Factory new peer and load data into it.
      * As a side effect set short description.
      * @return EntityResolver never <code>null</code>
      */
+    @SuppressWarnings("Convert2Lambda")
     private EntityResolver createPeer(String location, boolean pref) {
         try {
             NbCatalogManager manager = new NbCatalogManager(null);
@@ -263,15 +273,16 @@ public final class Catalog
             setShortDescription(NbBundle.getMessage(Catalog.class, "DESC_error_loading", ex.getLocalizedMessage()));
             //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("I/O error loading catalog " + location, ex);
         }
-        
+
         // return dumb peer
         return new EntityResolver () {
+            @Override
             public InputSource resolveEntity(String p, String s) {
                 return null;
             }
         };
     }
-    
+
     /**
      * Lazy init PropertyChangeSupport and return it.
      */
@@ -284,7 +295,7 @@ public final class Catalog
      * Lazy init peer and return it.
      */
     private synchronized EntityResolver getPeer() {
-        
+
         if (peer == null) peer = createPeer(location, preference);
         return peer;
     }
@@ -293,6 +304,7 @@ public final class Catalog
      * Get registered URI for the given name or null if not registered.
      * @return null if not registered
      */
+    @Override
     public String resolveURI(String name) {
         Object p = getPeer();
         if (p instanceof org.apache.xml.resolver.tools.NbCatalogResolver)
@@ -305,7 +317,8 @@ public final class Catalog
     /**
      * Get registered URI for the given publicId or null if not registered.
      * @return null if not registered
-     */ 
+     */
+    @Override
     public String resolvePublic(String publicId) {
         Object p = getPeer();
         if (p instanceof org.apache.xml.resolver.tools.NbCatalogResolver)
@@ -315,5 +328,5 @@ public final class Catalog
               catch (java.io.IOException ex) {}
         return null;
     }
-    
+
 }

--- a/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/sun/SunCatalogProvider.java
+++ b/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/sun/SunCatalogProvider.java
@@ -29,7 +29,7 @@ import org.openide.util.lookup.ServiceProvider;
  * @author  Petr Kuzel
  * @version
  */
-@ServiceProvider(service = CatalogProvider.class)
+@ServiceProvider(service = CatalogProvider.class, position = 100)
 public class SunCatalogProvider implements CatalogProvider {
 
     @Override

--- a/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/sun/SunCatalogProvider.java
+++ b/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/impl/sun/SunCatalogProvider.java
@@ -32,6 +32,7 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = CatalogProvider.class)
 public class SunCatalogProvider implements CatalogProvider {
 
+    @Override
     public Class provideClass() throws IOException, ClassNotFoundException {
         return Catalog.class;
     }

--- a/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/settings/CatalogSettings.java
+++ b/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/settings/CatalogSettings.java
@@ -34,7 +34,7 @@ import org.openide.util.lookup.Lookups;
 import org.openide.util.lookup.ServiceProvider;
 
 
-/** 
+/**
  * The pool holding mounted catalogs both at per project basics
  * and at at global basics. Project scope catalogs are always considered a higher
  * priority ones.
@@ -47,9 +47,9 @@ import org.openide.util.lookup.ServiceProvider;
  * <filesystem>
  * <folder name="Plugins"><folder name="XML"><folder name="UserCatalogs">
  *   <file name="org-mycompany-mymodule-MyCatalog.instance">
- *      <attr name="instanceCreate" 
+ *      <attr name="instanceCreate"
  *            methodValue="org.mycompany.mymodule.MyCatalog.createSingleton"/>
- *      <attr name="instanceOf" 
+ *      <attr name="instanceOf"
  *            stringValue="org.netbeans.modules.xml.catalog.spi.CatalogReader"/>
  *   </file>
  * </folder></folder></folder>
@@ -88,21 +88,21 @@ public final class CatalogSettings implements Externalizable {
     // ordered set of mounted catalogs
     private List mountedCatalogs = new ArrayList(5);
 
-    private PropertyChangeSupport listeners = null; 
+    private PropertyChangeSupport listeners = null;
 
     private final CatalogListener catalogListener = new CL();
-    
+
     // the only active instance in current project
     private static CatalogSettings instance = null;
-    
-    /** 
+
+    /**
      * Just for externalization purposes.
      * It MUST NOT be called directly by a user code.
      */
     public CatalogSettings() {
         init();
     }
-    
+
 
     /**
      * Initialized the instance from externalization.
@@ -110,8 +110,8 @@ public final class CatalogSettings implements Externalizable {
     private void init() {
         listeners = new PropertyChangeSupport(this);
     }
-    
-    
+
+
     /**
      * Return active settings <b>instance</b> in the only one active project.
      * @deprecated does not allow multiple opened projects
@@ -122,8 +122,8 @@ public final class CatalogSettings implements Externalizable {
         }
         return instance;
     }
-    
-    /** 
+
+    /**
      * Register mounted catalog at project scope level.
      * @param provider to be registered. Must not be null.
      */
@@ -133,10 +133,10 @@ public final class CatalogSettings implements Externalizable {
                 throw new IllegalArgumentException("null provider not permited"); // NOI18N
             if (mountedCatalogs.contains(provider) == false) {
                 mountedCatalogs.add(provider);
-            }   
+            }
         }
         firePropertyChange(PROP_MOUNTED_CATALOGS, null, null);
-        
+
         // add listener to the catalog
         try {
             provider.addCatalogListener(catalogListener);
@@ -146,23 +146,23 @@ public final class CatalogSettings implements Externalizable {
             // change
         }
     }
-    
-    /** 
-     * Deregister given catalog at project scope level. 
+
+    /**
+     * Deregister given catalog at project scope level.
      */
     public final void removeCatalog(CatalogReader provider) {
         synchronized (this) {
             mountedCatalogs.remove(provider);
         }
         firePropertyChange(PROP_MOUNTED_CATALOGS, null, null);
-        
+
         // remove listener to the catalog
         try {
             provider.removeCatalogListener(catalogListener);
         } catch (UnsupportedOperationException ex) {
             // ignore it
         }
-        
+
     }
 
     /**
@@ -176,7 +176,7 @@ public final class CatalogSettings implements Externalizable {
 
     /**
      * Return iterator of providers of given class.
-     * 
+     *
      * @param providerClasses returned providers will be assignable to it
      *                        e.g. <code>CatalogReader</code> class or <code>null</code>
      *                        as a wildcard.
@@ -186,18 +186,18 @@ public final class CatalogSettings implements Externalizable {
     public final synchronized Iterator getCatalogs(Class[] providerClasses) {
 
         // compose global registrations and local(project) registrations
-        IteratorIterator it = new IteratorIterator();                       
+        IteratorIterator it = new IteratorIterator();
         it.add(mountedCatalogs.iterator());
-        
+
         Lookup.Template template = new Lookup.Template(CatalogReader.class);
         Lookup.Result result = getUserCatalogsLookup().lookup(template);
         it.add(result.allInstances().iterator());
-        
+
         if (providerClasses == null)
             return it;
-        
+
         ArrayList list = new ArrayList();
-        
+
         while (it.hasNext()) {
             Object next = it.next();
             // provider test
@@ -212,7 +212,7 @@ public final class CatalogSettings implements Externalizable {
             if (add) list.add(next);
         }
         return list.iterator();
-    }    
+    }
 
     /**
      * Provide Lookup containing registered module catalogs.
@@ -223,46 +223,46 @@ public final class CatalogSettings implements Externalizable {
         }
         return userCatalogLookup;
     }
-    
+
     // ~~~~~~~~~~~~~~~~~~~~~~ listeners ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    
-    
+
+
     public void addPropertyChangeListener(PropertyChangeListener l){
         listeners.addPropertyChangeListener(l);
     }
-    
+
     public void removePropertyChangeListener(PropertyChangeListener l) {
         listeners.removePropertyChangeListener(l);
     }
-    
+
     private void firePropertyChange(String name, Object oldValue, Object newValue) {
         listeners.firePropertyChange(name, oldValue, newValue);
     }
-    
+
     // ~~~~~~~~~~~~~~~~~~ Persistent state ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    
-    
+
+
     /**
      * Read persistent catalog settings logging diagnostics information if needed.
      */
     public synchronized void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-        //super.readExternal(in);        
+        //super.readExternal(in);
 
         //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("CatalogSettings.readExternal()"); // NOI18N
 
         int version = in.readInt();  //IN version
-        
+
         // version switch
-        
+
         if (version != VERSION_1) throw new StreamCorruptedException("Unsupported catalog externalization protocol version (" + version + ").");  // NOI18N
-        
+
         int persistentCount = in.readInt();  //IN count
-        
+
         for (int i = 0; i<persistentCount; i++) {
 
             String catalogClass = (String) in.readObject();  //IN class name
             NbMarshalledObject marshaled = (NbMarshalledObject) in.readObject(); //IN marshalled object
-            try {              
+            try {
                 Object unmarshaled = marshaled.get();
                 if (mountedCatalogs.contains(unmarshaled) == false) {
                     mountedCatalogs.add(unmarshaled);
@@ -294,7 +294,7 @@ public final class CatalogSettings implements Externalizable {
             }
         }
     }
-    
+
     /**
      * Write persistent catalog settings as NbMarshalledObjects with some diagnostics information.
      */
@@ -304,22 +304,22 @@ public final class CatalogSettings implements Externalizable {
         //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug("CatalogSettings.writeExternal()"); // NOI18N
 
         out.writeInt(VERSION_1);  //OUT version
-        
+
         int persistentCount = 0;
 
         Iterator it = mountedCatalogs.iterator();
-        
+
         while (it.hasNext()) {
             Object next = it.next();
             if (next instanceof Serializable) {
                 persistentCount++;
-            }            
+            }
         }
-        
+
         it = mountedCatalogs.iterator();
-                
+
         out.writeInt(persistentCount);  //OUT count
-        
+
         while (it.hasNext()) {
             Object next = it.next();
             if (next instanceof Serializable) {
@@ -345,26 +345,26 @@ public final class CatalogSettings implements Externalizable {
                     );
                 }
             }
-        }        
-    }    
-        
+        }
+    }
+
     /**
      * For debugging purposes only.
      */
     @Override public String toString() {
         Lookup.Template template = new Lookup.Template<CatalogReader>(CatalogReader.class);
-        Lookup.Result result = getUserCatalogsLookup().lookup(template);        
-        return "CatalogSettings[ global-scope: " + result.allInstances() + 
+        Lookup.Result result = getUserCatalogsLookup().lookup(template);
+        return "CatalogSettings[ global-scope: " + result.allInstances() +
             ", project-scope: " + mountedCatalogs + " ]";
-    }        
-    
-    
+    }
+
+
     /**
      * Private catalog listener exposing all changes at catalogs
      * as a change at this bean, so it get saved later.
      */
     private class CL implements CatalogListener {
-    
+
         /** Given public ID has changed - disappeared.  */
         public void notifyRemoved(String publicID) {
         }
@@ -384,5 +384,5 @@ public final class CatalogSettings implements Externalizable {
             firePropertyChange("settings changed!", null, CatalogSettings.this);
         }
     }
-    
+
 }

--- a/ide/xml.catalog/test/unit/src/org/netbeans/modules/xml/catalog/impl/XCatalogTest.java
+++ b/ide/xml.catalog/test/unit/src/org/netbeans/modules/xml/catalog/impl/XCatalogTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.xml.catalog.impl;
+
+import java.net.URL;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.*;
+
+public class XCatalogTest {
+
+    @Test
+    public void testXCatalogReportedValid() throws Exception {
+        XCatalog catalog = new XCatalog();
+        URL locationURL = getClass().getResource("xcatalog.xml");
+        assertNotNull(locationURL);
+        String location = locationURL.toExternalForm();
+        catalog.setSource(location);
+        catalog.refresh();
+        assertTrue(catalog.isValid());
+    }
+
+    @Test
+    public void testOasisCatalogNotAcceptedAsXCatalog() throws Exception {
+        XCatalog catalog = new XCatalog();
+        URL locationURL = getClass().getResource("sun/data/catalog.xml");
+        assertNotNull(locationURL);
+        String location = locationURL.toExternalForm();
+        catalog.setSource(location);
+        catalog.refresh();
+        assertFalse(catalog.isValid());
+    }
+}

--- a/ide/xml.catalog/test/unit/src/org/netbeans/modules/xml/catalog/impl/sun/CatalogTest.java
+++ b/ide/xml.catalog/test/unit/src/org/netbeans/modules/xml/catalog/impl/sun/CatalogTest.java
@@ -53,4 +53,24 @@ public final class CatalogTest extends TestCase {
 
         System.err.println("Done");
     }
+
+    public void testOasisCatalogReportedValid() throws Exception {
+        Catalog catalog = new Catalog();
+        URL locationURL = getClass().getResource("data/catalog.xml");
+        assertNotNull(locationURL);
+        String location = locationURL.toExternalForm();
+        catalog.setLocation(location);
+        catalog.refresh();
+        assertTrue(catalog.isValid());
+    }
+
+    public void testXCatalogNotAcceptedAsOasis() throws Exception {
+        Catalog catalog = new Catalog();
+        URL locationURL = getClass().getResource("../xcatalog.xml");
+        assertNotNull(locationURL);
+        String location = locationURL.toExternalForm();
+        catalog.setLocation(location);
+        catalog.refresh();
+        assertFalse(catalog.isValid());
+    }
 }

--- a/ide/xml.catalog/test/unit/src/org/netbeans/modules/xml/catalog/impl/xcatalog.xml
+++ b/ide/xml.catalog/test/unit/src/org/netbeans/modules/xml/catalog/impl/xcatalog.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<!DOCTYPE XMLCatalog PUBLIC "-//DTD XMLCatalog//EN" "nbres:/org/netbeans/modules/xml/catalog/impl/XCatalog-0_4.dtd">
+
+<XMLCatalog>
+    <Map PublicId="-//Company//Entity ID//EN" HRef="file:/path/entity.dtd" />
+</XMLCatalog>


### PR DESCRIPTION
NetBeans allows users to validate XML files against their grammars. XML Catalogs allow users to supply their own grammars and enable faster access to the DTD and schema files. NetBeans has to options:

- Users can register their DTDs and XSDs in the "User Catalog"
- Users can register XML catalog files (OASIS XML catalog, XCatalog, XMLCatalog)

There are multiple problems here:

1. The registered XML catalog file entries were not saved and thus only usable in a single session
2. The default format for XML catalog files is the OASIS XML catalog format, but this was listed as second option only
3. Registering a catalog did not give feedback, whether the catalog seemed to be correct

With this change the problems are solved:

After a restart registered catalog is still present (see the "Resolver at ..." entry):

![grafik](https://github.com/user-attachments/assets/d408ac90-8d06-41a5-9578-7746175e8918)

The first entry of the provider list is now the OASIS Catalog Resolver:

![grafik](https://github.com/user-attachments/assets/b50a2193-4e25-43b3-af87-14831e756d65)

If the catalog does not yield entries, this is shown:

![Bildschirmfoto vom 2025-05-05 18-33-56](https://github.com/user-attachments/assets/7d6e3f68-6f71-45f7-8e70-ca49b1c97e52)




Closes: #8464