### PR TITLE
Properly resolving types in ChangeMethodParameters refactoring.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/ChangeMethodParametersRefactoring.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/ChangeMethodParametersRefactoring.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.java.lsp.server.refactoring;
 
 import com.google.gson.Gson;
+import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import com.sun.source.util.Trees;
@@ -61,6 +62,7 @@ import org.netbeans.modules.java.lsp.server.protocol.CodeActionsProvider;
 import org.netbeans.modules.java.lsp.server.protocol.NbCodeLanguageClient;
 import org.netbeans.modules.parsing.api.ResultIterator;
 import org.netbeans.modules.refactoring.java.api.ChangeParametersRefactoring;
+import org.netbeans.modules.refactoring.java.api.ChangeParametersRefactoring.ParameterInfo;
 import org.netbeans.modules.refactoring.java.api.JavaRefactoringUtils;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
@@ -196,10 +198,11 @@ public final class ChangeMethodParametersRefactoring extends CodeRefactoring {
         ParameterUI[] params = new ParameterUI[method.getParameters().size()];
         for (int i = 0; i < method.getParameters().size(); i++) {
             VariableElement param = method.getParameters().get(i);
-            ChangeParametersRefactoring.ParameterInfo info = new ChangeParametersRefactoring.ParameterInfo(i, param.getSimpleName().toString(), Utilities.getTypeName(ci, param.asType(), true).toString(), null);
+            ChangeParametersRefactoring.ParameterInfo info = new ChangeParametersRefactoring.ParameterInfo(i, param.getSimpleName().toString(), ParameterInfo.parameterTypeFromSource(ci, param), null);
             params[i] = new ParameterUI(info.getType(), info.getName());
             params[i].assignInfo(info);
         }
+        MethodTree methodTree = ci.getTrees().getTree(method);
         Modifier mod;
         if (method.getModifiers().contains(javax.lang.model.element.Modifier.PUBLIC)) {
             mod = Modifier.PUBLIC;
@@ -212,7 +215,7 @@ public final class ChangeMethodParametersRefactoring extends CodeRefactoring {
         }
         ChangeMethodParameterUI model = new ChangeMethodParameterUI();
         model.withName(method.getSimpleName().toString())
-                .withReturnType(Utilities.getTypeName(ci, method.getReturnType(), true).toString())
+                .withReturnType(methodTree.getReturnType().toString())
                 .withSelectedModifier(mod)
                 .withIsStatic(method.getModifiers().contains(javax.lang.model.element.Modifier.STATIC))
                 .withParameters(params)

--- a/java/refactoring.java/apichanges.xml
+++ b/java/refactoring.java/apichanges.xml
@@ -25,6 +25,20 @@
         <apidef name="JavaRefactoringAPI">Java Refactoring API</apidef>
     </apidefs>
     <changes>
+        <change id="parameterTypeFromSource">
+            <api name="JavaRefactoringAPI"/>
+            <summary>Added parameterTypeFromSource method to ParameterInfo.</summary>
+            <version major="1" minor="96"/>
+            <date day="23" month="7" year="2026"/>
+            <author login="jlahoda"/>
+            <compatibility addition="yes"/>
+            <description>
+                <p>
+                    Ability to get the parameter type as it appears in the source code.
+                </p>    
+            </description>
+            <class package="org.netbeans.modules.refactoring.java.api" name="ChangeParametersRefactoring"/>
+        </change>
         <change id="FilterDependency">
             <api name="JavaRefactoringAPI"/>
             <summary>Added BINARYFILE, DEPENDENCY, PLATFORM constants to JavaWhereUsedFilters.</summary>

--- a/java/refactoring.java/nbproject/project.properties
+++ b/java/refactoring.java/nbproject/project.properties
@@ -18,7 +18,7 @@ javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 
-spec.version.base=1.95.0
+spec.version.base=1.96.0
 #test configs
 test.config.find.includes=\
     **/FindUsagesSuite.class

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ChangeParametersRefactoring.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/api/ChangeParametersRefactoring.java
@@ -18,10 +18,14 @@
  */
 package org.netbeans.modules.refactoring.java.api;
 
+import com.sun.source.tree.VariableTree;
 import java.util.Set;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.VariableElement;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NullAllowed;
+import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.java.source.TreePathHandle;
 import org.netbeans.modules.refactoring.api.AbstractRefactoring;
 import org.openide.util.lookup.Lookups;
@@ -196,6 +200,25 @@ public final class ChangeParametersRefactoring extends AbstractRefactoring {
      * Parameter can be added, changed or moved to another position.
      */
     public static final class ParameterInfo {
+        /**
+         * Return the type of the given parameter as it appears in the source code.
+         *
+         * @param info the relevant {@code CompilationInfo}
+         * @param parameter the parameter for which the type should be detected
+         * @return the parameter type as it appears in the source code
+         * @since 1.96
+         */
+        public static String parameterTypeFromSource(CompilationInfo info, VariableElement parameter) {
+            VariableTree parTree = (VariableTree) info.getTrees().getTree(parameter);
+            ExecutableElement method = (ExecutableElement) parameter.getEnclosingElement();
+            int index = method.getParameters().indexOf(parameter);
+            if (method.isVarArgs() && index == method.getParameters().size() - 1) {
+                return parTree.getType().toString().replace("[]", "..."); // NOI18N
+            } else {
+                return parTree.getType().toString();
+            }
+        }
+
         int origIndex;
         String name;
         String type;

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/ChangeParamsTransformer.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/ChangeParamsTransformer.java
@@ -401,11 +401,15 @@ public class ChangeParamsTransformer extends RefactoringVisitor {
             int originalIndex = pi[i].getOriginalIndex();
             VariableTree vt;
             boolean isVarArgs = i == pi.length -1 && pi[i].getType().endsWith("..."); // NOI18N
-            String newType = isVarArgs? pi[i].getType().replace("...", "") : pi[i].getType(); //NOI18N
+            ExpressionTree newTypeAsTree = (ExpressionTree) make.Type(isVarArgs? pi[i].getType().replace("...", "") : pi[i].getType()); //NOI18N
+            if (isVarArgs) {
+                //hack: insert '...'
+                newTypeAsTree = make.MemberSelect(newTypeAsTree, "..");
+            }
             if (originalIndex < 0) {
                 vt = make.Variable(make.Modifiers(Collections.<Modifier>emptySet()),
                         pi[i].getName(),
-                        skipType? null : make.Identifier(newType), // NOI18N
+                        skipType? null : newTypeAsTree, // NOI18N
                         null);
             } else {
                 vt = currentParameters.get(originalIndex);
@@ -413,10 +417,10 @@ public class ChangeParamsTransformer extends RefactoringVisitor {
                     Tree typeTree = null;
                     if (origMethod != null) {
                         if (!pi[i].getType().equals(origMethod.getParameters().get(originalIndex).getType().toString())) {
-                            typeTree = make.Identifier(newType);
+                            typeTree = newTypeAsTree;
                         }
                     } else {
-                        typeTree = make.Identifier(newType);
+                        typeTree = newTypeAsTree;
                     }
                     if(typeTree != null) {
                         vt = make.Variable(vt.getModifiers(),
@@ -601,7 +605,7 @@ public class ChangeParamsTransformer extends RefactoringVisitor {
                     boolean isVarArgs = i == p.length -1 && p[i].getType().endsWith("..."); // NOI18N
                     vt = make.Variable(make.Modifiers(Collections.<Modifier>emptySet()),
                             p[i].getName(),
-                            make.Identifier(isVarArgs? p[i].getType().replace("...", "") : p[i].getType()), // NOI18N
+                            make.Type(isVarArgs? p[i].getType().replace("...", "") : p[i].getType()), // NOI18N
                             null);
                 } else {
                     VariableTree originalVt = currentParameters.get(originalIndex);
@@ -613,10 +617,10 @@ public class ChangeParamsTransformer extends RefactoringVisitor {
                         if (p[i].getType().equals(origMethod.getParameters().get(originalIndex).getType().toString())) { // Type has not changed
                             typeTree = originalVt.getType();
                         } else {
-                            typeTree = make.Identifier(newType); // NOI18N
+                            typeTree = make.Type(newType); // NOI18N
                         }
                     } else {
-                        typeTree = make.Identifier(newType); // NOI18N
+                        typeTree = make.Type(newType); // NOI18N
                     }
                     vt = make.Variable(originalVt.getModifiers(),
                             renameParams? p[i].getName() : originalVt.getName(),

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/IntroduceParameterPlugin.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/IntroduceParameterPlugin.java
@@ -497,14 +497,7 @@ public class IntroduceParameterPlugin extends JavaRefactoringPlugin {
                 paramTable = new ChangeParametersRefactoring.ParameterInfo[parameters.size() + 1];
                 for (int originalIndex = 0; originalIndex < parameters.size(); originalIndex++) {
                     VariableElement param = parameters.get(originalIndex);
-                    VariableTree parTree = (VariableTree) info.getTrees().getTree(param);
-                    String typeRepresentation;
-                    if (method.isVarArgs() && originalIndex == parameters.size()-1) {
-                        typeRepresentation = parTree.getType().toString().replace("[]", "..."); // NOI18N
-                    } else {
-                        typeRepresentation = parTree.getType().toString();
-                    }
-                    paramTable[originalIndex] = new ChangeParametersRefactoring.ParameterInfo(originalIndex, param.getSimpleName().toString(), typeRepresentation, null);
+                    paramTable[originalIndex] = new ChangeParametersRefactoring.ParameterInfo(originalIndex, param.getSimpleName().toString(), ParameterInfo.parameterTypeFromSource(info, param), null);
                 }
                 index = paramTable.length - 1;
                 if (method.isVarArgs()) {

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ChangeParametersPanel.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/ChangeParametersPanel.java
@@ -179,6 +179,7 @@ public class ChangeParametersPanel extends JPanel implements CustomRefactoringPa
                     try {
                         info.toPhase(org.netbeans.api.java.source.JavaSource.Phase.RESOLVED);
                         ExecutableElement e = (ExecutableElement) refactoredObj.resolveElement(info);
+                        MethodTree methodTree = (MethodTree) refactoredObj.resolve(info).getLeaf();
                         isConstructor = e.getKind() == ElementKind.CONSTRUCTOR;
                         TreePath enclosingClass = JavaRefactoringUtils.findEnclosingClass(info, refactoredObj.resolve(info), true, true, true, true, true);
                         TreePathHandle tph = TreePathHandle.create(enclosingClass, info);
@@ -187,10 +188,9 @@ public class ChangeParametersPanel extends JPanel implements CustomRefactoringPa
                                 enclosingElement.getSimpleName().toString() :
                                 e.getSimpleName().toString());
                         final FileObject fileObject = refactoredObj.getFileObject();
-                        final String returnType = e.getReturnType().toString();
+                        final String returnType = methodTree.getReturnType().toString();
                         final long[] returnSpan = {-1, -1};
                         if(!isConstructor) {
-                            MethodTree methodTree = (MethodTree) refactoredObj.resolve(info).getLeaf();
                             final long methodStart = info.getTreeUtilities().findNameSpan(methodTree)[0];
                             Tree tree = methodTree.getReturnType();
                             returnSpan[0] = tree == null ? methodStart -1 : info.getTrees().getSourcePositions().getStartPosition(info.getCompilationUnit(), tree);
@@ -764,13 +764,7 @@ public class ChangeParametersPanel extends JPanel implements CustomRefactoringPa
         List<? extends VariableElement> pars = method.getParameters();
         int originalIndex = 0;
         for (VariableElement par : pars) {
-            VariableTree parTree = (VariableTree) info.getTrees().getTree(par);
-            String typeRepresentation;
-            if (method.isVarArgs() && originalIndex == pars.size() - 1) {
-                typeRepresentation = getTypeStringRepresentation(parTree).replace("[]", "..."); // NOI18N
-            } else {
-                typeRepresentation = getTypeStringRepresentation(parTree);
-            }
+            String typeRepresentation = ParameterInfo.parameterTypeFromSource(info, par);
             LocalVarScanner scan = new LocalVarScanner(info, null);
             scan.scan(path, par);
             Boolean removable = !scan.hasRefernces();


### PR DESCRIPTION
Consider code like:
```java
package test;

import java.util.List;

public class JavaApplication113 {

    public List<String> test(String str) {
        return null;
    }

    public static class SubClass extends JavaApplication113 {

        @Override
        public java.util.List<java.lang.String> test(java.lang.String str) {
            return null;
        }
        
    }
}
```

put cursor at `JavaApplication113.test`, open the `Refactor/Change Method Parameters`, and add a new parameter with type `java.util.List<java.lang.String>` and name `par1`. The refactoring will use `java.util.List<java.lang.String>` as the parameter type that is written in the source code. I think imports should be properly resolved on every place where the type is printed, and typically `java.util.List` should be imported, and the inserted type should be `List<String>`.

This is what this PR is attempting to do.
