### PR TITLE
Cleanup parsing.lucene module and fix deprecations

### DIFF
--- a/ide/parsing.lucene/nbproject/project.properties
+++ b/ide/parsing.lucene/nbproject/project.properties
@@ -15,11 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javadoc.apichanges=${basedir}/apichanges.xml
 javac.compilerargs=-Xlint -Xlint:-serial
 
 spec.version.base=2.65.0
-test.config.stableBTD.includes=**/*Test.class
-test.config.stableBTD.excludes=\
-    **/LuceneIndexTest.class

--- a/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/Convertors.java
+++ b/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/Convertors.java
@@ -40,8 +40,6 @@ class Convertors {
         throw  new IllegalStateException();
     }
 
-
-
     static Convertor<IndexDocument, Document> newIndexDocumentToDocumentConvertor() {
         return new AddConvertor();
     }
@@ -54,14 +52,12 @@ class Convertors {
         return new RemoveConvertor();
     }
 
-    static <T> StoppableConvertor<TermEnum,T> newTermEnumToTermConvertor(
-        @NonNull StoppableConvertor<Term,T> delegate) {
-        return new TermEnumToTerm<T>(delegate);
+    static <T> StoppableConvertor<TermEnum, T> newTermEnumToTermConvertor(@NonNull StoppableConvertor<Term, T> delegate) {
+        return new TermEnumToTerm<>(delegate);
     }
 
-    static <T> StoppableConvertor<TermEnum,T> newTermEnumToFreqConvertor(
-        @NonNull StoppableConvertor<Index.WithTermFrequencies.TermFreq,T> delegate) {
-        return new TermEnumToFreq<T>(delegate);
+    static <T> StoppableConvertor<TermEnum, T> newTermEnumToFreqConvertor(@NonNull StoppableConvertor<Index.WithTermFrequencies.TermFreq, T> delegate) {
+        return new TermEnumToFreq<>(delegate);
     }
 
 
@@ -104,9 +100,9 @@ class Convertors {
         }
 
         @Override
-        public void setIndexReader(@NonNull final IndexReader indexReader) {
-            if (delegate instanceof IndexReaderInjection) {
-                ((IndexReaderInjection)delegate).setIndexReader(indexReader);
+        public void setIndexReader(@NonNull IndexReader indexReader) {
+            if (delegate instanceof IndexReaderInjection iri) {
+                iri.setIndexReader(indexReader);
             }
         }
     }
@@ -132,9 +128,9 @@ class Convertors {
         }
 
         @Override
-        public void setIndexReader(@NonNull final IndexReader indexReader) {
-            if (delegate instanceof IndexReaderInjection) {
-                ((IndexReaderInjection)delegate).setIndexReader(indexReader);
+        public void setIndexReader(@NonNull IndexReader indexReader) {
+            if (delegate instanceof IndexReaderInjection iri) {
+                iri.setIndexReader(indexReader);
             }
         }
     }

--- a/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/RecordOwnerLockFactory.java
+++ b/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/RecordOwnerLockFactory.java
@@ -50,12 +50,7 @@ class RecordOwnerLockFactory extends LockFactory {
     @Override
     public Lock makeLock(String lockName) {
         synchronized (locks) {
-            RecordOwnerLock res = locks.get(lockName);
-            if (res == null) {
-                res = new RecordOwnerLock();
-                locks.put(lockName, res);
-            }
-            return res;
+            return locks.computeIfAbsent(lockName, k -> new RecordOwnerLock());
         }
     }
 

--- a/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/SimpleDocumentIndexCache.java
+++ b/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/SimpleDocumentIndexCache.java
@@ -95,9 +95,9 @@ public class SimpleDocumentIndexCache implements DocumentIndexCache {
         if (toAdd == null || toRemove == null) {
             assert toAdd == null && toRemove == null;
             assert dataRef == null;
-            toAdd = new ArrayList<IndexDocument>();
-            toRemove = new ArrayList<String>();
-            dataRef = new SoftReference<List<?>[]>(new List<?>[] {toAdd, toRemove});
+            toAdd = new ArrayList<>();
+            toRemove = new ArrayList<>();
+            dataRef = new SoftReference<>(new List<?>[] {toAdd, toRemove});
         }
         return dataRef;
     }

--- a/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/TermCollector.java
+++ b/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/TermCollector.java
@@ -46,17 +46,13 @@ public final class TermCollector extends Collector {
     
     TermCollector(Collector collector) {
         this.delegate = collector;
-        doc2Terms = new HashMap<Integer, Set<Term>>();
+        doc2Terms = new HashMap<>();
     }
     
     public void add (final int docId, final @NonNull Term term) {
         final int realId = docId + indexOffset;
-        Set<Term> slot = doc2Terms.get(realId);
-        if (slot == null) {
-            slot = new HashSet<Term>();
-            doc2Terms.put(realId, slot);
-        }
-        slot.add(term);
+        doc2Terms.computeIfAbsent(realId, k -> new HashSet<>())
+                 .add(term);
     }
     
     Set<Term> get(final int docId) {
@@ -71,19 +67,23 @@ public final class TermCollector extends Collector {
         void attach (TermCollector collector);
     }
 
+    @Override
     public void setScorer(Scorer scorer) throws IOException {
         delegate.setScorer(scorer);
     }
 
+    @Override
     public void setNextReader(IndexReader reader, int i) throws IOException {
         delegate.setNextReader(reader, i);
         indexOffset = i;
     }
 
+    @Override
     public void collect(int i) throws IOException {
         delegate.collect(i);
     }
 
+    @Override
     public boolean acceptsDocsOutOfOrder() {
         return delegate.acceptsDocsOutOfOrder();
     }

--- a/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/DocumentIndex.java
+++ b/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/DocumentIndex.java
@@ -89,7 +89,7 @@ public interface DocumentIndex {
     
     /**
      * Performs a search on the index using primary key
-     * @param value of the primary key
+     * @param primaryKeyValue of the primary key
      * @param kind of the query, see {@link Queries.QueryKind} for details
      * @param fieldsToLoad names of the field which should be loaded into the document.
      * Loading only needed fields speeds up the search. If null or empty all fields are loaded.

--- a/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/Index.java
+++ b/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/Index.java
@@ -165,7 +165,6 @@ public interface Index {
          * @param toDelete the objects to be removed from the index
          * @param docConvertor the {@link Convertor} used to convert toAdd objects into lucene's Documents which are stored into the {@link Index}
          * @param queryConvertor the {@link Convertor} used to convert toDelete objects into lucene's Queries used to delete the documents from {@link Index}
-         * @param optimize if true the index is optimized. The optimized index is faster for queries but optimize takes significant time.
          * @throws IOException in case of IO problem
          * @see #store
          */

--- a/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/LowMemoryWatcher.java
+++ b/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/LowMemoryWatcher.java
@@ -39,7 +39,7 @@ public final class LowMemoryWatcher {
 
     private static final Logger LOG = Logger.getLogger(LowMemoryWatcher.class.getName());
     private static final long LOGGER_RATE = Integer.getInteger(
-            String.format("%s.logger_rate",LowMemoryWatcher.class.getName()),   //NOI18N
+            "%s.logger_rate".formatted(LowMemoryWatcher.class.getName()),   //NOI18N
             1000);   //1s
 
 

--- a/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/StoppableConvertor.java
+++ b/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/StoppableConvertor.java
@@ -35,7 +35,7 @@ public interface StoppableConvertor<P,R> {
     
     /**
      * Converts given object
-     * @param p the object to be converted
+     * @param param the object to be converted
      * @return the result of conversion
      * @throws Stop to stop the index iteration
      */

--- a/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/AsyncCloseTest.java
+++ b/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/AsyncCloseTest.java
@@ -20,9 +20,9 @@ package org.netbeans.modules.parsing.lucene;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -69,25 +69,22 @@ public class AsyncCloseTest extends NbTestCase {
     public void testAsyncClose() throws Exception {
         final CountDownLatch slot = new CountDownLatch(1);
         final CountDownLatch signal = new CountDownLatch(1);
-        final  CountDownLatch done = new CountDownLatch(1);
-        final AtomicReference<Exception> exception = new AtomicReference<Exception>();
+        final CountDownLatch done = new CountDownLatch(1);
+        final AtomicReference<Exception> exception = new AtomicReference<>();
 
         final Index index = IndexManager.createTransactionalIndex(indexFolder, new KeywordAnalyzer());
-        final Thread worker = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    index.store(
-                       new ArrayList<String>(Arrays.asList("foo")), //NOI18N
-                       Collections.<String>emptySet(),
-                       new TestInsertConvertor(slot, signal),
-                       new TestDeleteConvertor(),
-                       true);
-                } catch (Exception ex) {
-                    exception.set(ex);
-                } finally {
-                    done.countDown();
-                }
+        final Thread worker = new Thread(() -> {
+            try {
+                index.store(
+                        new ArrayList<>(List.of("foo")), //NOI18N
+                        Collections.emptySet(),
+                        new TestInsertConvertor(slot, signal),
+                        new TestDeleteConvertor(),
+                        true);
+            } catch (Exception ex) {
+                exception.set(ex);
+            } finally {
+                done.countDown();
             }
         });
         worker.start();
@@ -102,8 +99,8 @@ public class AsyncCloseTest extends NbTestCase {
     public void testConcurrentReadWrite() throws Exception {
         final Index index = IndexManager.createTransactionalIndex(indexFolder, new KeywordAnalyzer());
         index.store(
-            new ArrayList<String>(Arrays.asList("a")), //NOI18N
-            Collections.<String>emptySet(),
+            new ArrayList<>(List.of("a")), //NOI18N
+            Collections.emptySet(),
             new TestInsertConvertor(),
             new TestDeleteConvertor(),
             true);
@@ -111,30 +108,27 @@ public class AsyncCloseTest extends NbTestCase {
         final CountDownLatch slot = new CountDownLatch(1);
         final CountDownLatch signal = new CountDownLatch(1);
         final CountDownLatch done = new CountDownLatch(1);
-        final AtomicReference<Exception> result = new AtomicReference<Exception>();
+        final AtomicReference<Exception> result = new AtomicReference<>();
 
-        final Thread worker = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    index.store(
-                           new ArrayList<String>(Arrays.asList("b")), //NOI18N
-                           Collections.<String>emptySet(),
-                           new TestInsertConvertor(slot, signal),
-                           new TestDeleteConvertor(),
-                           true);
-                } catch (Exception e) {
-                    result.set(e);
-                } finally {
-                    done.countDown();
-                }
+        final Thread worker = new Thread(() -> {
+            try {
+                index.store(
+                        new ArrayList<>(List.of("b")), //NOI18N
+                        Collections.emptySet(),
+                        new TestInsertConvertor(slot, signal),
+                        new TestDeleteConvertor(),
+                        true);
+            } catch (Exception e) {
+                result.set(e);
+            } finally {
+                done.countDown();
             }
         });
 
         worker.start();
         signal.await();
 
-        final Collection<String> data = new ArrayList<String>();
+        final Collection<String> data = new ArrayList<>();
         index.query(
             data,
             new Convertor<Document,String>(){

--- a/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/IndexTransactionTest.java
+++ b/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/IndexTransactionTest.java
@@ -19,7 +19,6 @@
 package org.netbeans.modules.parsing.lucene;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -75,9 +74,9 @@ public class IndexTransactionTest extends NbTestCase {
 
         //Empty index => invalid
         assertEquals(Index.Status.EMPTY, index.getStatus(true));
-        final List<String> refs = new ArrayList<String>();
+        List<String> refs = new ArrayList<>();
         refs.add("A");
-        final Set<String> toDel = new HashSet<String>();
+        Set<String> toDel = new HashSet<>();
         
         index.txStore(
                 refs,
@@ -90,7 +89,7 @@ public class IndexTransactionTest extends NbTestCase {
         assertTrue(cache.listFiles().length>0);
         
         // Open a reader, and check that the reader does NOT see the change, although flushed
-        Collection<String> result = new LinkedList<String>();
+        Collection<String> result = new LinkedList<>();
         AtomicBoolean cancel = new AtomicBoolean(false);
         index.query(
                 result, 
@@ -231,7 +230,7 @@ public class IndexTransactionTest extends NbTestCase {
     }
     
     private static class DocToStrConvertor implements Convertor<Document, String> {
-        private String name;
+        private final String name;
 
         public DocToStrConvertor(String name) {
             this.name = name;

--- a/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/LRUCacheTest.java
+++ b/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/LRUCacheTest.java
@@ -35,12 +35,12 @@ public class LRUCacheTest extends NbTestCase {
         super(name);
     }
 
-    private Set<Integer> used = new HashSet<Integer>();
+    private Set<Integer> used = new HashSet<>();
 
     @Test
     public void testLRU() {
-        final LRUCache<Integer,Evictable> ev = new LRUCache<Integer, Evictable>(new TestEvictionPolicy());
-        final Set<Integer> golden = new HashSet<Integer>();
+        final LRUCache<Integer,Evictable> ev = new LRUCache<>(new TestEvictionPolicy());
+        final Set<Integer> golden = new HashSet<>();
         for (int i=0; i<10; i++) {
             used.add(i);
             ev.put(i, new EvictableInt(i));
@@ -78,7 +78,7 @@ public class LRUCacheTest extends NbTestCase {
 
     private class EvictableInt implements Evictable {
 
-        private Integer value;
+        private final Integer value;
         
         public EvictableInt(final int i) {
             this.value = i;

--- a/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/LuceneIndexTest.java
+++ b/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/LuceneIndexTest.java
@@ -19,10 +19,6 @@
 
 package org.netbeans.modules.parsing.lucene;
 
-/**
- *
- * @author Tomas Zezula
- */
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -44,9 +40,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.parsing.lucene.support.Convertor;
-import org.netbeans.modules.parsing.lucene.support.DocumentIndex;
 import org.netbeans.modules.parsing.lucene.support.Index;
-import org.netbeans.modules.parsing.lucene.support.IndexDocument;
 import org.netbeans.modules.parsing.lucene.support.IndexManager;
 
 /**
@@ -75,9 +69,9 @@ public class LuceneIndexTest extends NbTestCase {
         assertEquals(Index.Status.EMPTY, index.getStatus(true));
 
         clearValidityCache(index);
-        List<String> refs = new ArrayList<String>();
+        List<String> refs = new ArrayList<>();
         refs.add("A");
-        Set<String> toDel = new HashSet<String>();
+        Set<String> toDel = new HashSet<>();
         index.store(
                 refs,
                 toDel,
@@ -116,11 +110,8 @@ public class LuceneIndexTest extends NbTestCase {
             }
         }
         assertNotNull(bt);
-        FileOutputStream out = new FileOutputStream(bt);
-        try {
-            out.write(new byte[] {0,0,0,0,0,0,0,0,0,0}, 0, 10);
-        } finally {
-            out.close();
+        try (FileOutputStream out = new FileOutputStream(bt)) {
+            out.write(new byte[10]);
         }
         assertEquals(Index.Status.INVALID, index.getStatus(true));
         assertTrue(cache.listFiles().length==0);
@@ -140,9 +131,9 @@ public class LuceneIndexTest extends NbTestCase {
         
         //No TX store -> no warning
         handler.clear();
-        List<String> refs = new ArrayList<String>();
+        List<String> refs = new ArrayList<>();
         refs.add("A");
-        Set<String> toDel = new HashSet<String>();
+        Set<String> toDel = new HashSet<>();
         index.store(
             refs,
             toDel,

--- a/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/NativeFSLockFactoryTest.java
+++ b/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/NativeFSLockFactoryTest.java
@@ -111,7 +111,7 @@ public class NativeFSLockFactoryTest extends NbTestCase {
         try {
             index.store(
                 dataSet,
-                Collections.<String>emptySet(),
+                Collections.emptySet(),
                 new Convertor<Integer, Document>() {
                     @Override
                     public Document convert(Integer p) {
@@ -142,7 +142,7 @@ public class NativeFSLockFactoryTest extends NbTestCase {
 
 
     private static Collection<? extends Integer> generateDataSet(final int count) {
-        final List<Integer> res = new ArrayList<Integer>(count);
+        final List<Integer> res = new ArrayList<>(count);
         for (int i=0; i< count; i++) {
             res.add(i);
         }

--- a/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/RawIndexPerfTest.java
+++ b/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/RawIndexPerfTest.java
@@ -104,7 +104,7 @@ public class RawIndexPerfTest extends NbTestCase {
 
     private List<Long> generateData(int size) {
         final List<Long> res = new ArrayList<>(size);
-        for (int i=0; i<size; i++) {
+        for (int i = 0; i < size; i++) {
             res.add(seq.incrementAndGet());
         }
         return res;
@@ -130,7 +130,7 @@ public class RawIndexPerfTest extends NbTestCase {
     private static final class LongToDoc implements Convertor<Long, Document> {
         @Override
         public Document convert(Long p) {
-            final Document doc = new Document();
+            Document doc = new Document();
             doc.add(new Field("dec", Long.toString(p), Field.Store.YES, Field.Index.NOT_ANALYZED_NO_NORMS));
             doc.add(new Field("hex", Long.toHexString(p), Field.Store.NO, Field.Index.NOT_ANALYZED_NO_NORMS));
             doc.add(new Field("bin", Long.toBinaryString(p), Field.Store.YES, Field.Index.NO));

--- a/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/support/IndexManagerTestUtilities.java
+++ b/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/support/IndexManagerTestUtilities.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.parsing.lucene.support;
 
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.modules.parsing.lucene.IndexFactory;
-import org.netbeans.modules.parsing.lucene.LuceneIndex;
 import org.openide.util.Parameters;
 
 /**

--- a/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/support/LMListenerTest.java
+++ b/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/support/LMListenerTest.java
@@ -32,7 +32,7 @@ public class LMListenerTest extends NbTestCase {
     private static final int _10K = 10 * 1024;
 
 
-    private List<byte []> refs = new LinkedList<byte []>();
+    private List<byte []> refs = new LinkedList<>();
 
     public LMListenerTest (final String name) {
         super (name);


### PR DESCRIPTION
 - all lucene deprecations fixed
 - javac warnings fixed
 - JDK 17 language level and other cleanup

Lucene 4.0 breaks API which makes an upgrade a bit tricky since not much builds after that. This moves some of the work to 3.6.2 while tests are still working as attempt to make https://github.com/apache/netbeans/issues/8384 easier.