### PR TITLE
Avoid SourceVersion query in javadoc hint

### DIFF
--- a/java/javadoc/src/org/netbeans/modules/javadoc/hints/GenerateJavadocFix.java
+++ b/java/javadoc/src/org/netbeans/modules/javadoc/hints/GenerateJavadocFix.java
@@ -19,17 +19,10 @@
 package org.netbeans.modules.javadoc.hints;
 
 import com.sun.source.doctree.DocCommentTree;
-import com.sun.source.doctree.DocTree;
-import com.sun.source.tree.ClassTree;
-import com.sun.source.tree.ExpressionTree;
-import com.sun.source.tree.MethodTree;
-import com.sun.source.tree.Tree;
-import com.sun.source.tree.VariableTree;
 import com.sun.source.util.DocTrees;
 import com.sun.source.util.TreePath;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
-import org.netbeans.api.java.source.Comment;
 import org.netbeans.api.java.source.TreeMaker;
 import org.netbeans.api.java.source.TreePathHandle;
 import org.netbeans.api.java.source.WorkingCopy;

--- a/java/javadoc/src/org/netbeans/modules/javadoc/hints/JavadocHint.java
+++ b/java/javadoc/src/org/netbeans/modules/javadoc/hints/JavadocHint.java
@@ -45,9 +45,7 @@ import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
-import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
-import javax.swing.text.Position;
 import org.netbeans.api.java.queries.AccessibilityQuery;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.java.source.TreePathHandle;
@@ -149,7 +147,7 @@ public final class JavadocHint {
             }
 
             errors = new ArrayList<>();
-            GenerateJavadocFix javadocFix = new GenerateJavadocFix(description, handle, resolveSourceVersion(javac.getFileObject()));
+            GenerateJavadocFix javadocFix = new GenerateJavadocFix(description, handle, ctx.getInfo().getSourceVersion());
             errors.add(ErrorDescriptionFactory.forSpan(ctx, positions[0], positions[1], NbBundle.getMessage(Analyzer.class, "MISSING_JAVADOC_DESC"), javadocFix.toEditorFix()));
         }
         return errors;


### PR DESCRIPTION
as seen in https://github.com/apache/netbeans/pull/8417, source level query is fairly expensive, luckily compilation info knows the source version already.

(not sure why I didn't add it to the other PR)