### PR TITLE
Allow optional language specification when analyzing stack

### DIFF
--- a/java/java.navigation/manifest.mf
+++ b/java/java.navigation/manifest.mf
@@ -3,5 +3,5 @@ OpenIDE-Module: org.netbeans.modules.java.navigation/1
 OpenIDE-Module-Layer: org/netbeans/modules/java/navigation/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/java/navigation/Bundle.properties
 OpenIDE-Module-Requires: org.openide.windows.WindowManager
-OpenIDE-Module-Specification-Version: 1.69
+OpenIDE-Module-Specification-Version: 1.70
 AutoUpdate-Show-In-Client: false

--- a/java/java.navigation/nbproject/project.properties
+++ b/java/java.navigation/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.release=11
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 test.qa-functional.cp.extra=${java.navigation.dir}/modules/org-netbeans-modules-java-navigation.jar:\
 ${openide.filesystems.dir}/core/org-openide-filesystems.jar:\

--- a/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyser.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyser.java
@@ -56,6 +56,7 @@ class StackLineAnalyser {
         "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*";
     private static final Pattern LINE_PATTERN = Pattern.compile(
         "at\\s+" +                                                      // initial 'at'
+        "(?:<\\w+>\\s+)?" +                                             // optional identification of a language like <java>
         "("+IDENTIFIER+"\\S*/)?" +                                      // optional module name like 'java.base/' or 'Mavenproject1@0.1-SNAPSHOT/'
         "(("+IDENTIFIER+"(\\."+IDENTIFIER+")*)\\.)?("+IDENTIFIER+")" +  // class name
         "\\.("+IDENTIFIER+"|\\<init\\>|\\<clinit\\>)\\s*"+              // method name
@@ -117,6 +118,10 @@ class StackLineAnalyser {
             this.startOffset = startOffset;
             this.endOffset = endOffset;
             this.extension = extension;
+        }
+
+        int getLineNumber() {
+            return lineNumber;
         }
 
         int getStartOffset () {


### PR DESCRIPTION
Enso (as well as other Truffle languages) produces mixed stacktraces. Those aren't currently recognized by stack analyzer. That makes it hard for me to _"navigate them"_ in NetBeans and I often need to switch to VSCode which handles them with bigger grace. Turns out the only problem with the language identification enclosed in `<` and `>`. This PR modifies the regex to swallow such a specification, when present. This is the result then:

![enso stack](https://github.com/user-attachments/assets/2513394f-5bec-44a8-9b66-e4ff4fd4c26d)
