### PR TITLE
Break cyclical test dependency between html and css editor

### DIFF
--- a/ide/css.editor/nbproject/project.xml
+++ b/ide/css.editor/nbproject/project.xml
@@ -391,7 +391,6 @@
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.html.editor</code-name-base>
                         <recursive/>
-                        <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.html.editor.lib</code-name-base>

--- a/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/CssGotoDeclarationTest.java
+++ b/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/CssGotoDeclarationTest.java
@@ -20,7 +20,6 @@ package org.netbeans.modules.css.editor.csl;
 
 import org.netbeans.modules.csl.spi.DefaultLanguageConfig;
 import org.netbeans.modules.css.editor.ProjectTestBase;
-import org.netbeans.modules.html.editor.gsf.HtmlLanguage;
 
 public class CssGotoDeclarationTest extends ProjectTestBase {
 
@@ -30,7 +29,11 @@ public class CssGotoDeclarationTest extends ProjectTestBase {
 
     @Override
     protected DefaultLanguageConfig getPreferredLanguage() {
-        return new HtmlLanguage();
+        try {
+            return (DefaultLanguageConfig) Class.forName("org.netbeans.modules.html.editor.gsf.HtmlLanguage").getDeclaredConstructor().newInstance();
+        } catch (ReflectiveOperationException ex) {
+            throw new RuntimeException(ex);
+        }
     }
 
     public void testClass_01() throws Exception {

--- a/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/TestIssue166592.java
+++ b/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/TestIssue166592.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import javax.swing.text.Document;
 import org.netbeans.modules.css.editor.test.TestBase;
 import org.netbeans.modules.css.lib.api.CssParserResult;
-import org.netbeans.modules.html.editor.api.gsf.HtmlParserResult;
 import org.netbeans.modules.parsing.api.ParserManager;
 import org.netbeans.modules.parsing.api.ResultIterator;
 import org.netbeans.modules.parsing.api.Source;
@@ -52,13 +51,13 @@ public class TestIssue166592 extends TestBase {
         //         0         1         2         3         4
 
         //works - html
-        assertParserResultType(content, 0, HtmlParserResult.class);
-        assertParserResultType(content, 3, HtmlParserResult.class);
-        assertParserResultType(content, 48, HtmlParserResult.class);
+        assertParserResultType(content, 0, "org.netbeans.modules.html.editor.api.gsf.HtmlParserResult");
+        assertParserResultType(content, 3, "org.netbeans.modules.html.editor.api.gsf.HtmlParserResult");
+        assertParserResultType(content, 48, "org.netbeans.modules.html.editor.api.gsf.HtmlParserResult");
 
         //works - css
-        assertParserResultType(content, 12, CssParserResult.class);
-        assertParserResultType(content, 38, CssParserResult.class);
+        assertParserResultType(content, 12, CssParserResult.class.getName());
+        assertParserResultType(content, 38, CssParserResult.class.getName());
 
         //fails between the two styles - returns css instead of html parser result
 
@@ -67,7 +66,7 @@ public class TestIssue166592 extends TestBase {
 
     }
 
-    private void assertParserResultType(String content, final int offset, Class resultType) throws ParseException {
+    private void assertParserResultType(String content, final int offset, String resultType) throws ParseException {
         Document doc = getDocument(content);
         Source source = Source.create(doc);
         final Result[] _result = new Result[1];
@@ -80,7 +79,7 @@ public class TestIssue166592 extends TestBase {
 
         Result result = _result[0];
         assertNotNull(result);
-        assertEquals(resultType, result.getClass());
+        assertEquals(resultType, result.getClass().getName());
     }
 
 }

--- a/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/indent/CssIndenterTest.java
+++ b/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/indent/CssIndenterTest.java
@@ -36,14 +36,13 @@ import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.csl.api.Formatter;
 import org.netbeans.modules.css.editor.test.TestBase;
 import org.netbeans.modules.css.lib.api.CssTokenId;
-import org.netbeans.modules.html.editor.api.HtmlKit;
-import org.netbeans.modules.html.editor.indent.HtmlIndentTaskFactory;
+import org.netbeans.modules.editor.NbEditorKit;
+import org.netbeans.modules.editor.indent.spi.IndentTask;
 import org.netbeans.modules.web.indent.api.support.AbstractIndenter;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.loaders.DataObject;
 import org.openide.util.Exceptions;
-import org.openide.util.Lookup;
 
 public class CssIndenterTest extends TestBase {
 
@@ -57,10 +56,12 @@ public class CssIndenterTest extends TestBase {
         AbstractIndenter.inUnitTestRun = true;
 //        CssBracketCompleter.unitTestingSupport = true;
 
-        CssIndentTaskFactory cssFactory = new CssIndentTaskFactory();
+        IndentTask.Factory cssFactory = new CssIndentTaskFactory();
         MockMimeLookup.setInstances(MimePath.parse("text/css"), cssFactory, CssTokenId.language());
-        HtmlIndentTaskFactory htmlReformatFactory = new HtmlIndentTaskFactory();
-        MockMimeLookup.setInstances(MimePath.parse("text/html"), htmlReformatFactory, new HtmlKit("text/x-jsp"), HTMLTokenId.language());
+
+        IndentTask.Factory htmlReformatFactory = (IndentTask.Factory) Class.forName("org.netbeans.modules.html.editor.indent.HtmlIndentTaskFactory").getDeclaredConstructor().newInstance();
+        NbEditorKit htmlKit = (NbEditorKit) Class.forName("org.netbeans.modules.html.editor.api.HtmlKit").getDeclaredConstructor(String.class).newInstance("text/x-jsp");
+        MockMimeLookup.setInstances(MimePath.parse("text/html"), htmlReformatFactory, htmlKit, HTMLTokenId.language());
     }
 
     public static Test xxsuite() throws IOException, BadLocationException {


### PR DESCRIPTION
second attempt to fix the failing jenkins build (first was https://github.com/apache/netbeans/pull/8584)

 - `css.editor` tests some features by embedding in html docs
 - `html.editor` has a direct dependency to `css.editor`
 - building `css.edtor `first would fail the build, e.g jenkins fails during clean `ant build-nbm`

I tried to move some mixed css/html tests to `html.editor` to remove the dependency entirely but test data and project tests are too tightly coupled atm. We could still do this but I didn't have time to pull this apart.

So lets make it worse and use reflection to downgrade the cyclical compiletime test dependency to runtime. Footprint is small at least.

cleaner solutions welcome, I suppose we could also not fix it and call build first on jenkins before building nbms (analog to what github actions do atm), or tweak the `build-nbms` ant target.

jenkins fails with:
```
[subant-junit] /mnt/ram/netbeans/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/CssGotoDeclarationTest.java:23: error: package org.netbeans.modules.html.editor.gsf does not exist
[subant-junit] import org.netbeans.modules.html.editor.gsf.HtmlLanguage;
[subant-junit]                                            ^
[subant-junit] /mnt/ram/netbeans/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/TestIssue166592.java:26: error: package org.netbeans.modules.html.editor.api.gsf does not exist
[subant-junit] import org.netbeans.modules.html.editor.api.gsf.HtmlParserResult;
[subant-junit]                                                ^
[subant-junit] /mnt/ram/netbeans/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/indent/CssIndenterTest.java:39: error: package org.netbeans.modules.html.editor.api does not exist
[subant-junit] import org.netbeans.modules.html.editor.api.HtmlKit;
[subant-junit]                                            ^
[subant-junit] /mnt/ram/netbeans/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/indent/CssIndenterTest.java:40: error: package org.netbeans.modules.html.editor.indent does not exist
[subant-junit] import org.netbeans.modules.html.editor.indent.HtmlIndentTaskFactory;
[subant-junit]                                               ^
[subant-junit] 4 errors
```

reproducible with:
1. clone repo 
2. `ant build-nbms`



