### PR TITLE
In VSCode extension added user configuration for commit characters for accepting code suggestions

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -298,6 +298,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
     private static final String NETBEANS_JAVADOC_LOAD_TIMEOUT = "javadoc.load.timeout";// NOI18N
     private static final String NETBEANS_COMPLETION_WARNING_TIME = "completion.warning.time";// NOI18N
     private static final String NETBEANS_JAVA_ON_SAVE_ORGANIZE_IMPORTS = "java.onSave.organizeImports";// NOI18N
+    private static final String NETBEANS_CODE_COMPLETION_COMMIT_CHARS = "java.completion.commit.chars";// NOI18N
     private static final String URL = "url";// NOI18N
     private static final String INDEX = "index";// NOI18N
     
@@ -374,6 +375,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
         AtomicReference<Sampler> samplerRef = new AtomicReference<>();
         AtomicLong samplingStart = new AtomicLong();
         AtomicLong samplingWarningLength = new AtomicLong(DEFAULT_COMPLETION_WARNING_LENGTH);
+        AtomicReference<List<String>> codeCompletionCommitChars = new AtomicReference<>(List.of());
         long completionStart = System.currentTimeMillis();
         COMPLETION_SAMPLER_WORKER.post(() -> {
             if (!done.get()) {
@@ -418,7 +420,10 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
             ConfigurationItem completionWarningLength = new ConfigurationItem();
             completionWarningLength.setScopeUri(uri);
             completionWarningLength.setSection(client.getNbCodeCapabilities().getConfigurationPrefix() + NETBEANS_COMPLETION_WARNING_TIME);
-            return client.configuration(new ConfigurationParams(Arrays.asList(conf, completionWarningLength))).thenApply(c -> {
+            ConfigurationItem commitCharacterConfig = new ConfigurationItem();
+            commitCharacterConfig.setScopeUri(uri);
+            commitCharacterConfig.setSection(client.getNbCodeCapabilities().getConfigurationPrefix() + NETBEANS_CODE_COMPLETION_COMMIT_CHARS);
+            return client.configuration(new ConfigurationParams(Arrays.asList(conf, completionWarningLength, commitCharacterConfig))).thenApply(c -> {
                 if (c != null && !c.isEmpty()) {
                     if (c.get(0) instanceof JsonPrimitive) {
                         JsonPrimitive javadocTimeSetting = (JsonPrimitive) c.get(0);
@@ -429,6 +434,10 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                         JsonPrimitive samplingWarningsLengthSetting = (JsonPrimitive) c.get(1);
 
                         samplingWarningLength.set(samplingWarningsLengthSetting.getAsLong());
+                    }
+                    if(c.get(2) instanceof JsonArray){
+                        JsonArray commitCharsJsonArray = (JsonArray) c.get(2);
+                        codeCompletionCommitChars.set(commitCharsJsonArray.asList().stream().map(ch -> ch.toString()).collect(Collectors.toList()));
                     }
                 }
                 final int caret = Utils.getOffset(doc, params.getPosition());
@@ -492,8 +501,8 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                                 }).collect(Collectors.toList()));
                             }
                         }
-                        if (completion.getCommitCharacters() != null) {
-                            item.setCommitCharacters(completion.getCommitCharacters().stream().map(ch -> ch.toString()).collect(Collectors.toList()));
+                        if (codeCompletionCommitChars.get() != null) {
+                            item.setCommitCharacters(codeCompletionCommitChars.get());
                         }
                         lastCompletions.add(completion);
                         item.setData(new CompletionData(uri, index.getAndIncrement()));

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -230,6 +230,14 @@
 					"default": 999,
 					"minimum": 1
 				},
+				"netbeans.java.completion.commit.chars": {
+					"type": "array",
+					"default": [
+						".",
+						","
+					],
+					"description": "Specifies the characters that trigger accepting a code completion suggestion. Defaults to '.' and ','. For example, to accept suggestions when typing a dot (.), set this to [\".\"]"
+				},
 				"netbeans.guides.notified": {
 					"type": "array",
 					"items": {
@@ -271,15 +279,19 @@
 					"description": "Enable or disable various inline hints.",
 					"type": "array",
 					"default": [],
-                                        "items": {
-                                            "type": "string",
-                                            "enum": ["chained", "parameter", "var"],
-                                            "markdownEnumDescriptions": [
-                                                "show return types of chained methods",
-                                                "show parameter names",
-                                                "show types of `var` variables"
-                                            ]
-                                        }
+					"items": {
+						"type": "string",
+						"enum": [
+							"chained",
+							"parameter",
+							"var"
+						],
+						"markdownEnumDescriptions": [
+							"show return types of chained methods",
+							"show parameter names",
+							"show types of `var` variables"
+						]
+					}
 				}
 			}
 		},


### PR DESCRIPTION
This PR adds support for configurable commit characters in the Java LSP server. Users can now define which characters (e.g., ., ,) trigger the acceptance of a code completion suggestion via the new `netbeans.java.completion.commit.chars` setting in the Netbeans VS Code extension. The server reads this configuration and applies the characters to completion items dynamically. This improves the flexibility and user control over the code completion behaviour.