### PR TITLE
PHP: Added autocompletion for the use keyword in the body of a class, trait, and enum

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
@@ -1344,6 +1344,9 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
         if (!foundConst && !foundFunction) {
             autoCompleteKeywords(completionResult, request, PHP_SET_VISIBILITY_KEYWORDS);
             autoCompleteKeywords(completionResult, request, PHP_ASYMMETRIC_VISIBILITY_KEYWORDS);
+            if (!completeAfterModificatorsKeywords(tokenSequence, caretOffset, th, info.getSnapshot().getSource().getFileObject())){
+                autoCompleteKeywords(completionResult, request, Arrays.asList("use"));
+            }
         }
         if (offerMagicAndInherited(tokenSequence, caretOffset, th)) {
             EnclosingClass enclosingClass = findEnclosingClass(info, lexerToASTOffset(info, caretOffset));
@@ -1549,6 +1552,29 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
             ));
         }
         return completeTypes;
+    }
+
+    private boolean completeAfterModificatorsKeywords(TokenSequence<PHPTokenId> tokenSequence, int caretOffset, TokenHierarchy<?> th, FileObject fileObject) {
+        boolean completeAfterModificatorsKeywords = false;
+        tokenSequence.move(caretOffset);
+        if (!(!tokenSequence.moveNext() && !tokenSequence.movePrevious())) {
+            Token<PHPTokenId> token = tokenSequence.token();
+            int tokenIdOffset = tokenSequence.token().offset(th);
+            completeAfterModificatorsKeywords = CompletionContextFinder.lineContainsAny(token, caretOffset - tokenIdOffset, tokenSequence, Arrays.asList(
+                PHPTokenId.PHP_PUBLIC,
+                PHPTokenId.PHP_PUBLIC_SET,
+                PHPTokenId.PHP_PRIVATE,
+                PHPTokenId.PHP_PRIVATE_SET,
+                PHPTokenId.PHP_PROTECTED,
+                PHPTokenId.PHP_PROTECTED_SET,
+                PHPTokenId.PHP_ABSTRACT,
+                PHPTokenId.PHP_STATIC,
+                PHPTokenId.PHP_VAR,
+                PHPTokenId.PHP_READONLY,
+                PHPTokenId.PHP_FINAL
+            ));
+        }
+        return completeAfterModificatorsKeywords;
     }
 
     private static Set<String> toNames(Set<? extends PhpElement> elements) {

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/clsDeclaration02.php.testClsDeclaration_10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/clsDeclaration02.php.testClsDeclaration_10.completion
@@ -69,6 +69,7 @@ CLASS      TestIssue145206                 [PUBLIC]   issue145206.php
 CLASS      TestIssue146176                 [PUBLIC]   issue146176.php
 CLASS      TestOptionalArgsClass           [PUBLIC]   optional_args.php
 CLASS      TypesinPHPDoc                   [PUBLIC]   types_in_phpdoc.php
+CLASS      UseKeywordClass                 [PUBLIC]   useKeywordInClass.php
 CLASS      User                            [PUBLIC]   issue142051.php
 CLASS      User147427                      [PUBLIC]   issue147427.php
 CLASS      VarAdvancedTest                 [PUBLIC]   varAssignment2.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/clsDeclaration02.php.testClsDeclaration_13.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/clsDeclaration02.php.testClsDeclaration_13.completion
@@ -69,6 +69,7 @@ CLASS      TestIssue145206                 [PUBLIC]   issue145206.php
 CLASS      TestIssue146176                 [PUBLIC]   issue146176.php
 CLASS      TestOptionalArgsClass           [PUBLIC]   optional_args.php
 CLASS      TypesinPHPDoc                   [PUBLIC]   types_in_phpdoc.php
+CLASS      UseKeywordClass                 [PUBLIC]   useKeywordInClass.php
 CLASS      User                            [PUBLIC]   issue142051.php
 CLASS      User147427                      [PUBLIC]   issue147427.php
 CLASS      VarAdvancedTest                 [PUBLIC]   varAssignment2.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/clsDeclaration02.php.testClsDeclaration_9.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/clsDeclaration02.php.testClsDeclaration_9.completion
@@ -69,6 +69,7 @@ CLASS      TestIssue145206                 [PUBLIC]   issue145206.php
 CLASS      TestIssue146176                 [PUBLIC]   issue146176.php
 CLASS      TestOptionalArgsClass           [PUBLIC]   optional_args.php
 CLASS      TypesinPHPDoc                   [PUBLIC]   types_in_phpdoc.php
+CLASS      UseKeywordClass                 [PUBLIC]   useKeywordInClass.php
 CLASS      User                            [PUBLIC]   issue142051.php
 CLASS      User147427                      [PUBLIC]   issue147427.php
 CLASS      VarAdvancedTest                 [PUBLIC]   varAssignment2.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/issue153707.php.testIssue153707_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/issue153707.php.testIssue153707_01.completion
@@ -82,6 +82,8 @@ CLASS      TestIssue145206                 [PUBLIC]   issue145206.php
 CLASS      TestIssue146176                 [PUBLIC]   issue146176.php
 CLASS      TestOptionalArgsClass           [PUBLIC]   optional_args.php
 CLASS      TypesinPHPDoc                   [PUBLIC]   types_in_phpdoc.php
+CLASS      UseKeywordClass                 [PUBLIC]   useKeywordInClass.php
+CLASS      UseKeywordEnum                  [PUBLIC]   useKeywordInEnum.php
 CLASS      User                            [PUBLIC]   issue142051.php
 CLASS      User147427                      [PUBLIC]   issue147427.php
 CLASS      VarAdvancedTest                 [PUBLIC]   varAssignment2.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/issue153867.php.testIssue153867.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/issue153867.php.testIssue153867.completion
@@ -73,6 +73,8 @@ CLASS      TestIssue145206                 [PUBLIC]   issue145206.php
 CLASS      TestIssue146176                 [PUBLIC]   issue146176.php
 CLASS      TestOptionalArgsClass           [PUBLIC]   optional_args.php
 CLASS      TypesinPHPDoc                   [PUBLIC]   types_in_phpdoc.php
+CLASS      UseKeywordClass                 [PUBLIC]   useKeywordInClass.php
+CLASS      UseKeywordEnum                  [PUBLIC]   useKeywordInEnum.php
 CLASS      User                            [PUBLIC]   issue142051.php
 CLASS      User147427                      [PUBLIC]   issue147427.php
 CLASS      VarAdvancedTest                 [PUBLIC]   varAssignment2.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/issue200795.php.testIssue200795.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/issue200795.php.testIssue200795.completion
@@ -68,6 +68,7 @@ CLASS      TestIssue145206                 [PUBLIC]   issue145206.php
 CLASS      TestIssue146176                 [PUBLIC]   issue146176.php
 CLASS      TestOptionalArgsClass           [PUBLIC]   optional_args.php
 CLASS      TypesinPHPDoc                   [PUBLIC]   types_in_phpdoc.php
+CLASS      UseKeywordClass                 [PUBLIC]   useKeywordInClass.php
 CLASS      User                            [PUBLIC]   issue142051.php
 CLASS      User147427                      [PUBLIC]   issue147427.php
 CLASS      VarAdvancedTest                 [PUBLIC]   varAssignment2.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInClass.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInClass.php
@@ -1,0 +1,9 @@
+<?php
+
+class UseKeywordClass {
+    use TestKeywordTrait;
+}
+
+
+trait TestKeywordTrait {}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInClass.php.testUseKeywordInClass.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInClass.php.testUseKeywordInClass.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+u|se TestKeywordTrait;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInEnum.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+enum UseKeywordEnum {
+    use TestKeywordTrait;
+}
+
+trait TestKeywordTrait {}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInEnum.php.testUseKeywordInEnum.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInEnum.php.testUseKeywordInEnum.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+u|se TestKeywordTrait;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInInterface.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+interface UseKeywordInterface {
+    use TestKeywordTrait;
+}
+
+trait TestKeywordTrait {}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInInterface.php.testUseKeywordInInterface.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInInterface.php.testUseKeywordInInterface.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+u|se TestKeywordTrait;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInTrait.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInTrait.php
@@ -1,0 +1,8 @@
+<?php
+
+trait UseKeywordTrait {
+    use TestKeywordTrait;
+}
+
+trait TestKeywordTrait {}
+

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInTrait.php.testUseKeywordInTrait.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/useKeywordInTrait.php.testUseKeywordInTrait.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+u|se TestKeywordTrait;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+KEYWORD    use                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/anonymousClass01.php.testAnonymousClass01h.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/anonymousClass01.php.testAnonymousClass01h.completion
@@ -34,4 +34,5 @@ KEYWORD    public protected(set)                      null
 KEYWORD    public(set)                                null
 KEYWORD    readonly                                   null
 KEYWORD    static                                     null
+KEYWORD    use                                        null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPropertiesTyping01/readonlyPropertiesTyping01.php.testReadonlyPropertiesTyping01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php81/testReadonlyPropertiesTyping01/readonlyPropertiesTyping01.php.testReadonlyPropertiesTyping01.completion
@@ -34,4 +34,5 @@ KEYWORD    public protected(set)                      null
 KEYWORD    public(set)                                null
 KEYWORD    readonly                                   null
 KEYWORD    static                                     null
+KEYWORD    use                                        null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php84/testAsymmetricVisibilityClass01/testAsymmetricVisibilityClass01.php.testAsymmetricVisibilityClass01_01a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php84/testAsymmetricVisibilityClass01/testAsymmetricVisibilityClass01.php.testAsymmetricVisibilityClass01_01a.completion
@@ -34,4 +34,5 @@ KEYWORD    public protected(set)                      null
 KEYWORD    public(set)                                null
 KEYWORD    readonly                                   null
 KEYWORD    static                                     null
+KEYWORD    use                                        null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php84/testAsymmetricVisibilityClassTyping01/testAsymmetricVisibilityClassTyping01.php.testAsymmetricVisibilityClassTyping01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php84/testAsymmetricVisibilityClassTyping01/testAsymmetricVisibilityClassTyping01.php.testAsymmetricVisibilityClassTyping01.completion
@@ -34,4 +34,5 @@ KEYWORD    public protected(set)                      null
 KEYWORD    public(set)                                null
 KEYWORD    readonly                                   null
 KEYWORD    static                                     null
+KEYWORD    use                                        null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/test209117/issue209117.php.testUseCase1.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/test209117/issue209117.php.testUseCase1.completion
@@ -35,4 +35,5 @@ KEYWORD    public protected(set)                      null
 KEYWORD    public(set)                                null
 KEYWORD    readonly                                   null
 KEYWORD    static                                     null
+KEYWORD    use                                        null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/test233756/issue233756.php.testUseCase1.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/test233756/issue233756.php.testUseCase1.completion
@@ -37,4 +37,5 @@ KEYWORD    public protected(set)                      null
 KEYWORD    public(set)                                null
 KEYWORD    readonly                                   null
 KEYWORD    static                                     null
+KEYWORD    use                                        null
 KEYWORD    var                                        null

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionTest.java
@@ -869,6 +869,21 @@ public class PHPCodeCompletionTest extends PHPCodeCompletionTestBase {
         checkCompletion("testfiles/completion/lib/_base/issue202281.php", "function^Name($myInt);", false);
     }
 
+    public void testUseKeywordInClass() throws Exception {
+        checkCompletion("testfiles/completion/lib/_base/useKeywordInClass.php", "u^se", false);
+    }
+
+    public void testUseKeywordInTrait() throws Exception {
+        checkCompletion("testfiles/completion/lib/_base/useKeywordInTrait.php", "u^se", false);
+    }
+
+    public void testUseKeywordInEnum() throws Exception {
+        checkCompletion("testfiles/completion/lib/_base/useKeywordInEnum.php", "u^se", false);
+    }
+    public void testUseKeywordInInterface() throws Exception {
+        checkCompletion("testfiles/completion/lib/_base/useKeywordInInterface.php", "u^se", false);
+    }
+
     @Override
     protected Map<String, ClassPath> createClassPathsForTest() {
         //just test them as standalone files (just PHP Platform in index)


### PR DESCRIPTION
What was done in this PR:

- Added autocompletion for the `use` keyword in the body of a class, trait, and enum.
- Added new tests and fixed broken tests


Example:
```php

<?php

class UseKeywordClass {
    
}


trait TestKeywordTrait {}

```

Before:

https://github.com/user-attachments/assets/6c310f68-dc21-43fa-ba49-18a4476546c8

After:


https://github.com/user-attachments/assets/0271b266-f5e0-4f85-8d8d-ae382a90af5c




---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>