### PR TITLE
Permit multiple LSP servers.

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
@@ -32,6 +32,7 @@ import java.lang.reflect.Type;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -83,6 +84,7 @@ import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
 import org.eclipse.lsp4j.util.Preconditions;
+import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.progress.*;
 import org.netbeans.api.project.FileOwnerQuery;
@@ -123,7 +125,7 @@ public class LSPBindings {
     private static final RequestProcessor WORKER = new RequestProcessor(LanguageClientImpl.class.getName(), 1, false, false);
     private static final ChangeSupport cs = new ChangeSupport(LSPBindings.class);
     private static final Map<LSPBindings,Long> lspKeepAlive = new IdentityHashMap<>();
-    private static final Map<URI, Map<String, ServerDescription>> project2MimeType2Server = new HashMap<>();
+    private static final Map<URI, Map<String, Map<LanguageServerProvider, ServerDescription>>> project2MimeType2Server = new HashMap<>();
     private static final Map<FileObject, Map<String, LSPBindings>> workspace2Extension2Server = new HashMap<>();
 
     static {
@@ -150,16 +152,18 @@ public class LSPBindings {
             TimeUnit.MINUTES);
     }
 
-    private static final Map<FileObject, Map<BackgroundTask, RequestProcessor.Task>> backgroundTasks = new WeakHashMap<>();
+    private static final Map<FileObject, Map<Object/*BackgroundTask|SimpleBackgroundTask*/, RequestProcessor.Task>> backgroundTasks = new WeakHashMap<>();
     private final Set<FileObject> openedFiles = new HashSet<>();
 
-    public static synchronized LSPBindings getBindings(FileObject file) {
+    public static synchronized @NonNull List<LSPBindings> getBindings(FileObject file) {
+        List<LSPBindings> fromWorkspace = List.of();
+
         for (Entry<FileObject, Map<String, LSPBindings>> e : workspace2Extension2Server.entrySet()) {
             if (FileUtil.isParentOf(e.getKey(), file)) {
                 LSPBindings bindings = e.getValue().get(file.getExt());
 
                 if (bindings != null) {
-                    return bindings;
+                    fromWorkspace = List.of(bindings);
                 }
 
                 break;
@@ -169,11 +173,19 @@ public class LSPBindings {
         String mimeType = FileUtil.getMIMEType(file);
         Project prj = FileOwnerQuery.getOwner(file);
 
-        if (mimeType == null) {
-            return null;
-        }
+        List<LSPBindings> fromProviders = mimeType != null ? getBindingsImpl(prj, file, mimeType) : List.of();
+        if (fromWorkspace.isEmpty()) {
+            return fromProviders;
+        } else if (fromProviders.isEmpty()) {
+            return fromWorkspace;
+        } else {
+            List<LSPBindings> result = new ArrayList<>();
 
-        return getBindingsImpl(prj, file, mimeType);
+            result.addAll(fromWorkspace);
+            result.addAll(fromProviders);
+
+            return result;
+        }
     }
 
     public static void ensureServerRunning(Project prj, String mimeType) {
@@ -181,7 +193,7 @@ public class LSPBindings {
     }
 
     @SuppressWarnings("AccessingNonPublicFieldOfAnotherObject")
-    public static synchronized LSPBindings getBindingsImpl(Project prj, FileObject file, String mimeType) {
+    public static synchronized List<LSPBindings> getBindingsImpl(Project prj, FileObject file, String mimeType) {
         FileObject dir;
 
         if (prj == null) {
@@ -199,45 +211,7 @@ public class LSPBindings {
 
         URI uri = dir.toURI();
 
-        LSPBindings bindings = null;
-        ServerDescription description =
-                project2MimeType2Server.computeIfAbsent(uri, p -> new HashMap<>())
-                                       .computeIfAbsent(mimeType, m -> new ServerDescription());
-
-        if (description.bindings != null) {
-            bindings = description.bindings.get();
-        }
-
-        if (bindings != null && bindings.process != null && !bindings.process.isAlive()) {
-            startFailed(description, mimeType);
-            bindings = null;
-        }
-
-        if (description.failedCount >= INVALID_START_MAX_COUNT) {
-            return null;
-        }
-
-        if (bindings == null) {
-            bindings = buildBindings(description, prj, mimeType, dir, uri);
-            if (bindings != null) {
-                description.bindings = new WeakReference<>(bindings);
-                description.lastStartTimeStamp = System.currentTimeMillis();
-                // If ServerDescription acknowledges another mimetypes, add these
-                // to project2MimeType2Server too.
-                Map<String, ServerDescription> mimeType2Server = project2MimeType2Server.get(uri);
-                for(String mt: description.mimeTypes) {
-                    mimeType2Server.put(mt, description);
-                }
-                TextDocumentSyncServerCapabilityHandler.refreshOpenedFilesInServers();
-                WORKER.post(() -> cs.fireChange());
-            }
-        }
-
-        if(bindings != null) {
-            lspKeepAlive.put(bindings, System.currentTimeMillis());
-        }
-
-        return bindings != null ? bindings : null;
+        return buildBindings(prj, mimeType, dir, uri);
     }
 
     @Messages({
@@ -262,53 +236,81 @@ public class LSPBindings {
     }
 
     @SuppressWarnings({"AccessingNonPublicFieldOfAnotherObject", "ResultOfObjectAllocationIgnored"})
-    private static LSPBindings buildBindings(ServerDescription inDescription, Project prj, String mt, FileObject dir, URI baseUri) {
+    private static List<LSPBindings> buildBindings(Project prj, String mt, FileObject dir, URI baseUri) {
         MimeTypeInfo mimeTypeInfo = new MimeTypeInfo(mt);
-        ServerRestarter restarter = () -> {
-            synchronized (LSPBindings.class) {
-                ServerDescription description = project2MimeType2Server.getOrDefault(baseUri, Collections.emptyMap()).remove(mt);
-                // Remove any other mimetypes as well.
-                if (description != null) {
-                    for(String anotherMT: description.mimeTypes) {
-                        project2MimeType2Server.get(baseUri).remove(anotherMT);
-                    }
-                }
-                Reference<LSPBindings> bRef = description != null ? description.bindings : null;
-                LSPBindings b = bRef != null ? bRef.get() : null;
-
-                if (b != null) {
-                    lspKeepAlive.remove(b);
-
-                    try {
-                        b.server.shutdown().get();
-                    } catch (InterruptedException | ExecutionException ex) {
-                        LOG.log(Level.FINE, null, ex);
-                    }
-                    if (b.process != null) {
-                        b.process.destroy();
-                    }
-                }
-            }
-        };
-
-        boolean foundServer = false;
+        List<LSPBindings> servers = new ArrayList<>();
+        Map<LanguageServerProvider, ServerDescription> provider2Description =
+                project2MimeType2Server.computeIfAbsent(baseUri, p -> new HashMap<>())
+                                       .computeIfAbsent(mt, m -> new HashMap<>());
 
         for (LanguageServerProvider provider : MimeLookup.getLookup(mt).lookupAll(LanguageServerProvider.class)) {
+            ServerDescription serverDescription = provider2Description.computeIfAbsent(provider, m -> new ServerDescription());
+            LSPBindings existingBindings = null;
+
+            if (serverDescription.bindings != null) {
+                existingBindings = serverDescription.bindings.get();
+            }
+
+            if (existingBindings != null && existingBindings.process != null && !existingBindings.process.isAlive()) {
+                startFailed(serverDescription, mt);
+                existingBindings = null;
+            }
+
+            if (serverDescription.failedCount >= INVALID_START_MAX_COUNT) {
+                continue;
+            }
+
+            if (existingBindings != null) {
+                servers.add(existingBindings);
+                continue;
+            }
+
+            ServerRestarter restarter = () -> {
+                synchronized (LSPBindings.class) {
+                    Map<LanguageServerProvider, ServerDescription> provider2Desc = project2MimeType2Server.getOrDefault(baseUri, Collections.emptyMap()).get(mt);
+                    ServerDescription description = provider2Desc != null ? provider2Desc.remove(provider) : null;
+
+                    // Remove any other mimetypes as well.
+                    if (description != null) {
+                        for(String anotherMT: description.mimeTypes) {
+                            project2MimeType2Server.get(baseUri).remove(anotherMT);
+                        }
+                    }
+                    Reference<LSPBindings> bRef = description != null ? description.bindings : null;
+                    LSPBindings b = bRef != null ? bRef.get() : null;
+
+                    if (b != null) {
+                        lspKeepAlive.remove(b);
+
+                        try {
+                            b.server.shutdown().get();
+                        } catch (InterruptedException | ExecutionException ex) {
+                            LOG.log(Level.FINE, null, ex);
+                        }
+                        if (b.process != null) {
+                            b.process.destroy();
+                        }
+                    }
+                }
+            };
+
             final Lookup lkp = prj != null ? Lookups.fixed(prj, mimeTypeInfo, restarter) : Lookups.fixed(mimeTypeInfo, restarter);
-            inDescription.mimeTypes = Collections.singleton(mt);
+            serverDescription.mimeTypes = Collections.singleton(mt);
             // If this is a MultiMimeLanguageServerProvider, then retrieve all 
             // mime types handled by this server.
             if (provider instanceof MultiMimeLanguageServerProvider) {
-                inDescription.mimeTypes = new HashSet<>(((MultiMimeLanguageServerProvider)provider).getMimeTypes());
+                serverDescription.mimeTypes = new HashSet<>(((MultiMimeLanguageServerProvider)provider).getMimeTypes());
             }
             LanguageServerDescription desc = provider.startServer(lkp);
 
             if (desc != null) {
                 LSPBindings b = LanguageServerProviderAccessor.getINSTANCE().getBindings(desc);
+
                 if (b != null) {
-                    return b;
+                    servers.add(b);
+                    continue;
                 }
-                foundServer = true;
+
                 try {
                     LanguageClientImpl lci = new LanguageClientImpl();
                     LanguageServer server = LanguageServerProviderAccessor.getINSTANCE().getServer(desc);
@@ -375,16 +377,33 @@ public class LSPBindings {
                     new LSPReference(b, Utilities.activeReferenceQueue());
                     lci.setBindings(b);
                     LanguageServerProviderAccessor.getINSTANCE().setBindings(desc, b);
-                    return b;
+
+                    serverDescription.bindings = new WeakReference<>(b);
+                    serverDescription.lastStartTimeStamp = System.currentTimeMillis();
+                    // If ServerDescription acknowledges another mimetypes, add these
+                    // to project2MimeType2Server too.
+                    Map<String, Map<LanguageServerProvider, ServerDescription>> mimeType2Server = project2MimeType2Server.get(baseUri);
+
+                    for(String otherMimeType: serverDescription.mimeTypes) {
+                        mimeType2Server.computeIfAbsent(otherMimeType, m -> new HashMap<>())
+                                       .put(provider, serverDescription);
+                    }
+                    TextDocumentSyncServerCapabilityHandler.refreshOpenedFilesInServers();
+                    WORKER.post(() -> cs.fireChange());
+
+                    lspKeepAlive.put(b, System.currentTimeMillis());
+
+                    servers.add(b);
+
+                    continue;
                 } catch (InterruptedException | ExecutionException ex) {
                     LOG.log(Level.WARNING, null, ex);
                 }
+
+                startFailed(serverDescription, mt);
             }
         }
-        if (foundServer) {
-            startFailed(inDescription, mt);
-        }
-        return null;
+        return servers;
     }
 
     @Messages("LBL_Connecting=Connecting to language server")
@@ -487,6 +506,7 @@ public class LSPBindings {
         project2MimeType2Server.values()
                                .stream()
                                .flatMap(n -> n.values().stream())
+                               .flatMap(n -> n.values().stream())
                                .map(description -> description.bindings != null ? description.bindings.get() : null)
                                .filter(binding -> binding != null)
                                .forEach(allBindings::add);
@@ -524,12 +544,24 @@ public class LSPBindings {
     @SuppressWarnings("AccessingNonPublicFieldOfAnotherObject")
     public static synchronized void addBackgroundTask(FileObject file, BackgroundTask task) {
         RequestProcessor.Task req = WORKER.create(() -> {
-            LSPBindings bindings = getBindings(file);
+            List<LSPBindings> bindingsList = getBindings(file);
 
-            if (bindings == null)
-                return ;
+            if (!bindingsList.isEmpty()) {
+                task.run(bindingsList, file);
+            }
+        });
 
-            task.run(bindings, file);
+        backgroundTasks.computeIfAbsent(file, f -> new LinkedHashMap<>()).put(task, req);
+        scheduleBackgroundTask(req);
+    }
+
+    public static synchronized void addBackgroundTask(FileObject file, SimpleBackgroundTask task) {
+        RequestProcessor.Task req = WORKER.create(() -> {
+            List<LSPBindings> bindingsList = getBindings(file);
+
+            if (!bindingsList.isEmpty()) {
+                task.run(file);
+            }
         });
 
         backgroundTasks.computeIfAbsent(file, f -> new LinkedHashMap<>()).put(task, req);
@@ -544,11 +576,19 @@ public class LSPBindings {
         }
     }
 
+    public static synchronized void removeBackgroundTask(FileObject file, SimpleBackgroundTask task) {
+        RequestProcessor.Task req = backgroundTasksMapFor(file).remove(task);
+
+        if (req != null) {
+            req.cancel();
+        }
+    }
+
     public static void addChangeListener(ChangeListener l) {
         cs.addChangeListener(WeakListeners.change(l, cs));
     }
 
-    public void runOnBackground(Runnable r) {
+    public static void runOnBackground(Runnable r) {
         WORKER.post(r);
     }
 
@@ -568,7 +608,7 @@ public class LSPBindings {
         backgroundTasksMapFor(file).values().stream().forEach(LSPBindings::scheduleBackgroundTask);
     }
 
-    private static Map<BackgroundTask, Task> backgroundTasksMapFor(FileObject file) {
+    private static Map<?, Task> backgroundTasksMapFor(FileObject file) {
         return backgroundTasks.computeIfAbsent(file, f -> new IdentityHashMap<>());
     }
 
@@ -577,7 +617,11 @@ public class LSPBindings {
     }
 
     public interface BackgroundTask {
-        public void run(LSPBindings bindings, FileObject file);
+        public void run(List<LSPBindings> bindings, FileObject file);
+    }
+
+    public interface SimpleBackgroundTask {
+        public void run(FileObject file);
     }
 
     @OnStop
@@ -587,11 +631,13 @@ public class LSPBindings {
         @SuppressWarnings("AccessingNonPublicFieldOfAnotherObject")
         public void run() {
             synchronized(LSPBindings.class) {
-                for (Map<String, ServerDescription> mime2Bindings : project2MimeType2Server.values()) {
-                    for (ServerDescription description : mime2Bindings.values()) {
-                        LSPBindings b = description.bindings != null ? description.bindings.get() : null;
-                        if (b != null && b.process != null) {
-                            b.process.destroy();
+                for (Map<String, Map<LanguageServerProvider, ServerDescription>> mime2Bindings : project2MimeType2Server.values()) {
+                    for (Map<LanguageServerProvider, ServerDescription> provider2Server : mime2Bindings.values()) {
+                        for (ServerDescription description : provider2Server.values()) {
+                            LSPBindings b = description.bindings != null ? description.bindings.get() : null;
+                            if (b != null && b.process != null) {
+                                b.process.destroy();
+                            }
                         }
                     }
                 }

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/Utils.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/Utils.java
@@ -28,7 +28,15 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.SwingUtilities;
@@ -45,10 +53,12 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.RenameFile;
 import org.eclipse.lsp4j.ResourceOperation;
 import org.eclipse.lsp4j.ResourceOperationKind;
+import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.editor.document.LineDocument;
 import org.netbeans.api.editor.document.LineDocumentUtils;
 import org.netbeans.lib.editor.util.swing.DocumentUtilities;
@@ -63,6 +73,7 @@ import org.openide.loaders.DataObject;
 import org.openide.text.Line;
 import org.openide.text.NbDocument;
 import org.openide.util.Exceptions;
+import org.openide.util.Pair;
 
 /**
  *
@@ -319,8 +330,109 @@ public class Utils {
     public static boolean isTrue(Boolean b) {
         return b != null && b;
     }
+
+    public static @NonNull ServerCapabilities getCapabilities(LSPBindings server) {
+        if (server.getInitResult() != null && server.getInitResult().getCapabilities() != null) {
+            return server.getInitResult().getCapabilities();
+        } else {
+            return new ServerCapabilities();
+        }
+    }
+
     public static boolean isEnabled(Either<Boolean, ?> settings) {
         return settings != null && (settings.isLeft() ? isTrue(settings.getLeft())
                                                        : settings.getRight() != null);
+    }
+
+    public static <P, V> void handleBindings(List<LSPBindings> servers,
+                                             Predicate<ServerCapabilities> filter,
+                                             CreateParameters<P> createParameter,
+                                             BiFunction<LSPBindings, P, CompletableFuture<V>> runTask,
+                                             BiConsumer<LSPBindings, V> handler) {
+        handleBindings(servers, filter, createParameter, runTask, handler, Environment.NOOP);
+    }
+
+    public static <P, V> void handleBindings(List<LSPBindings> servers,
+                                             Predicate<ServerCapabilities> filter,
+                                             CreateParameters<P> createParameter,
+                                             BiFunction<LSPBindings, P, CompletableFuture<V>> runTask,
+                                             BiConsumer<LSPBindings, V> handler,
+                                             Environment env) {
+        if (servers.isEmpty()) {
+            return ;
+        }
+
+        List<Pair<LSPBindings, CompletableFuture<V>>> pending = new ArrayList<>();
+        P p = null;
+
+        for (LSPBindings server : servers) {
+            if (env.isCanceled()) {
+                return ;
+            }
+
+            if (!filter.test(getCapabilities(server))) {
+                continue;
+            }
+
+            if (p == null) {
+                try {
+                    p = createParameter.createParameters();
+                } catch (BadLocationException ex) {
+                    Exceptions.printStackTrace(ex);
+                    return ;
+                }
+            }
+
+            CompletableFuture<V> cf = runTask.apply(server, p);
+
+            env.registerCancelCallback(() -> cf.cancel(true));
+
+            if (env.isCanceled()) {
+                return ;
+            }
+
+            pending.add(Pair.of(server, cf));
+        }
+
+        for (Pair<LSPBindings, CompletableFuture<V>> current : pending) {
+            if (env.isCanceled()) {
+                return ;
+            }
+
+            try {
+                V value = current.second().get();
+
+                handler.accept(current.first(), value);
+            } catch (CancellationException ex) {
+                env.handleCancellationException(ex);
+            } catch (InterruptedException | ExecutionException ex) {
+                env.handleException(ex);
+            }
+        }
+    }
+
+    public interface CreateParameters<P> {
+        public P createParameters() throws BadLocationException;
+    }
+
+    public interface Environment {
+        public static final Environment NOOP = new Environment() {
+            @Override public boolean isCanceled() {
+                return false;
+            }
+            @Override public void registerCancelCallback(Runnable callback) {
+            }
+            @Override public void handleCancellationException(CancellationException ex) {
+                handleException(ex);
+            }
+            @Override public void handleException(Exception ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        };
+
+        public boolean isCanceled();
+        public void registerCancelCallback(Runnable callback);
+        public void handleCancellationException(CancellationException ex);
+        public void handleException(Exception ex);
     }
 }

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/CompletionProviderImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/CompletionProviderImpl.java
@@ -28,12 +28,10 @@ import java.awt.event.KeyEvent;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.Action;
-import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JToolTip;
 import javax.swing.text.BadLocationException;
@@ -95,7 +93,6 @@ public class CompletionProviderImpl implements CompletionProvider {
     private static final Logger LOG = Logger.getLogger(CompletionProviderImpl.class.getName());
 
     @Override
-    @Messages("DN_NoParameter=No parameter.")
     public CompletionTask createTask(int queryType, JTextComponent component) {
         if ((queryType & TOOLTIP_QUERY_TYPE) != 0) {
             return new AsyncCompletionTask(new AsyncCompletionQuery() {
@@ -107,63 +104,21 @@ public class CompletionProviderImpl implements CompletionProvider {
                             //TODO: beep
                             return ;
                         }
-                        LSPBindings server = LSPBindings.getBindings(file);
-                        if (server == null) {
-                            return ;
-                        }
-                        String uri = Utils.toURI(file);
-                        SignatureHelpParams params;
-                        params = new SignatureHelpParams(new TextDocumentIdentifier(uri),
-                                Utils.createPosition(doc, caretOffset));
-                        SignatureHelp help = server.getTextDocumentService().signatureHelp(params).get();
-                        if (help == null || help.getSignatures().isEmpty()) {
-                            return ;
-                        }
                         //TODO: active signature?
                         StringBuilder signatures = new StringBuilder();
-                        signatures.append("<html>");
-                        for (SignatureInformation info : help.getSignatures()) {
-                            if (info.getParameters() == null || info.getParameters().isEmpty()) {
-                                if (info.getLabel().isEmpty()) {
-                                    signatures.append(Bundle.DN_NoParameter());
-                                } else {
-                                    signatures.append(info.getLabel());
-                                }
-                                signatures.append("<br>");
-                                continue;
-                            }
-                            String sigSep = "";
-                            int idx = 0;
-                            for (ParameterInformation pi : info.getParameters()) {
-                                signatures.append(sigSep);
-                                if (idx == help.getActiveParameter()) {
-                                    signatures.append("<b>");
-                                }
-                                String label;
-                                if (pi.getLabel().isLeft()) {
-                                    label = pi.getLabel().getLeft();
-                                } else {
-                                    Integer start = pi.getLabel().getRight().getFirst();
-                                    Integer end = pi.getLabel().getRight().getSecond();
-
-                                    label = info.getLabel().substring(start, end);
-                                }
-                                signatures.append(label);
-                                if (idx == help.getActiveParameter()) {
-                                    signatures.append("</b>");
-                                }
-                                sigSep = ", ";
-                                idx++;
-                            }
-                            signatures.append("<br>");
+                        Utils.handleBindings(LSPBindings.getBindings(file),
+                                             capa -> capa.getSignatureHelpProvider() != null,
+                                             () -> new SignatureHelpParams(new TextDocumentIdentifier(Utils.toURI(file)),
+                                                        Utils.createPosition(doc, caretOffset)),
+                                             (server, params) -> server.getTextDocumentService().signatureHelp(params),
+                                             (server, result) -> handleSignatureInfo(result, signatures));
+                        if (signatures.isEmpty()) {
+                            return;
                         }
+                        signatures.insert(0, "<html>");
                         JToolTip tip = new JToolTip();
                         tip.setTipText(signatures.toString());
                         resultSet.setToolTip(tip);
-                    } catch (BadLocationException | InterruptedException ex) {
-                        Exceptions.printStackTrace(ex);
-                    } catch (ExecutionException ex) {
-                        Exceptions.printStackTrace(ex);
                     } finally {
                         resultSet.finish();
                     }
@@ -179,277 +134,309 @@ public class CompletionProviderImpl implements CompletionProvider {
                         //TODO: beep
                         return ;
                     }
-                    LSPBindings server = LSPBindings.getBindings(file);
-                    if (server == null) {
-                        return ;
-                    }
-                    CompletionOptions completionOptions = server.getInitResult().getCapabilities().getCompletionProvider();
-                    if (completionOptions == null) {
-                        //no completion in the server
-                        return ;
-                    }
-                    String uri = Utils.toURI(file);
-                    CompletionParams params;
-                    params = new CompletionParams(new TextDocumentIdentifier(uri),
-                            Utils.createPosition(doc, caretOffset));
-                    CountDownLatch l = new CountDownLatch(1);
-                    //TODO: Location or Location[]
-                    Either<List<CompletionItem>, CompletionList> completionResult = server.getTextDocumentService().completion(params).get();
-                    if (completionResult == null) {
-                        return ; //no results
-                    }
-                    List<CompletionItem> items;
-                    boolean incomplete;
-                    if (completionResult.isLeft()) {
-                        items = completionResult.getLeft();
-                        incomplete = true;
-                    } else {
-                        items = completionResult.getRight().getItems();
-                        incomplete = completionResult.getRight().isIncomplete();
-                    }
-                    for (CompletionItem i : items) {
-                        String insert = i.getInsertText() != null ? i.getInsertText() : i.getLabel();
-                        String leftLabel;
-                        String rightLabel;
-                        if (i.getLabelDetails() != null) {
-                            leftLabel = encode(i.getLabel() + (i.getLabelDetails().getDetail() != null ? i.getLabelDetails().getDetail() : ""));
-                            if (i.getLabelDetails().getDescription() != null) {
-                                rightLabel = encode(i.getLabelDetails().getDescription());
-                            } else {
-                                rightLabel = null;
-                            }
-                        } else {
-                            leftLabel = encode(i.getLabel());
-                            if (i.getDetail() != null) {
-                                rightLabel = encode(i.getDetail());
-                            } else {
-                                rightLabel = null;
-                            }
-                        }
-                        String sortText = i.getSortText() != null ? i.getSortText() : i.getLabel();
-                        CompletionItemKind kind = i.getKind();
-                        ImageIcon icon = ImageUtilities.icon2ImageIcon(Icons.getCompletionIcon(kind));
-                        resultSet.addItem(new org.netbeans.spi.editor.completion.CompletionItem() {
-                            @Override
-                            public void defaultAction(JTextComponent jtc) {
-                                commit("");
-                            }
-                            private void commit(String appendText) {
-                                CompletionItem resolved;
-                                if (i.getTextEdit() == null && hasCompletionResolve(completionOptions)) {
-                                    CompletionItem resolvedTemp = i;
-                                    try {
-                                        resolvedTemp = server.getTextDocumentService().resolveCompletionItem(resolvedTemp).get();
-                                    } catch (InterruptedException | ExecutionException ex) {
-                                        //TODO: ?
-                                        LOG.log(Level.FINE, null, ex);
-                                    }
-                                    resolved = resolvedTemp;
-                                } else {
-                                    resolved = i;
-                                }
-                                Either<TextEdit, InsertReplaceEdit> edit = resolved.getTextEdit();
-                                if (edit != null && edit.isRight()) {
-                                    //TODO: the NetBeans client does not current support InsertReplaceEdits, should not happen
-                                    Completion.get().hideDocumentation();
-                                    Completion.get().hideCompletion();
-                                    return ;
-                                }
-                                NbDocument.runAtomic((StyledDocument) doc, () -> {
-                                    try {
-                                        CodeTemplate template = null;
-                                        TextEdit mainEdit;
-
-                                        if (edit != null ) {
-                                            TextEdit providedMainEdit = edit.getLeft();
-                                            if (resolved.getInsertTextFormat() == InsertTextFormat.Snippet) {
-                                                template = CodeTemplateManager.get(doc).createTemporary(convertSnippet2CodeTemplate(providedMainEdit.getNewText()));
-                                                mainEdit = new TextEdit(providedMainEdit.getRange(), "");
-                                            } else {
-                                                mainEdit = providedMainEdit;
-                                            }
-                                        } else {
-                                            String toAdd;
-                                            if (resolved.getInsertTextFormat() == InsertTextFormat.Snippet) {
-                                                //TODO: handle appendText
-                                                template = CodeTemplateManager.get(doc).createTemporary(convertSnippet2CodeTemplate(resolved.getInsertText()));
-                                                toAdd = "";
-                                            } else {
-                                                toAdd = resolved.getInsertText();
-                                                if (toAdd == null) {
-                                                    toAdd = resolved.getLabel();
-                                                }
-                                            }
-                                            int[] identSpan = Utilities.getIdentifierBlock((BaseDocument) doc, caretOffset);
-                                            Position start;
-                                            Position end;
-                                            if (identSpan != null) {
-                                                start = Utils.createPosition(doc, identSpan[0]);
-                                                end = Utils.createPosition(doc, identSpan[1]);
-                                            } else {
-                                                end = start = Utils.createPosition(doc, caretOffset);
-                                            }
-                                            mainEdit = new TextEdit(new Range(start, end), toAdd);
-                                        }
-
-                                        List<TextEdit> allEdits = new ArrayList<>();
-
-                                        allEdits.add(mainEdit);
-
-                                        if (resolved.getAdditionalTextEdits() != null) {
-                                            allEdits.addAll(resolved.getAdditionalTextEdits());
-                                        }
-
-                                        int insertPos = Utils.getOffset(doc, mainEdit.getRange().getStart());
-                                        LineDocument ld = LineDocumentUtils.as(doc, LineDocument.class);
-                                        javax.swing.text.Position startPos = ld.createPosition(insertPos, Bias.Backward);
-
-                                        Utils.applyEditsNoLock(doc, allEdits);
-
-                                        if (template != null) {
-                                            //XXX: this does format
-                                            template.insert(component);
-                                        } else {
-                                            int endPos = startPos.hashCode() + mainEdit.getNewText().length();
-
-                                            doc.insertString(endPos, appendText, null);
-                                        }
-                                    } catch (BadLocationException ex) {
-                                        Exceptions.printStackTrace(ex);
-                                    }
-                                });
-                                Completion.get().hideDocumentation();
-                                Completion.get().hideCompletion();
-                            }
-
-                            @Override
-                            public void processKeyEvent(KeyEvent ke) {
-                                if (ke.getID() == KeyEvent.KEY_TYPED) {
-                                    String commitText = String.valueOf(ke.getKeyChar());
-                                    List<String> commitCharacters = i.getCommitCharacters();
-
-                                    if (commitCharacters != null && commitCharacters.contains(commitText)) {
-                                        commit(commitText);
-                                        ke.consume();
-                                        if (isTriggerCharacter(server, commitText)) {
-                                            Completion.get().showCompletion();
-                                        }
-                                    }
-                                }
-                            }
-
-                            @Override
-                            public int getPreferredWidth(Graphics grphcs, Font font) {
-                                return CompletionUtilities.getPreferredWidth(leftLabel, rightLabel, grphcs, font);
-                            }
-
-                            @Override
-                            public void render(Graphics grphcs, Font font, Color color, Color color1, int i, int i1, boolean bln) {
-                                COMPLETION_ITEM_RENDERER.renderCompletionItem(icon, leftLabel, rightLabel, grphcs, font, color, i, i1, bln);
-                            }
-
-                            @Override
-                            public CompletionTask createDocumentationTask() {
-                                return new AsyncCompletionTask(new AsyncCompletionQuery() {
-                                    @Override
-                                    protected void query(CompletionResultSet resultSet, Document doc, int caretOffset) {
-                                        CompletionItem resolved;
-                                        if ((i.getDetail() == null || i.getDocumentation() == null) && hasCompletionResolve(completionOptions)) {
-                                            CompletionItem temp;
-                                            try {
-                                                temp = server.getTextDocumentService().resolveCompletionItem(i).get();
-                                            } catch (InterruptedException | ExecutionException ex) {
-                                                LOG.log(Level.INFO, "Failed to retrieve documentation data", ex);
-                                                temp = i;
-                                            }
-                                            resolved = temp;
-                                        } else {
-                                            resolved = i;
-                                        }
-                                        if (resolved.getDocumentation() != null || resolved.getDetail() != null) {
-                                            resultSet.setDocumentation(new CompletionDocumentation() {
-                                                @Override
-                                                public String getText() {
-                                                    StringBuilder documentation = new StringBuilder();
-                                                    documentation.append("<html>\n");
-                                                    if (resolved.getDetail() != null) {
-                                                        documentation.append("<b>").append(escape(resolved.getDetail())).append("</b>");
-                                                        documentation.append("\n<p>");
-                                                    }
-                                                    if (resolved.getDocumentation() != null) {
-                                                        MarkupContent content;
-                                                        if (resolved.getDocumentation().isLeft()) {
-                                                            content = new MarkupContent();
-                                                            content.setKind("plaintext");
-                                                            content.setValue(resolved.getDocumentation().getLeft());
-                                                        } else {
-                                                            content = resolved.getDocumentation().getRight();
-                                                        }
-                                                        switch (content.getKind()) {
-                                                            default:
-                                                            case "plaintext": documentation.append("<pre>\n").append(content.getValue()).append("\n</pre>"); break;
-                                                            case "markdown": documentation.append(HtmlRenderer.builder().build().render(Parser.builder().build().parse(content.getValue()))); break;
-                                                            case "html": documentation.append(content.getValue()); break;
-                                                        }
-                                                    }
-                                                    return documentation.toString();
-                                                }
-                                                @Override
-                                                public URL getURL() {
-                                                    return null;
-                                                }
-                                                @Override
-                                                public CompletionDocumentation resolveLink(String link) {
-                                                    return null;
-                                                }
-                                                @Override
-                                                public Action getGotoSourceAction() {
-                                                    return null;
-                                                }
-                                            });
-                                        }
-                                        resultSet.finish();
-                                    }
-                                });
-                            }
-
-                            @Override
-                            public CompletionTask createToolTipTask() {
-                                return null;
-                            }
-
-                            @Override
-                            public boolean instantSubstitution(JTextComponent jtc) {
-                                return false;
-                            }
-
-                            @Override
-                            public int getSortPriority() {
-                                return 100;
-                            }
-
-                            @Override
-                            public CharSequence getSortText() {
-                                return sortText;
-                            }
-
-                            @Override
-                            public CharSequence getInsertPrefix() {
-                                return insert;
-                            }
-                        });
-                    }
-                } catch (BadLocationException | InterruptedException ex) {
-                    Exceptions.printStackTrace(ex);
-                } catch (ExecutionException ex) {
-                    Exceptions.printStackTrace(ex);
+                    Utils.handleBindings(LSPBindings.getBindings(file),
+                                         capa -> capa.getCompletionProvider() != null,
+                                         () -> new CompletionParams(new TextDocumentIdentifier(Utils.toURI(file)),
+                                                                    Utils.createPosition(doc, caretOffset)),
+                                         (server, params) -> server.getTextDocumentService().completion(params),
+                                         (server, result) -> handleCompletionResult(resultSet, component, doc, caretOffset, server, result));
                 } finally {
                     resultSet.finish();
                 }
             }
         }, component);
     }
-    
+
+    @Messages("DN_NoParameter=No parameter.")
+    private void handleSignatureInfo(SignatureHelp help, StringBuilder signatures) {
+        if (help == null || help.getSignatures().isEmpty()) {
+            return ;
+        }
+        for (SignatureInformation info : help.getSignatures()) {
+            if (info.getParameters() == null || info.getParameters().isEmpty()) {
+                if (info.getLabel().isEmpty()) {
+                    signatures.append(Bundle.DN_NoParameter());
+                } else {
+                    signatures.append(info.getLabel());
+                }
+                signatures.append("<br>");
+                continue;
+            }
+            String sigSep = "";
+            int idx = 0;
+            for (ParameterInformation pi : info.getParameters()) {
+                signatures.append(sigSep);
+                if (idx == help.getActiveParameter()) {
+                    signatures.append("<b>");
+                }
+                String label;
+                if (pi.getLabel().isLeft()) {
+                    label = pi.getLabel().getLeft();
+                } else {
+                    Integer start = pi.getLabel().getRight().getFirst();
+                    Integer end = pi.getLabel().getRight().getSecond();
+
+                    label = info.getLabel().substring(start, end);
+                }
+                signatures.append(label);
+                if (idx == help.getActiveParameter()) {
+                    signatures.append("</b>");
+                }
+                sigSep = ", ";
+                idx++;
+            }
+            signatures.append("<br>");
+        }
+    }
+
+    private void handleCompletionResult(CompletionResultSet resultSet, JTextComponent component, Document doc, int caretOffset, LSPBindings server, Either<List<CompletionItem>, CompletionList> completionResult) {
+        if (completionResult == null) {
+            return ; //no results
+        }
+        CompletionOptions completionOptions = server.getInitResult().getCapabilities().getCompletionProvider();
+        List<CompletionItem> items;
+        boolean incomplete;
+        if (completionResult.isLeft()) {
+            items = completionResult.getLeft();
+            incomplete = true;
+        } else {
+            items = completionResult.getRight().getItems();
+            incomplete = completionResult.getRight().isIncomplete();
+        }
+        for (CompletionItem i : items) {
+            String insert = i.getInsertText() != null ? i.getInsertText() : i.getLabel();
+            String leftLabel;
+            String rightLabel;
+            if (i.getLabelDetails() != null) {
+                leftLabel = encode(i.getLabel() + (i.getLabelDetails().getDetail() != null ? i.getLabelDetails().getDetail() : ""));
+                if (i.getLabelDetails().getDescription() != null) {
+                    rightLabel = encode(i.getLabelDetails().getDescription());
+                } else {
+                    rightLabel = null;
+                }
+            } else {
+                leftLabel = encode(i.getLabel());
+                if (i.getDetail() != null) {
+                    rightLabel = encode(i.getDetail());
+                } else {
+                    rightLabel = null;
+                }
+            }
+            String sortText = i.getSortText() != null ? i.getSortText() : i.getLabel();
+            CompletionItemKind kind = i.getKind();
+            ImageIcon icon = ImageUtilities.icon2ImageIcon(Icons.getCompletionIcon(kind));
+            resultSet.addItem(new org.netbeans.spi.editor.completion.CompletionItem() {
+                @Override
+                public void defaultAction(JTextComponent jtc) {
+                    commit("");
+                }
+                private void commit(String appendText) {
+                    CompletionItem resolved;
+                    if (i.getTextEdit() == null && hasCompletionResolve(completionOptions)) {
+                        CompletionItem resolvedTemp = i;
+                        try {
+                            resolvedTemp = server.getTextDocumentService().resolveCompletionItem(resolvedTemp).get();
+                        } catch (InterruptedException | ExecutionException ex) {
+                            //TODO: ?
+                            LOG.log(Level.FINE, null, ex);
+                        }
+                        resolved = resolvedTemp;
+                    } else {
+                        resolved = i;
+                    }
+                    Either<TextEdit, InsertReplaceEdit> edit = resolved.getTextEdit();
+                    if (edit != null && edit.isRight()) {
+                        //TODO: the NetBeans client does not current support InsertReplaceEdits, should not happen
+                        Completion.get().hideDocumentation();
+                        Completion.get().hideCompletion();
+                        return ;
+                    }
+                    NbDocument.runAtomic((StyledDocument) doc, () -> {
+                        try {
+                            CodeTemplate template = null;
+                            TextEdit mainEdit;
+
+                            if (edit != null ) {
+                                TextEdit providedMainEdit = edit.getLeft();
+                                if (resolved.getInsertTextFormat() == InsertTextFormat.Snippet) {
+                                    template = CodeTemplateManager.get(doc).createTemporary(convertSnippet2CodeTemplate(providedMainEdit.getNewText()));
+                                    mainEdit = new TextEdit(providedMainEdit.getRange(), "");
+                                } else {
+                                    mainEdit = providedMainEdit;
+                                }
+                            } else {
+                                String toAdd;
+                                if (resolved.getInsertTextFormat() == InsertTextFormat.Snippet) {
+                                    //TODO: handle appendText
+                                    template = CodeTemplateManager.get(doc).createTemporary(convertSnippet2CodeTemplate(resolved.getInsertText()));
+                                    toAdd = "";
+                                } else {
+                                    toAdd = resolved.getInsertText();
+                                    if (toAdd == null) {
+                                        toAdd = resolved.getLabel();
+                                    }
+                                }
+                                int[] identSpan = Utilities.getIdentifierBlock((BaseDocument) doc, caretOffset);
+                                Position start;
+                                Position end;
+                                if (identSpan != null) {
+                                    start = Utils.createPosition(doc, identSpan[0]);
+                                    end = Utils.createPosition(doc, identSpan[1]);
+                                } else {
+                                    end = start = Utils.createPosition(doc, caretOffset);
+                                }
+                                mainEdit = new TextEdit(new Range(start, end), toAdd);
+                            }
+
+                            List<TextEdit> allEdits = new ArrayList<>();
+
+                            allEdits.add(mainEdit);
+
+                            if (resolved.getAdditionalTextEdits() != null) {
+                                allEdits.addAll(resolved.getAdditionalTextEdits());
+                            }
+
+                            int insertPos = Utils.getOffset(doc, mainEdit.getRange().getStart());
+                            LineDocument ld = LineDocumentUtils.as(doc, LineDocument.class);
+                            javax.swing.text.Position startPos = ld.createPosition(insertPos, Bias.Backward);
+
+                            Utils.applyEditsNoLock(doc, allEdits);
+
+                            if (template != null) {
+                                //XXX: this does format
+                                template.insert(component);
+                            } else {
+                                int endPos = startPos.hashCode() + mainEdit.getNewText().length();
+
+                                doc.insertString(endPos, appendText, null);
+                            }
+                        } catch (BadLocationException ex) {
+                            Exceptions.printStackTrace(ex);
+                        }
+                    });
+                    Completion.get().hideDocumentation();
+                    Completion.get().hideCompletion();
+                }
+
+                @Override
+                public void processKeyEvent(KeyEvent ke) {
+                    if (ke.getID() == KeyEvent.KEY_TYPED) {
+                        String commitText = String.valueOf(ke.getKeyChar());
+                        List<String> commitCharacters = i.getCommitCharacters();
+
+                        if (commitCharacters != null && commitCharacters.contains(commitText)) {
+                            commit(commitText);
+                            ke.consume();
+                            if (isTriggerCharacter(server, commitText)) {
+                                Completion.get().showCompletion();
+                            }
+                        }
+                    }
+                }
+
+                @Override
+                public int getPreferredWidth(Graphics grphcs, Font font) {
+                    return CompletionUtilities.getPreferredWidth(leftLabel, rightLabel, grphcs, font);
+                }
+
+                @Override
+                public void render(Graphics grphcs, Font font, Color color, Color color1, int i, int i1, boolean bln) {
+                    COMPLETION_ITEM_RENDERER.renderCompletionItem(icon, leftLabel, rightLabel, grphcs, font, color, i, i1, bln);
+                }
+
+                @Override
+                public CompletionTask createDocumentationTask() {
+                    return new AsyncCompletionTask(new AsyncCompletionQuery() {
+                        @Override
+                        protected void query(CompletionResultSet resultSet, Document doc, int caretOffset) {
+                            CompletionItem resolved;
+                            if ((i.getDetail() == null || i.getDocumentation() == null) && hasCompletionResolve(completionOptions)) {
+                                CompletionItem temp;
+                                try {
+                                    temp = server.getTextDocumentService().resolveCompletionItem(i).get();
+                                } catch (InterruptedException | ExecutionException ex) {
+                                    LOG.log(Level.INFO, "Failed to retrieve documentation data", ex);
+                                    temp = i;
+                                }
+                                resolved = temp;
+                            } else {
+                                resolved = i;
+                            }
+                            if (resolved.getDocumentation() != null || resolved.getDetail() != null) {
+                                resultSet.setDocumentation(new CompletionDocumentation() {
+                                    @Override
+                                    public String getText() {
+                                        StringBuilder documentation = new StringBuilder();
+                                        documentation.append("<html>\n");
+                                        if (resolved.getDetail() != null) {
+                                            documentation.append("<b>").append(escape(resolved.getDetail())).append("</b>");
+                                            documentation.append("\n<p>");
+                                        }
+                                        if (resolved.getDocumentation() != null) {
+                                            MarkupContent content;
+                                            if (resolved.getDocumentation().isLeft()) {
+                                                content = new MarkupContent();
+                                                content.setKind("plaintext");
+                                                content.setValue(resolved.getDocumentation().getLeft());
+                                            } else {
+                                                content = resolved.getDocumentation().getRight();
+                                            }
+                                            switch (content.getKind()) {
+                                                default:
+                                                case "plaintext": documentation.append("<pre>\n").append(content.getValue()).append("\n</pre>"); break;
+                                                case "markdown": documentation.append(HtmlRenderer.builder().build().render(Parser.builder().build().parse(content.getValue()))); break;
+                                                case "html": documentation.append(content.getValue()); break;
+                                            }
+                                        }
+                                        return documentation.toString();
+                                    }
+                                    @Override
+                                    public URL getURL() {
+                                        return null;
+                                    }
+                                    @Override
+                                    public CompletionDocumentation resolveLink(String link) {
+                                        return null;
+                                    }
+                                    @Override
+                                    public Action getGotoSourceAction() {
+                                        return null;
+                                    }
+                                });
+                            }
+                            resultSet.finish();
+                        }
+                    });
+                }
+
+                @Override
+                public CompletionTask createToolTipTask() {
+                    return null;
+                }
+
+                @Override
+                public boolean instantSubstitution(JTextComponent jtc) {
+                    return false;
+                }
+
+                @Override
+                public int getSortPriority() {
+                    return 100;
+                }
+
+                @Override
+                public CharSequence getSortText() {
+                    return sortText;
+                }
+
+                @Override
+                public CharSequence getInsertPrefix() {
+                    return insert;
+                }
+            });
+        }
+    }
+
     private boolean hasCompletionResolve(CompletionOptions completionOptions) {
         Boolean resolveProvider = completionOptions.getResolveProvider();
         return resolveProvider != null && resolveProvider;
@@ -475,11 +462,11 @@ public class CompletionProviderImpl implements CompletionProvider {
         if (file == null) {
             return 0;
         }
-        LSPBindings server = LSPBindings.getBindings(file);
-        if (server == null) {
+        List<LSPBindings> servers = LSPBindings.getBindings(file);
+        if (servers.isEmpty()) {
             return 0;
         }
-        return isTriggerCharacter(server, typedText) ? COMPLETION_QUERY_TYPE : 0;
+        return servers.stream().anyMatch(server -> isTriggerCharacter(server, typedText)) ? COMPLETION_QUERY_TYPE : 0;
     }
     
     private boolean isTriggerCharacter(LSPBindings server, String text) {

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/MarkOccurrences.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/MarkOccurrences.java
@@ -21,7 +21,9 @@ package org.netbeans.modules.lsp.client.bindings;
 import java.awt.Color;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -86,7 +88,7 @@ public class MarkOccurrences implements BackgroundTask, CaretListener, PropertyC
     @NbBundle.Messages(
             "LBL_ES_TOOLTIP=Mark Occurrences"
     )
-    public void run(LSPBindings bindings, FileObject file) {
+    public void run(List<LSPBindings> servers, FileObject file) {
         Document localDoc;
         int localCaretPos;
 
@@ -101,7 +103,7 @@ public class MarkOccurrences implements BackgroundTask, CaretListener, PropertyC
             return;
         }
 
-        List<int[]> highlights = computeHighlights(localDoc, localCaretPos);
+        List<int[]> highlights = computeHighlights(servers, localDoc, localCaretPos);
 
         if (highlights != null && !highlights.isEmpty()) {
             AttributeSet attr = getColoring(localDoc);
@@ -121,7 +123,7 @@ public class MarkOccurrences implements BackgroundTask, CaretListener, PropertyC
         }
     }
 
-    private List<int[]> computeHighlights(Document doc, int caretPos) {
+    private List<int[]> computeHighlights(List<LSPBindings> servers, Document doc, int caretPos) {
         if(caretPos < 0) {
             return null;
         }
@@ -129,31 +131,19 @@ public class MarkOccurrences implements BackgroundTask, CaretListener, PropertyC
         if (file == null) {
             return null;
         }
-        LSPBindings server = LSPBindings.getBindings(file);
-        if (server == null) {
-            return null;
-        }
-        if (!Utils.isEnabled(server.getInitResult().getCapabilities().getDocumentHighlightProvider())) {
-            return null;
-        }
-        String uri = Utils.toURI(file);
-        try {
-            List<? extends DocumentHighlight> highlights = server
-                    .getTextDocumentService()
-                    .documentHighlight(new DocumentHighlightParams(new TextDocumentIdentifier(uri), Utils.createPosition(doc, caretPos)))
-                    .get();
-            if (highlights != null) {
-                return highlights
-                        .stream()
-                        .map(h -> new int[]{Utils.getOffset(doc, h.getRange().getStart()), Utils.getOffset(doc, h.getRange().getEnd())})
-                        .collect(Collectors.toList());
-            } else {
-                return null;
-            }
-        } catch (BadLocationException | InterruptedException | ExecutionException ex) {
-            Exceptions.printStackTrace(ex);
-            return null;
-        }
+        List<int[]> output = new ArrayList<>();
+
+        Utils.handleBindings(servers,
+                             capa -> Utils.isEnabled(capa.getDocumentHighlightProvider()),
+                             () -> new DocumentHighlightParams(new TextDocumentIdentifier(Utils.toURI(file)), Utils.createPosition(doc, caretPos)),
+                             (server, param) -> server.getTextDocumentService().documentHighlight(param),
+                             (server, result) -> Optional.ofNullable(result)
+                                                         .stream()
+                                                         .flatMap(res -> res.stream())
+                                                         .map(h -> new int[]{Utils.getOffset(doc, h.getRange().getStart()), Utils.getOffset(doc, h.getRange().getEnd())})
+                                                         .forEach(output::add));
+
+        return output;
     }
 
     private AttributeSet getColoring(Document doc) {

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/refactoring/LSPBindingsCollection.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/refactoring/LSPBindingsCollection.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.lsp.client.bindings.refactoring;
+
+import java.util.List;
+import org.netbeans.modules.lsp.client.LSPBindings;
+
+public record LSPBindingsCollection(List<LSPBindings> servers) {
+}

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/refactoring/RenameRefactoringUIImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/refactoring/RenameRefactoringUIImpl.java
@@ -41,15 +41,15 @@ import org.openide.util.lookup.Lookups;
  */
 public class RenameRefactoringUIImpl implements RefactoringUI {
 
-    private final LSPBindings bindings;
+    private final LSPBindingsCollection servers;
     private final FileObject file;
     private final Position position;
     private final String name;
     private final RenameParams params;
     private RenamePanel panel;
 
-    public RenameRefactoringUIImpl(LSPBindings binding, FileObject file, Position position, String name) {
-        this.bindings = binding;
+    public RenameRefactoringUIImpl(LSPBindingsCollection servers, FileObject file, Position position, String name) {
+        this.servers = servers;
         this.file = file;
         this.position = position;
         this.name = name;
@@ -113,7 +113,7 @@ public class RenameRefactoringUIImpl implements RefactoringUI {
 
     @Override
     public AbstractRefactoring getRefactoring() {
-        return new RenameRefactoring(Lookups.fixed(bindings, params));
+        return new RenameRefactoring(Lookups.fixed(servers, params));
     }
 
     @Override

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/refactoring/WhereUsedRefactoringUIImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/refactoring/WhereUsedRefactoringUIImpl.java
@@ -38,12 +38,12 @@ import org.openide.util.lookup.Lookups;
  */
 public class WhereUsedRefactoringUIImpl implements RefactoringUI {
 
-    private final LSPBindings bindings;
+    private final LSPBindingsCollection servers;
     private final ReferenceParams params;
     private final String name;
 
-    public WhereUsedRefactoringUIImpl(LSPBindings binding, ReferenceParams params, String name) {
-        this.bindings = binding;
+    public WhereUsedRefactoringUIImpl(LSPBindingsCollection servers, ReferenceParams params, String name) {
+        this.servers = servers;
         this.params = params;
         this.name = name;
     }
@@ -98,7 +98,7 @@ public class WhereUsedRefactoringUIImpl implements RefactoringUI {
 
     @Override
     public AbstractRefactoring getRefactoring() {
-        return new WhereUsedQuery(Lookups.fixed(bindings, params));
+        return new WhereUsedQuery(Lookups.fixed(servers, params));
     }
 
     @Override

--- a/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/LSPBindingsTest.java
+++ b/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/LSPBindingsTest.java
@@ -24,12 +24,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.swing.Icon;
 import javax.swing.JComponent;
-import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.netbeans.api.editor.mimelookup.MimePath;
 import org.netbeans.api.project.FileOwnerQuery;
@@ -61,8 +63,8 @@ public class LSPBindingsTest {
         assertEquals("application/mock-txt", file.getMIMEType());
         assertNull("No project owner", FileOwnerQuery.getOwner(file));
 
-        LSPBindings bindings = LSPBindings.getBindings(file);
-        assertNotNull("Bindings for the projectless file found", bindings);
+        List<LSPBindings> bindings = LSPBindings.getBindings(file);
+        assertFalse("Bindings for the projectless file found", bindings.isEmpty());
     }
 
     public static final class SettableProxyLookup extends ProxyLookup {
@@ -188,8 +190,8 @@ public class LSPBindingsTest {
 
         NotifyDisplayerImpl.called.set(0);
 
-        LSPBindings bindings = LSPBindings.getBindings(file);
-        assertNull("No bindings after many failures", bindings);
+        List<LSPBindings> bindings = LSPBindings.getBindings(file);
+        assertTrue("No bindings after many failures", bindings.isEmpty());
         assertEquals(1, NotifyDisplayerImpl.called.get());
     }
 
@@ -229,8 +231,8 @@ public class LSPBindingsTest {
 
         NotifyDisplayerImpl.called.set(0);
 
-        LSPBindings bindings = LSPBindings.getBindings(file);
-        assertNull("No bindings after many failures", bindings);
+        List<LSPBindings> bindings = LSPBindings.getBindings(file);
+        assertTrue("No bindings after many failures", bindings.isEmpty());
         assertEquals(1, NotifyDisplayerImpl.called.get());
     }
 

--- a/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/bindings/refactoring/RenameRefactoringTest.java
+++ b/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/bindings/refactoring/RenameRefactoringTest.java
@@ -112,7 +112,7 @@ public class RenameRefactoringTest {
 
         String uri = Utils.toURI(file1);
 
-        LSPBindings bindings = LSPBindings.getBindings(file1);
+        List<LSPBindings> bindings = LSPBindings.getBindings(file1);
         RenameParams renameParams = new RenameParams(new TextDocumentIdentifier(uri), new Position(1, 8), "newName");
         List<Function<RenameParams, WorkspaceEdit>> renameFunctions = Arrays.asList(
             params -> {
@@ -151,7 +151,7 @@ public class RenameRefactoringTest {
         for (Function<RenameParams, WorkspaceEdit> renameFunc : renameFunctions) {
             renameFunction = renameFunc;
 
-            RenameRefactoring refactoring = new RenameRefactoring(Lookups.fixed(bindings, renameParams));
+            RenameRefactoring refactoring = new RenameRefactoring(Lookups.fixed(new LSPBindingsCollection(bindings), renameParams));
 
             RefactoringSession session = RefactoringSession.create("test rename");
             assertNull(refactoring.checkParameters());
@@ -226,7 +226,7 @@ public class RenameRefactoringTest {
 
         String uri = Utils.toURI(file1);
 
-        LSPBindings bindings = LSPBindings.getBindings(file1);
+        List<LSPBindings> bindings = LSPBindings.getBindings(file1);
         RenameParams renameParams = new RenameParams(new TextDocumentIdentifier(uri), new Position(1, 8), "newName");
         renameFunction = params -> {
             assertEquals(uri, params.getTextDocument().getUri());
@@ -256,7 +256,7 @@ public class RenameRefactoringTest {
             return result;
         };
 
-        RenameRefactoring refactoring = new RenameRefactoring(Lookups.fixed(bindings, renameParams));
+        RenameRefactoring refactoring = new RenameRefactoring(Lookups.fixed(new LSPBindingsCollection(bindings), renameParams));
 
         RefactoringSession session = RefactoringSession.create("test rename");
         assertNull(refactoring.checkParameters());


### PR DESCRIPTION
VS Code allows to run multiple LSP servers for each file. So that there may be alternative Navigator contents, or specialized code completion.

This PR is trying to do something similar for the NB's LSP client, it strives to permit multiple LSP servers for each file/mime type, producing hopefully sensible outcomes for each feature.
