### PR TITLE
Variable-hides-field hint optimization

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/HideFieldByVar.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/HideFieldByVar.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.java.hints;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
-import java.util.Collections;
 import java.util.List;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -102,7 +101,7 @@ public class HideFieldByVar extends HideField {
         if (span == null) {
             return null;
         }
-        List<Fix> fixes = Collections.<Fix>singletonList(new FixImpl(
+        List<Fix> fixes = List.of(new HideFieldFix(
             (span[1] + span[0]) / 2,
             compilationInfo.getFileObject(),
             true


### PR DESCRIPTION
compilationinfo.getElements() in inner loop prevented the JVM from inlining calls into the loop body. Moving it out of the loop improves hint performance by 10x in files with many fields.

rest is cleanup
