### PR TITLE
Add missinng logic for delete a local branch

### DIFF
--- a/ide/git/src/org/netbeans/modules/git/ui/branch/DeleteBranchAction.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/branch/DeleteBranchAction.java
@@ -16,24 +16,29 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.netbeans.modules.git.ui.branch;
 
 import org.netbeans.libs.git.GitException.NotMergedException;
 import org.netbeans.modules.git.client.GitClientExceptionHandler;
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.netbeans.libs.git.GitBranch;
 import org.netbeans.modules.git.client.GitClient;
 import org.netbeans.libs.git.GitException;
 import org.netbeans.modules.git.Git;
 import org.netbeans.modules.git.client.GitProgressSupport;
 import org.netbeans.modules.git.ui.actions.SingleRepositoryAction;
+import org.netbeans.modules.git.ui.history.BranchSelector;
+import org.netbeans.modules.git.ui.repository.RepositoryInfo;
 import org.netbeans.modules.versioning.spi.VCSContext;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionRegistration;
+import org.openide.nodes.Node;
 import org.openide.util.NbBundle;
 
 /**
@@ -47,26 +52,54 @@ public class DeleteBranchAction extends SingleRepositoryAction {
     private static final Logger LOG = Logger.getLogger(DeleteBranchAction.class.getName());
 
     @Override
-    protected void performAction (File repository, File[] roots, VCSContext context) {
-        throw new UnsupportedOperationException();
+    protected void performAction(File repository, File[] roots, VCSContext context) {
+        RepositoryInfo info = RepositoryInfo.getInstance(repository);
+        HashMap<String, GitBranch> branches = new HashMap<>(info.getBranches());
+        branches.remove(info.getActiveBranch().getName());
+
+        if (branches.isEmpty()) {
+            return;
+        }
+
+        BranchSelector selector = new BranchSelector(repository, branches);
+        if (selector.open()) {
+            deleteBranch(repository, selector.getSelectedBranch());
+        }
     }
 
-    public void deleteBranch (final File repository, final String branchName) {
+    @Override
+    protected boolean enable(Node[] activatedNodes) {
+        if (!super.enable(activatedNodes)) {
+            return false;
+        }
+
+        // require 2+ branches
+        Map.Entry<File, File[]> actionRoots = getActionRoots(getCurrentContext(activatedNodes));
+        if (actionRoots != null) {
+            RepositoryInfo info = RepositoryInfo.getInstance(actionRoots.getKey());
+
+            return info != null && info.getBranches().size() > 1;
+        }
+
+        return false;
+    }
+
+    public void deleteBranch(final File repository, final String branchName) {
         NotifyDescriptor nd = new NotifyDescriptor.Confirmation(NbBundle.getMessage(DeleteBranchAction.class, "MSG_DeleteBranchAction.confirmation", branchName), //NOI18N
-                NbBundle.getMessage(DeleteBranchAction.class, "LBL_DeleteBranchAction.confirmation"), //NOI18N
-                NotifyDescriptor.OK_CANCEL_OPTION, NotifyDescriptor.QUESTION_MESSAGE);
+            NbBundle.getMessage(DeleteBranchAction.class, "LBL_DeleteBranchAction.confirmation"), //NOI18N
+            NotifyDescriptor.OK_CANCEL_OPTION, NotifyDescriptor.QUESTION_MESSAGE);
 
         if (NotifyDescriptor.OK_OPTION == DialogDisplayer.getDefault().notify(nd)) {
             GitProgressSupport supp = new GitProgressSupport() {
                 @Override
-                protected void perform () {
+                protected void perform() {
                     try {
                         GitClient client = getClient();
                         boolean forceDelete = false;
                         boolean cont;
                         do {
                             try {
-                                LOG.log(Level.FINE, "Deleting a branch: {0}/{1}", new Object[] { branchName, forceDelete }); //NOI18N
+                                LOG.log(Level.FINE, "Deleting a branch: {0}/{1}", new Object[]{branchName, forceDelete}); //NOI18N
                                 client.deleteBranch(branchName, forceDelete, getProgressMonitor());
                                 cont = false;
                             } catch (GitException.NotMergedException ex) {
@@ -78,10 +111,10 @@ public class DeleteBranchAction extends SingleRepositoryAction {
                     }
                 }
 
-                private boolean handleException (NotMergedException ex) {
+                private boolean handleException(NotMergedException ex) {
                     NotifyDescriptor nd = new NotifyDescriptor.Confirmation(NbBundle.getMessage(DeleteBranchAction.class, "MSG_DeleteBranchAction.notMerged", ex.getUnmergedRevision()), //NOI18N
-                            NbBundle.getMessage(DeleteBranchAction.class, "LBL_DeleteBranchAction.notMerged"), //NOI18N
-                            NotifyDescriptor.YES_NO_OPTION, NotifyDescriptor.QUESTION_MESSAGE);
+                        NbBundle.getMessage(DeleteBranchAction.class, "LBL_DeleteBranchAction.notMerged"), //NOI18N
+                        NotifyDescriptor.YES_NO_OPTION, NotifyDescriptor.QUESTION_MESSAGE);
                     return NotifyDescriptor.YES_OPTION == DialogDisplayer.getDefault().notify(nd);
                 }
             };

--- a/ide/git/src/org/netbeans/modules/git/ui/history/BranchSelector.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/history/BranchSelector.java
@@ -24,6 +24,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.util.Collections;
+import java.util.HashMap;
 import javax.swing.JButton;
 import org.netbeans.libs.git.GitBranch;
 import org.netbeans.modules.git.ui.repository.RevisionDialogController;
@@ -45,6 +46,11 @@ public final class BranchSelector {
     public BranchSelector (File repository) {
         this.revisionPicker = new RevisionDialogController(repository, new File[0],
                 Collections.<String, GitBranch>emptyMap(), null);
+        panel = new SelectBranchPanel(revisionPicker.getPanel());
+    }
+    
+    public BranchSelector(File repository, HashMap<String, GitBranch> branches) {
+        this.revisionPicker = new RevisionDialogController(repository, new File[0], branches, null);
         panel = new SelectBranchPanel(revisionPicker.getPanel());
     }
 

--- a/ide/git/src/org/netbeans/modules/git/ui/menu/BranchMenu.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/menu/BranchMenu.java
@@ -30,6 +30,7 @@ import org.netbeans.modules.git.Annotator;
 import org.netbeans.modules.git.ui.branch.CherryPickAction;
 import org.netbeans.modules.git.ui.branch.CreateBranchAction;
 import org.netbeans.modules.git.ui.branch.RenameBranchAction;
+import org.netbeans.modules.git.ui.branch.DeleteBranchAction;
 import org.netbeans.modules.git.ui.branch.SetTrackingAction;
 import org.netbeans.modules.git.ui.checkout.AbstractCheckoutAction;
 import org.netbeans.modules.git.ui.checkout.SwitchBranchAction;
@@ -99,6 +100,7 @@ public final class BranchMenu extends DynamicMenu {
             Utils.setAcceleratorBindings(Annotator.ACTIONS_PATH_PREFIX, action);
             Actions.connect(item, action, false);
             menu.add(item);
+
             item = new JMenuItem();
             action = (Action) SystemAction.get(ManageTagsAction.class);
             Utils.setAcceleratorBindings(Annotator.ACTIONS_PATH_PREFIX, action);
@@ -126,6 +128,12 @@ public final class BranchMenu extends DynamicMenu {
 
             item = new JMenuItem();
             action = (Action) SystemAction.get(CherryPickAction.class);
+            Utils.setAcceleratorBindings(Annotator.ACTIONS_PATH_PREFIX, action);
+            Actions.connect(item, action, false);
+            menu.add(item);
+            
+            item = new JMenuItem();
+            action = (Action) SystemAction.get(DeleteBranchAction.class);
             Utils.setAcceleratorBindings(Annotator.ACTIONS_PATH_PREFIX, action);
             Actions.connect(item, action, false);
             menu.add(item);
@@ -173,6 +181,8 @@ public final class BranchMenu extends DynamicMenu {
             item = menu.add(SystemActionBridge.createAction(SystemAction.get(RenameBranchAction.class), NbBundle.getMessage(RenameBranchAction.class, "LBL_RenameBranchAction_PopupName"), lkp)); //NOI18N
             org.openide.awt.Mnemonics.setLocalizedText(item, item.getText());
             item = menu.add(SystemActionBridge.createAction(SystemAction.get(CherryPickAction.class), NbBundle.getMessage(CherryPickAction.class, "LBL_CherryPickAction_PopupName"), lkp)); //NOI18N
+            org.openide.awt.Mnemonics.setLocalizedText(item, item.getText());
+            item = menu.add(SystemActionBridge.createAction(SystemAction.get(DeleteBranchAction.class), NbBundle.getMessage(DeleteBranchAction.class, "LBL_DeleteBranchAction_PopupName"), lkp)); //NOI18N
             org.openide.awt.Mnemonics.setLocalizedText(item, item.getText());
         }        
         return menu;


### PR DESCRIPTION
The logic was still implemented but action items are missing and the logic to select a branch to delete it. The problem was, when you do a quick search for delete, the delete was found and the UnsupportedOperationException was thrown. Now everything works as expected.


---

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>