### PR TITLE
PHP: Disabling "Keep Marks" highlighting setting has no effect for PHP

### DIFF
--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/MarkOccurrencesHighlighter.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/semantic/MarkOccurrencesHighlighter.java
@@ -108,7 +108,7 @@ public final class MarkOccurrencesHighlighter extends ParserResultTask<ParserRes
             }
 
             List<OffsetRange> bag = processImpl(info, doc, caretPosition);
-            if (bag.isEmpty() || cancel.isCancelled()) {
+            if (cancel.isCancelled()) {
                 //the occurrences finder haven't found anything, just ignore the result
                 //and keep the previous occurrences
                 return ;


### PR DESCRIPTION
NetBeans allows users to configure whether to keep the occurence hightlighting when the cursor is moved off the origin symbol. If "Keep Marks" is enabled the highlights are kept until another symbol is marked by the caret. If it is disabled the highlights are removed once the caret is not on the symbol anymore.

There are two problems:

- the CSL integration of OccurrenceFinder ignores updates with empty highlights (essentially "Keep Marks" was always on for CSL languages)
- the marks are cleared always and thus without the problem in the CSL integration would act as if "Keep Marks" is always off

Start point:

Caret is inside the bounds of the second occurrence of variable `$var2`. All occurrences of `$var2` are highlighted:

![grafik](https://github.com/user-attachments/assets/52615344-2502-4d84-b31a-7d06bcbf2190)

"Keep Marks" is disabled:

![grafik](https://github.com/user-attachments/assets/57ae260e-febe-4563-80f4-cc4b0b0d7cb5)

Now the caret is moved off the variable and into the empty line 8. 

Before this change (variables `$var2` are still highlighted):

![grafik](https://github.com/user-attachments/assets/f083526d-63e0-413c-a576-60a095ab2fb2)

After the change the highlighting is removed in that case:

![grafik](https://github.com/user-attachments/assets/f01c837a-6fc2-4832-b141-8ea127d43310)

Closes: #8581 
