### PR TITLE
Enable JDK 21 LTS support for Payara 5.x

### DIFF
--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/config/PayaraV5.xml
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/config/PayaraV5.xml
@@ -27,6 +27,7 @@ under the License.
         <platform version="1.8"/>
         <platform version="11"/>
         <platform version="17"/>
+        <platform version="21"/>
     </java>
     <javaee version="1.8">
         <profile version="1.3" type="full"/>


### PR DESCRIPTION
Add support for running Payara 5.x with JDK 21 LTS, including necessary compatibility updates.