### PR TITLE
Fix disco client JDK download action

### DIFF
--- a/java/java.disco/src/org/netbeans/modules/java/disco/Client.java
+++ b/java/java.disco/src/org/netbeans/modules/java/disco/Client.java
@@ -135,8 +135,8 @@ public class Client {
                 .findFirst();
     }
 
-    public synchronized PkgInfo getPkgInfo(String ephemeralId, Semver javaVersion) {
-        return getDisco().getPkgInfoByEphemeralId(ephemeralId, javaVersion);
+    public synchronized PkgInfo getPkgInfoByPkgId(String id, Semver javaVersion) {
+        return getDisco().getPkgInfoByPkgId(id, javaVersion);
     }
 
     public synchronized Future<?> downloadPkg(PkgInfo pkgInfo, String absolutePath) throws InterruptedException {

--- a/java/java.disco/src/org/netbeans/modules/java/disco/DownloadPanel.java
+++ b/java/java.disco/src/org/netbeans/modules/java/disco/DownloadPanel.java
@@ -114,7 +114,7 @@ public class DownloadPanel extends javax.swing.JPanel {
         setStatus("Preparing...");
         submit(() -> {
             Pkg bundle = state.selection.get(discoClient);
-            return discoClient.getPkgInfo(bundle.getEphemeralId(), bundle.getJavaVersion());
+            return discoClient.getPkgInfoByPkgId(bundle.getId(), bundle.getJavaVersion());
         }).then(pkgInfo -> {
             download = new File(destinationFolder, pkgInfo.getFileName());
             String path = download.getAbsolutePath();


### PR DESCRIPTION
ephemeral id stopped working for some reason, but I noticed that it had the same value as the regular id field.

Using `getPkgInfoByPkgId()` which uses the regular id does appear to work.

how to test:
try to download a JDK using the java platform manager. It would fail during the download step.

targets delivery