### PR TITLE
Fixing create local variable fix for lambdas inside field initializers.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElement.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElement.java
@@ -170,6 +170,7 @@ public final class CreateElement implements ErrorRule<Void> {
         TreePath parent = null;
         TreePath firstClass = null;
         TreePath firstMethod = null;
+        TreePath firstLambda = null;
         TreePath firstVar = null;
         TreePath firstInitializer = null;
         TreePath methodInvocation = null;
@@ -194,6 +195,9 @@ public final class CreateElement implements ErrorRule<Void> {
                 firstClass = path;
             if (leafKind == Kind.METHOD && firstMethod == null && firstClass == null)
                 firstMethod = path;
+            if (leafKind == Kind.LAMBDA_EXPRESSION && firstMethod == null &&
+                firstClass == null && firstLambda == null && firstInitializer == null)
+                firstLambda = path;
             //static/dynamic initializer:
             if (   leafKind == Kind.BLOCK && TreeUtilities.CLASS_TREE_KINDS.contains(path.getParentPath().getLeaf().getKind())
                 && firstMethod == null && firstClass == null)
@@ -495,7 +499,7 @@ public final class CreateElement implements ErrorRule<Void> {
             int identifierPos = (int) info.getTrees().getSourcePositions().getStartPosition(info.getCompilationUnit(), errorPath.getLeaf());
             if (ee != null && fixTypes.contains(ElementKind.PARAMETER) && !Utilities.isMethodHeaderInsideGuardedBlock(info, (MethodTree) firstMethod.getLeaf()))
                 result.add(new AddParameterOrLocalFix(info, type, simpleName, ElementKind.PARAMETER, identifierPos).toEditorFix());
-            if ((firstMethod != null || firstInitializer != null) && fixTypes.contains(ElementKind.LOCAL_VARIABLE) && ErrorFixesFakeHint.enabled(ErrorFixesFakeHint.FixKind.CREATE_LOCAL_VARIABLE))
+            if ((firstMethod != null || firstInitializer != null || firstLambda != null) && fixTypes.contains(ElementKind.LOCAL_VARIABLE) && ErrorFixesFakeHint.enabled(ErrorFixesFakeHint.FixKind.CREATE_LOCAL_VARIABLE))
                 result.add(new AddParameterOrLocalFix(info, type, simpleName, ElementKind.LOCAL_VARIABLE, identifierPos).toEditorFix());
             if (fixTypes.contains(ElementKind.RESOURCE_VARIABLE))
                 result.add(new AddParameterOrLocalFix(info, type, simpleName, ElementKind.RESOURCE_VARIABLE, identifierPos).toEditorFix());

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AddParameterOrLocalFixTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AddParameterOrLocalFixTest.java
@@ -468,6 +468,27 @@ public class AddParameterOrLocalFixTest extends ErrorHintsTestBase {
                 "AddParameterOrLocalFix:in:java.io.FileInputStream:RESOURCE_VARIABLE");
     }
 
+    public void testLocalInLambdaInField() throws Exception {
+        performFixTest("test/Test.java",
+                """
+                package test;
+                public class Test {
+                    Runnable r = () -> {
+                        i|i = 0;
+                    };
+                }
+                """,
+                "AddParameterOrLocalFix:ii:int:LOCAL_VARIABLE",
+                """
+                package test;
+                public class Test {
+                    Runnable r = () -> {
+                        int ii = 0;
+                    };
+                }
+                """.replaceAll("[ \t\n]+", " "));
+    }
+
     @Override
     protected List<Fix> computeFixes(CompilationInfo info, String diagnosticCode, int pos, TreePath path) throws Exception {
         List<Fix> fixes = super.computeFixes(info, diagnosticCode, pos, path);


### PR DESCRIPTION
Consider code like:
```
public class Test {
    Runnable r = () -> {
        ii = 0;
    };
}
```

There's an error for undeclared `ii`, but no fix to introduce a local variable for it. This PR fixes that.


---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>