### PR TITLE
Update to DiscoClient 2.0.39 to use Disco API v3.

### DIFF
--- a/java/java.disco/external/binaries-list
+++ b/java/java.disco/external/binaries-list
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 4FCCADF37F1C61A0895BAC3D42FE0C530438826C org.checkerframework:checker-qual:3.9.1
-CE10D968585304A7463430DD53254E6D6893DF16 io.foojay.api:discoclient:2.0.24
-F66F9FC72A84FCAB1579202728EE572BDBB46DD7 eu.hansolo:jdktools:11.0.11
+BB975ACE8403330DCC7ABF61A3142B0B59ADC755 io.foojay.api:discoclient:2.0.39
+AD117688D24FACCF74D3B76AFFFC2693C4F5D122 eu.hansolo:jdktools:11.0.19

--- a/java/java.disco/external/discoclient-2.0.39-license.txt
+++ b/java/java.disco/external/discoclient-2.0.39-license.txt
@@ -1,6 +1,6 @@
 Name: DiscoClient
 Origin: Gerrit Grunwald
-Version: 2.0.24
+Version: 2.0.39
 License: Apache-2.0
 Description: Library to access the Foojay.io Discovery API service.
 Origin: https://github.com/foojayio/discoclient

--- a/java/java.disco/external/jdktools-11.0.19-license.txt
+++ b/java/java.disco/external/jdktools-11.0.19-license.txt
@@ -1,6 +1,6 @@
 Name: JDKTools
 Origin: Gerrit Grunwald
-Version: 11.0.11
+Version: 11.0.19
 License: Apache-2.0
 Description: Collection of classes for working with OpenJDK related things.
 Origin: https://github.com/HanSolo/jdktools

--- a/java/java.disco/nbproject/project.properties
+++ b/java/java.disco/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 release.external/checker-qual-3.9.1.jar=modules/ext/checker-qual-3.9.1.jar
-release.external/jdktools-11.0.11.jar=modules/ext/jdktools-11.0.11.jar
-release.external/discoclient-2.0.24.jar=modules/ext/discoclient-2.0.24.jar
-javac.release=11
+release.external/jdktools-11.0.19.jar=modules/ext/jdktools-11.0.19.jar
+release.external/discoclient-2.0.39.jar=modules/ext/discoclient-2.0.39.jar
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/java/java.disco/nbproject/project.xml
+++ b/java/java.disco/nbproject/project.xml
@@ -36,7 +36,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>2.8.5</specification-version>
+                        <specification-version>2.9.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -202,12 +202,12 @@
             </module-dependencies>
             <public-packages/>
             <class-path-extension>
-                <runtime-relative-path>ext/discoclient-2.0.24.jar</runtime-relative-path>
-                <binary-origin>external/discoclient-2.0.24.jar</binary-origin>
+                <runtime-relative-path>ext/discoclient-2.0.39.jar</runtime-relative-path>
+                <binary-origin>external/discoclient-2.0.39.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/jdktools-11.0.11.jar</runtime-relative-path>
-                <binary-origin>external/jdktools-11.0.11.jar</binary-origin>
+                <runtime-relative-path>ext/jdktools-11.0.19.jar</runtime-relative-path>
+                <binary-origin>external/jdktools-11.0.19.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path>ext/checker-qual-3.9.1.jar</runtime-relative-path>


### PR DESCRIPTION
Follows up on #8682 Upgrade to DiscoClient 2.0.39 to use current [Disco API v3](https://api.foojay.io/swagger-ui/).  Version 2.0.24 was the last version to use the legacy Disco API v2.  The legacy API is temperamental and often not returning results for the download location.