### PR TITLE
Add Njord extension to ignored Maven lifecycle participants.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/layer.xml
+++ b/java/maven/src/org/netbeans/modules/maven/layer.xml
@@ -180,6 +180,12 @@
                 <folder name="org.sonatype.nexus.maven.staging.deploy.DeployLifecycleParticipant">
                     <attr name="ignoreOnModelLoad" boolvalue="true"/>
                 </folder>
+                <folder name="eu.maveniverse.maven.njord.extension3.NjordSessionLifecycleParticipant">
+                    <attr name="ignoreOnModelLoad" boolvalue="true"/>
+                </folder>
+                <folder name="eu.maveniverse.maven.shared.extension.RuntimeRequirementEnforcerLifecycleParticipant">
+                    <attr name="ignoreOnModelLoad" boolvalue="true"/>
+                </folder>
             </folder>
             <file name="nbactions.xml" url="nbactions.xml"/>
             <folder name="RunGoals">


### PR DESCRIPTION
With the [sunsetting of OSSRH](https://central.sonatype.org/pages/ossrh-eol/) the sensible(!) projects are switching to [Njord](https://maveniverse.eu/docs/njord/) to handle publishing to central.  Unfortunately, if added as an extension in the POM, NetBeans adds a project warning that cannot be removed.

This is a quick fix for NB27 to add Njord to the ignore list.  There may be other Maveniverse extensions that do not impact on NetBeans' Maven support that could be added too.

Longer term, we should improve user configuration here, and possibly a better UI for marking problems as ignored?

cc/ @cstamas 