### PR TITLE
Fixes #8314 : Missing domainsfolder Setting for Payara Services Configuration

### DIFF
--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/PayaraInstance.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/PayaraInstance.java
@@ -400,10 +400,6 @@ public class PayaraInstance implements ServerInstanceImplementation,
         Map<String, String> ip = new HashMap<>();
         ip.put(PayaraModule.WSL_ATTR, String.valueOf(wsl));
         ip.put(PayaraModule.DOCKER_ATTR, String.valueOf(docker));
-        if(wsl && domainsDir == null) {
-            domainsDir = payaraRoot + File.separator + "domains";
-        }
-
         ip.put(PayaraModule.DISPLAY_NAME_ATTR, displayName);
         ip.put(PayaraModule.INSTALL_FOLDER_ATTR, installRoot);
         ip.put(PayaraModule.PAYARA_FOLDER_ATTR, payaraRoot);
@@ -1073,9 +1069,6 @@ public class PayaraInstance implements ServerInstanceImplementation,
      */
     public void setWSL(boolean isWSL) {
         properties.put(PayaraModule.WSL_ATTR, Boolean.toString(isWSL));
-        if (!isWSL) {
-            properties.put(PayaraModule.DOMAINS_FOLDER_ATTR, null);
-        }
     }
 
     /**
@@ -1126,8 +1119,6 @@ public class PayaraInstance implements ServerInstanceImplementation,
         String domainsDir = properties.get(PayaraModule.DOMAINS_FOLDER_ATTR);
         if(isDocker()) {
             return null;
-        } else if(isWSL() && domainsDir == null) {
-            domainsDir = getPayaraRoot() + File.separator + "domains";
         }
         return domainsDir;
     }

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/actions/DebugAction.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/actions/DebugAction.java
@@ -74,7 +74,8 @@ public class DebugAction extends NodeAction {
     }
     
     private static boolean enableImpl(PayaraModule commonSupport) {
-        return PayaraState.canStart(commonSupport.getInstance()) &&
+        return (! commonSupport.getInstance().isWSL()) &&
+                PayaraState.canStart(commonSupport.getInstance()) &&
                 null != commonSupport.getInstanceProperties().get(PayaraModule.DOMAINS_FOLDER_ATTR) &&
                 Util.isDefaultOrServerTarget(commonSupport.getInstanceProperties());
     }

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/actions/ProfileAction.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/actions/ProfileAction.java
@@ -73,7 +73,8 @@ public class ProfileAction extends NodeAction {
     }
     
     private static boolean enableImpl(PayaraModule commonSupport, Node node) {
-        return PayaraState.canStart(commonSupport.getInstance()) &&
+        return (! commonSupport.getInstance().isWSL()) &&
+                PayaraState.canStart(commonSupport.getInstance()) &&
                 null != commonSupport.getInstanceProperties().get(PayaraModule.DOMAINS_FOLDER_ATTR) &&
                 Util.isDefaultOrServerTarget(commonSupport.getInstanceProperties());
     }

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/actions/StartServerAction.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/actions/StartServerAction.java
@@ -73,7 +73,7 @@ public class StartServerAction extends NodeAction {
     
     private static boolean enableImpl(PayaraModule commonSupport) {
         PayaraServer server = commonSupport.getInstance();
-        return PayaraState.canStart(server) && !server.isRemote();
+        return (!server.isWSL()) && PayaraState.canStart(server) && !server.isRemote();
     }
     
     @Override

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/actions/StopServerAction.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/actions/StopServerAction.java
@@ -71,6 +71,9 @@ public class StopServerAction extends NodeAction {
     }
 
     private static boolean enableImpl(PayaraModule commonSupport) {
+        if (commonSupport.getInstance().isWSL()) {
+            return false;
+        }
         boolean online = PayaraState.isOnline(commonSupport.getInstance());
         return (online
                 || commonSupport.getServerState() == ServerState.STOPPED_JVM_PROFILER)

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/wizards/ServerWizardIterator.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/wizards/ServerWizardIterator.java
@@ -396,13 +396,19 @@ public class ServerWizardIterator extends PortCollection implements WizardDescri
     /**
      * Set values for remote domain.
      * <p/>
-     * Domains directory shall be <code>null</code> for remote domains.
+     * For remote domains, sets the domain name and determines the domains directory path based on the environment.
+     * If running in a WSL (Windows Subsystem for Linux) environment, the domains directory is set to
+     * <code>payaraRoot/domains</code>; otherwise, the domains directory is set to <code>null</code>.
      * <p/>
      * @param domainName Domain name to set.
      */
     public void setRemoteDomain(final String domainName) {
-        this.domainsDir = null;
         this.domainName = domainName;
+        if (isWSL()) {
+            this.domainsDir = this.payaraRoot + File.separator + "domains";
+        } else {
+            this.domainsDir = null;
+        }
     }
 
     // expose for qa-functional tests
@@ -547,11 +553,11 @@ public class ServerWizardIterator extends PortCollection implements WizardDescri
         if ("localhost".equals(hn)) {
             hn = "127.0.0.1";
         }
-        PayaraInstance instance = PayaraInstance.create((String) wizard.getProperty("ServInstWizard_displayName"),   // NOI18N
-                installRoot, payaraRoot, null, domainName,
-                getHttpPort(), getAdminPort(), userName, password, 
+        PayaraInstance instance = PayaraInstance.create((String) wizard.getProperty("ServInstWizard_displayName"), // NOI18N
+                installRoot, payaraRoot, wsl ? domainsDir : null, domainName,
+                getHttpPort(), getAdminPort(), userName, password,
                 wsl, docker, hostPath, containerPath, targetValue,
-                formatUri(hn, getAdminPort(), getTargetValue(),null, domainName), 
+                formatUri(hn, getAdminPort(), getTargetValue(), null, domainName),
                 instanceProvider);
         result.add(instance.getCommonInstance());
     }


### PR DESCRIPTION
**Fixes Payara Server Configuration Issue by Restoring `domainsfolder` Support in NetBeans**

This PR addresses an issue introduced in NetBeans 25+ where the `domainsfolder` attribute was unintentionally removed from Payara Server service configurations. As a result, users experienced broken server setups after accessing the service properties in the UI, since the domains directory could no longer be resolved.
