### PR TITLE
Prevents NPE if buildscript does not exist

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.gradle.loaders;
 
+import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -124,7 +125,11 @@ public abstract class AbstractProjectLoader {
             }
         }
         for (String s : problems) {
-            reps.add(GradleProject.createGradleReport(gf.getBuildScript().toPath(), s));
+            File p = gf.getBuildScript();
+            if (p == null) {
+                p = gf.getSettingsScript();
+            }
+            reps.add(GradleProject.createGradleReport(p == null ? null : p.toPath(), s));
         }
         return new GradleProject(info.getQuality(), reps, results.values());
 


### PR DESCRIPTION
During debugging of other bugs, a gradle project load failed on me (some unrelated error) for a top-level project that does not have an `build.gradle` but just `settings.gradle`. The code that consumes error reports from gradle process threw a NPE - this PR just adds a fallback to settings if buildscript is not present - and finally probably "null" string if even settings file does not exist.