### PR TITLE
fixes evaluation stack trace for unit tests with ant

### DIFF
--- a/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
+++ b/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
@@ -183,7 +183,7 @@ public final class AntJUnitNodeOpener extends NodeOpener {
                 // if not found, return top line of stack trace.
                 if (index == st.length) {
                     index=0;
-                    while(true) {
+                    for(index=0; index < st.length; index++) {
                         String trimmed=JavaRegexpUtils.specialTrim(st[index]);
                         if (trimmed.startsWith(JavaRegexpUtils.CALLSTACK_LINE_PREFIX_CATCH) ||
                                trimmed.startsWith(JavaRegexpUtils.CALLSTACK_LINE_PREFIX )){

--- a/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
+++ b/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
@@ -29,7 +29,6 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.util.ElementFilter;
 import javax.swing.Action;
-import jdk.internal.net.http.common.Log;
 import org.netbeans.api.extexecution.print.LineConvertors.FileLocator;
 import org.netbeans.api.java.source.CompilationController;
 import org.netbeans.api.java.source.JavaSource;
@@ -160,7 +159,7 @@ public final class AntJUnitNodeOpener extends NodeOpener {
         }
         // Method node might belong to an inner class
         FileObject testfo = methodNode.getTestcase().getClassFileObject(true);
-        String fqMethodName = methodNode.getTestcase().getClassName() + '.' + methodNode.getTestcase().getName();
+        String fqMethodNameParen = methodNode.getTestcase().getClassName() + '.' + methodNode.getTestcase().getName()+'(';
         if (testfo == null) {
             return;
         }
@@ -174,7 +173,7 @@ public final class AntJUnitNodeOpener extends NodeOpener {
                 //Jump to the first line matching the fully qualified test method name.
                 // and ignore the infrastructure stack lines in the process
                 while (index < st.length) {
-                    if (st[index].contains(fqMethodName)) {
+                    if (st[index].contains(fqMethodNameParen)) {
                         file = UIJavaUtils.getFile(st[index], lineNumStorage, locator);
                         break;
                     }

--- a/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
+++ b/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
@@ -182,7 +182,6 @@ public final class AntJUnitNodeOpener extends NodeOpener {
                 }
                 // if not found, return top line of stack trace.
                 if (index == st.length) {
-                    index=0;
                     for(index=0; index < st.length; index++) {
                         String trimmed=JavaRegexpUtils.specialTrim(st[index]);
                         if (trimmed.startsWith(JavaRegexpUtils.CALLSTACK_LINE_PREFIX_CATCH) ||
@@ -194,7 +193,6 @@ public final class AntJUnitNodeOpener extends NodeOpener {
                 }
                 // if that fails, return the test file object.
                 if (file == null) {
-
                     file = testfo;
                 }
             }

--- a/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
+++ b/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
@@ -195,7 +195,8 @@ public final class AntJUnitNodeOpener extends NodeOpener {
                 }
                 // if that fails, return the test file object.
                 if (file == null) {
-                    file = testfo;
+                    openTestMethod(methodNode);
+                    return;
                 }
             }
         }

--- a/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
+++ b/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
@@ -161,9 +161,9 @@ public final class AntJUnitNodeOpener extends NodeOpener {
         // Method node might belong to an inner class
         FileObject testfo = methodNode.getTestcase().getClassFileObject(true);
         String fqMethodName = methodNode.getTestcase().getClassName() + '.' + methodNode.getTestcase().getName();
-	if(testfo == null) {
-	    return;
-	}
+        if (testfo == null) {
+            return;
+        }
         final int[] lineNumStorage = new int[1];
         FileObject file = UIJavaUtils.getFile(frameInfo, lineNumStorage, locator);
         //lineNumStorage -1 means no regexp for stacktrace was matched.
@@ -182,10 +182,10 @@ public final class AntJUnitNodeOpener extends NodeOpener {
                 }
                 // if not found, return top line of stack trace.
                 if (index == st.length) {
-                    for(index=0; index < st.length; index++) {
-                        String trimmed=JavaRegexpUtils.specialTrim(st[index]);
-                        if (trimmed.startsWith(JavaRegexpUtils.CALLSTACK_LINE_PREFIX_CATCH) ||
-                               trimmed.startsWith(JavaRegexpUtils.CALLSTACK_LINE_PREFIX )){
+                    for (index = 0; index < st.length; index++) {
+                        String trimmed = JavaRegexpUtils.specialTrim(st[index]);
+                        if (trimmed.startsWith(JavaRegexpUtils.CALLSTACK_LINE_PREFIX_CATCH)
+                                || trimmed.startsWith(JavaRegexpUtils.CALLSTACK_LINE_PREFIX)) {
                             file = UIJavaUtils.getFile(st[index], lineNumStorage, locator);
                             break;
                         }

--- a/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
+++ b/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
@@ -187,7 +187,9 @@ public final class AntJUnitNodeOpener extends NodeOpener {
                         if (trimmed.startsWith(JavaRegexpUtils.CALLSTACK_LINE_PREFIX_CATCH)
                                 || trimmed.startsWith(JavaRegexpUtils.CALLSTACK_LINE_PREFIX)) {
                             file = UIJavaUtils.getFile(st[index], lineNumStorage, locator);
-                            break;
+                            if (testfo.equals(file)) {
+                                break;
+                            }
                         }
                     }
                 }

--- a/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
+++ b/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
@@ -189,6 +189,9 @@ public final class AntJUnitNodeOpener extends NodeOpener {
                             file = UIJavaUtils.getFile(st[index], lineNumStorage, locator);
                             if (testfo.equals(file)) {
                                 break;
+                            } else {
+                                file = null;
+                                lineNumStorage[0] = -1;
                             }
                         }
                     }

--- a/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
+++ b/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/AntJUnitNodeOpener.java
@@ -38,6 +38,8 @@ import org.netbeans.modules.gsf.testrunner.api.TestSuite;
 import org.netbeans.modules.gsf.testrunner.api.CommonUtils;
 import org.netbeans.modules.gsf.testrunner.ui.api.TestMethodNode;
 import org.netbeans.modules.gsf.testrunner.ui.api.TestsuiteNode;
+import org.netbeans.modules.java.testrunner.JavaRegexpPatterns;
+import org.netbeans.modules.java.testrunner.JavaRegexpUtils;
 import org.openide.ErrorManager;
 import org.openide.filesystems.FileObject;
 import org.netbeans.modules.junit.api.JUnitTestSuite;
@@ -157,29 +159,46 @@ public final class AntJUnitNodeOpener extends NodeOpener {
         }
         // Method node might belong to an inner class
         FileObject testfo = methodNode.getTestcase().getClassFileObject(true);
-	if(testfo == null) {
-	    return;
-	}
+        String fqMethodNameParen = methodNode.getTestcase().getClassName() + '.' + methodNode.getTestcase().getName()+'(';
+        if (testfo == null) {
+            return;
+        }
         final int[] lineNumStorage = new int[1];
         FileObject file = UIJavaUtils.getFile(frameInfo, lineNumStorage, locator);
         //lineNumStorage -1 means no regexp for stacktrace was matched.
         if ((file == null) && (methodNode.getTestcase().getTrouble() != null) && lineNumStorage[0] == -1) {
-            //213935 we could not recognize the stack trace line and map it to known file
-            //if it's a failure text, grab the testcase's own line from the stack.
-            boolean methodNodeParentOfStackTraceNode = false;
             String[] st = methodNode.getTestcase().getTrouble().getStackTrace();
             if ((st != null) && (st.length > 0)) {
-                int index = st.length - 1;
-                //213935 we need to find the testcase linenumber to jump to.
+                int index = 0;//st.length - 1;
+                //Jump to the first line matching the fully qualified test method name.
                 // and ignore the infrastructure stack lines in the process
-                while (!testfo.equals(file) && index != -1 && !methodNodeParentOfStackTraceNode) {
-                    file = UIJavaUtils.getFile(st[index], lineNumStorage, locator);
-                    index = index - 1;
-                    // if frameInfo.isEmpty() == true, user clicked on a failed method node. 
-                    // Try to find if the stack trace node is relevant to the method node
-                    if(file != null && frameInfo.isEmpty()) {
-                        methodNodeParentOfStackTraceNode = FileUtil.isParentOf(testfo.getParent(), file);
+                while (index < st.length) {
+                    if (st[index].contains(fqMethodNameParen)) {
+                        file = UIJavaUtils.getFile(st[index], lineNumStorage, locator);
+                        break;
                     }
+                    index++;
+                }
+                // if not found, return top line of stack trace.
+                if (index == st.length) {
+                    for (index = 0; index < st.length; index++) {
+                        String trimmed = JavaRegexpUtils.specialTrim(st[index]);
+                        if (trimmed.startsWith(JavaRegexpUtils.CALLSTACK_LINE_PREFIX_CATCH)
+                                || trimmed.startsWith(JavaRegexpUtils.CALLSTACK_LINE_PREFIX)) {
+                            file = UIJavaUtils.getFile(st[index], lineNumStorage, locator);
+                            if (testfo.equals(file)) {
+                                break;
+                            } else {
+                                file = null;
+                                lineNumStorage[0] = -1;
+                            }
+                        }
+                    }
+                }
+                // if that fails, return the test file object.
+                if (file == null) {
+                    openTestMethod(methodNode);
+                    return;
                 }
             }
         }


### PR DESCRIPTION
This version works for ant projects. (Including netbeans projects).
This PR closes #8567

This implementation of finding file object+line number reverses the search by starting at the top of the stack and try to find the stack frame that is directly related to the test method.


It reverses the loop running from bottom to top into running from the top stack frame to the bottom one.
It effectively tries to find the first stack element that matches the testMethod involved instead of the first element that is NOT in some (testing) framework. For most tests this appears to be the logical choice, in particular in the non-optimal practice of having multiple assert or assert-like statements in one test method.

For NetBeans developers, in particular those working on refactoring related stuff and tests, it is more useful to point to the failing assert or verifyXXX call than in some method inside some method inside the test class or a superclass thereof that generalizes repetitive work in the tests. 

In the original the goto source landed me in 
https://github.com/apache/netbeans/blob/68e420dcd08d0e1a3bb7fc1687dd0722881e9422/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/RefactoringTestBase.java#L405-L418

instead of say line 118 below, which is the more logical line to choose in most cases.

https://github.com/apache/netbeans/blob/68e420dcd08d0e1a3bb7fc1687dd0722881e9422/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/InnerToOutterTest.java#L117-L118

This PR solves the problem for both maven and ant projects in a similar way.



