### PR TITLE
Fix mvnd test session regression

### DIFF
--- a/java/maven.junit/nbproject/project.properties
+++ b/java/maven.junit/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class


### PR DESCRIPTION
Test session was never set to finished when EventSpy was not active. EventSpy is currently disabled when multi threaded builds are detected and mvnd is multi threaded by default (unless e.g `-Dmvnd.serial` is set). This caused the test window to think tests are still running.

This adds a fallback to signal session completion.

see https://github.com/apache/maven-mvnd/issues/1333

second regression since https://github.com/apache/netbeans/pull/7979 (first: https://github.com/apache/netbeans/pull/8433)