### PR TITLE
Do not introspect static properties

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -307,7 +307,6 @@ class NbProjectInfoBuilder {
         "shouldRunAfter",
         "enabled",
         "description",
-        "vendor",
         "group"
     ));
     
@@ -716,6 +715,11 @@ class NbProjectInfoBuilder {
             }
             Object value = null;
             if ((mp.getModifiers() & Modifier.PUBLIC) == 0) {
+                continue;
+            }
+            // ignore static properties for now. If needed, they must be exported somehow per-class and protected
+            // against recursion.
+            if ((mp.getModifiers() & Modifier.STATIC) != 0) {
                 continue;
             }
             if (object != null) {

--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.java
@@ -307,7 +307,8 @@ class NbProjectInfoBuilder {
         "shouldRunAfter",
         "enabled",
         "description",
-        "group"
+        "group",
+        "toolchainDownloadUrls" // UpdateDaemonJvm fron org.gradle.toolchains.foojay-resolver-convention accesses online sevice for URLs
     ));
     
     private void detectTaskProperties(NbProjectInfoModel model) {


### PR DESCRIPTION
A followup to #8703 that I couldn't deliver on time before it was merged. The culprit for the OOM was that the introspection included static properties of the dumped objects. These values are not (still) needed and should they be provided, some tweaks should be implemented to somehow handle class-based enums like `JvmVendorSpec`.

The OOM happened since from a reference to `JvmVendorSpec.ADOPTIUM`, all its static fields were dumped, so `ADOPTOPENJDK`. From `ADOPTOPENJDK`, `ADOPTIUM` was avoided, but all others were dumped (except ADOPTIUM and ADOPTOPENJDK). And so on. When it went back to root `JvmVendorSpec.ADOPTIUM`, and to the next sibling `AMAZON`, all statics except these two were dumped. The same for each of the fields as a root. If I count well, it is `13! * 13` items in total, which seems sufficient for OOM.

This PR reverts @mbien exclusion of `vendor` (not needed any more) and avoids static field dumps, which will cover mor cases.