### PR TITLE
For jtreg tests, ignore package clauses that do not match directory structure, or that lead outside of test root.

### DIFF
--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/ClassPathProviderImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/ClassPathProviderImpl.java
@@ -195,6 +195,13 @@ public class ClassPathProviderImpl implements ClassPathProvider {
                 for (String s : pckge.split("\\.")) {
                     packageDir = packageDir.getParent();
                 }
+
+                String realPackage = FileUtil.getRelativePath(packageDir, file.getParent()).replace('/', '.');
+
+                if (!pckge.equals(realPackage) ||
+                    (!FileUtil.isParentOf(rootDesc.testRoot, packageDir) && !rootDesc.testRoot.equals(packageDir))) {
+                    packageDir = file.getParent();
+                }
             }
 
             roots.add(packageDir);

--- a/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/jtreg/ClassPathProviderImplTest.java
+++ b/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/jtreg/ClassPathProviderImplTest.java
@@ -162,6 +162,40 @@ public class ClassPathProviderImplTest extends NbTestCase {
                                  sourceCP.getRoots());
     }
 
+    public void testWrongPackageClause() throws Exception {
+        File workDir = getWorkDir();
+
+        FileUtil.createFolder(new File(workDir, "src/share/classes"));
+        FileObject testRoot = createData("test/jdk/TEST.ROOT", "");
+        FileObject testFile = createData("test/jdk/testpkg/nested/Test.java",
+                                         """
+                                         package other.nested;
+                                         /** @test */
+                                         public class Test {}
+                                         """);
+        ClassPath sourceCP = new ClassPathProviderImpl().findClassPath(testFile, ClassPath.SOURCE);
+
+        Assert.assertArrayEquals(new FileObject[] {testFile.getParent()},
+                                 sourceCP.getRoots());
+    }
+
+    public void testPackageClausePointsOutOfRoot() throws Exception {
+        File workDir = getWorkDir();
+
+        FileUtil.createFolder(new File(workDir, "src/share/classes"));
+        FileObject testRoot = createData("test/jdk/TEST.ROOT", "");
+        FileObject testFile = createData("test/jdk/testpkg/nested/Test.java",
+                                         """
+                                         package test.jdk.testpkg.nested;
+                                         /** @test */
+                                         public class Test {}
+                                         """);
+        ClassPath sourceCP = new ClassPathProviderImpl().findClassPath(testFile, ClassPath.SOURCE);
+
+        Assert.assertArrayEquals(new FileObject[] {testFile.getParent()},
+                                 sourceCP.getRoots());
+    }
+
     private FileObject createData(String relPath, String content) throws IOException {
         File workDir = getWorkDir();
         FileObject file = FileUtil.createData(new File(workDir, relPath));


### PR DESCRIPTION
The source path for jtreg tests is inferred (among other things) from the package clause. But, this may lead to computation of weird source roots that are outside of the test directory. This PR is striving to not follow the package clause if:
- the directory structure does not match the package clause
- the inferred source root would be outside of the specific test directory



---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [ ] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [ ] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [ ] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [ ] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>