### PR TITLE
Maven-JUnit Integration: Support nested and toplevel non-public tests and stabiize result extraction

### DIFF
--- a/ide/projectapi/nbproject/project.properties
+++ b/ide/projectapi/nbproject/project.properties
@@ -18,7 +18,7 @@
 is.autoload=true
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.target=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/projectapi/src/org/netbeans/spi/project/NestedClass.java
+++ b/ide/projectapi/src/org/netbeans/spi/project/NestedClass.java
@@ -46,11 +46,16 @@ public final class NestedClass {
      * Creates a new instance holding the specified identification
      * of a nested class.
      *
-     * @param className name of a class inside the file
-     * @param topLevelClassName top level name of a class inside the file
+     * @param className name of a class inside the file. Can be an empty string
+     * if this NestedClass represents a top level element in the source file.
+     * This is relevant for Java, which allows multiple top level class
+     * declarations as long as they are not public. The class assumes, that the
+     * {@code className} follows java convention (i.e. is separated by dots).
+     * @param topLevelClassName top level name of a class inside the file.  This
+     * is the simple name without package qualification.
      * @param file file to be kept in the object
      * @exception  java.lang.IllegalArgumentException
-     *             if the file or class name is {@code null}
+     *             if the file, topLevelClassName or class name is {@code null}
      * @since 1.99
      */
     public NestedClass(String className, String topLevelClassName, FileObject file) {
@@ -90,7 +95,8 @@ public final class NestedClass {
     }
     
     /**
-     * Returns name of a top level class within a file.
+     * Returns name of a top level class within a file. This is the simple name
+     * without package qualification.
      *
      * @return top level class name held by this object
      * @since 1.99
@@ -108,9 +114,19 @@ public final class NestedClass {
      * @since 1.99
      */
     public String getFQN(String packageName) {
-        return String.join(".", packageName, topLevelClassName, className);
+        String classNameSuffix;
+        if (className.isBlank()) {
+            classNameSuffix = topLevelClassName;
+        } else {
+            classNameSuffix = topLevelClassName + "." + className;
+        }
+        if (packageName.isBlank()) {
+            return classNameSuffix;
+        } else {
+            return String.join(".", packageName, classNameSuffix);
+        }
     }
-    
+
     /**
      * Returns fully qualified name.
      *
@@ -121,9 +137,19 @@ public final class NestedClass {
      * @since 1.99
      */
     public String getFQN(String packageName, String nestedClassSeparator) {
-        return String.join(".", packageName, String.join(nestedClassSeparator, topLevelClassName, className.replace(".", nestedClassSeparator)));
+        String classNameSuffix;
+        if (className.isBlank()) {
+            classNameSuffix = topLevelClassName;
+        } else {
+            classNameSuffix = topLevelClassName + nestedClassSeparator + className.replace(".", nestedClassSeparator);
+        }
+        if (packageName.isBlank()) {
+            return classNameSuffix;
+        } else {
+            return String.join(".", packageName, classNameSuffix);
+        }
     }
-    
+
     @Override
     public int hashCode() {
         int hash = 3;

--- a/java/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
@@ -1490,20 +1490,33 @@ public class SourceUtils {
         String className = rel.replace('/', '.');
         int lastDotIndex = className.lastIndexOf('.');
         String fqnForNestedClass = null;
-        if (lastDotIndex > -1 && nestedClass != null) {
-            String packageName = className.substring(0, lastDotIndex);
+        String topLevelClass = null;
+        if (nestedClass != null) {
+            String packageName;
+            if(lastDotIndex >= 0) {
+                packageName = className.substring(0, lastDotIndex);
+            } else {
+                packageName = "";
+            }
             fqnForNestedClass = nestedClass.getFQN(packageName, "$");
+            topLevelClass = packageName + ( packageName.isBlank() ? "" : "." ) + nestedClass.getTopLevelClassName();
         }
+        // This is really an ugly hack. It is pure luck, that the cache directory
+        // is placed on the CP, nothing guarantes that or at least that is non
+        // obvious. This also makes it hard/impossible to test.
         FileObject rsFile = cachedCP.findResource(rel + '.' + FileObjects.RS);
         if (rsFile != null) {
             List<String> lines = new ArrayList<>();
             try (BufferedReader in = new BufferedReader(new InputStreamReader(rsFile.getInputStream(), StandardCharsets.UTF_8))) {
                 String line;
-                while ((line = in.readLine())!=null) {
-                    if (className.equals(line)) {
+                while ((line = in.readLine()) != null) {
+                    if (topLevelClass == null && className.equals(line)) {
                         return className;
-                    } else if (fqnForNestedClass != null && fqnForNestedClass.equals(line)) {
-                        return line;
+                    } else if (topLevelClass != null && topLevelClass.equals(line)) {
+                        // The "RS" Index holds only toplevel classes, so we
+                        // assume, that if the toplevel is found here, the FQN
+                        // based on NestedClass is also present
+                        return fqnForNestedClass;
                     }
                     lines.add(line);
                 }

--- a/java/maven.junit.ui/nbproject/project.properties
+++ b/java/maven.junit.ui/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 requires.nb.javac=true

--- a/java/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitNodeOpener.java
+++ b/java/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitNodeOpener.java
@@ -29,24 +29,24 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.util.ElementFilter;
-import javax.swing.Action;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.extexecution.print.LineConvertors.FileLocator;
-import org.netbeans.api.java.source.CompilationController;
 import org.netbeans.api.java.source.JavaSource;
 import org.netbeans.api.java.source.JavaSource.Phase;
-import org.netbeans.api.java.source.Task;
 import org.netbeans.modules.gsf.testrunner.api.CommonUtils;
 import org.netbeans.modules.gsf.testrunner.ui.api.TestMethodNode;
 import org.netbeans.modules.gsf.testrunner.ui.api.TestsuiteNode;
 import org.netbeans.modules.junit.ui.api.JUnitTestMethodNode;
 import org.netbeans.modules.java.testrunner.ui.api.NodeOpener;
 import org.netbeans.modules.java.testrunner.ui.api.UIJavaUtils;
+import org.netbeans.modules.junit.api.JUnitTestcase;
 import org.netbeans.modules.junit.ui.api.JUnitCallstackFrameNode;
 import org.openide.ErrorManager;
 import org.openide.filesystems.FileObject;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
+
+import static java.util.Arrays.asList;
 
 /**
  *
@@ -57,33 +57,31 @@ public final class MavenJUnitNodeOpener extends NodeOpener {
 
     private static final Logger LOG = Logger.getLogger(MavenJUnitNodeOpener.class.getName());
 
-    static final Action[] NO_ACTIONS = new Action[0];
-
+    @Override
     public void openTestsuite(TestsuiteNode node) {
         Children childrens = node.getChildren();
         if (childrens != null) {
             Node child = childrens.getNodeAt(0);
-            if (child instanceof MavenJUnitTestMethodNode) {
-                final FileObject fo = ((MavenJUnitTestMethodNode) child).getTestcaseFileObject();
+            if (child instanceof MavenJUnitTestMethodNode junitMethodNode) {
+                final FileObject fo = junitMethodNode.getTestcaseFileObject();
+                final MethodInfo mi = MethodInfo.fromTestCase(junitMethodNode.getTestcase());
                 if (fo != null) {
                     final long[] line = new long[]{0};
                     JavaSource javaSource = JavaSource.forFileObject(fo);
                     if (javaSource != null) {
                         try {
-                            javaSource.runUserActionTask(new Task<CompilationController>() {
-                                @Override
-                                public void run(CompilationController compilationController) throws Exception {
-                                    compilationController.toPhase(Phase.ELEMENTS_RESOLVED);
-                                    Trees trees = compilationController.getTrees();
-                                    CompilationUnitTree compilationUnitTree = compilationController.getCompilationUnit();
-                                    List<? extends Tree> typeDecls = compilationUnitTree.getTypeDecls();
-                                    for (Tree tree : typeDecls) {
-                                        Element element = trees.getElement(trees.getPath(compilationUnitTree, tree));
-                                        if (element != null && element.getKind() == ElementKind.CLASS && element.getSimpleName().contentEquals(fo.getName())) {
-                                            long pos = trees.getSourcePositions().getStartPosition(compilationUnitTree, tree);
-                                            line[0] = compilationUnitTree.getLineMap().getLineNumber(pos);
-                                            break;
-                                        }
+                            javaSource.runUserActionTask(compilationController -> {
+                                compilationController.toPhase(Phase.ELEMENTS_RESOLVED);
+                                Trees trees = compilationController.getTrees();
+                                CompilationUnitTree compilationUnitTree = compilationController.getCompilationUnit();
+                                List<? extends Tree> typeDecls = compilationUnitTree.getTypeDecls();
+                                for (Tree tree : typeDecls) {
+                                    Element element = trees.getElement(trees.getPath(compilationUnitTree, tree));
+                                    if (element != null && element.getKind() == ElementKind.CLASS && element.getSimpleName().contentEquals(mi.topLevelClass())) {
+                                        element = resolveNestedClass(mi.nestedClasses(), element);
+                                        long pos = trees.getSourcePositions().getStartPosition(compilationUnitTree, trees.getTree(element));
+                                        line[0] = compilationUnitTree.getLineMap().getLineNumber(pos);
+                                        break;
                                     }
                                 }
                             }, true);
@@ -97,42 +95,43 @@ public final class MavenJUnitNodeOpener extends NodeOpener {
         }
     }
 
+    @Override
     public void openTestMethod(final TestMethodNode node) {
         if (!(node instanceof MavenJUnitTestMethodNode)) {
             return;
         }
-        final FileObject fo = ((MavenJUnitTestMethodNode) node).getTestcaseFileObject();
+        MavenJUnitTestMethodNode mtn = (MavenJUnitTestMethodNode) node;
+        final FileObject fo = mtn.getTestcaseFileObject();
+        final MethodInfo mi = MethodInfo.fromTestCase(mtn.getTestcase());
         if (fo != null) {
             final FileObject[] fo2open = new FileObject[]{fo};
             final long[] line = new long[]{0};
             JavaSource javaSource = JavaSource.forFileObject(fo2open[0]);
             if (javaSource != null) {
                 try {
-                    javaSource.runUserActionTask(new Task<CompilationController>() {
-                        @Override
-                        public void run(CompilationController compilationController) throws Exception {
-                            compilationController.toPhase(Phase.ELEMENTS_RESOLVED);
-                            Trees trees = compilationController.getTrees();
-                            CompilationUnitTree compilationUnitTree = compilationController.getCompilationUnit();
-                            List<? extends Tree> typeDecls = compilationUnitTree.getTypeDecls();
-                            for (Tree tree : typeDecls) {
-                                Element element = trees.getElement(trees.getPath(compilationUnitTree, tree));
-                                if (element != null && element.getKind() == ElementKind.CLASS && element.getSimpleName().contentEquals(fo2open[0].getName())) {
-                                    List<? extends ExecutableElement> methodElements = ElementFilter.methodsIn(element.getEnclosedElements());
-                                    for (Element child : methodElements) {
-                                        String name = node.getTestcase().getName(); // package.name.method.name
-                                        if (child.getSimpleName().contentEquals(name.substring(name.lastIndexOf(".") + 1))) {
-                                            long pos = trees.getSourcePositions().getStartPosition(compilationUnitTree, trees.getTree(child));
-                                            line[0] = compilationUnitTree.getLineMap().getLineNumber(pos);
-                                            break;
-                                        }
+                    javaSource.runUserActionTask(compilationController -> {
+                        compilationController.toPhase(Phase.ELEMENTS_RESOLVED);
+                        Trees trees = compilationController.getTrees();
+                        CompilationUnitTree compilationUnitTree = compilationController.getCompilationUnit();
+                        List<? extends Tree> typeDecls = compilationUnitTree.getTypeDecls();
+                        for (Tree tree : typeDecls) {
+                            Element element = trees.getElement(trees.getPath(compilationUnitTree, tree));
+                            if (element != null && element.getKind() == ElementKind.CLASS && element.getSimpleName().contentEquals(mi.topLevelClass())) {
+                                element = resolveNestedClass(mi.nestedClasses(), element);
+                                List<? extends ExecutableElement> methodElements = ElementFilter.methodsIn(element.getEnclosedElements());
+                                for (Element child : methodElements) {
+                                    String name = node.getTestcase().getName(); // package.name.method.name
+                                    if (child.getSimpleName().contentEquals(name.substring(name.lastIndexOf(".") + 1))) {
+                                        long pos = trees.getSourcePositions().getStartPosition(compilationUnitTree, trees.getTree(child));
+                                        line[0] = compilationUnitTree.getLineMap().getLineNumber(pos);
+                                        break;
                                     }
-                                    // method not found in this FO, so try to find where this method belongs
-                                    if (line[0] == 0) {
-                                        UIJavaUtils.searchAllMethods(node, fo2open, line, compilationController, element);
-                                    }
-                                    break;
                                 }
+                                // method not found in this FO, so try to find where this method belongs
+                                if (line[0] == 0) {
+                                    UIJavaUtils.searchAllMethods(node, fo2open, line, compilationController, element);
+                                }
+                                break;
                             }
                         }
                     }, true);
@@ -145,6 +144,7 @@ public final class MavenJUnitNodeOpener extends NodeOpener {
         }
     }
 
+    @Override
     public void openCallstackFrame(Node node, @NonNull String frameInfo) {
         if(frameInfo.isEmpty()) { // user probably clicked on a failed test method node, find failing line within the testMethod using the stacktrace
             if (!(node instanceof JUnitTestMethodNode)) {
@@ -195,7 +195,7 @@ public final class MavenJUnitNodeOpener extends NodeOpener {
                 // and ignore the infrastructure stack lines in the process
                 while (!testfo.equals(file) && index != -1) {
                     file = UIJavaUtils.getFile(st[index], lineNumStorage, locator);
-                    index = index - 1;
+                    index -= 1;
                 }
             }
         }
@@ -206,4 +206,35 @@ public final class MavenJUnitNodeOpener extends NodeOpener {
         UIJavaUtils.openFile(file, lineNumStorage[0]);
     }
 
+    private Element resolveNestedClass(List<String> nestedClasses, Element e) {
+        if(nestedClasses.isEmpty()) {
+            return e;
+        } else {
+            String simpleName = nestedClasses.get(0);
+            for(Element childElement: e.getEnclosedElements()) {
+                if(childElement.getSimpleName().contentEquals(simpleName)) {
+                    return resolveNestedClass(nestedClasses.subList(1, nestedClasses.size()), childElement);
+                }
+            }
+            return e;
+        }
+    }
+
+    private record MethodInfo (String packageName, String topLevelClass, List<String> nestedClasses, String method) {
+        public static MethodInfo fromTestCase(JUnitTestcase testcase) {
+            String className = testcase.getClassName();
+            String[] nestedClasses = className.split("\\$");
+            String packageName = null;
+            int lastDotInTopLevelClass = nestedClasses[0].lastIndexOf(".");
+            if (lastDotInTopLevelClass >= 0) {
+                packageName = nestedClasses[0].substring(0, lastDotInTopLevelClass);
+                nestedClasses[0] = nestedClasses[0].substring(lastDotInTopLevelClass + 1);
+            }
+            String method = null;
+            if(testcase.getName().startsWith(className)) {
+                method = testcase.getName().substring(className.length() + 1);
+            }
+            return new MethodInfo(packageName, nestedClasses[0], asList(nestedClasses).subList(1, nestedClasses.length), method);
+        }
+    }
 }

--- a/java/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitTestMethodNode.java
+++ b/java/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitTestMethodNode.java
@@ -28,17 +28,19 @@ import javax.swing.Action;
 import org.netbeans.api.extexecution.print.LineConvertors;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
-import org.netbeans.modules.gsf.testrunner.api.Testcase;
 import org.netbeans.modules.gsf.testrunner.api.TestMethodNodeAction;
+import org.netbeans.modules.gsf.testrunner.api.Testcase;
 import org.netbeans.modules.junit.ui.api.JUnitTestMethodNode;
 import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.NestedClass;
 import org.netbeans.spi.project.SingleMethod;
-import static org.netbeans.spi.project.SingleMethod.COMMAND_DEBUG_SINGLE_METHOD;
-import static org.netbeans.spi.project.SingleMethod.COMMAND_RUN_SINGLE_METHOD;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.lookup.Lookups;
+
+import static org.netbeans.spi.project.SingleMethod.COMMAND_DEBUG_SINGLE_METHOD;
+import static org.netbeans.spi.project.SingleMethod.COMMAND_RUN_SINGLE_METHOD;
 
 /**
  * mkleint: copied from junit module
@@ -72,13 +74,29 @@ public class MavenJUnitTestMethodNode extends JUnitTestMethodNode {
                 if (actionProvider != null) {
                     String mName = testcase.getName();
                     String tcName= testcase.getClassName();
-                    if (tcName!=null
+                    if (tcName != null
                             && mName.startsWith(tcName)
-                            && mName.charAt(tcName.length())=='.'){
-                        mName= mName.substring(tcName.length()+1);
+                            && mName.charAt(tcName.length()) == '.') {
+                        mName = mName.substring(tcName.length() + 1);
                     }
-                    SingleMethod methodSpec = new SingleMethod(testFO, mName);
-                    Lookup nodeContext = Lookups.singleton(methodSpec);
+                    SingleMethod methodSpec;
+                    if (tcName != null && tcName.contains("$")) {
+                        String[] nestedSplit = tcName.split("\\$", 2);
+                        String[] topLevelSplit = nestedSplit[0].split("\\.");
+                        methodSpec = new SingleMethod(mName, new NestedClass(nestedSplit[1].replace("$", "."), topLevelSplit[topLevelSplit.length - 1], testFO));
+                    } else {
+                        if(tcName != null) {
+                            String[] topLevelSplit = tcName.split("\\.");
+                            if(! testFO.getName().equals(topLevelSplit[topLevelSplit.length - 1])) {
+                                methodSpec = new SingleMethod(mName, new NestedClass("", topLevelSplit[topLevelSplit.length - 1], testFO));
+                            } else {
+                                methodSpec = new SingleMethod(testFO, mName);
+                            }
+                        } else {
+                            methodSpec = new SingleMethod(testFO, mName);
+                        }
+                    }
+                    Lookup nodeContext = Lookups.fixed(methodSpec);
 
                     for (String action : actionProvider.getSupportedActions()) {
                         if (unitTest

--- a/java/maven.junit/nbproject/project.xml
+++ b/java/maven.junit/nbproject/project.xml
@@ -35,6 +35,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.libs.javacapi</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>8.53</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.gsf.testrunner</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputListenerProvider.java
+++ b/java/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputListenerProvider.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.maven.junit;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -30,6 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -37,6 +39,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.lang.model.element.ElementKind;
 import javax.swing.event.ChangeListener;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.artifact.Artifact;
@@ -50,6 +54,9 @@ import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
+import org.netbeans.api.java.source.ClasspathInfo;
+import org.netbeans.api.java.source.ElementHandle;
+import org.netbeans.api.java.source.SourceUtils;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.gsf.testrunner.api.RerunHandler;
@@ -71,6 +78,7 @@ import org.netbeans.modules.maven.api.execute.RunConfig;
 import org.netbeans.modules.maven.api.execute.RunUtils;
 import org.netbeans.modules.maven.api.output.OutputProcessor;
 import org.netbeans.modules.maven.api.output.OutputVisitor;
+import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
@@ -735,6 +743,22 @@ public class JUnitOutputListenerProvider implements OutputProcessor {
             LOG.log(Level.FINE, "No session for outdir {0}", outputDir);
             return;
         }
+        Map<ClasspathInfo,Path> classpathInfo = Map.of();
+        NbMavenProject nbMavenProject = session.getProject()
+                .getLookup()
+                .lookup(NbMavenProject.class);
+        if(nbMavenProject != null) {
+            classpathInfo = nbMavenProject
+                    .getMavenProject()
+                    .getTestCompileSourceRoots()
+                    .stream()
+                    .map(p -> (p.endsWith("/") || p.endsWith("\\")) ? p : (p + "/"))
+                    .map(p -> new File(p))
+                    .collect(Collectors.toMap(
+                        f -> ClasspathInfo.create(f),
+                        f -> f.toPath()
+                    ));
+        }
         if (report.length() > 50 * 1024 * 1024) {
             LOG.log(Level.INFO, "Skipping report file as size is too big (> 50MB): {0}", report.getPath());
             return;
@@ -831,7 +855,19 @@ public class JUnitOutputListenerProvider implements OutputProcessor {
                         classname = classname.substring(0, classname.length() - nameSuffix.length());
                     }
                     test.setClassName(classname);
-                    test.setLocation(test.getClassName().replace('.', '/') + ".java");
+                    String relativePath = null;
+                    for (Entry<ClasspathInfo, Path> ci : classpathInfo.entrySet()) {
+                        FileObject fo = SourceUtils.getFile(ElementHandle.createTypeElementHandle(ElementKind.CLASS, classname), ci.getKey());
+                        if (fo != null) {
+                            relativePath = ci.getValue().relativize(FileUtil.toFile(fo).toPath()).toString();
+                            break;
+                        }
+                    }
+                    if (relativePath != null) {
+                        test.setLocation(relativePath);
+                    } else {
+                        test.setLocation(classname.replace('.', '/').split("\\$")[0] + ".java");
+                    }
                 }
                 session.addTestCase(test);
             }

--- a/java/maven/src/org/netbeans/modules/maven/ActionProviderImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/ActionProviderImpl.java
@@ -226,8 +226,11 @@ public class ActionProviderImpl implements ActionProvider {
     private boolean usingJUnit5() {
         return proj.getLookup().lookup(NbMavenProject.class).getMavenProject().getArtifacts()
                 .stream()
-                .anyMatch((a) -> ("org.junit.jupiter".equals(a.getGroupId()) && "junit-jupiter-engine".equals(a.getArtifactId()) ||
-                        "org.junit.platform".equals(a.getGroupId()) && "junit-platform-engine".equals(a.getArtifactId())));
+                .anyMatch((a) -> (
+                        "org.junit.jupiter".equals(a.getGroupId()) && "junit-jupiter-engine".equals(a.getArtifactId()) ||
+                        "org.junit.jupiter".equals(a.getGroupId()) && "junit-jupiter-api".equals(a.getArtifactId()) ||
+                        "org.junit.platform".equals(a.getGroupId()) && "junit-platform-engine".equals(a.getArtifactId()))
+                );
     }
 
     private boolean usingTestNG() {

--- a/java/maven/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProvider.java
@@ -102,8 +102,22 @@ public class DefaultReplaceTokenProvider implements ReplaceTokenProvider, Action
         return files.toArray(new FileObject[0]);
     }
 
-    @Override public Map<String, String> createReplacements(String actionName, Lookup lookup) {
+    private static NestedClass extractNestedClassFromLookup(Lookup lookup) {
         NestedClass nestedClass = lookup.lookup(NestedClass.class);
+        if (nestedClass != null) {
+            return nestedClass;
+        }
+
+        SingleMethod sm = lookup.lookup(SingleMethod.class);
+        if (sm != null) {
+            return sm.getNestedClass();
+        }
+
+        return null;
+    }
+
+    @Override public Map<String, String> createReplacements(String actionName, Lookup lookup) {
+        NestedClass nestedClass = extractNestedClassFromLookup(lookup);
         FileObject[] fos = extractFileObjectsfromLookup(lookup);
         List<Project> projects = extractProjectsFromLookup(lookup);
         


### PR DESCRIPTION
JUnit allows to declare tests on nested (`NestedClass2` and `DoubleNestedClass3` below)  and also non public top level classes (`PackagedTopLevelNonPublicTest`) in addition to the traditional toplevel class tests (`test4`):

```java
public class PackagedTopLevelTest {
  @Test
  public void test4() {
    System.out.println("Executed test.PackagedTopLevel#test4");
  }

  @Nested
  class NestedClass2 {
    @Test
    public void test6() {
      System.out.println("Executed test.PackagedTopLevelTest$NestedClass2#test6");
    }
    @Nested
    class DoubleNestedClass3 {
      @Test
      public void test8() {
        System.out.println("Executed test.PackagedTopLevelTest$NestedClass2$DoubleNestedClass3#test8");
      }
    }
  }

}

class PackagedTopLevelNonPublicTest {
    @Test
    public void test10() {
        System.out.println("Executed test.PackagedTopLevelNonPublic#test10");
    }
}
```

In addition to that Unittests can be placed in the default package and support the same set of special cases.

This PR adds support for these cases:
- running of single test from nested/top level non-public classes
- rerunning/debugging test from nested/top level non-public classes

In addition while investigating the fix, it was observed, that the unittest result extraction sometimes yielded an incomplete set. I.e. some of the test data was missing. Analysis showed, that he XML reports from maven surefire were not yet written/updated while the console output was already done.

Another identified problem fixed here was incomplete detection of Jupiter (JUnit5) usage in the unittest run.

It is inspired by the work from @ratcashdev.

Closes: #3975 
Closes. #3995