### PR TITLE
Don't load the windows clipboard agent on JDK 25 and later

### DIFF
--- a/ide/o.n.agent/nbproject/project.properties
+++ b/ide/o.n.agent/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.release=17
+javac.release=8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 agent.src.dir=src-agent

--- a/ide/o.n.agent/src-agent/org/netbeans/agent/WClipboardTransformer.java
+++ b/ide/o.n.agent/src-agent/org/netbeans/agent/WClipboardTransformer.java
@@ -23,7 +23,7 @@ import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.lang.instrument.Instrumentation;
 import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.security.ProtectionDomain;
 import org.objectweb.asm.ClassReader;
@@ -210,8 +210,8 @@ public class WClipboardTransformer implements ClassFileTransformer {
                 };
                 cr.accept(cv, 0);
                 byte[] result = cw.toByteArray();
-                if (DEBUG_DUMP_TRANSFORMED_CLASS != null && !DEBUG_DUMP_TRANSFORMED_CLASS.isBlank()) {
-                    Files.write(Path.of(DEBUG_DUMP_TRANSFORMED_CLASS), result, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                if (DEBUG_DUMP_TRANSFORMED_CLASS != null && !DEBUG_DUMP_TRANSFORMED_CLASS.trim().isEmpty()) {
+                    Files.write(Paths.get(DEBUG_DUMP_TRANSFORMED_CLASS), result, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
                 }
                 logMsg("%s: Transforming %s done", WClipboardTransformer.class.getName(), className);
                 return result;


### PR DESCRIPTION
 - JDK 25+ contains the fix already - no patching needed ([JDK-8353950](https://bugs.openjdk.org/browse/JDK-8353950))
 - avoids trouble with ASM or other unexpected interactions

downgraded classfile version of the agent to 8, so that the JDK  warning msg popup can show (https://github.com/apache/netbeans/pull/8608#issuecomment-2993583686).