### PR TITLE
CI - Fix vscode build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -520,7 +520,7 @@ jobs:
         if: ${{ (matrix.config == 'release') && success() }}
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20.18.1
 
       - name: Build NBVSCodeExt from ${{ matrix.config }}-src zip
         if: ${{ (matrix.config == 'release') && success() }}
@@ -2627,7 +2627,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20.18.1
 
       - name: Setup Xvfb
         run: |


### PR DESCRIPTION
Based on the following message from [CI build](https://github.com/apache/netbeans/actions/runs/16651028817/job/47124368668#step:10:7123)
```
[mkdir] Created dir: /home/runner/work/netbeans/netbeans/tmpbuild/java/java.lsp.server/build/vsce
     [exec] npm warn EBADENGINE Unsupported engine {
     [exec] npm warn EBADENGINE   package: 'undici@7.13.0',
     [exec] npm warn EBADENGINE   required: { node: '>=20.18.1' },
     [exec] npm warn EBADENGINE   current: { node: 'v18.20.8', npm: '10.8.2' }
     [exec] npm warn EBADENGINE }
```
It looks like vscode must be built with node >=20.18.1.

Same error in [build-vscode-ext](https://github.com/apache/netbeans/actions/runs/16651028817/job/47124368985#step:7:7106)

Workflows updated to use node 20.18.1.