### PR TITLE
Gradle 9 compatibility fixes

### DIFF
--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -85,7 +85,7 @@ is the proper place.
     <changes>
         <change id="current-gradle-version-discovery">
             <api name="general"/>
-            <summary>GradleDistributionManager can query latest available version and use in init</summary>
+            <summary>GradleDistributionManager can query latest available and latest supported versions and use in init</summary>
             <version major="2" minor="47"/>
             <date day="20" month="6" year="2025"/>
             <author login="neilcsmith"/>
@@ -93,6 +93,8 @@ is the proper place.
             <description>
                 Added <code><a href="@TOP@/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.html#currentDistribution()">GradleDistributionManager.currentDistribution()</a></code> 
                 method to query the current (latest) release available from the Gradle web service.
+                Added <code><a href="@TOP@/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.html#latestSupportedDistribution()">GradleDistributionManager.latestSupportedDistribution()</a></code>
+                method to query the latest supported release from the Gradle web service.
                 Added <code>gradleVersion(String version)</code> to
                 <a href="@TOP@/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.InitOperation.html">TemplateOperation.InitOperation</a>.
             </description>

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/GradleInternalAdapter.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/GradleInternalAdapter.java
@@ -37,7 +37,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.plugin.use.PluginId;
-import org.gradle.util.VersionNumber;
+import org.gradle.util.GradleVersion;
 import org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.ExceptionCallable;
 import org.netbeans.modules.gradle.tooling.NbProjectInfoBuilder.ValueAndType;
 
@@ -53,11 +53,11 @@ public class GradleInternalAdapter {
     private static final Logger LOG =  Logging.getLogger(NbProjectInfoBuilder.class);
 
     private final Project project;
-    private final VersionNumber gradleVersion;
+    private final GradleVersion gradleVersion;
     /**
-     * Accummulates error messages, so that just one problem is logger a given type of error.
+     * Accumulates error messages, so that just one problem is logger a given type of error.
      */
-    private Set<String> reportedIncompatibilities = new HashSet<>();
+    private final Set<String> reportedIncompatibilities = new HashSet<>();
     
     protected NbProjectInfoModel model;
     
@@ -70,7 +70,7 @@ public class GradleInternalAdapter {
 
     public GradleInternalAdapter(Project project) {
         this.project = project;
-        this.gradleVersion = VersionNumber.parse(project.getGradle().getGradleVersion());
+        this.gradleVersion = GradleVersion.version(project.getGradle().getGradleVersion());
     }
     
     boolean initPlugins() {
@@ -143,7 +143,7 @@ public class GradleInternalAdapter {
     }        
     
     private <T, E extends Throwable> T sinceGradleOrDefault(String version, NbProjectInfoBuilder.ExceptionCallable<T, E> c, Supplier<T> def) {
-        if (gradleVersion.compareTo(VersionNumber.parse(version)) >= 0) {
+        if (gradleVersion.compareTo(GradleVersion.version(version)) >= 0) {
             try {
                 return c.call();
             } catch (RuntimeException | Error e) {

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -97,7 +97,6 @@ import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
-import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskDependency;
@@ -308,6 +307,7 @@ class NbProjectInfoBuilder {
         "shouldRunAfter",
         "enabled",
         "description",
+        "vendor",
         "group"
     ));
     
@@ -587,7 +587,7 @@ class NbProjectInfoBuilder {
         try {
             if (depth++ >= MAX_INTROSPECTION_DEPTH) {
                 if (!suppressDepthWarning) {
-                    LOG.warn("Too deep structure, truncating");
+                    LOG.warn("Too deep structure, truncating: " + String.format("path: %s, value: %s", prefix, object));
                     model.noteProblem(Report.Severity.WARNING, 
                             String.format("Object structure too deep encountered in class %s", clazz),
                             String.format("Object structure is too deep for the project model builder. This is unlikely to affect basic project operations. "
@@ -1701,7 +1701,7 @@ class NbProjectInfoBuilder {
                     try {
                         it.getResolvedConfiguration()
                                 .getLenientConfiguration()
-                                .getFirstLevelModuleDependencies(Specs.SATISFIES_ALL)
+                                .getFirstLevelModuleDependencies()
                                 .forEach(rd -> collectArtifacts(rd, resolvedJvmArtifacts));
                     } catch (ArtifactResolveException ex) {
                         convertOfflineException(ex);

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/GradleInitWizard.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/GradleInitWizard.java
@@ -212,7 +212,7 @@ public final class GradleInitWizard {
 
             if (!GradleSettings.getDefault().isOffline()) {
                 try {
-                    init.gradleVersion(GradleDistributionManager.get().currentDistribution().getVersion());
+                    init.gradleVersion(GradleDistributionManager.get().latestSupportedDistribution().getVersion());
                 } catch (IOException ex) {
                     Exceptions.printStackTrace(ex);
                 }


### PR DESCRIPTION
 - [gradle 9](https://docs.gradle.org/9.0.0/release-notes.html) removed some deprecated API (which broke gradle project support)
 - introspecting `updateDaemonJvm.vendor.*` causes OOME in daemon (uses 512MB by default, but 4GB were also not sufficient). Added 'vendor' to exclude set.
 - init with latest supported gradle version by locking the major component (instead of using 'current')

tested hello world project loading between gradle 5 and 9.


for future reference:
I found this by increasing daemon Xmx, setting `MAX_INTROSPECTION_DEPTH` to a low value, e.g 8, then setting a breakpoint at https://github.com/apache/netbeans/blob/e54117d19a7bb5390e8aa07412dd5589def56a6b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java#L590 and attaching the debugger to the daemon.

`MAX_INTROSPECTION_DEPTH` is probably far too high to protect from OOMEs but it will depend on the shape of the graph.

The annoying part was to debug a daemon while `extide/gradle/netbeans-gradle-tooling` is trying to start daemons too, given that it is a gradle project ;)