### PR TITLE
Improve support for using latest Gradle version in new projects.

### DIFF
--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -83,6 +83,20 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="current-gradle-version-discovery">
+            <api name="general"/>
+            <summary>GradleDistributionManager can query latest available version and use in init</summary>
+            <version major="2" minor="47"/>
+            <date day="20" month="6" year="2025"/>
+            <author login="neilcsmith"/>
+            <compatibility semantic="compatible" addition="yes"/>
+            <description>
+                Added <code><a href="@TOP@/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.html#currentDistribution()">GradleDistributionManager.currentDistribution()</a></code> 
+                method to query the current (latest) release available from the Gradle web service.
+                Added <code>gradleVersion(String version)</code> to
+                <a href="@TOP@/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.InitOperation.html">TemplateOperation.InitOperation</a>.
+            </description>
+        </change>
         <change id="action-for-running-tests-in-parallel">
             <api name="general"/>
             <summary>Added action for running tests in parallel</summary>

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/GradleInitWizard.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/GradleInitWizard.java
@@ -19,11 +19,15 @@
 package org.netbeans.modules.gradle.spi.newproject;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import org.netbeans.modules.gradle.api.execute.GradleDistributionManager;
 import org.netbeans.modules.gradle.newproject.GradleInitPanel;
+import org.netbeans.modules.gradle.spi.GradleSettings;
 import org.netbeans.spi.project.ui.support.CommonProjectActions;
 import org.openide.WizardDescriptor;
+import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 
 /**
@@ -206,8 +210,13 @@ public final class GradleInitWizard {
             init.comments((Boolean)params.get(PROP_COMMENTS));
             init.add();
 
-
-            ops.addWrapperInit(root, "latest"); //NOI18N
+            if (!GradleSettings.getDefault().isOffline()) {
+                try {
+                    init.gradleVersion(GradleDistributionManager.get().currentDistribution().getVersion());
+                } catch (IOException ex) {
+                    Exceptions.printStackTrace(ex);
+                }
+            }
             List<String> open = important.stream()
                     .map((s) -> packageBase != null ? s.replace("${package}", packageBase.replace('.', '/')) : s) //NOI18N
                     .map((s) -> s.replace("${projectName}", name)) //NOI18N

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
@@ -247,6 +247,15 @@ public final class TemplateOperation implements Runnable {
          */
         public abstract InitOperation projectName(String name);
 
+        /**
+         * Specify the Gradle version to use to initialize the project.
+         *
+         * @param version gradle version
+         * @return this builder to chain the calls
+         * @since 2.47
+         */
+        public abstract InitOperation gradleVersion(String version);
+
         /** Specify the Java version the project would be compiled, tested,
          * and executed with.
          * @param version the Java version to be used
@@ -270,6 +279,7 @@ public final class TemplateOperation implements Runnable {
         private String testFramework;
         private String basePackage;
         private String projectName;
+        private String gradleVersion;
         private String javaVersion;
         private Boolean comments;
 
@@ -313,6 +323,9 @@ public final class TemplateOperation implements Runnable {
         @Override
         public Set<FileObject> execute() {
             GradleConnector gconn = GradleConnector.newConnector();
+            if (gradleVersion != null) {
+                gconn.useGradleVersion(gradleVersion);
+            }
             JavaRuntimeManager.JavaRuntime defaultRuntime = GradleExperimentalSettings.getDefault().getDefaultJavaRuntime();
 
             target.mkdirs();
@@ -381,6 +394,12 @@ public final class TemplateOperation implements Runnable {
             }
             gconn.disconnect();
             return Collections.singleton(FileUtil.toFileObject(target));
+        }
+
+        @Override
+        public InitOperation gradleVersion(String version) {
+            this.gradleVersion = version;
+            return this;
         }
 
         @Override


### PR DESCRIPTION
Support for using the latest Gradle version when initializing a project was added initially in #6333  but it's somewhat temperamental.  It does not always pick up later versions, and it works by reinitializing the wrapper, potentially downloading two different Gradle versions and/or failing on some JDKs inside the init step.

This PR adds a new method to `GradleDistributionManager` to query the current (latest) version from the Gradle web service at https://services.gradle.org/versions/current

Support for setting a Gradle version is added in to `TemplateOperation.InitOperation`.  If set, this is passed to the Tooling API - https://docs.gradle.org/current/javadoc/org/gradle/tooling/GradleConnector.html#useGradleVersion(java.lang.String)  This downloads the required Gradle version and runs the init step with it.

The current version is queried in the wizard, replacing the previous additional wrapper step.  In future this should allow the wizard to be enhanced to offer a choice of Gradle version.

With this change, the new Gradle project wizard should currently pick up the current `8.14.2` version, rather than the `8.14` version that matches the bundled Tooling API.  The Tooling API is designed to be forwards compatible, so this should reduce the pressure to update it very late in the release cycle or wait on Gradle releases.

This change was also discussed on Slack and in #8461 


