### PR TITLE
Fix launcher extbin license name and info.

### DIFF
--- a/nb/ide.launcher/external/launcher-external-binaries-3-282bbc032bcd-license.txt
+++ b/nb/ide.launcher/external/launcher-external-binaries-3-282bbc032bcd-license.txt
@@ -1,6 +1,6 @@
 Name: NetBeans Application Launchers
 Description: Windows Launchers for NetBeans Applications
-Version: 2-6c17cc6
+Version: 3-282bbc032bcd
 License: Apache-2.0
 Source: https://netbeans.org/
 Origin: NetBeans


### PR DESCRIPTION
Fix launcher license file name and info.  Minor issue with #8361 - same as #8249  Showed up in release testing, but as it doesn't affect the output I left it until now.  Would be great to somehow not have this in three places!