### PR TITLE
Remove sun.awt.shell add-opens flag

### DIFF
--- a/nbbuild/jms-config/desktop.flags
+++ b/nbbuild/jms-config/desktop.flags
@@ -8,7 +8,6 @@
 --add-opens=java.desktop/com.sun.java.swing.plaf.gtk=ALL-UNNAMED
 --add-opens=java.desktop/com.sun.java.swing.plaf.windows=ALL-UNNAMED
 --add-opens=java.desktop/com.apple.laf=ALL-UNNAMED
---add-opens=java.desktop/sun.awt.shell=ALL-UNNAMED
 --add-opens=java.desktop/sun.awt.im=ALL-UNNAMED
 --add-exports=java.desktop/sun.awt=ALL-UNNAMED
 --add-exports=java.desktop/java.awt.peer=ALL-UNNAMED


### PR DESCRIPTION
hopefully not needed anymore since 12d71f45a18874 / #8110 / NB 25

```shell
$ ag "sun.awt.shell"

nbbuild/jms-config/desktop.flags
11:--add-opens=java.desktop/sun.awt.shell=ALL-UNNAMED

platform/openide.filesystems/src/org/openide/filesystems/FileUtil.java
135:            assert path.getClass().getName().startsWith("sun.awt.shell") ||
1847:        if (file.getClass().getName().startsWith("sun.awt.shell")) { // NOI18N
```
https://github.com/search?q=repo%3Aapache%2Fnetbeans%20sun.awt.shell&type=code


tested file chooser UI on windows and linux without the flag in the config file.