### PR TITLE
fixes Rerun failed test with maven and junit5 creates the wrong command line.

### DIFF
--- a/java/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitTestMethodNode.java
+++ b/java/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitTestMethodNode.java
@@ -70,7 +70,14 @@ public class MavenJUnitTestMethodNode extends JUnitTestMethodNode {
             if (suiteProject != null) {
                 ActionProvider actionProvider = suiteProject.getLookup().lookup(ActionProvider.class);
                 if (actionProvider != null) {
-                    SingleMethod methodSpec = new SingleMethod(testFO, testcase.getName());
+                    String mName = testcase.getName();
+                    String tcName= testcase.getClassName();
+                    if (tcName!=null
+                            && mName.startsWith(tcName)
+                            && mName.charAt(tcName.length())=='.'){
+                        mName= mName.substring(tcName.length()+1);
+                    }
+                    SingleMethod methodSpec = new SingleMethod(testFO, mName);
                     Lookup nodeContext = Lookups.singleton(methodSpec);
 
                     for (String action : actionProvider.getSupportedActions()) {

--- a/java/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputListenerProvider.java
+++ b/java/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputListenerProvider.java
@@ -449,15 +449,23 @@ public class JUnitOutputListenerProvider implements OutputProcessor {
                             int windowslimitcount = 0;
                             for (Testcase tc : tests) {
                                 //TODO just when is the classname null??
-                                if (tc.getClassName() != null) {
+                                String tcName= tc.getClassName();
+                                if (tcName != null) {
                                     Collection<String> lst = methods.get(tc.getClassName());
                                     if (lst == null) {
                                         lst = new ArrayList<>();
                                         methods.put(tc.getClassName(), lst);
                                         windowslimitcount = windowslimitcount + tc.getClassName().length() + 1; // + 1 for ,
                                     }
-                                    lst.add(tc.getName());
-                                    windowslimitcount = windowslimitcount + tc.getName().length() + 1; // + 1 for # or +
+                                    String mName = tc.getName();
+
+                                    if (tcName!=null
+                                            && mName.startsWith(tcName)
+                                            && mName.charAt(tcName.length())=='.'){
+                                        mName = mName.substring(tcName.length()+1);
+                                    }
+                                    lst.add(mName);
+                                    windowslimitcount = windowslimitcount + mName.length() + 1; // + 1 for # or +
                                 }
                             }
                             boolean exceedsWindowsLimit = Utilities.isWindows() && windowslimitcount > 6000; //just be conservative here, the limit is more (8000+)


### PR DESCRIPTION
This fix reformats the `test` property passed to the MavenCommandLineExecutor
by replacing occurrences of `f.q.c.n.TestClass#f.q.c.n.TestClass.testMethod` with
` f.q.c.n.TestClass#testMethod`.

Closes: #8533