### PR TITLE
update: Fix BreadCrumbComponent use of double

### DIFF
--- a/ide/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/BreadCrumbComponent.java
+++ b/ide/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/BreadCrumbComponent.java
@@ -145,8 +145,8 @@ public class BreadCrumbComponent<T extends JLabel&Renderer> extends JComponent i
 
     private final T renderer = (T) HtmlRenderer.createLabel();
     private Node[] nodes;
-    private double[] sizes;
-    private double height;
+    private int[] sizes;
+    private int height;
 
     private void measurePrepaint() {
         List<Node> path = computeNodePath();
@@ -154,7 +154,7 @@ public class BreadCrumbComponent<T extends JLabel&Renderer> extends JComponent i
         int i = 0;
         
         nodes = path.toArray(new Node[0]);
-        sizes = new double[path.size()];
+        sizes = new int[path.size()];
         
         int xTotal = 0;
         
@@ -170,7 +170,8 @@ public class BreadCrumbComponent<T extends JLabel&Renderer> extends JComponent i
             i++;
         }
 
-        setPreferredSize(new Dimension((xTotal + (nodes.length - 1) * (LEFT_SEPARATOR_INSET + SEPARATOR.getIconWidth() + RIGHT_SEPARATOR_INSET) + START_INSET), USABLE_HEIGHT/*(int) (height + 2 * INSET_HEIGHT)*/));
+        setPreferredSize(new Dimension((xTotal + (nodes.length - 1) *
+                         (LEFT_SEPARATOR_INSET + SEPARATOR.getIconWidth() + RIGHT_SEPARATOR_INSET) + START_INSET), USABLE_HEIGHT));
     }
     
     @Override


### PR DESCRIPTION
update: Fix BreadCrumbComponent use of double

desc: The code in BreadCrumbComponent reads the fields from the Dimension class. These fields are integers. So the code encounters an implicit case. This is problematic for several reasons:

1 - casting leads to an error
   [repeat] /home/bwalker/src/netbeans/ide/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/BreadCrumbComponent.java:166: warning: [lossy-conversions] implicit cast from double to int in compound assignment is possibly lossy
   [repeat]             xTotal += sizes[i] = preferedSize.width;
   [repeat]                                ^
   [repeat] /home/bwalker/src/netbeans/ide/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/BreadCrumbComponent.java:193: warning: [lossy-conversions] implicit cast from double to int in compound assignment is possibly lossy
   [repeat]             elemX += sizes[i];
   [repeat]                           ^

2 - There is no need for floating point precision here.

testing: built and executed with no issues.


---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [ ] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [ ] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [ ] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [ ] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>