### PR TITLE
Upgrade nb-javac to JDK 25b31

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1467,11 +1467,10 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        # TODO bump together with nb-javac 25 update
-        java: [ '17', '24' ]
+        java: [ '17', '25-ea' ]
         config: [ 'batch1', 'batch2' ]
         exclude:
-          - java: ${{ github.event_name == 'pull_request' && 'nothing' || '24' }}
+          - java: ${{ github.event_name == 'pull_request' && 'nothing' || '25-ea' }}
       fail-fast: false
     steps:
 

--- a/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
+++ b/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
@@ -57,7 +57,6 @@ import static javax.lang.model.element.Modifier.*;
 import static javax.lang.model.SourceVersion.RELEASE_10;
 import static javax.lang.model.SourceVersion.RELEASE_11;
 import static javax.lang.model.SourceVersion.RELEASE_16;
-import static javax.lang.model.SourceVersion.RELEASE_19;
 import static javax.lang.model.SourceVersion.RELEASE_21;
 import static javax.lang.model.type.TypeKind.VOID;
 
@@ -2020,25 +2019,23 @@ public final class JavaCompletionTask<T> extends BaseTask {
         TokenSequence<JavaTokenId> ts = findLastNonWhitespaceToken(env, let, env.getOffset());
         if (ts != null) {
             switch (ts.token().id()) {
-                case ARROW:
+                case ARROW -> {
                     localResult(env);
                     addValueKeywords(env);
-                    break;
-                case COMMA:
+                }
+                case COMMA -> {
                     if (let.getParameters().isEmpty()
-                            || env.getController().getTrees().getSourcePositions().getStartPosition(path.getCompilationUnit(), let.getParameters().get(0).getType()) >= 0) {
+                            || !env.getController().getTreeUtilities().isSynthetic(new TreePath(path, let.getParameters().get(0).getType()))) {
                         addClassTypes(env, null);
                         addPrimitiveTypeKeywords(env);
                         addKeyword(env, FINAL_KEYWORD, SPACE, false);
-                    }
-                    else {
+                    } else {
                         boolean isFirstParamVarType = isLambdaVarType(env, let);
-
                         if (isFirstParamVarType) {
                             addVarTypeForLambdaParam(env);
                         }
                     }
-                    break;
+                }
             }
         }
     }

--- a/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/1.8/typesRecordStaticMembersAndVars.pass
+++ b/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/1.8/typesRecordStaticMembersAndVars.pass
@@ -1,6 +1,0 @@
-Readable
-ReflectiveOperationException
-Runnable
-Runtime
-RuntimeException
-RuntimePermission

--- a/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/14/typesRecordStaticMembersAndVars.pass
+++ b/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/14/typesRecordStaticMembersAndVars.pass
@@ -1,5 +1,6 @@
 Readable
 Record
+Records
 ReflectiveOperationException
 Runnable
 Runtime

--- a/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask114FeaturesTest.java
+++ b/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask114FeaturesTest.java
@@ -18,15 +18,8 @@
  */
 package org.netbeans.modules.java.completion;
 
-import java.util.ArrayList;
-import java.util.List;
-import javax.lang.model.SourceVersion;
-import javax.swing.event.ChangeListener;
-import org.netbeans.junit.NbTestSuite;
 import org.netbeans.modules.java.source.parsing.JavacParser;
-import org.netbeans.spi.java.queries.CompilerOptionsQueryImplementation;
-import org.openide.filesystems.FileObject;
-import org.openide.util.lookup.ServiceProvider;
+
 /**
  *
  * @author arusinha
@@ -39,98 +32,12 @@ public class JavaCompletionTask114FeaturesTest extends CompletionTestBase {
         super(testName);
     }
 
-    public static NbTestSuite suite() {
-        NbTestSuite suite = new NbTestSuite();
-        try {
-            SourceVersion.valueOf("RELEASE_14"); //NOI18N
-            suite.addTestSuite(JavaCompletionTask114FeaturesTest.class);
-        } catch (IllegalArgumentException ex) {
-            //OK, no RELEASE_13, skip tests
-            suite.addTest(new JavaCompletionTask114FeaturesTest("noop")); //NOI18N
-        }
-        return suite;
-    }
-
     public void testBindingUse() throws Exception {
         performTest("GenericMethodInvocation", 1231, "boolean b = argO instanceof String str && st", "BindingUse.pass", SOURCE_LEVEL);
     }
     
-
-    public void testBeforeLeftRecordBraces() throws Exception {
-        TestCompilerOptionsQueryImplementation.EXTRA_OPTIONS.add("--enable-preview");
-        performTest("Records", 896, null, "implementsKeyword.pass", getLatestSource());
-    }
-        
-    public void testBeforeRecParamsLeftParen() throws Exception {
-        TestCompilerOptionsQueryImplementation.EXTRA_OPTIONS.add("--enable-preview");
-        performTest("Records", 892, null, "empty.pass", getLatestSource());
-    }
-
-    public void testAfterTypeParamInRecParam() throws Exception {
-        performTest("Records", 890, null, "extendsKeyword.pass", SOURCE_LEVEL);
-    }
-    
-    public void testInsideRecAfterStaticKeyWord() throws Exception {
-        performTest("Records", 918, "R", "typesRecordStaticMembersAndVars.pass", SOURCE_LEVEL);
-    }
-    
-    public void testAnnotationInRecordParam() throws Exception {
-        performTest("Records", 999, null, "override.pass", SOURCE_LEVEL);
-    } 
-    
-    public void testRecordKeywordInsideMethod() throws Exception {
-        performTest("Records", 1014, "rec", "record.pass", SOURCE_LEVEL);
-    }
-
-    public void testRecordKeywordInsideClass() throws Exception {
-        performTest("Records", 844, "rec", "record.pass", SOURCE_LEVEL);
-    }
-
-    public void testRecordKeywordInsideMethodIfPrefixDoesntMatch() throws Exception {
-        performTest("Records", 1014, "someprefix", "empty.pass", SOURCE_LEVEL);
-    }
-
-    public void testRecordKeywordInsideClassIfPrefixDoesntMatch() throws Exception {
-        performTest("Records", 844, "someprefix", "empty.pass", SOURCE_LEVEL);
-    }
-    
-    public void testVariableNameSuggestion() throws Exception {
-        TestCompilerOptionsQueryImplementation.EXTRA_OPTIONS.add("--enable-preview");
-        performTest("Records", 1071, null, "recordVariableSuggestion.pass", getLatestSource());
-    } 
-    
-    public void noop() {
-    }
-
     static {
         JavacParser.DISABLE_SOURCE_LEVEL_DOWNGRADE = true;
     }
     
-    private String getLatestSource(){
-        return SourceVersion.latest().name().substring(SourceVersion.latest().name().indexOf("_")+1);
-    }
-    @ServiceProvider(service = CompilerOptionsQueryImplementation.class, position = 100)
-    public static class TestCompilerOptionsQueryImplementation implements CompilerOptionsQueryImplementation {
-
-        private static final List<String> EXTRA_OPTIONS = new ArrayList<>();
-
-        @Override
-        public CompilerOptionsQueryImplementation.Result getOptions(FileObject file) {
-            return new CompilerOptionsQueryImplementation.Result() {
-                @Override
-                public List<? extends String> getArguments() {
-                    return EXTRA_OPTIONS;
-                }
-
-                @Override
-                public void addChangeListener(ChangeListener listener) {
-                }
-
-                @Override
-                public void removeChangeListener(ChangeListener listener) {
-                }
-            };
-        }
-
-    }
 }

--- a/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask116FeaturesTest.java
+++ b/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask116FeaturesTest.java
@@ -41,6 +41,46 @@ public class JavaCompletionTask116FeaturesTest extends CompletionTestBase {
         performTest("InstanceofPattern", 926, null, "stringContent.pass", SOURCE_LEVEL);
     }
 
+    public void testBeforeLeftRecordBraces() throws Exception {
+        performTest("Records", 896, null, "implementsKeyword.pass", SOURCE_LEVEL);
+    }
+
+    public void testBeforeRecParamsLeftParen() throws Exception {
+        performTest("Records", 892, null, "empty.pass", SOURCE_LEVEL);
+    }
+
+    public void testAfterTypeParamInRecParam() throws Exception {
+        performTest("Records", 890, null, "extendsKeyword.pass", SOURCE_LEVEL);
+    }
+
+    public void testInsideRecAfterStaticKeyWord() throws Exception {
+        performTest("Records", 918, "R", "typesRecordStaticMembersAndVars.pass", SOURCE_LEVEL);
+    }
+
+    public void testAnnotationInRecordParam() throws Exception {
+        performTest("Records", 999, null, "override.pass", SOURCE_LEVEL);
+    }
+
+    public void testRecordKeywordInsideMethod() throws Exception {
+        performTest("Records", 1014, "rec", "record.pass", SOURCE_LEVEL);
+    }
+
+    public void testRecordKeywordInsideClass() throws Exception {
+        performTest("Records", 844, "rec", "record.pass", SOURCE_LEVEL);
+    }
+
+    public void testRecordKeywordInsideMethodIfPrefixDoesntMatch() throws Exception {
+        performTest("Records", 1014, "someprefix", "empty.pass", SOURCE_LEVEL);
+    }
+
+    public void testRecordKeywordInsideClassIfPrefixDoesntMatch() throws Exception {
+        performTest("Records", 844, "someprefix", "empty.pass", SOURCE_LEVEL);
+    }
+
+    public void testVariableNameSuggestion() throws Exception {
+        performTest("Records", 1071, null, "recordVariableSuggestion.pass", SOURCE_LEVEL);
+    }
+
     static {
         JavacParser.DISABLE_SOURCE_LEVEL_DOWNGRADE = true;
     }

--- a/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/editor/java/GoToSupportTest/javadocsnippet_LinkTag.pass
+++ b/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/editor/java/GoToSupportTest/javadocsnippet_LinkTag.pass
@@ -1,10 +1,9 @@
 <html><body><font size='+0'><b><a href='*0'>test.&#x200B;Test</a></b></font><pre>public void <b>testLinkTag</b>()</pre><p>A simple program
 
- <div id="snippet1" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet1">Copy</a></div>
-<pre><code> class HelloWorld {
-     public static void main(String... args) {
-         <a href='*1'>S</a><a href='*1'>y</a><a href='*1'>s</a><a href='*1'>t</a><a href='*1'>e</a><a href='*1'>m</a><a href='*1'>.</a><a href='*1'>o</a><a href='*1'>u</a><a href='*1'>t</a>.println("Hello World!");  
- }
- }
- 
+<div id="snippet1" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet1">Copy</a></div>
+<pre><code>class HelloWorld {
+    public static void main(String... args) {
+        <a href='*1'>S</a><a href='*1'>y</a><a href='*1'>s</a><a href='*1'>t</a><a href='*1'>e</a><a href='*1'>m</a><a href='*1'>.</a><a href='*1'>o</a><a href='*1'>u</a><a href='*1'>t</a>.println("Hello World!");  
+}
+}
 </code></pre></div><p>

--- a/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/editor/java/GoToSupportTest/javadocsnippet_SingleLine_Replace_RegexDot.pass
+++ b/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/editor/java/GoToSupportTest/javadocsnippet_SingleLine_Replace_RegexDot.pass
@@ -1,8 +1,7 @@
 <html><body><font size='+0'><b><a href='*0'>test.&#x200B;Test</a></b></font><pre>public void <b>testSingleLine_Replace_RegexDot</b>()</pre><p><div id="snippet1" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet1">Copy</a></div>
-<pre><code> class HelloWorld {
-     public static void main(String... args) {
-..........................................................................................................................................
- }
- }
- 
+<pre><code>class HelloWorld {
+    public static void main(String... args) {
+.......................................................................................................................................
+}
+}
 </code></pre></div><p>

--- a/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/editor/java/GoToSupportTest/javadocsnippet_TestError_HighlightTag.pass
+++ b/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/editor/java/GoToSupportTest/javadocsnippet_TestError_HighlightTag.pass
@@ -1,56 +1,54 @@
 <html><body><font size='+0'><b><a href='*0'>test.&#x200B;Test</a></b></font><pre>public void <b>errorsInHighlightTag</b>()</pre><p><div id="snippet1" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet1">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i>Blank</b></i> for <sub>^</sub><b><i>highlight</b></i> tag mark up attribute <sub>^</sub><b><i>substring</b></i></span>
 </code></pre></div>
- 
- <div id="snippet2" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet2">Copy</a></div>
+
+<div id="snippet2" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet2">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i>Blank</b></i> for <sub>^</sub><b><i>highlight</b></i> tag mark up attribute <sub>^</sub><b><i>substring</b></i></span>
 </code></pre></div>
- 
- <div id="snippet3" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet3">Copy</a></div>
+
+<div id="snippet3" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet3">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i>Blank</b></i> for <sub>^</sub><b><i>highlight</b></i> tag mark up attribute <sub>^</sub><b><i>substring</b></i></span>
 </code></pre></div>
- 
- <div id="snippet4" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet4">Copy</a></div>
+
+<div id="snippet4" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet4">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i>Blank</b></i> for <sub>^</sub><b><i>highlight</b></i> tag mark up attribute <sub>^</sub><b><i>substring</b></i></span>
 </code></pre></div>
- 
- 
- <div id="snippet5" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet5">Copy</a></div>
+
+
+<div id="snippet5" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet5">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i>Blank</b></i> for <sub>^</sub><b><i>highlight</b></i> tag mark up attribute <sub>^</sub><b><i>regex</b></i></span>
 </code></pre></div>
- 
- <div id="snippet6" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet6">Copy</a></div>
+
+<div id="snippet6" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet6">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i>Blank</b></i> for <sub>^</sub><b><i>highlight</b></i> tag mark up attribute <sub>^</sub><b><i>regex</b></i></span>
 </code></pre></div>
- 
- <div id="snippet7" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet7">Copy</a></div>
+
+<div id="snippet7" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet7">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i>Blank</b></i> for <sub>^</sub><b><i>highlight</b></i> tag mark up attribute <sub>^</sub><b><i>regex</b></i></span>
 </code></pre></div>
- 
- <div id="snippet8" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet8">Copy</a></div>
+
+<div id="snippet8" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet8">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i></b></i> for <sub>^</sub><b><i>highlight</b></i> tag mark up attribute <sub>^</sub><b><i>type</b></i>.<br>Valid values, such as bold, italic, or highlighted</span>
 </code></pre></div>
- 
- <div id="snippet9" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet9">Copy</a></div>
+
+<div id="snippet9" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet9">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i></b></i> for <sub>^</sub><b><i>highlight</b></i> tag mark up attribute <sub>^</sub><b><i>type</b></i>.<br>Valid values, such as bold, italic, or highlighted</span>
 </code></pre></div>
- 
- <div id="snippet10" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet10">Copy</a></div>
+
+<div id="snippet10" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet10">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i></b></i> for <sub>^</sub><b><i>highlight</b></i> tag mark up attribute <sub>^</sub><b><i>type</b></i>.<br>Valid values, such as bold, italic, or highlighted</span>
 </code></pre></div>
- 
- <div id="snippet11" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet11">Copy</a></div>
+
+<div id="snippet11" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet11">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i>xyz</b></i> for <sub>^</sub><b><i>highlight</b></i> tag mark up attribute <sub>^</sub><b><i>type</b></i>.<br>Valid values, such as bold, italic, or highlighted</span>
 </code></pre></div>
- 
- <div id="snippet12" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet12">Copy</a></div>
-<pre><code><span style="background-color:yellow;"> </span>class<span style="background-color:yellow;"> </span>HelloWorld<span style="background-color:yellow;"> </span>{
- }
- 
+
+<div id="snippet12" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet12">Copy</a></div>
+<pre><code>class<span style="background-color:yellow;"> </span>HelloWorld<span style="background-color:yellow;"> </span>{
+}
 </code></pre></div>
- 
- <div id="snippet13" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet13">Copy</a></div>
-<pre><code> class HelloWorld {
- }
- 
+
+<div id="snippet13" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet13">Copy</a></div>
+<pre><code>class HelloWorld {
+}
 </code></pre></div><p>

--- a/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/editor/java/GoToSupportTest/javadocsnippet_TestError_LinkTag.pass
+++ b/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/editor/java/GoToSupportTest/javadocsnippet_TestError_LinkTag.pass
@@ -1,59 +1,55 @@
 <html><body><font size='+0'><b><a href='*0'>test.&#x200B;Test</a></b></font><pre>public void <b>errorsInLinkTag</b>()</pre><p><div id="snippet1" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet1">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i>Blank</b></i> for <sub>^</sub><b><i>link</b></i> tag mark up attribute <sub>^</sub><b><i>substring</b></i></span>
 </code></pre></div>
- 
- <div id="snippet2" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet2">Copy</a></div>
+
+<div id="snippet2" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet2">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i>Blank</b></i> for <sub>^</sub><b><i>link</b></i> tag mark up attribute <sub>^</sub><b><i>substring</b></i></span>
 </code></pre></div>
- 
- <div id="snippet3" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet3">Copy</a></div>
+
+<div id="snippet3" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet3">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i>Blank</b></i> for <sub>^</sub><b><i>link</b></i> tag mark up attribute <sub>^</sub><b><i>substring</b></i></span>
 </code></pre></div>
- 
- <div id="snippet4" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet4">Copy</a></div>
+
+<div id="snippet4" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet4">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i>Blank</b></i> for <sub>^</sub><b><i>link</b></i> tag mark up attribute <sub>^</sub><b><i>regex</b></i></span>
 </code></pre></div>
- 
- <div id="snippet5" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet5">Copy</a></div>
+
+<div id="snippet5" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet5">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i>Blank</b></i> for <sub>^</sub><b><i>link</b></i> tag mark up attribute <sub>^</sub><b><i>regex</b></i></span>
 </code></pre></div>
- 
- <div id="snippet6" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet6">Copy</a></div>
+
+<div id="snippet6" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet6">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i>Blank</b></i> for <sub>^</sub><b><i>link</b></i> tag mark up attribute <sub>^</sub><b><i>regex</b></i></span>
 </code></pre></div>
- 
- <div id="snippet7" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet7">Copy</a></div>
+
+<div id="snippet7" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet7">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Missing <sub>^</sub><b><i>link</b></i> tag attribute : <sub>^</sub><b><i>target</b></i></span>
 </code></pre></div>
- 
- <div id="snippet8" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet8">Copy</a></div>
+
+<div id="snippet8" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet8">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Missing <sub>^</sub><b><i>link</b></i> tag attribute : <sub>^</sub><b><i>target</b></i></span>
 </code></pre></div>
- 
- <div id="snippet9" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet9">Copy</a></div>
+
+<div id="snippet9" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet9">Copy</a></div>
 <pre><code><span style="color:red;">error: snippet markup: Invalid value <sub>^</sub><b><i>Blank</b></i> for <sub>^</sub><b><i>link</b></i> tag mark up attribute <sub>^</sub><b><i>substring</b></i></span>
 </code></pre></div>
- 
- <div id="snippet10" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet10">Copy</a></div>
-<pre><code> <a href='*1'>c</a><a href='*1'>l</a><a href='*1'>a</a><a href='*1'>s</a><a href='*1'>s</a> Helloclass {
- }
- 
+
+<div id="snippet10" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet10">Copy</a></div>
+<pre><code><a href='*1'>c</a><a href='*1'>l</a><a href='*1'>a</a><a href='*1'>s</a><a href='*1'>s</a> Helloclass {
+}
 </code></pre></div>
- 
- <div id="snippet11" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet11">Copy</a></div>
-<pre><code> class Hello<a href='*2'>C</a><a href='*2'>l</a><a href='*2'>a</a><a href='*2'>s</a><a href='*2'>s</a> {
- }
- 
+
+<div id="snippet11" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet11">Copy</a></div>
+<pre><code>class Hello<a href='*2'>C</a><a href='*2'>l</a><a href='*2'>a</a><a href='*2'>s</a><a href='*2'>s</a> {
+}
 </code></pre></div>
- 
- <div id="snippet12" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet12">Copy</a></div>
-<pre><code> class Helloclass {
- }
- 
+
+<div id="snippet12" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet12">Copy</a></div>
+<pre><code>class Helloclass {
+}
 </code></pre></div>
- 
- <div id="snippet13" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet13">Copy</a></div>
-<pre><code><a href='*4'> </a>class<a href='*4'> </a>HelloClass<a href='*4'> </a>{
- }
- 
+
+<div id="snippet13" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet13">Copy</a></div>
+<pre><code>class<a href='*4'> </a>HelloClass<a href='*4'> </a>{
+}
 </code></pre></div><p>

--- a/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/editor/java/GoToSupportTest/javadocsnippet_highlightTagRegexWithAllCharacterChange.pass
+++ b/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/editor/java/GoToSupportTest/javadocsnippet_highlightTagRegexWithAllCharacterChange.pass
@@ -1,7 +1,6 @@
 <html><body><font size='+0'><b><a href='*0'>test.&#x200B;Test</a></b></font><pre>public void <b>highlightTagRegexWithAllCharacterChange</b>()</pre><p><div id="snippet1" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet1">Copy</a></div>
-<pre><code>   public static void main(String... args) {
-      
-<b> </b><b> </b><b> </b><b> </b><b> </b><b>S</b><b>y</b><b>s</b><b>t</b><b>e</b><b>m</b><b>.</b><b>o</b><b>u</b><b>t</b><b>.</b><b>p</b><b>r</b><b>i</b><b>n</b><b>t</b><b>l</b><b>n</b><b>(</b><b>"</b><b>a</b><b>r</b><b>g</b><b>s</b><b>"</b><b>)</b><b>;</b><b> </b><b>/</b><b>/</b><b> </b><b>t</b><b>o</b><b>-</b><b>d</b><b>o</b><b> </b><b>a</b><b>r</b><b>g</b><b>s</b>
- }
- 
+<pre><code>  public static void main(String... args) {
+     
+<b> </b><b> </b><b> </b><b> </b><b>S</b><b>y</b><b>s</b><b>t</b><b>e</b><b>m</b><b>.</b><b>o</b><b>u</b><b>t</b><b>.</b><b>p</b><b>r</b><b>i</b><b>n</b><b>t</b><b>l</b><b>n</b><b>(</b><b>"</b><b>a</b><b>r</b><b>g</b><b>s</b><b>"</b><b>)</b><b>;</b><b> </b><b>/</b><b>/</b><b> </b><b>t</b><b>o</b><b>-</b><b>d</b><b>o</b><b> </b><b>a</b><b>r</b><b>g</b><b>s</b>
+}
 </code></pre></div><p>

--- a/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/editor/java/GoToSupportTest/javadocsnippet_highlightTagRegexWithAllCharacterChangeUsingDot.pass
+++ b/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/editor/java/GoToSupportTest/javadocsnippet_highlightTagRegexWithAllCharacterChangeUsingDot.pass
@@ -1,7 +1,6 @@
 <html><body><font size='+0'><b><a href='*0'>test.&#x200B;Test</a></b></font><pre>public void <b>highlightTagRegexWithAllCharacterChangeUsingDot</b>()</pre><p><div id="snippet1" style="font-size: 10px; border: 1px solid black; margin-top: 2px; margin-bottom: 2px"><div align=right><a href="copy.snippet1">Copy</a></div>
-<pre><code>   public static void main(String... args) {
-      
-<b> </b><b> </b><b> </b><b> </b><b> </b><b>S</b><b>y</b><b>s</b><b>t</b><b>e</b><b>m</b><b>.</b><b>o</b><b>u</b><b>t</b><b>.</b><b>p</b><b>r</b><b>i</b><b>n</b><b>t</b><b>l</b><b>n</b><b>(</b><b>"</b><b>a</b><b>r</b><b>g</b><b>s</b><b>"</b><b>)</b><b>;</b><b> </b><b>/</b><b>/</b><b> </b><b>t</b><b>o</b><b>-</b><b>d</b><b>o</b><b> </b><b>a</b><b>r</b><b>g</b><b>s</b>
- }
- 
+<pre><code>  public static void main(String... args) {
+     
+<b> </b><b> </b><b> </b><b> </b><b>S</b><b>y</b><b>s</b><b>t</b><b>e</b><b>m</b><b>.</b><b>o</b><b>u</b><b>t</b><b>.</b><b>p</b><b>r</b><b>i</b><b>n</b><b>t</b><b>l</b><b>n</b><b>(</b><b>"</b><b>a</b><b>r</b><b>g</b><b>s</b><b>"</b><b>)</b><b>;</b><b> </b><b>/</b><b>/</b><b> </b><b>t</b><b>o</b><b>-</b><b>d</b><b>o</b><b> </b><b>a</b><b>r</b><b>g</b><b>s</b>
+}
 </code></pre></div><p>

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/Utilities.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/Utilities.java
@@ -1917,7 +1917,7 @@ public class Utilities {
         JavaFileObject prev = log.useSource(new DummyJFO());
         Enter enter = Enter.instance(jti.getContext());
         
-        Log.DiagnosticHandler discardHandler = new Log.DiscardDiagnosticHandler(log) {
+        Log.DiagnosticHandler discardHandler = log.new DiscardDiagnosticHandler() {
             private Diagnostic.Kind f = filter == null ? Diagnostic.Kind.ERROR : filter;
             @Override
             public void report(JCDiagnostic diag) {

--- a/java/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
@@ -1038,7 +1038,8 @@ public class SourceUtils {
         Source source = Source.instance(ctx);
         Preview preview = Preview.instance(ctx);
 
-        if (source.compareTo(Source.JDK21) < 0 || !preview.isEnabled()) {
+        // old launch protocol before JDK 25
+        if (source.compareTo(Source.JDK21) < 0 || (source.compareTo(Source.JDK25) < 0 && !preview.isEnabled())) {
             long flags = ((Symbol.MethodSymbol)method).flags();
 
             if (((flags & Flags.PUBLIC) == 0) || ((flags & Flags.STATIC) == 0)) {
@@ -1047,7 +1048,7 @@ public class SourceUtils {
             return !method.getParameters().isEmpty();
         }
 
-        //new launch prototocol from JEP 445:
+        // new launch prototocol from JEP 512:
         int currentMethodPriority = mainMethodPriority(method);
         int highestPriority = Integer.MAX_VALUE;
 

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -707,12 +707,7 @@ public final class TreeUtilities {
             Context context = task.getContext();
             JavaCompiler compiler = JavaCompiler.instance(context);
             JavaFileObject prev = compiler.log.useSource(new DummyJFO());
-            Log.DiagnosticHandler discardHandler = new Log.DiscardDiagnosticHandler(compiler.log) {
-                @Override
-                public void report(JCDiagnostic diag) {
-                    //ignore:
-                }            
-            };
+            Log.DiagnosticHandler discardHandler = compiler.log.new DiscardDiagnosticHandler();
             try {
                 CharBuffer buf = CharBuffer.wrap((text+"\u0000").toCharArray(), 0, text.length());
                 ParserFactory factory = ParserFactory.instance(context);
@@ -901,7 +896,7 @@ public final class TreeUtilities {
     private static TypeMirror attributeTree(JavacTaskImpl jti, CompilationUnitTree cut, Tree tree, Scope scope, final List<Diagnostic<? extends JavaFileObject>> errors) {
         Log log = Log.instance(jti.getContext());
         JavaFileObject prev = log.useSource(new DummyJFO());
-        Log.DiagnosticHandler discardHandler = new Log.DiscardDiagnosticHandler(log) {
+        Log.DiagnosticHandler discardHandler = log.new DiscardDiagnosticHandler() {
             @Override
             public void report(JCDiagnostic diag) {
                 errors.add(diag);
@@ -941,7 +936,7 @@ public final class TreeUtilities {
     private static Scope attributeTreeTo(JavacTaskImpl jti, CompilationUnitTree cut, Tree tree, Scope scope, Tree to, final List<Diagnostic<? extends JavaFileObject>> errors) {
         Log log = Log.instance(jti.getContext());
         JavaFileObject prev = log.useSource(new DummyJFO());
-        Log.DiagnosticHandler discardHandler = new Log.DiscardDiagnosticHandler(log) {
+        Log.DiagnosticHandler discardHandler = log.new DiscardDiagnosticHandler() {
             @Override
             public void report(JCDiagnostic diag) {
                 errors.add(diag);

--- a/java/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
@@ -34,7 +34,7 @@ import org.openide.modules.OnStart;
  */
 public class NoJavacHelper {
 
-    public static final int REQUIRED_JAVAC_VERSION = 24; // <- TODO: increment on every release
+    public static final int REQUIRED_JAVAC_VERSION = 25; // <- TODO: increment on every release
     private static final boolean HAS_WORKING_JAVAC;
 
     static {

--- a/java/java.source.base/src/org/netbeans/modules/java/source/builder/TreeFactory.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/builder/TreeFactory.java
@@ -64,7 +64,6 @@ import com.sun.tools.javac.model.JavacElements;
 import com.sun.tools.javac.model.JavacTypes;
 import com.sun.tools.javac.parser.Tokens.Comment;
 import com.sun.tools.javac.parser.Tokens.Comment.CommentStyle;
-import com.sun.tools.javac.tree.DCTree.DCDocComment;
 import com.sun.tools.javac.tree.DCTree.DCReference;
 import com.sun.tools.javac.tree.DocTreeMaker;
 import com.sun.tools.javac.tree.JCTree;
@@ -2070,5 +2069,11 @@ public class TreeFactory {
         public boolean isDeprecated() {
             return false;
         }
+
+        @Override
+        public Comment stripIndent() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+        
     }
 }

--- a/java/libs.javacapi/external/binaries-list
+++ b/java/libs.javacapi/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-9FB1613756338EE706C23D53F1423E6925D127C8 com.dukescript.nbjavac:nb-javac:jdk-24-ga
-AD9963C5C1DA19B72628F48364562C014A972B69 com.dukescript.nbjavac:nb-javac:jdk-24-ga:api
+CD9EA8DDE23DF41A129D563A51C9A2E502BD85BF com.dukescript.nbjavac:nb-javac:jdk-25+31.1
+183E5391BCCC0A27AE0F5014A3A9FA7F93214911 com.dukescript.nbjavac:nb-javac:jdk-25+31.1:api

--- a/java/libs.javacapi/external/nb-javac-jdk-25+31.1-license.txt
+++ b/java/libs.javacapi/external/nb-javac-jdk-25+31.1-license.txt
@@ -1,7 +1,7 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Version: 24-ga
-Files: nb-javac-jdk-24-ga-api.jar nb-javac-jdk-24-ga.jar
+Version: 25+31.1
+Files: nb-javac-jdk-25+31.1-api.jar nb-javac-jdk-25+31.1.jar
 License: GPL-2-CP
 Origin: OpenJDK (https://github.com/openjdk/jdk)
 Source: https://github.com/openjdk/jdk

--- a/java/libs.javacapi/nbproject/org-netbeans-libs-javacapi.sig
+++ b/java/libs.javacapi/nbproject/org-netbeans-libs-javacapi.sig
@@ -1646,7 +1646,6 @@ fld public final static javax.lang.model.SourceVersion RELEASE_6
 fld public final static javax.lang.model.SourceVersion RELEASE_7
 fld public final static javax.lang.model.SourceVersion RELEASE_8
 fld public final static javax.lang.model.SourceVersion RELEASE_9
-meth public nbjavac.RuntimeWR$Version runtimeVersion()
 meth public static boolean isIdentifier(java.lang.CharSequence)
 meth public static boolean isKeyword(java.lang.CharSequence)
 meth public static boolean isKeyword(java.lang.CharSequence,javax.lang.model.SourceVersion)
@@ -1655,7 +1654,6 @@ meth public static boolean isName(java.lang.CharSequence,javax.lang.model.Source
 meth public static javax.lang.model.SourceVersion latest()
 meth public static javax.lang.model.SourceVersion latestSupported()
 meth public static javax.lang.model.SourceVersion valueOf(java.lang.String)
-meth public static javax.lang.model.SourceVersion valueOf(nbjavac.RuntimeWR$Version)
 meth public static javax.lang.model.SourceVersion[] values()
 supr java.lang.Enum<javax.lang.model.SourceVersion>
 hfds latestSupported

--- a/java/libs.javacapi/nbproject/project.xml
+++ b/java/libs.javacapi/nbproject/project.xml
@@ -40,11 +40,11 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-jdk-24-ga-api.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-25+31.1-api.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-jdk-24-ga.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-25+31.1.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/libs.nbjavacapi/external/binaries-list
+++ b/java/libs.nbjavacapi/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-9FB1613756338EE706C23D53F1423E6925D127C8 com.dukescript.nbjavac:nb-javac:jdk-24-ga
-AD9963C5C1DA19B72628F48364562C014A972B69 com.dukescript.nbjavac:nb-javac:jdk-24-ga:api
+CD9EA8DDE23DF41A129D563A51C9A2E502BD85BF com.dukescript.nbjavac:nb-javac:jdk-25+31.1
+183E5391BCCC0A27AE0F5014A3A9FA7F93214911 com.dukescript.nbjavac:nb-javac:jdk-25+31.1:api

--- a/java/libs.nbjavacapi/external/nb-javac-jdk-25+31.1-license.txt
+++ b/java/libs.nbjavacapi/external/nb-javac-jdk-25+31.1-license.txt
@@ -1,7 +1,7 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Version: 24-ga
-Files: nb-javac-jdk-24-ga-api.jar nb-javac-jdk-24-ga.jar
+Version: 25+31.1
+Files: nb-javac-jdk-25+31.1-api.jar nb-javac-jdk-25+31.1.jar
 License: GPL-2-CP
 Origin: OpenJDK (https://github.com/openjdk/jdk)
 Source: https://github.com/openjdk/jdk

--- a/java/libs.nbjavacapi/nbproject/project.properties
+++ b/java/libs.nbjavacapi/nbproject/project.properties
@@ -18,8 +18,8 @@
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 license.file.override=${nb_all}/nbbuild/licenses/GPL-2-CP
-release.external/nb-javac-jdk-24-ga-api.jar=modules/ext/nb-javac-jdk-24-ga-api.jar
-release.external/nb-javac-jdk-24-ga.jar=modules/ext/nb-javac-jdk-24-ga.jar
+release.external/nb-javac-jdk-25+31.1-api.jar=modules/ext/nb-javac-jdk-25-31.1-api.jar
+release.external/nb-javac-jdk-25+31.1.jar=modules/ext/nb-javac-jdk-25-31.1.jar
 
 # for tests
 requires.nb.javac=true

--- a/java/libs.nbjavacapi/nbproject/project.xml
+++ b/java/libs.nbjavacapi/nbproject/project.xml
@@ -45,12 +45,12 @@
             </test-dependencies>
             <public-packages/>
             <class-path-extension>
-                <runtime-relative-path>ext/nb-javac-jdk-24-ga-api.jar</runtime-relative-path>
-                <binary-origin>external/nb-javac-jdk-24-ga-api.jar</binary-origin>
+                <runtime-relative-path>ext/nb-javac-jdk-25-31.1-api.jar</runtime-relative-path>
+                <binary-origin>external/nb-javac-jdk-25+31.1-api.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/nb-javac-jdk-24-ga.jar</runtime-relative-path>
-                <binary-origin>external/nb-javac-jdk-24-ga.jar</binary-origin>
+                <runtime-relative-path>ext/nb-javac-jdk-25-31.1.jar</runtime-relative-path>
+                <binary-origin>external/nb-javac-jdk-25+31.1.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/libs.nbjavacapi/src/org/netbeans/modules/nbjavac/api/Bundle.properties
+++ b/java/libs.nbjavacapi/src/org/netbeans/modules/nbjavac/api/Bundle.properties
@@ -18,6 +18,6 @@
 OpenIDE-Module-Display-Category=Java
 OpenIDE-Module-Long-Description=\
     This library provides a Java language parser for the IDE. \
-    Supports JDK-24 features.
+    Supports JDK-25 features.
 OpenIDE-Module-Name=The nb-javac Java editing support library
 OpenIDE-Module-Short-Description=The nb-javac Java editing support library

--- a/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/ui/JavaRefactoringActionsProviderTest.java
+++ b/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/ui/JavaRefactoringActionsProviderTest.java
@@ -20,8 +20,8 @@
 package org.netbeans.modules.refactoring.java.ui;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Ignore;
 import org.netbeans.modules.refactoring.java.test.RefactoringTestBase;
-import static org.junit.Assert.*;
 import org.netbeans.modules.refactoring.spi.ui.RefactoringUI;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
@@ -41,12 +41,13 @@ public class JavaRefactoringActionsProviderTest extends RefactoringTestBase {
     
     public void test211193() throws Exception {
         writeFilesAndWaitForScan(src,
-                new File("t/A.java", "package t;\n"
-                + "public class A {\n"
-                + "    public static void foo() {\n"
-                + "        int someArray[] = {};\n"
-                + "    }\n"
-                + "}"));
+                new File("t/A.java", """
+                                     package t;
+                                     public class A {
+                                         public static void foo() {
+                                             int someArray[] = {};
+                                         }
+                                     }"""));
         FileObject testFile = src.getFileObject("t/A.java");
         DataObject testFileDO = DataObject.find(testFile);
         EditorCookie ec = testFileDO.getLookup().lookup(EditorCookie.class);
@@ -66,12 +67,18 @@ public class JavaRefactoringActionsProviderTest extends RefactoringTestBase {
         assertEquals(++expectedCount, called.get());
     }
 
+    // hg blame: "#190101: preventing exceptions from various refactorings for very broken sources (without a top-level class)"
+
+    // disabled, javac 25 assumes everything what doesn't have a class declaration is
+    // a compact source file, so the orignal regression test isn't working atm
+    @Ignore
     public void test190101() throws Exception {
         writeFilesAndWaitForScan(src,
-                                 new File("t/A.java", "package t;\n" +
-                                                      "//public class A {\n" +
-                                                      "    public static void foo() {}\n" +
-                                                      "}"));
+                                 new File("t/A.java", """
+                                                      package t;
+                                                      //public class A {
+                                                          public static void foo() {}
+                                                      }"""));
         FileObject testFile = src.getFileObject("t/A.java");
         DataObject testFileDO = DataObject.find(testFile);
         EditorCookie ec = testFileDO.getLookup().lookup(EditorCookie.class);

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
@@ -572,7 +572,7 @@ public class Utilities {
             throw new IllegalArgumentException();
         JavaCompiler compiler = JavaCompiler.instance(context);
         JavaFileObject prev = compiler.log.useSource(new DummyJFO());
-        Log.DiagnosticHandler discardHandler = new Log.DiscardDiagnosticHandler(compiler.log) {
+        Log.DiagnosticHandler discardHandler = compiler.log.new DiscardDiagnosticHandler() {
             @Override
             public void report(JCDiagnostic diag) {
                 errors.add(diag);
@@ -599,7 +599,7 @@ public class Utilities {
             throw new IllegalArgumentException();
         JavaCompiler compiler = JavaCompiler.instance(context);
         JavaFileObject prev = compiler.log.useSource(new DummyJFO());
-        Log.DiagnosticHandler discardHandler = new Log.DiscardDiagnosticHandler(compiler.log) {
+        Log.DiagnosticHandler discardHandler = compiler.log.new DiscardDiagnosticHandler() {
             @Override
             public void report(JCDiagnostic diag) {
                 errors.add(diag);
@@ -630,7 +630,7 @@ public class Utilities {
     private static TypeMirror attributeTree(JavacTaskImpl jti, Tree tree, Scope scope, final List<Diagnostic<? extends JavaFileObject>> errors) {
         Log log = Log.instance(jti.getContext());
         JavaFileObject prev = log.useSource(new DummyJFO());
-        Log.DiagnosticHandler discardHandler = new Log.DiscardDiagnosticHandler(log) {
+        Log.DiagnosticHandler discardHandler = log.new DiscardDiagnosticHandler() {
             @Override
             public void report(JCDiagnostic diag) {
                 errors.add(diag);
@@ -743,7 +743,7 @@ public class Utilities {
         Annotate annotate = Annotate.instance(context);
         Names names = Names.instance(context);
         Symtab syms = Symtab.instance(context);
-        Log.DiagnosticHandler discardHandler = new Log.DiscardDiagnosticHandler(compiler.log);
+        Log.DiagnosticHandler discardHandler = log.new DiscardDiagnosticHandler();
 
         JavaFileObject jfo = FileObjects.memoryFileObject("$", "$", new File("/tmp/$$scopeclass$constraints$" + count + ".java").toURI(), System.currentTimeMillis(), clazz.toString());
 

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -96,8 +96,8 @@ nb/ide.launcher/external/launcher-external-binaries-3-282bbc032bcd.zip platform/
 nb/ide.launcher/external/launcher-external-binaries-3-282bbc032bcd.zip harness/apisupport.harness/external/launcher-external-binaries-3-282bbc032bcd.zip
 
 # only one is part of the product:
-java/libs.javacapi/external/nb-javac-jdk-24-ga-api.jar java/libs.nbjavacapi/external/nb-javac-jdk-24-ga-api.jar
-java/libs.javacapi/external/nb-javac-jdk-24-ga.jar java/libs.nbjavacapi/external/nb-javac-jdk-24-ga.jar
+java/libs.javacapi/external/nb-javac-jdk-25+31.1-api.jar java/libs.nbjavacapi/external/nb-javac-jdk-25+31.1-api.jar
+java/libs.javacapi/external/nb-javac-jdk-25+31.1.jar java/libs.nbjavacapi/external/nb-javac-jdk-25+31.1.jar
 
 # Used only in unittests for mysql db specific tests
 ide/db.metadata.model/external/mysql-connector-j-8.0.31.jar ide/db.mysql/external/mysql-connector-j-8.0.31.jar


### PR DESCRIPTION
Upgrade javac integration to nb-javac based on JDK 25 build 31

~this is not meant to be integrated yet, the wrapped nb-javac is an experimental build which was backported to JDK 17 instead of 8 to reduce the delta to upstream. It was built from this [old branch](https://github.com/mbien/nb-javac/commits/target-jdk17-2/) I created a while ago.~ 

~nb-javac 25 is not available yet, uses a temporary build for now with extra patches.~

refs to javac regressions which were discovered during testing:
 - [JDK-8361445](https://bugs.openjdk.org/browse/JDK-8361445) https://github.com/openjdk/jdk/pull/26142
 - [JDK-8361570](https://bugs.openjdk.org/browse/JDK-8361570) https://github.com/openjdk/jdk/pull/26181