### PR TITLE
Fixing Jackpot rules when target typing fails, and the AST contains error types.

### DIFF
--- a/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/TargetTypingTest.hint
+++ b/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/TargetTypingTest.hint
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$mods$ long $test = $init :: $init instanceof java.lang.String
+=>
+$mods$ java.lang.String $test = $init
+;;
+
+$test = $init :: $test instanceof String && $init instanceof int
+=>
+$test = String.valueOf($init)
+;;

--- a/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/TargetTypingTest.test
+++ b/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/TargetTypingTest.test
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+%%TestCase declaration
+package test;
+public class Test {
+    private void test() {
+        long l = "";
+    }
+}
+%%=>
+package test;
+public class Test {
+    private void test() {
+        String l = "";
+    }
+}
+%%TestCase assignment
+package test;
+public class Test {
+    private void test() {
+        String t;
+        t = 0;
+    }
+}
+%%=>
+package test;
+public class Test {
+    private void test() {
+        String t;
+        t = String.valueOf(0);
+    }
+}

--- a/java/java.source.base/src/org/netbeans/modules/java/source/matching/CopyFinder.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/matching/CopyFinder.java
@@ -101,6 +101,7 @@ import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ErrorType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import org.netbeans.api.annotations.common.CheckForNull;
@@ -324,6 +325,10 @@ public class CopyFinder extends ErrorAwareTreeScanner<Boolean, TreePath> {
 
         if (designed != null && designed.getKind() != TypeKind.ERROR) {
             TypeMirror real = info.getTrees().getTypeMirror(currentPath);
+            if (real != null && real.getKind() == TypeKind.ERROR) {
+                ErrorType et = (ErrorType) real;
+                real = info.getTrees().getOriginalType(et);
+            }
             if (real != null && !IGNORE_KINDS.contains(real.getKind())) {
                 // special hack: if the designed type is DECLARED (assuming a boxed primitive) and the real type is 
                 // not DECLARED or is null (assuming a real primitive), do not treat them as assignable.

--- a/java/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/matching/CopyFinderTest.java
+++ b/java/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/matching/CopyFinderTest.java
@@ -1332,6 +1332,51 @@ public class CopyFinderTest extends NbTestCase {
                              false);
     }
 
+    public void testTargetTyping1() throws Exception {
+        sourceLevel = "17";
+        performVariablesTest("""
+                             package test;
+                             public class Test {
+                                 boolean test() {
+                                     long l = "";
+                                 }
+                             }
+                             """,
+                             "long $var = $1{java.lang.String};",
+                             new Pair[] {
+                                 new Pair<String, int[]>("$1", new int[] {72, 74}),
+                                 new Pair<String, int[]>("$var", new int[] {63, 75}),
+                             },
+                             new Pair[0],
+                             new Pair[] {
+                                 new Pair<String, String>("$var", "l"),
+                             },
+                             false,
+                             false);
+    }
+
+    public void testTargetTyping2() throws Exception {
+        sourceLevel = "17";
+        performVariablesTest("""
+                             package test;
+                             public class Test {
+                                 boolean test() {
+                                     long l;
+                                     l = "";
+                                 }
+                             }
+                             """,
+                             "$0{long} = $1{java.lang.String};",
+                             new Pair[] {
+                                 new Pair<String, int[]>("$1", new int[] {83, 85}),
+                                 new Pair<String, int[]>("$0", new int[] {79, 80}),
+                             },
+                             new Pair[0],
+                             new Pair[0],
+                             false,
+                             false);
+    }
+
     public void testKeepImplicitThis() throws Exception {
         prepareTest("package test; public class Test { void t() { toString(); } }", -1);
 


### PR DESCRIPTION
Consider a Jackpot rule like this:
```
$mods$ long $test = $init :: $init instanceof java.lang.String
=>
$mods$ java.lang.String $test = $init
;;
```

and code:
```
long l = "";
```

It seems the rule should match this code, but it doesn't. It is because (due to target typing in javac, I believe), the type of `""` will be an erroneous type, and those are rejected when matching.

The proposal in this PR is, for erroneous types, to look at the "original type", and use that one. For cases like the above, the original type is the "obvious" of the expression and the rule matches.

---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>