### PR TITLE
Add build-prerequisite flag to css.prep dep of javascript2.vue

### DIFF
--- a/webcommon/javascript2.vue/nbproject/project.xml
+++ b/webcommon/javascript2.vue/nbproject/project.xml
@@ -79,6 +79,7 @@
                 </dependency>
                 <dependency>
                     <code-name-base>org.netbeans.modules.css.prep</code-name-base>
+                    <build-prerequisite/>
                     <compile-dependency/>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
this was observed to fix build order of the css.editor/html.editor pair (html has to build first).

workaround for https://github.com/apache/netbeans/pull/8600