### PR TITLE
Fix Javadoc external link errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -456,13 +456,15 @@ jobs:
         if: env.test_javadoc == 'true' && success()
         run: |
           export ANT_OPTS=-Djdk.xml.totalEntitySizeLimit=200000
-          ant $OPTS build-javadoc
+          ant $OPTS -Djavadoc.fail.broken.links=true build-javadoc
 
       - name: Create Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4
         if: failure()
         with:
-          paths: "./*/*/build/test/*/results/TEST-*.xml"
+          paths: |
+            ./*/*/build/test/*/results/TEST-*.xml
+            ./nbbuild/build/javadoc/checklinks-errors.xml
 
 
   build-from-src-zip:

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CheckLinks.java
@@ -52,6 +52,7 @@ public class CheckLinks extends MatchingTask {
     private boolean checkexternal = true;
     private boolean checkspaces = true;
     private boolean checkforbidden = true;
+    private boolean failbroken = false;
     private List<Mapper> mappers = new LinkedList<>();
     private List<Filter> filters = new ArrayList<>();
     private File report;
@@ -76,7 +77,16 @@ public class CheckLinks extends MatchingTask {
     public void setCheckforbidden(boolean s) {
         checkforbidden = s;
     }
-    
+
+    /**
+     * Allows to fail build on broken links. Default to false.
+     *
+     * @param fail fail build on broken links
+     */
+    public void setFailbroken(boolean fail) {
+        failbroken = fail;
+    }
+
     /** Set the base directory from which to scan files.
      */
     public void setBasedir (File basedir) {
@@ -142,6 +152,9 @@ public class CheckLinks extends MatchingTask {
             testMessage = b.toString();
         }
         JUnitReportWriter.writeReport(this, null, report, Collections.singletonMap("testBrokenLinks", testMessage));
+        if (!errors.isEmpty() && failbroken) {
+            throw new BuildException("Broken links found in Javadoc");
+        }
     }
     
     private static Pattern hrefOrAnchor = Pattern.compile("<(a|code|div|img|link|h1|h2|h3|h4|h5|li|section|span)(\\s+class=\"[\\w\\-]*\")?(\\s+shape=\"rect\")?(?:\\s+rel=\"stylesheet\")?\\s+(href|name|id|src)=\"([^\"#]*)(#[^\"$]+)?\"(\\s+shape=\"rect\")?(?:\\s+type=\"text/css\")?(\\s+class=\"[\\w\\-]*\")?\\s*/?>", Pattern.CASE_INSENSITIVE);

--- a/nbbuild/javadoctools/build.xml
+++ b/nbbuild/javadoctools/build.xml
@@ -245,12 +245,14 @@
     <target name="check-broken-links" depends="init" unless="javadoc.skip.brokenlinks.check">
         <taskdef name="checklinks" classname="org.netbeans.nbbuild.CheckLinks" classpath="${nbantext.jar}"/>
         <property name="javadoc.check.forbidden.links" value="true"/>
+        <property name="javadoc.fail.broken.links" value="false"/>
         <!-- -->
         <property name="javadoc.externallinks" location="${nb_all}/nbbuild/build/javadoclinks"/>
         <mkdir dir="${javadoc.externallinks}"/>
         <delete file="${javadoc.externallinks}*.txt" failonerror="false"/>
         <!-- -->
-        <checklinks basedir="${netbeans.javadoc.dir}" checkexternal="${javadoc.check.external.links}" checkforbidden="${javadoc.check.forbidden.links}" checkspaces="false" report="${netbeans.javadoc.dir}/checklinks-errors.xml" externallinkslist="${javadoc.externallinks}">
+        <checklinks basedir="${netbeans.javadoc.dir}" checkexternal="${javadoc.check.external.links}" checkforbidden="${javadoc.check.forbidden.links}"
+                    failbroken="${javadoc.fail.broken.links}" checkspaces="false" report="${netbeans.javadoc.dir}/checklinks-errors.xml" externallinkslist="${javadoc.externallinks}">
             <include name="*/overview-summary.html"/>
             <include name="*/apichanges.html"/>
             <include name="*/architecture-summary.html"/>

--- a/nbbuild/javadoctools/disallowed-links.xml
+++ b/nbbuild/javadoctools/disallowed-links.xml
@@ -65,7 +65,7 @@
     <filter pattern="http://www\.saxproject\.org" accept="true" />
     <filter pattern="https://www\.eclipse\.org/jgit" accept="true" />
     <filter pattern="https://knockoutjs\.com" accept="true" />
-    <filter pattern="https://services\.gradle\.org/versions/all" accept="true" /> 
+    <filter pattern="https://services\.gradle\.org/.*" accept="true" />
     
     <!-- documentation API -->
     <filter pattern="https://docs\.oracle\.com/javase.*" accept="true" />

--- a/nbbuild/javadoctools/disallowed-links.xml
+++ b/nbbuild/javadoctools/disallowed-links.xml
@@ -44,7 +44,6 @@
     <filter pattern="https://github\.com/graalvm/fastr" accept="true" />
     <filter pattern="https://github\.com/graalvm/graalpython" accept="true" />
     <filter pattern="https://github\.com/graalvm/truffleruby" accept="true" />
-    <filter pattern="https://github\.com/twall/jna" accept="true" />
     <filter pattern="https://github\.com/openjdk/.*" accept="true" />
     <filter pattern="https://github\.com/simpligility/.*" accept="true" />
     

--- a/platform/openide.modules/src/org/openide/modules/doc-files/api.html
+++ b/platform/openide.modules/src/org/openide/modules/doc-files/api.html
@@ -1324,11 +1324,6 @@ JARs loaded from the classpath (application classloader) are never
 reloaded, so it may be possible to include the native-dependent
 classes in such a JAR and make use of it from a module JAR.</p>
 
-<p class="nonnormative">NetBeans currently includes a <a
-href="https://github.com/twall/jna">JNA</a> wrapper module which can also be used
-for native access. As of this writing, however, this module exports only a
-friend API, so it is not available for use from arbitrary modules.<p>
-
 <hr>@FOOTER@
 
 </body>


### PR DESCRIPTION
Jenkins build currently reporting a disallowed external link in Javadoc due to link to https://services.gradle.org/versions/current in #8606 

This is not picked up in the GitHub build - add report to output before fixing.

Fix to allow all links to services.gradle.org - good possibility we'll want to link to other things on there in future.

Also fixes incorrect and invalid JNA link and information in Javadoc I noticed while addressing this.