### PR TITLE
Fix move/copy/rename/etc for standalone java files.

### DIFF
--- a/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/api/SourceLauncher.java
+++ b/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/api/SourceLauncher.java
@@ -55,6 +55,18 @@ public final class SourceLauncher {
         return msrp != null && msrp.isSourceLauncher(file);
     }
 
+    /**Returns {@code true} if and only if the given file is known as a
+     * file that is handled by a source file launcher, for which index is created.
+     *
+     * @param file the file to test
+     * @return {@code true} if and only if the file is known as a file handled by the
+     *         source launcher. {@code false} otherwise.
+     */
+    public static boolean isIndexedSourceLauncherFile(FileObject file) {
+        MultiSourceRootProvider msrp = Lookup.getDefault().lookup(MultiSourceRootProvider.class);
+        return msrp != null && msrp.isRegisteredSourceLauncher(file);
+    }
+
     public static String joinCommandLines(Iterable<? extends String> inputLines) {
         Map<String, String> joinedOptions = new HashMap<>();
 

--- a/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/queries/MultiSourceRootProvider.java
+++ b/java/java.file.launcher/src/org/netbeans/modules/java/file/launcher/queries/MultiSourceRootProvider.java
@@ -230,6 +230,18 @@ public class MultiSourceRootProvider implements ClassPathProvider {
         return getSourceRoot(file) != null;
     }
 
+    public boolean isRegisteredSourceLauncher(FileObject file) {
+        FileObject root = getSourceRoot(file);
+
+        if (root == null) {
+            return false;
+        }
+
+        synchronized (registeredRoots) {
+            return registeredRoots.contains(root);
+        }
+    }
+
     private ClassPath getBootPath(FileObject file) {
         if (isSourceLauncher(file)) {
             return JavaPlatformManager.getDefault()

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/RefactoringUtils.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/RefactoringUtils.java
@@ -305,7 +305,7 @@ public class RefactoringUtils {
     public static boolean isOnSourceClasspath(FileObject fo) {
         Project pr = FileOwnerQuery.getOwner(fo);
         if (pr == null) {
-            return SourceLauncher.isSourceLauncherFile(fo);
+            return isIndexedSourceLauncherFile(fo);
         }
 
         //workaround for 143542
@@ -319,6 +319,11 @@ public class RefactoringUtils {
         return false;
         //end of workaround
         //return ClassPath.getClassPath(fo, ClassPath.SOURCE)!=null;
+    }
+
+    public static boolean isIndexedSourceLauncherFile(FileObject fo) {
+        // TODO: don't call from this module
+        return SourceLauncher.isIndexedSourceLauncherFile(fo);
     }
 
     /**

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/RefactoringActionsProvider.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/ui/RefactoringActionsProvider.java
@@ -49,6 +49,7 @@ import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
 import org.openide.util.datatransfer.PasteType;
+
 import static org.netbeans.modules.refactoring.java.ui.Bundle.*;
 
 
@@ -185,7 +186,7 @@ public class RefactoringActionsProvider extends ActionsImplementationProvider{
             if (!fo.isFolder()) {
                 return false;
             }
-            if (!JavaRefactoringUtils.isOnSourceClasspath(fo)) {
+            if (!JavaRefactoringUtils.isOnSourceClasspath(fo) || RefactoringUtils.isIndexedSourceLauncherFile(fo)) {
                 return false;
             }
         }
@@ -331,7 +332,7 @@ public class RefactoringActionsProvider extends ActionsImplementationProvider{
             if (!fo.isFolder()) {
                 return false;
             }
-            if (!JavaRefactoringUtils.isOnSourceClasspath(fo)) {
+            if (!JavaRefactoringUtils.isOnSourceClasspath(fo) || RefactoringUtils.isIndexedSourceLauncherFile(fo)) {
                 return false;
             }
             
@@ -343,7 +344,8 @@ public class RefactoringActionsProvider extends ActionsImplementationProvider{
                 if (dob==null) {
                     return false;
                 }
-                if (!JavaRefactoringUtils.isOnSourceClasspath(dob.getPrimaryFile())) {
+                if (!JavaRefactoringUtils.isOnSourceClasspath(dob.getPrimaryFile())
+                        || RefactoringUtils.isIndexedSourceLauncherFile(dob.getPrimaryFile())) {
                     return false;
                 }
                 if (dob instanceof DataFolder) {
@@ -380,7 +382,9 @@ public class RefactoringActionsProvider extends ActionsImplementationProvider{
                         return false;
                     } else {
                         //Ctrl-X
-                        if (!JavaRefactoringUtils.isOnSourceClasspath(dob.getPrimaryFile()) || RefactoringUtils.isClasspathRoot(dob.getPrimaryFile())) {
+                        if (!JavaRefactoringUtils.isOnSourceClasspath(dob.getPrimaryFile())
+                                || RefactoringUtils.isClasspathRoot(dob.getPrimaryFile())
+                                || RefactoringUtils.isIndexedSourceLauncherFile(dob.getPrimaryFile())) {
                             return false;
                         } else {
                             LinkedList<DataFolder> folders = new LinkedList<DataFolder>();
@@ -399,7 +403,8 @@ public class RefactoringActionsProvider extends ActionsImplementationProvider{
                         }
                     }
                 }
-                if (!JavaRefactoringUtils.isOnSourceClasspath(dob.getPrimaryFile())) {
+                if (!JavaRefactoringUtils.isOnSourceClasspath(dob.getPrimaryFile())
+                        || RefactoringUtils.isIndexedSourceLauncherFile(dob.getPrimaryFile())) {
                     return false;
                 }
                 if (RefactoringUtils.isJavaFile(dob.getPrimaryFile())) {


### PR DESCRIPTION
 - disable some refactoring actions for standalone source files, since they throw exceptions without having project context
 - they will now delegate to the respective generic file actions like in NB 26

alternative would be to revert https://github.com/apache/netbeans/pull/8442 instead of attempting this selective approach

tested by dragging java files around which triggers the move refactoring, renamed some etc. This should work with "source file launcher indexing" enabled and disabled (file properties). With indexing disabled it should handle files without doing any code refactoring (like in NB 26).

Not all refactorings work but those which failed, failed gracefully, e.g window telling that the file is outside a project.

targets delivery