### PR TITLE
Fix web.common test dependency

### DIFF
--- a/ide/web.common/nbproject/project.xml
+++ b/ide/web.common/nbproject/project.xml
@@ -143,6 +143,7 @@
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.editor.lib</code-name-base>
+                        <compile-dependency/>
                         <test/>
                     </test-dependency>
                     <test-dependency>


### PR DESCRIPTION
fixes `FileReferenceTest.java:31: error: cannot access BaseDocument`

jenkns didn't run for a few days due to maintenance but is failing now:
https://ci-builds.apache.org/job/Netbeans/job/netbeans-TLP/job/master/527/cloudbees-pipeline-explorer/?filter=35

I got a different error locally though, this PR tries to fix it. Lets build all tests and javadoc.