### PR TITLE
Refactored configuration management for LSP module

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ClientConfigurationManager.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ClientConfigurationManager.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import org.eclipse.lsp4j.ConfigurationItem;
+import org.eclipse.lsp4j.ConfigurationParams;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.java.lsp.server.Utils;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.Lookup;
+
+/**
+ * Manages configuration settings for LSP clients
+ *
+ * @author atalati
+ */
+public class ClientConfigurationManager {
+
+    final WeakHashMap<LanguageClient, ConfigValueCache> clientCaches = new WeakHashMap<>();
+
+    private ClientConfigurationManager() {
+    }
+
+    public static ClientConfigurationManager getInstance() {
+        return SingletonHolder.INSTANCE;
+    }
+
+    private static class SingletonHolder {
+
+        private static final ClientConfigurationManager INSTANCE = new ClientConfigurationManager();
+    }
+
+    public void registerClient(LanguageClient client) {
+        clientCaches.put(client, new ConfigValueCache());
+    }
+
+    public void registerConfigChangeListener(NbCodeLanguageClient client, String section, BiConsumer<String, JsonElement> consumer) {
+        ConfigValueCache cache = clientCaches.get(client);
+        if (cache != null) {
+            cache.registerListener(section, consumer);
+        }
+    }
+
+    public void registerConfigCache(NbCodeLanguageClient client, String section) {
+        ConfigValueCache cache = clientCaches.get(client);
+        if (cache != null) {
+            cache.registerCache(section);
+        }
+    }
+
+    public CompletableFuture<JsonElement> getConfigurationUsingAltPrefix(NbCodeLanguageClient client, String config) {
+        return lookupCacheAndGetConfig(client, List.of(config), null, true)
+                .thenApply(result -> result.isEmpty() ? null : result.get(0));
+    }
+
+    public CompletableFuture<JsonElement> getConfigurationUsingAltPrefix(NbCodeLanguageClient client, String config, String scope) {
+        return lookupCacheAndGetConfig(client, List.of(config), scope, true)
+                .thenApply(result -> result.isEmpty() ? null : result.get(0));
+    }
+
+    public CompletableFuture<List<JsonElement>> getConfigurationsUsingAltPrefix(NbCodeLanguageClient client, List<String> configs) {
+        return lookupCacheAndGetConfig(client, configs, null, true);
+    }
+
+    public CompletableFuture<JsonElement> getConfiguration(NbCodeLanguageClient client, String config) {
+        return lookupCacheAndGetConfig(client, List.of(config), null, false)
+                .thenApply(result -> result.isEmpty() ? null : result.get(0));
+    }
+
+    public CompletableFuture<JsonElement> getConfiguration(NbCodeLanguageClient client, String config, String scope) {
+        return lookupCacheAndGetConfig(client, List.of(config), scope, false)
+                .thenApply(result -> result.isEmpty() ? null : result.get(0));
+    }
+
+    public CompletableFuture<List<JsonElement>> getConfigurations(NbCodeLanguageClient client, List<String> configs) {
+        return lookupCacheAndGetConfig(client, configs, null, false);
+    }
+
+    public CompletableFuture<List<JsonElement>> getConfigurations(NbCodeLanguageClient client, List<String> configs, String scope) {
+        return lookupCacheAndGetConfig(client, configs, scope, false);
+    }
+
+    private CompletableFuture<List<JsonElement>> lookupCacheAndGetConfig(NbCodeLanguageClient client, List<String> configs, String scope, boolean isAltPrefix) {
+        ConfigValueCache cache = clientCaches.get(client);
+        if (cache == null) {
+            return CompletableFuture.completedFuture(new ArrayList<>());
+        }
+        final String configPrefix = isAltPrefix ? client.getNbCodeCapabilities().getAltConfigurationPrefix() : client.getNbCodeCapabilities().getConfigurationPrefix();
+        List<ConfigurationItem> itemsToRequest = new ArrayList<>();
+        List<JsonElement> result = new ArrayList<>();
+        String prjScope = getProjectFromFileScope(scope);
+
+        for (int i = 0; i < configs.size(); i++) {
+            String config = configs.get(i);
+            String prefixedConfig = configPrefix + config;
+            JsonElement cachedValue = cache.getConfigValue(prefixedConfig, prjScope);
+            if (cachedValue != null) {
+                result.add(cachedValue);
+            } else {
+                ConfigurationItem item = new ConfigurationItem();
+                if (scope != null) {
+                    item.setScopeUri(scope);
+                }
+                item.setSection(prefixedConfig);
+                itemsToRequest.add(item);
+                result.add(null);
+            }
+        }
+
+        if (itemsToRequest.isEmpty()) {
+            return CompletableFuture.completedFuture(result);
+        }
+
+        return client.configuration(new ConfigurationParams(itemsToRequest))
+                .thenApply(clientConfigs -> {
+                    int j = 0;
+                    for (int i = 0; i < result.size(); i++) {
+                        if (result.get(i) == null) {
+                            JsonElement value = (JsonElement) clientConfigs.get(j);
+                            result.set(i, value);
+                            String prefixedConfig = configPrefix + configs.get(i);
+                            cache.cacheConfigValueIfNeeded(prefixedConfig, value, prjScope);
+                            j++;
+                        }
+                    }
+                    return result;
+                });
+    }
+
+    public void handleConfigurationChange(NbCodeLanguageClient client, JsonObject settings) {
+        ConfigValueCache cache = clientCaches.get(client);
+        if (cache != null) {
+            cache.updateCache(client, null, cache, settings);
+        }
+    }
+
+    private String getProjectFromFileScope(String scope) {
+        try {
+            if (scope == null) {
+                return null;
+            }
+            FileObject fo = Utils.fromUri(scope);
+            if(fo == null){
+                return null;
+            }
+            Project prj = FileOwnerQuery.getOwner(fo);
+            if (prj == null) {
+                return findWorkspaceFolder(fo);
+            }
+            
+            return Utils.toUri(prj.getProjectDirectory());
+        } catch (MalformedURLException ignored) {
+        }
+        return null;
+    }
+    // Copied from abstract class SingleFileOptionsQueryImpl
+    private String findWorkspaceFolder(FileObject file) {
+        Workspace workspace = Lookup.getDefault().lookup(Workspace.class);
+        if (workspace == null) {
+            return null;
+        }
+        for (FileObject workspaceFolder : workspace.getClientWorkspaceFolders()) {
+            if (FileUtil.isParentOf(workspaceFolder, file) || workspaceFolder == file) {
+                return Utils.toUri(workspaceFolder);
+            }
+        }
+
+        //in case file is a source root, and the workspace folder is nested inside the root:
+        for (FileObject workspaceFolder : workspace.getClientWorkspaceFolders()) {
+            if (FileUtil.isParentOf(file, workspaceFolder)) {
+                return Utils.toUri(workspaceFolder);
+            }
+        }
+
+        return null;
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ConfigValueCache.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ConfigValueCache.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import com.google.gson.JsonElement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import org.eclipse.lsp4j.ConfigurationItem;
+import org.eclipse.lsp4j.ConfigurationParams;
+
+/**
+ * Cache for configuration values with support for hierarchical keys and change
+ * notifications
+ *
+ * @author atalati
+ */
+public class ConfigValueCache {
+
+    private final ConcurrentHashMap<String, Object> rootCache = new ConcurrentHashMap<>();
+    private static final String ROOT_KEY_VALUE = "";
+
+    public void registerListener(String section, BiConsumer<String, JsonElement> listener) {
+        ConfigData configData = getCachedConfigData(section);
+        if (configData != null) {
+            configData.setConsumer(listener);
+        } else {
+            setConfigInTree(section, new ConfigData(listener));
+        }
+    }
+
+    public void registerCache(String section) {
+        ConfigData configData = getCachedConfigData(section);
+        if (configData == null) {
+            setConfigInTree(section, new ConfigData());
+        }
+    }
+
+    public JsonElement getConfigValue(String section, String scope) {
+        ConfigData configData = getCachedConfigData(section);
+        if (configData == null) {
+            return null;
+        } else if (scope == null) {
+            return configData.getRootValue();
+        }
+        return configData.getScopedValue(scope);
+    }
+
+    public void updateCache(NbCodeLanguageClient client, String section, Object cacheValue, JsonElement tree) {
+        if (tree == null || cacheValue == null) {
+            return;
+        }
+
+        ConfigData rootData;
+        ConfigValueCache currentCache = null;
+
+        if (isConfigDataInstance(cacheValue)) {
+            rootData = (ConfigData) cacheValue;
+        } else if (isConfigValueInstance(cacheValue)) {
+            currentCache = (ConfigValueCache) cacheValue;
+            rootData = currentCache.getRootCacheValue();
+        } else {
+            return;
+        }
+
+        if (rootData != null) {
+            rootData.setRootValue(tree);
+            try {
+                BiConsumer<String, JsonElement> consumer = rootData.getConsumer();
+                if (consumer != null) {
+                    consumer.accept(section, tree);
+                }
+            } catch (RuntimeException e) {
+            }
+            Map<String, JsonElement> scopedValuesMap = rootData.getAllScopedValues();
+            if (scopedValuesMap != null && !scopedValuesMap.isEmpty()) {
+                List<ConfigurationItem> configs = new ArrayList<>();
+                scopedValuesMap.forEach((key, value) -> {
+                    ConfigurationItem item = new ConfigurationItem();
+                    item.setScopeUri(key);
+                    item.setSection(section);
+                    configs.add(item);
+                });
+
+                client.configuration(new ConfigurationParams(configs))
+                        .thenAccept(results -> {
+                            if (results != null) {
+                                for (int i = 0; i < results.size(); i++) {
+                                    if (results.get(i) != null) {
+                                        String scopeUri = configs.get(i).getScopeUri();
+                                        rootData.setScopedValue(scopeUri, (JsonElement) results.get(i));
+                                    }
+                                }
+                            }
+                        });
+            }
+        }
+
+        if (currentCache != null && tree.isJsonObject()) {
+            if (currentCache.getRootCacheValue() != null) {
+                currentCache.getRootCacheValue().setRootValue(tree);
+            }
+            Map<String, JsonElement> entries
+                    = new HashMap<>(tree.getAsJsonObject().asMap());
+            for (Map.Entry<String, JsonElement> entry : entries.entrySet()) {
+                Object child = currentCache.getCacheData(entry.getKey());
+                String newSection = section != null ? section + "." + entry.getKey() : entry.getKey();
+                updateCache(client, newSection, child, entry.getValue());
+            }
+        }
+    }
+
+    public void cacheConfigValueIfNeeded(String section, JsonElement value, String scope) {
+        ConfigData configData = getCachedConfigData(section);
+        if (configData != null) {
+            if (scope != null) {
+                configData.setScopedValue(scope, value);
+            } else {
+                configData.setRootValue(value);
+            }
+        }
+    }
+
+    // Method used only in unit test
+    protected ConfigData getConfigData(String section) {
+        return getCachedConfigData(section);
+    }
+
+    private ConfigData getCachedConfigData(String section) {
+        if (section == null || section.isEmpty()) {
+            return null;
+        }
+
+        Object current = this;
+        String[] parts = section.split("\\.");
+
+        for (int i = 0; i <= parts.length; i++) {
+            if (!isConfigValueInstance(current)) {
+                return i == parts.length ? (ConfigData) current : null;
+            }
+            if (i == parts.length) {
+                break;
+            }
+
+            ConfigValueCache currentCache = (ConfigValueCache) current;
+            current = currentCache.getCacheData(parts[i]);
+
+            if (current == null) {
+                return null;
+            }
+        }
+
+        if (isConfigValueInstance(current)) {
+            return ((ConfigValueCache) current).getRootCacheValue();
+        }
+
+        return isConfigDataInstance(current) ? (ConfigData) current : null;
+    }
+
+    private Object getCacheData(String section) {
+        return rootCache.get(section);
+    }
+
+    private ConfigData getRootCacheValue() {
+        return (ConfigData) rootCache.get(ROOT_KEY_VALUE);
+    }
+
+    private void setRootCacheValue(ConfigData configData) {
+        rootCache.put(ROOT_KEY_VALUE, configData);
+    }
+
+    private Object put(String section, Object value) {
+        return rootCache.merge(section, value, (oldValue, newValue) -> {
+            if (value == null) {
+                return null;
+            } else if (isConfigValueInstance(oldValue) && isConfigDataInstance(newValue)) {
+                ((ConfigValueCache) oldValue).setRootCacheValue((ConfigData) newValue);
+                return oldValue;
+            } else if (isConfigDataInstance(oldValue) && isConfigValueInstance(newValue)) {
+                ((ConfigValueCache) newValue).setRootCacheValue((ConfigData) oldValue);
+            }
+            return newValue;
+        });
+    }
+
+    private void setConfigInTree(String section, ConfigData configData) {
+        if (section == null || section.isEmpty() || configData == null) {
+            return;
+        }
+
+        Object current = this;
+        String[] parts = section.split("\\.");
+
+        for (String part : Arrays.asList(parts).subList(0, parts.length - 1)) {
+            if (!isConfigValueInstance(current)) {
+                return;
+            }
+
+            Object child = ((ConfigValueCache) current).getCacheData(part);
+            if (isConfigValueInstance(child)) {
+                current = child;
+            } else {
+                ConfigValueCache configValueCache = new ConfigValueCache();
+                if (child != null) {
+                    configValueCache.setRootCacheValue((ConfigData) child);
+                }
+                current = ((ConfigValueCache) current).put(part, configValueCache);
+            }
+        }
+        if (!isConfigValueInstance(current)) {
+            return;
+        }
+        ((ConfigValueCache) current).put(parts[parts.length - 1], configData);
+    }
+
+    private boolean isConfigValueInstance(Object o) {
+        return o instanceof ConfigValueCache;
+    }
+
+    private boolean isConfigDataInstance(Object o) {
+        return o instanceof ConfigData;
+    }
+
+    // protected due to unit test requirements
+    protected class ConfigData {
+
+        private JsonElement rootValue;
+        private BiConsumer<String, JsonElement> consumer;
+        private final ConcurrentHashMap<String, JsonElement> scopedValues = new ConcurrentHashMap<>();
+
+        public ConfigData() {
+        }
+
+        public ConfigData(BiConsumer<String, JsonElement> consumer) {
+            this(null, consumer);
+        }
+
+        public ConfigData(JsonElement value) {
+            this(value, null);
+        }
+
+        public ConfigData(JsonElement value, BiConsumer<String, JsonElement> consumer) {
+            this.rootValue = value;
+            this.consumer = consumer;
+        }
+
+        public JsonElement getRootValue() {
+            return rootValue;
+        }
+
+        public void setRootValue(JsonElement value) {
+            this.rootValue = value;
+        }
+
+        public BiConsumer<String, JsonElement> getConsumer() {
+            return consumer;
+        }
+
+        public void setConsumer(BiConsumer<String, JsonElement> consumer) {
+            this.consumer = consumer;
+        }
+
+        public JsonElement getScopedValue(String fo) {
+            return scopedValues.get(fo);
+        }
+
+        public void setScopedValue(String fo, JsonElement value) {
+            this.scopedValues.put(fo, value);
+        }
+
+        public Map<String, JsonElement> getAllScopedValues() {
+            return Collections.unmodifiableMap(new HashMap<>(scopedValues));
+        }
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspServerTelemetryManager.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspServerTelemetryManager.java
@@ -166,15 +166,13 @@ public class LspServerTelemetryManager {
             if (client == null) {
                 return false;
             }
-            AtomicBoolean isEnablePreviewSet = new AtomicBoolean(false);
-            ConfigurationItem conf = new ConfigurationItem();
-            conf.setSection(client.getNbCodeCapabilities().getAltConfigurationPrefix() + "runConfig.vmOptions");
-            client.configuration(new ConfigurationParams(Collections.singletonList(conf))).thenAccept(c -> {
-                String config = ((JsonPrimitive) ((List<Object>) c).get(0)).getAsString();
-                isEnablePreviewSet.set(config.contains(this.ENABLE_PREVIEW));
+            boolean[] isEnablePreviewSet = {false};
+            ClientConfigurationManager.getInstance().getConfigurationUsingAltPrefix(client, "runConfig.vmOptions").thenAccept(c -> {
+                isEnablePreviewSet[0] = c != null && !c.getAsJsonArray().isEmpty()
+                                && c.getAsJsonArray().get(0).getAsString().contains(ENABLE_PREVIEW);
             });
             
-            return isEnablePreviewSet.get();
+            return isEnablePreviewSet[0];
         }
         
         Result result = CompilerOptionsQuery.getOptions(source);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -955,6 +955,8 @@ public final class Server {
         public CompletableFuture<InitializeResult> initialize(InitializeParams init) {
             NbCodeClientCapabilities capa = NbCodeClientCapabilities.get(init);
             client.setClientCaps(capa);
+            workspaceService.registerConfigChangeListeners();
+            textDocumentService.registerConfigChangeListeners();
             hackConfigureGroovySupport(capa);
             hackNoReuseOfOutputsForAntProjects();
             List<FileObject> projectCandidates = new ArrayList<>();
@@ -1049,44 +1051,53 @@ public final class Server {
 
         private void initializeOptions() {
             getWorkspaceProjects().thenAccept(projects -> {
-                ConfigurationItem item = new ConfigurationItem();
-                // PENDING: what about doing just one roundtrip to the client- we may request multiple ConfiguratonItems in one message ?
-                item.setSection(client.getNbCodeCapabilities().getConfigurationPrefix() + NETBEANS_JAVA_HINTS);
-                client.configuration(new ConfigurationParams(Collections.singletonList(item))).thenAccept(c -> {
-                    if (c != null && !c.isEmpty() && c.get(0) instanceof JsonObject) {
-                        textDocumentService.updateJavaHintPreferences((JsonObject) c.get(0));
-                    }
-                    else {
+                List<String> defaultConfigs = List.of(NETBEANS_JAVA_HINTS, NETBEANS_PROJECT_JDKHOME);
+                List<String> projectConfigs = List.of(NETBEANS_FORMAT, NETBEANS_JAVA_IMPORTS);
+
+                AtomicReference<FileObject> projectDirectory = new AtomicReference<>(null);
+                if (projects != null && projects.length > 0) {
+                    projectDirectory.set(projects[0].getProjectDirectory());
+                }
+
+                List<String> allConfigs = new ArrayList<>(defaultConfigs);
+                if (projectDirectory.get() != null) {
+                    allConfigs.addAll(projectConfigs);
+                }
+
+                ClientConfigurationManager.getInstance().getConfigurations(
+                        client,
+                        allConfigs,
+                        projectDirectory.get() != null ? Utils.toUri(projectDirectory.get()) : null
+                ).thenAccept(configs -> {
+                    if (configs != null && !configs.isEmpty()) {
+                        if (configs.get(0) instanceof JsonObject) {
+                            textDocumentService.updateJavaHintPreferences((JsonObject) configs.get(0));
+                        } else {
+                            textDocumentService.hintsSettingsRead = true;
+                            textDocumentService.reRunDiagnostics();
+                        }
+
+                        JsonPrimitive newProjectJDKHomePath = null;
+                        if (configs.size() > 1 && configs.get(1) instanceof JsonPrimitive) {
+                            newProjectJDKHomePath = (JsonPrimitive) configs.get(1);
+                        }
+                        textDocumentService.updateProjectJDKHome(newProjectJDKHomePath);
+
+                        if (projectDirectory.get() != null) {
+                            if (configs.size() > 2 && configs.get(2) instanceof JsonObject) {
+                                workspaceService.updateJavaFormatPreferences(projectDirectory.get(), (JsonObject) configs.get(2));
+                            }
+
+                            if (configs.size() > 3 && configs.get(3) instanceof JsonObject) {
+                                workspaceService.updateJavaImportPreferences(projectDirectory.get(), (JsonObject) configs.get(3));
+                            }
+                        }
+                    } else {
                         textDocumentService.hintsSettingsRead = true;
                         textDocumentService.reRunDiagnostics();
+                        textDocumentService.updateProjectJDKHome(null);
                     }
                 });
-                item.setSection(client.getNbCodeCapabilities().getConfigurationPrefix() + NETBEANS_PROJECT_JDKHOME);
-                client.configuration(new ConfigurationParams(Collections.singletonList(item))).thenAccept(c -> {
-                    JsonPrimitive newProjectJDKHomePath = null;
-
-                    if (c != null && !c.isEmpty() && c.get(0) instanceof JsonPrimitive) {
-                        newProjectJDKHomePath = (JsonPrimitive) c.get(0);
-                    } else {
-                    }
-                    textDocumentService.updateProjectJDKHome(newProjectJDKHomePath);
-                });
-                if (projects != null && projects.length > 0) {
-                    FileObject fo = projects[0].getProjectDirectory();
-                    item.setScopeUri(Utils.toUri(fo));
-                    item.setSection(client.getNbCodeCapabilities().getConfigurationPrefix() + NETBEANS_FORMAT);
-                    client.configuration(new ConfigurationParams(Collections.singletonList(item))).thenAccept(c -> {
-                        if (c != null && !c.isEmpty() && c.get(0) instanceof JsonObject) {
-                            workspaceService.updateJavaFormatPreferences(fo, (JsonObject) c.get(0));
-                        }
-                    });
-                    item.setSection(client.getNbCodeCapabilities().getConfigurationPrefix() + NETBEANS_JAVA_IMPORTS);
-                    client.configuration(new ConfigurationParams(Collections.singletonList(item))).thenAccept(c -> {
-                        if (c != null && !c.isEmpty() && c.get(0) instanceof JsonObject) {
-                            workspaceService.updateJavaImportPreferences(fo, (JsonObject) c.get(0));
-                        }
-                    });
-                }
             });
         }
 

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -362,7 +362,15 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
     private static final int DEFAULT_COMPLETION_WARNING_LENGTH = 10_000;
     private static final RequestProcessor COMPLETION_SAMPLER_WORKER = new RequestProcessor("java-lsp-completion-sampler", 1, false, false);
     private static final AtomicReference<Sampler> RUNNING_SAMPLER = new AtomicReference<>();
-
+    
+    void registerConfigChangeListeners() {
+        ClientConfigurationManager confManager = ClientConfigurationManager.getInstance();
+        String fullConfigPrefix = client.getNbCodeCapabilities().getConfigurationPrefix();
+        
+        confManager.registerConfigCache(client, fullConfigPrefix + NETBEANS_JAVADOC_LOAD_TIMEOUT);
+        confManager.registerConfigCache(client, fullConfigPrefix + NETBEANS_COMPLETION_WARNING_TIME);
+    }
+    
     @Override
     @Messages({
         "# {0} - the timeout elapsed",
@@ -418,15 +426,16 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
             ConfigurationItem completionWarningLength = new ConfigurationItem();
             completionWarningLength.setScopeUri(uri);
             completionWarningLength.setSection(client.getNbCodeCapabilities().getConfigurationPrefix() + NETBEANS_COMPLETION_WARNING_TIME);
-            return client.configuration(new ConfigurationParams(Arrays.asList(conf, completionWarningLength))).thenApply(c -> {
+            List<String> configValues = List.of(NETBEANS_JAVADOC_LOAD_TIMEOUT, NETBEANS_COMPLETION_WARNING_TIME);
+            return ClientConfigurationManager.getInstance().getConfigurations(client, configValues, uri).thenApply(c -> {
                 if (c != null && !c.isEmpty()) {
-                    if (c.get(0) instanceof JsonPrimitive) {
-                        JsonPrimitive javadocTimeSetting = (JsonPrimitive) c.get(0);
+                    if (c.get(0).isJsonPrimitive()) {
+                        JsonPrimitive javadocTimeSetting = c.get(0).getAsJsonPrimitive();
 
                         javadocTimeout.set(javadocTimeSetting.getAsInt());
                     }
-                    if (c.get(1) instanceof JsonPrimitive) {
-                        JsonPrimitive samplingWarningsLengthSetting = (JsonPrimitive) c.get(1);
+                    if (c.get(1).isJsonPrimitive()) {
+                        JsonPrimitive samplingWarningsLengthSetting = c.get(1).getAsJsonPrimitive();
 
                         samplingWarningLength.set(samplingWarningsLengthSetting.getAsLong());
                     }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -1374,37 +1374,62 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
 
     @Override
     public void didChangeConfiguration(DidChangeConfigurationParams params) {
-        String fullConfigPrefix = client.getNbCodeCapabilities().getConfigurationPrefix();
-        String configPrefix = fullConfigPrefix.substring(0, fullConfigPrefix.length() - 1);
-        server.openedProjects().thenAccept(projects -> {
-            // PENDING: invent a pluggable mechanism for this, this does not scale and the typecast to serviceImpl is ugly
-            ((TextDocumentServiceImpl)server.getTextDocumentService()).updateJavaHintPreferences(((JsonObject) params.getSettings()).getAsJsonObject(configPrefix).getAsJsonObject(NETBEANS_JAVA_HINTS));
-            ((TextDocumentServiceImpl)server.getTextDocumentService()).updateProjectJDKHome(((JsonObject) params.getSettings()).getAsJsonObject(configPrefix).getAsJsonObject("project").getAsJsonPrimitive("jdkhome"));
-            if (projects != null && projects.length > 0) {
-                updateJavaFormatPreferences(projects[0].getProjectDirectory(), ((JsonObject) params.getSettings()).getAsJsonObject(configPrefix).getAsJsonObject("format"));
-                updateJavaImportPreferences(projects[0].getProjectDirectory(), ((JsonObject) params.getSettings()).getAsJsonObject(configPrefix).getAsJsonObject("java").getAsJsonObject("imports"));
-            }
-        });
-        String fullAltConfigPrefix = client.getNbCodeCapabilities().getAltConfigurationPrefix();
-        String altConfigPrefix = fullAltConfigPrefix.substring(0, fullAltConfigPrefix.length() - 1);
-        boolean modified = false;
-        String newVMOptions = "";
-        String newWorkingDirectory = null;
-        JsonObject javaPlus = ((JsonObject) params.getSettings()).getAsJsonObject(altConfigPrefix);
-        if (javaPlus != null) {
-            JsonObject runConfig = javaPlus.getAsJsonObject("runConfig");
+        ClientConfigurationManager.getInstance().handleConfigurationChange(client, (JsonObject)params.getSettings());
+    }
+
+    private BiConsumer<String, JsonElement> getRunConfigChangeListener() {
+        return (config, newValue) -> {
+            boolean modified = false;
+            String newVMOptions = "";
+            String newWorkingDirectory = null;
+            JsonObject runConfig = newValue.isJsonObject() ? newValue.getAsJsonObject() : null;
             if (runConfig != null) {
                 newVMOptions = runConfig.getAsJsonPrimitive("vmOptions").getAsString();
                 JsonPrimitive cwd = runConfig.getAsJsonPrimitive("cwd");
                 newWorkingDirectory = cwd != null ? cwd.getAsString() : null;
             }
-        }
-        for (SingleFileOptionsQueryImpl query : Lookup.getDefault().lookupAll(SingleFileOptionsQueryImpl.class)) {
-            modified |= query.setConfiguration(workspace, newVMOptions, newWorkingDirectory);
-        }
-        if (modified) {
-            ((TextDocumentServiceImpl)server.getTextDocumentService()).reRunDiagnostics();
-        }
+            for (SingleFileOptionsQueryImpl query : Lookup.getDefault().lookupAll(SingleFileOptionsQueryImpl.class)) {
+                modified |= query.setConfiguration(workspace, newVMOptions, newWorkingDirectory);
+            }
+            if (modified) {
+                ((TextDocumentServiceImpl) server.getTextDocumentService()).reRunDiagnostics();
+            }
+        };
+    }
+    
+    void registerConfigChangeListeners() {
+        String fullConfigPrefix = client.getNbCodeCapabilities().getConfigurationPrefix();
+        String fullAltConfigPrefix = client.getNbCodeCapabilities().getAltConfigurationPrefix();
+        ClientConfigurationManager confManager = ClientConfigurationManager.getInstance();
+
+        BiConsumer<String, JsonElement> formatPrefsListener = (config, newValue)
+                -> server.openedProjects().thenAccept(projects -> {
+                    if (projects != null && projects.length > 0) {
+                        updateJavaFormatPreferences(projects[0].getProjectDirectory(), newValue.getAsJsonObject());
+                    }
+                });
+
+        BiConsumer<String, JsonElement> importPrefsListener = (config, newValue)
+                -> server.openedProjects().thenAccept(projects -> {
+                    if (projects != null && projects.length > 0) {
+                        updateJavaImportPreferences(projects[0].getProjectDirectory(), newValue.getAsJsonObject());
+                    }
+                });
+
+        // PENDING: The typecast to serviceImpl is ugly
+        BiConsumer<String, JsonElement> hintPrefsListener = (config, newValue)
+                -> ((TextDocumentServiceImpl) server.getTextDocumentService()).updateJavaHintPreferences(newValue.getAsJsonObject());
+
+        BiConsumer<String, JsonElement> projectJdkHomeListener = (config, newValue)
+                -> ((TextDocumentServiceImpl) server.getTextDocumentService()).updateProjectJDKHome(newValue.getAsJsonPrimitive());
+        
+        
+        
+        confManager.registerConfigChangeListener(this.client, fullConfigPrefix + "hints", hintPrefsListener);
+        confManager.registerConfigChangeListener(this.client, fullConfigPrefix + "project.jdkhome", projectJdkHomeListener);
+        confManager.registerConfigChangeListener(this.client, fullConfigPrefix + "format", formatPrefsListener);
+        confManager.registerConfigChangeListener(this.client, fullConfigPrefix + "java.imports", importPrefsListener);
+        confManager.registerConfigChangeListener(this.client, fullAltConfigPrefix + "runConfig", getRunConfigChangeListener());
     }
 
     void updateJavaFormatPreferences(FileObject fo, JsonObject configuration) {
@@ -1518,6 +1543,7 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
     @Override
     public void connect(LanguageClient client) {
         this.client = (NbCodeLanguageClient)client;
+        ClientConfigurationManager.getInstance().registerClient(this.client);
     }
 
     public Workspace getWorkspace() {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/singlesourcefile/EnablePreviewSingleSourceFile.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/singlesourcefile/EnablePreviewSingleSourceFile.java
@@ -32,6 +32,7 @@ import org.openide.util.Parameters;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.java.hints.spi.preview.PreviewEnabler;
 import org.netbeans.modules.java.lsp.server.Utils;
+import org.netbeans.modules.java.lsp.server.protocol.ClientConfigurationManager;
 import org.netbeans.modules.java.lsp.server.protocol.NbCodeLanguageClient;
 import org.netbeans.modules.java.lsp.server.protocol.UpdateConfigParams;
 import org.openide.util.Lookup;
@@ -63,11 +64,8 @@ public class EnablePreviewSingleSourceFile implements PreviewEnabler {
             return ;
         }
 
-        ConfigurationItem conf = new ConfigurationItem();
-        conf.setScopeUri(Utils.toUri(file));
-        conf.setSection(client.getNbCodeCapabilities().getAltConfigurationPrefix() + "runConfig.vmOptions");
-        client.configuration(new ConfigurationParams(Collections.singletonList(conf))).thenApply(c -> {
-            String compilerArgs = ((JsonPrimitive) ((List<Object>) c).get(0)).getAsString();
+        ClientConfigurationManager.getInstance().getConfigurationUsingAltPrefix(client, "runConfig.vmOptions", Utils.toUri(file)).thenApply(c -> {
+            String compilerArgs = ((JsonPrimitive) c).getAsString();
             if (compilerArgs == null) {
                 compilerArgs = "";
             }

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ClientConfigurationManagerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ClientConfigurationManagerTest.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import org.eclipse.lsp4j.ConfigurationParams;
+import org.junit.Test;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.java.lsp.server.TestCodeLanguageClient;
+
+public class ClientConfigurationManagerTest extends NbTestCase {
+
+    private final ClientConfigurationManager manager = ClientConfigurationManager.getInstance();
+    private MockClient mockClient;
+
+    public ClientConfigurationManagerTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        mockClient = new MockClient();
+        manager.registerClient(mockClient);
+    }
+
+    @Test
+    public void testGetConfiguration() throws InterruptedException, ExecutionException {
+        String section = "project.jdkhome";
+        JsonElement expectedValue = new JsonPrimitive("test JDK path");
+        mockClient.addConfig(mockClient.codeCapa.getConfigurationPrefix() + section, expectedValue);
+
+        CompletableFuture<JsonElement> future = manager.getConfiguration(mockClient, section);
+        JsonElement actualValue = future.get();
+
+        assertEquals("Config value mismatch", expectedValue, actualValue);
+    }
+
+    @Test
+    public void testGetConfigurationWithScope() throws InterruptedException, ExecutionException, URISyntaxException {
+        String section = "project.jdkhome";
+        JsonElement expectedValue = new JsonPrimitive("test JDK path");
+        URI expectedScope = new URI("file://scope1");
+        mockClient.addConfig(mockClient.codeCapa.getConfigurationPrefix() + section, expectedValue);
+
+        CompletableFuture<JsonElement> future = manager.getConfiguration(mockClient, section, expectedScope.toString());
+        JsonElement actualValue = future.get();
+
+        assertEquals("Scoped value mismatch", expectedValue, actualValue.getAsJsonObject().get("value"));
+        assertEquals("Scope URI mismatch", expectedScope.toString(), actualValue.getAsJsonObject().get("scope").getAsString());
+    }
+
+    @Test
+    public void testGetAltConfiguration() throws InterruptedException, ExecutionException {
+        String section = "project.jdkhome";
+        JsonElement expectedValue = new JsonPrimitive("test JDK path");
+        mockClient.addConfig(mockClient.codeCapa.getAltConfigurationPrefix() + section, expectedValue);
+
+        CompletableFuture<JsonElement> future = manager.getConfigurationUsingAltPrefix(mockClient, section);
+        JsonElement actualValue = future.get();
+
+        assertEquals("Alt config value mismatch", expectedValue, actualValue);
+    }
+
+    @Test
+    public void testGetConfigurations() throws ExecutionException, InterruptedException {
+        List<String> configKeys = List.of("format.enabled", "debug.enabled");
+        List<JsonElement> configValues = List.of(new JsonPrimitive(Boolean.TRUE), new JsonPrimitive(Boolean.FALSE));
+
+        for (int i = 0; i < configValues.size(); i++) {
+            mockClient.addConfig(mockClient.codeCapa.getConfigurationPrefix() + configKeys.get(i), configValues.get(i));
+        }
+
+        CompletableFuture<List<JsonElement>> future = manager.getConfigurations(mockClient, configKeys);
+        List<JsonElement> results = future.get();
+
+        assertEquals("Config list size mismatch", configValues.size(), results.size());
+        for (int i = 0; i < configValues.size(); i++) {
+            assertEquals("Config value mismatch at index " + i, configValues.get(i), results.get(i));
+        }
+    }
+
+    @Test
+    public void testGetConfigurationsWithScope() throws ExecutionException, InterruptedException, URISyntaxException {
+        List<String> configKeys = List.of("format.enabled", "debug.enabled");
+        List<JsonElement> configValues = List.of(new JsonPrimitive(Boolean.TRUE), new JsonPrimitive(Boolean.FALSE));
+        URI expectedScope = new URI("file://scope1");
+
+        for (int i = 0; i < configValues.size(); i++) {
+            mockClient.addConfig(mockClient.codeCapa.getConfigurationPrefix() + configKeys.get(i), configValues.get(i));
+        }
+
+        CompletableFuture<List<JsonElement>> future = manager.getConfigurations(mockClient, configKeys, expectedScope.toString());
+        List<JsonElement> results = future.get();
+
+        assertEquals("Scoped config list size mismatch", configValues.size(), results.size());
+        for (int i = 0; i < configValues.size(); i++) {
+            assertEquals("Scoped value mismatch at index " + i, configValues.get(i), results.get(i).getAsJsonObject().get("value"));
+            assertEquals("Scope URI mismatch at index " + i, expectedScope.toString(), results.get(i).getAsJsonObject().get("scope").getAsString());
+        }
+    }
+
+    @Test
+    public void testRegisterConfigListener() {
+        String expectedSection = "project.jdkhome";
+        JsonPrimitive expectedValue = new JsonPrimitive("New Value");
+
+        BiConsumer<String, JsonElement> listener = (actualSection, actualValue) -> {
+            assertEquals("Section mismatch in listener", expectedSection, actualSection);
+            assertEquals("Value mismatch in listener", expectedValue, actualValue);
+        };
+
+        manager.registerConfigChangeListener(mockClient, expectedSection, listener);
+
+        mockClient.addConfig(expectedSection, new JsonPrimitive("Old Value"));
+        JsonObject newConfigTree = mockClient.updateSectionAndGetDeepCopy(expectedSection, expectedValue);
+        manager.handleConfigurationChange(mockClient, newConfigTree);
+    }
+
+    private class MockClient extends TestCodeLanguageClient {
+
+        NbCodeClientCapabilities codeCapa = new NbCodeClientCapabilities();
+        JsonObject rootConfiguration = new JsonObject();
+
+        public MockClient() {
+            codeCapa.setConfigurationPrefix("jdk");
+            codeCapa.setAltConfigurationPrefix("java+");
+        }
+
+        public void addConfig(String section, JsonElement value) {
+            addConfigToObject(rootConfiguration, section, value);
+        }
+
+        public JsonObject updateSectionAndGetDeepCopy(String section, JsonElement newValue) {
+            JsonObject obj = rootConfiguration.deepCopy();
+            addConfigToObject(obj, section, newValue);
+            return obj;
+        }
+
+        public JsonElement getConfigurationValue(String section) {
+            String[] keys = section.split("\\.");
+            JsonObject current = rootConfiguration;
+
+            for (int i = 0; i < keys.length; i++) {
+                String key = keys[i];
+
+                if (!current.has(key)) {
+                    return null;
+                }
+
+                if (i == keys.length - 1) {
+                    return current.get(key);
+                }
+
+                JsonElement next = current.get(key);
+                if (!next.isJsonObject()) {
+                    return null;
+                }
+
+                current = next.getAsJsonObject();
+            }
+
+            return null;
+        }
+
+        private void addConfigToObject(JsonObject root, String section, JsonElement value) {
+            String[] keys = section.split("\\.");
+            JsonObject current = root;
+
+            for (int i = 0; i < keys.length; i++) {
+                String key = keys[i];
+
+                if (i == keys.length - 1) {
+                    current.add(key, value);
+                } else {
+                    if (!current.has(key) || !current.get(key).isJsonObject()) {
+                        current.add(key, new JsonObject());
+                    }
+                    current = current.getAsJsonObject(key);
+                }
+            }
+        }
+
+        @Override
+        public NbCodeClientCapabilities getNbCodeCapabilities() {
+            return codeCapa;
+        }
+
+        @Override
+        public CompletableFuture<List<Object>> configuration(ConfigurationParams params) {
+            List<Object> result = params.getItems().stream()
+                    .map(item -> {
+                        if (item.getScopeUri() == null) {
+                            return getConfigurationValue(item.getSection());
+                        }
+                        JsonObject o = new JsonObject();
+                        o.add("value", getConfigurationValue(item.getSection()));
+                        o.add("scope", new JsonPrimitive(item.getScopeUri()));
+                        return o;
+                    })
+                    .collect(Collectors.toList());
+
+            return CompletableFuture.completedFuture(result);
+        }
+    }
+}

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ConfigValueCacheTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ConfigValueCacheTest.java
@@ -1,0 +1,389 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import org.eclipse.lsp4j.ConfigurationParams;
+import org.junit.Test;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.java.lsp.server.TestCodeLanguageClient;
+
+public class ConfigValueCacheTest extends NbTestCase {
+
+    public ConfigValueCacheTest(String name) {
+        super(name);
+    }
+
+    @Test
+    public void testRegistrationOfListener() {
+        ConfigValueCache cache = new ConfigValueCache();
+        BiConsumer<String, JsonElement> expectedListener = (section, value) -> {
+        };
+        String section = "jdk.test.section";
+
+        assertNull("Config should be null before registering listener", cache.getConfigData(section));
+
+        cache.registerListener(section, expectedListener);
+        ConfigValueCache.ConfigData configData = cache.getConfigData(section);
+
+        assertNotNull("Config should exist after registering listener", configData);
+        assertEquals("Listener should match", expectedListener, configData.getConsumer());
+    }
+
+    @Test
+    public void testRegistrationOfCache() {
+        ConfigValueCache cache = new ConfigValueCache();
+        String section = "jdk.test.section";
+
+        assertNull("Config should be null before registering cache", cache.getConfigData(section));
+
+        cache.registerCache(section);
+        ConfigValueCache.ConfigData configData = cache.getConfigData(section);
+
+        assertNotNull("Config should exist after registering cache", configData);
+        assertNull("Consumer should be null", configData.getConsumer());
+    }
+
+    @Test
+    public void testGetConfigValueWithInvalidSections() {
+        ConfigValueCache cache = new ConfigValueCache();
+
+        JsonElement result1 = cache.getConfigValue(null, null);
+        assertNull("Result should be null for null section", result1);
+
+        JsonElement result2 = cache.getConfigValue("non.existent.section", null);
+        assertNull("Result should be null for non-existent section", result2);
+    }
+
+    @Test
+    public void testGetConfigValueWithDifferentScopes() {
+        ConfigValueCache cache = new ConfigValueCache();
+        String section = "project.jdkhome";
+        String scope1 = "file:///project1";
+        String scope2 = "file:///project2";
+        String nonExistentScope = "file:///non-existent";
+
+        JsonElement rootValue = new JsonPrimitive("default");
+        JsonElement scope1Value = new JsonPrimitive("project1");
+        JsonElement scope2Value = new JsonPrimitive("project2");
+
+        cache.registerCache(section);
+        ConfigValueCache.ConfigData configData = cache.getConfigData(section);
+        configData.setRootValue(rootValue);
+        configData.setScopedValue(scope1, scope1Value);
+        configData.setScopedValue(scope2, scope2Value);
+
+        JsonElement rootResult = cache.getConfigValue(section, null);
+        JsonElement scope1Result = cache.getConfigValue(section, scope1);
+        JsonElement scope2Result = cache.getConfigValue(section, scope2);
+        JsonElement nonExistentResult = cache.getConfigValue(section, nonExistentScope);
+
+        assertEquals("Should return root value with null scope", rootValue, rootResult);
+        assertEquals("Should return scope1 value", scope1Value, scope1Result);
+        assertEquals("Should return scope2 value", scope2Value, scope2Result);
+        assertNull("Should return null for non-existent scope", nonExistentResult);
+    }
+
+    @Test
+    public void testGetConfigValueWithHierarchicalSections() {
+        ConfigValueCache cache = new ConfigValueCache();
+        MockClient mockClient = new MockClient();
+        
+        String section1 = "editor";
+        String section2 = "editor.format";
+        String section3 = "editor.format.indentation";
+        String section4 = "editor.size";
+
+        JsonElement value3 = new JsonPrimitive("indentation value");
+        JsonElement value4 = new JsonPrimitive("editor size value");
+        
+        mockClient.addConfig(section3, value3);
+        mockClient.addConfig(section4, value4);
+
+        cache.registerCache(section1);
+        cache.registerCache(section2);
+        cache.registerCache(section3);
+        cache.registerCache(section4);
+        
+        cache.updateCache(mockClient, section1, cache, mockClient.getTree());
+
+        JsonElement result1 = cache.getConfigValue(section1, null);
+        JsonElement result2 = cache.getConfigValue(section2, null);
+        JsonElement result3 = cache.getConfigValue(section3, null);
+        JsonElement result4 = cache.getConfigValue(section4, null);
+
+        assertEquals("Should return level 1 value", mockClient.getConfigurationValue(section1), result1);
+        assertEquals("Should return level 2 value", mockClient.getConfigurationValue(section2), result2);
+        assertEquals("Should return level 2 value", value4, result4);
+        assertEquals("Should return level 3 value", value3, result3);
+    }
+    
+        @Test
+    public void testGetConfigValueWithHierarchicalSectionsRegisterInReverseOrder() {
+        ConfigValueCache cache = new ConfigValueCache();
+        MockClient mockClient = new MockClient();
+        
+        String section1 = "editor";
+        String section2 = "editor.format";
+        String section3 = "editor.format.indentation";
+        String section4 = "editor.size";
+
+        JsonElement value3 = new JsonPrimitive("indentation value");
+        JsonElement value4 = new JsonPrimitive("editor size value");
+        
+        mockClient.addConfig(section3, value3);
+        mockClient.addConfig(section4, value4);
+
+        cache.registerCache(section4);
+        cache.registerCache(section3);
+        cache.registerCache(section2);
+        cache.registerCache(section1);
+        
+        cache.updateCache(mockClient, section1, cache, mockClient.getTree());
+
+        JsonElement result1 = cache.getConfigValue(section1, null);
+        JsonElement result2 = cache.getConfigValue(section2, null);
+        JsonElement result3 = cache.getConfigValue(section3, null);
+        JsonElement result4 = cache.getConfigValue(section4, null);
+
+        assertEquals("Should return level 1 value", mockClient.getConfigurationValue(section1), result1);
+        assertEquals("Should return level 2 value", mockClient.getConfigurationValue(section2), result2);
+        assertEquals("Should return level 2 value", value4, result4);
+        assertEquals("Should return level 3 value", value3, result3);
+    }
+
+    @Test
+    public void testCacheConfigValueIfNeeded() {
+        ConfigValueCache cache = new ConfigValueCache();
+        String section = "project.jdkhome";
+        String scope1 = "file:///project1";
+        JsonElement rootValue = new JsonPrimitive("root value");
+        JsonElement scopedValue = new JsonPrimitive("scoped value");
+
+        cache.cacheConfigValueIfNeeded(section, rootValue, null);
+        assertNull("Non-existent section should return null", cache.getConfigValue(section, null));
+
+        cache.registerCache(section);
+        cache.cacheConfigValueIfNeeded(section, rootValue, null);
+        JsonElement result1 = cache.getConfigValue(section, null);
+        assertEquals("Root value should be updated", rootValue, result1);
+
+        cache.cacheConfigValueIfNeeded(section, scopedValue, scope1);
+        JsonElement result2 = cache.getConfigValue(section, scope1);
+        assertEquals("Scoped value should be updated", scopedValue, result2);
+
+        JsonElement result3 = cache.getConfigValue(section, null);
+        assertEquals("Root value should be unchanged", rootValue, result3);
+    }
+
+    @Test
+    public void testUpdateCacheWithNullValues() {
+        ConfigValueCache cache = new ConfigValueCache();
+        MockClient mockClient = new MockClient();
+        String section = "project.jdkhome";
+        JsonElement tree = new JsonPrimitive("test JDK value");
+        cache.updateCache(mockClient, section, new ConfigValueCache().new ConfigData(), null);
+        assertNull("Cache should not be updated with null tree", cache.getConfigValue(section, null));
+
+        cache.updateCache(mockClient, section, null, tree);
+        assertNull("Cache should not be updated with null cacheValue", cache.getConfigValue(section, null));
+    }
+
+    @Test
+    public void testUpdateCacheWithConfigDataInstance() {
+        ConfigValueCache cache = new ConfigValueCache();
+        MockClient mockClient = new MockClient();
+        String section = "project.jdkhome";
+        JsonElement tree = new JsonPrimitive("test JDK value");
+        AtomicReference<JsonElement> listenerValue = new AtomicReference<>();
+
+        cache.registerListener(section, (s, v) -> listenerValue.set(v));
+        ConfigValueCache.ConfigData configData = cache.getConfigData(section);
+
+        cache.updateCache(mockClient, section, configData, tree);
+
+        JsonElement result = cache.getConfigValue(section, null);
+        assertEquals("Root value should be updated", tree, result);
+
+        assertEquals("Listener should be called with tree value", tree, listenerValue.get());
+    }
+
+    @Test
+    public void testUpdateCacheWithConfigValueInstance() {
+        ConfigValueCache cache = new ConfigValueCache();
+        MockClient mockClient = new MockClient();
+        String parentSection = "editor";
+        String fontColorSection = parentSection + ".fontColor";
+        String fontSizeSection = parentSection + ".fontSize";
+        
+        cache.registerCache(fontColorSection);        
+        cache.registerCache(fontSizeSection);
+
+        JsonObject tree = new JsonObject();
+        JsonObject childTree = new JsonObject();
+        tree.add(parentSection, childTree);
+        JsonElement expectedFontColorValue = new JsonPrimitive("blue");
+        JsonElement expectedFontSizeValue = new JsonPrimitive(12);
+        childTree.add("fontColor", expectedFontColorValue);
+        childTree.add("fontSize", expectedFontSizeValue);
+
+        mockClient.addConfig(fontColorSection, expectedFontColorValue);
+        mockClient.addConfig(fontSizeSection, expectedFontSizeValue);
+
+        cache.updateCache(mockClient, parentSection, cache, tree);
+
+        JsonElement fontColorValue = cache.getConfigValue(fontColorSection, null);
+        JsonElement fontSizeValue = cache.getConfigValue(fontSizeSection, null);
+
+        assertNotNull("Nested section should be created", cache.getConfigData(fontColorSection));
+        assertNotNull("Nested section should be created", cache.getConfigData(fontSizeSection));
+        assertEquals("Nested value should be updated", expectedFontColorValue, fontColorValue);
+        assertEquals("Nested value should be updated", expectedFontSizeValue, fontSizeValue);
+    }
+
+    @Test
+    public void testUpdateCacheWithScopedValues() {
+        ConfigValueCache cache = new ConfigValueCache();
+        MockClient mockClient = new MockClient();
+        String section = "project.jdkhome";
+        JsonElement tree = new JsonPrimitive("updated value");
+
+        cache.registerCache(section);
+        ConfigValueCache.ConfigData configData = cache.getConfigData(section);
+
+        String scope1 = "file:///project1";
+        String scope2 = "file:///project2";
+        JsonElement scope1Value = new JsonPrimitive("scope1 value");
+        JsonElement scope2Value = new JsonPrimitive("scope2 value");
+        configData.setScopedValue(scope1, scope1Value);
+        configData.setScopedValue(scope2, scope2Value);
+
+        mockClient.resetRequests();
+        cache.updateCache(mockClient, section, configData, tree);
+        Map<String, Map<String, JsonElement>> requests = mockClient.getRequestsReceived();
+
+        assertTrue("Should request client for updated scoped values", requests.get(section).containsKey(scope1));
+        assertTrue("Should request client for updated scoped values", requests.get(section).containsKey(scope2));
+        assertEquals("Scope1 should have updated value", scope1Value, cache.getConfigValue(section, scope1));
+        assertEquals("Scope2 should have updated value", scope2Value, cache.getConfigValue(section, scope2));
+    }
+
+    private class MockClient extends TestCodeLanguageClient {
+
+        NbCodeClientCapabilities codeCapa = new NbCodeClientCapabilities();
+        JsonObject rootConfiguration = new JsonObject();
+        Map<String, Map<String, JsonElement>> requestsReceived = new HashMap<>();
+
+        public MockClient() {
+            codeCapa.setConfigurationPrefix("jdk");
+        }
+
+        public void addConfig(String section, JsonElement value) {
+            String[] keys = section.split("\\.");
+            JsonObject current = rootConfiguration;
+
+            for (int i = 0; i < keys.length; i++) {
+                String key = keys[i];
+
+                if (i == keys.length - 1) {
+                    current.add(key, value);
+                } else {
+                    if (!current.has(key) || !current.get(key).isJsonObject()) {
+                        current.add(key, new JsonObject());
+                    }
+                    current = current.getAsJsonObject(key);
+                }
+            }
+        }
+
+        public JsonElement getConfigurationValue(String section) {
+            String[] keys = section.split("\\.");
+            JsonObject current = rootConfiguration;
+
+            for (int i = 0; i < keys.length; i++) {
+                String key = keys[i];
+
+                if (!current.has(key)) {
+                    return null;
+                }
+
+                if (i == keys.length - 1) {
+                    return current.get(key);
+                }
+
+                JsonElement next = current.get(key);
+                if (!next.isJsonObject()) {
+                    return null;
+                }
+
+                current = next.getAsJsonObject();
+            }
+
+            return null;
+        }
+        
+        public void resetRequests() {
+            requestsReceived = new HashMap<>();
+        }
+
+        public Map<String, Map<String, JsonElement>> getRequestsReceived() {
+            return Collections.unmodifiableMap(requestsReceived);
+        }
+        
+        public JsonObject getTree(){
+            return rootConfiguration;
+        }
+
+        @Override
+        public NbCodeClientCapabilities getNbCodeCapabilities() {
+            return codeCapa;
+        }
+
+        @Override
+        public CompletableFuture<List<Object>> configuration(ConfigurationParams params) {
+            List<Object> result = params.getItems().stream()
+                    .map(item -> {
+                        if (item.getScopeUri() == null) {
+                            return getConfigurationValue(item.getSection());
+                        }
+                        JsonElement value = getConfigurationValue(item.getSection());
+                        if (requestsReceived.containsKey(item.getSection())) {
+                            requestsReceived.get(item.getSection()).put(item.getScopeUri(), value);
+                        } else {
+                            requestsReceived.put(item.getSection(), new HashMap<>());
+                            requestsReceived.get(item.getSection()).put(item.getScopeUri(), value);
+                        }
+                        return value;
+                    })
+                    .collect(Collectors.toList());
+
+            return CompletableFuture.completedFuture(result);
+        }
+    }
+}


### PR DESCRIPTION
Currently, configuration requests require a round trip every time the language server needs a value from the client. For example, in `TextDocumentServiceImpl`, the `completion` method, which provides auto-complete suggestions, performs a round trip to fetch configuration values like `netbeans.javadoc.load.timeout` and `netbeans.completion.warning.time`. Additionally, listening to changes in specific configurations is difficult, as it requires registration in `WorkspaceServiceImpl` and it is not extensible.

This PR aims to address these challenges by introducing a new class, `ClientConfigurationManager`, which manages clients along with their configurations. It serves configuration values from a local cache if available, and only performs a request to the client when necessary. It also listens for configuration changes to keep the cache in sync.
There is also a new class `ConfigValueCache` which takes care of all the business logic of traversing the tree and maintaining configs according to the scopes as well. 
Moreover, it allows listeners in the form of `BiConsumer` to be attached to specific configuration keys, enabling appropriate actions to be taken automatically when those configurations change.
