### PR TITLE
Java Editor: remove some reflective calls and improve logging

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItem.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItem.java
@@ -170,13 +170,10 @@ public abstract class JavaCompletionItem implements CompletionItem {
     }
 
     public static JavaCompletionItem createVariableItem(CompilationInfo info, VariableElement elem, TypeMirror type, TypeMirror castType, int substitutionOffset, ReferencesCount referencesCount, boolean isInherited, boolean isDeprecated, boolean smartType, int assignToVarOffset, WhiteListQuery.WhiteList whiteList) {
-        ElementKind ek = elem.getKind();
-        if ("BINDING_VARIABLE".equals(ek.name())) {
-            ek = ElementKind.LOCAL_VARIABLE;
-        }
-        switch (ek) {
+        switch (elem.getKind()) {
             case LOCAL_VARIABLE:
             case RESOURCE_VARIABLE:
+            case BINDING_VARIABLE:
             case PARAMETER:
             case EXCEPTION_PARAMETER:
                 return new VariableItem(info, type, elem.getSimpleName().toString(), substitutionOffset, false, smartType, assignToVarOffset);

--- a/java/java.hints/src/org/netbeans/modules/java/hints/perf/Tiny.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/perf/Tiny.java
@@ -33,7 +33,6 @@ import com.sun.source.util.TreePath;
 import com.sun.source.util.Trees;
 import java.util.Collection;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -76,18 +75,6 @@ import static javax.lang.model.type.TypeKind.EXECUTABLE;
  * @author lahvac
  */
 public class Tiny {
-
-    private static final SourceVersion RELEASE_11;
-
-    static {
-        SourceVersion tmp;
-        try {
-            tmp = SourceVersion.valueOf("RELEASE_11");
-        } catch (IllegalArgumentException ex) {
-            tmp = null;
-        }
-        RELEASE_11 = tmp;
-    }
 
     static final boolean SC_IGNORE_SUBSTRING_DEFAULT = true;
     @BooleanOption(displayName = "#LBL_org.netbeans.modules.java.hints.perf.Tiny.SC_IGNORE_SUBSTRING", tooltip = "#TP_org.netbeans.modules.java.hints.perf.Tiny.SC_IGNORE_SUBSTRING", defaultValue=SC_IGNORE_SUBSTRING_DEFAULT)
@@ -379,7 +366,7 @@ public class Tiny {
             TreePath type = ctx.getVariables().get("$clazz");
             String typeName = type.getLeaf().toString();
             
-            if (RELEASE_11 != null && version.compareTo(RELEASE_11) >= 0) {
+            if (version.compareTo(SourceVersion.RELEASE_11) >= 0) {
                 String byRef = NbBundle.getMessage(Tiny.class, "FIX_Tiny_collectionsToArrayByMethodRef", typeName);
                 fixes = new Fix[] {
                     JavaFixUtilities.rewriteFix(ctx, byRef, ctx.getPath(), "$collection.toArray($clazz[]::new)"),
@@ -403,8 +390,8 @@ public class Tiny {
 
     private static boolean isNewArrayWithSize(TreePath type) {
         Tree parent = type.getParentPath().getLeaf();
-        if (parent instanceof NewArrayTree) {
-            List<? extends ExpressionTree> dim = ((NewArrayTree) parent).getDimensions();
+        if (parent instanceof NewArrayTree newArrayTree) {
+            List<? extends ExpressionTree> dim = newArrayTree.getDimensions();
             return dim.isEmpty() ? false : dim.get(0).getKind() == Kind.METHOD_INVOCATION; // size()
         }
         return false;

--- a/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
@@ -106,7 +106,6 @@ import javax.lang.model.type.TypeVariable;
 import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
-import javax.script.Bindings;
 import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
@@ -1102,10 +1101,6 @@ public final class GeneratorUtilities {
                 case ENUM_CONSTANT:
                 case FIELD:
                     String name = new StringBuilder(((TypeElement)e.getEnclosingElement()).getQualifiedName()).append('.').append(e.getSimpleName()).toString();
-                    // skip default static imports
-                    if ("java.lang.StringTemplate.STR".equals(name)) {
-                        break;
-                    }
                     if (!staticImportNames.add(name))
                         break;
                 default:


### PR DESCRIPTION
`VanillaPartialParser`:

 - partial reparse verification is now controlled by the log level 
   (`-J-Dorg.netbeans.modules.java.source.parsing.VanillaPartialReparser.level=FINE`)
 - improved logging (e.g formatting for easy comparison)
 - removed some reflective calls

`Tiny`, `JavaCompletionItem`:

 - some enums can be now used directly

`GeneratorUtilities`, `ClipboardHandler`:

 - remove remaining string template code from https://github.com/apache/netbeans/pull/6908
 - minor cleanup

