### PR TITLE
Use bold font for declarations using flatlaf dark color profile

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-Java-tokenColorings.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-Java-tokenColorings.xml
@@ -37,18 +37,18 @@
     <fontcolor name="mod-annotation-type" default="identifier"/>
     <fontcolor name="mod-annotation-type-declaration" default="identifier"><font style="bold"/></fontcolor>
     <fontcolor name="mod-class" default="identifier"/>
-    <fontcolor name="mod-class-declaration" default="identifier"/>
+    <fontcolor name="mod-class-declaration" default="identifier"><font style="bold"/></fontcolor>
     <fontcolor name="mod-constructor" default="identifier"/>
-    <fontcolor name="mod-constructor-declaration" default="identifier"/>
+    <fontcolor name="mod-constructor-declaration" default="identifier"><font style="bold"/></fontcolor>
     <fontcolor name="mod-deprecated" strikeThrough="ffc3c3c3"/>
     <fontcolor name="mod-enum" default="identifier"/>
-    <fontcolor name="mod-enum-declaration" default="identifier"/>
+    <fontcolor name="mod-enum-declaration" default="identifier"><font style="bold"/></fontcolor>
     <fontcolor name="mod-field" default="field"/>
     <fontcolor name="mod-field-declaration" default="field"/>
     <fontcolor name="mod-interface" default="identifier"/>
     <fontcolor name="mod-interface-declaration" default="identifier"><font style="bold"/></fontcolor>
     <fontcolor name="mod-local-variable" default="identifier"/>
-    <fontcolor name="mod-local-variable-declaration" default="identifier"/>
+    <fontcolor name="mod-local-variable-declaration" default="identifier"><font style="bold"/></fontcolor>
     <fontcolor name="mod-method" default="method"/>
     <fontcolor name="mod-method-declaration" default="method" foreColor="ffffc66d"/>
     <fontcolor name="mod-package-private"/>
@@ -57,7 +57,7 @@
     <fontcolor name="mod-private"/>
     <fontcolor name="mod-protected"/>
     <fontcolor name="mod-public"/>
-    <fontcolor name="mod-record-declaration" default="identifier"/>
+    <fontcolor name="mod-record-declaration" default="identifier"><font style="bold"/></fontcolor>
     <fontcolor name="mod-static"><font style="italic"/></fontcolor>
     <fontcolor name="mod-unused" foreColor="gray" waveUnderlined="gray"/>
     <fontcolor name="number" default="number"/>


### PR DESCRIPTION
makes it more consistent with the light color profile. (I didn't change method decl because the dark theme uses a different color for methods and making bright colors bold is a bit much on a low contrast theme IMO)

inspired by https://github.com/apache/netbeans/pull/8732#issuecomment-3188734145

proposed:
<img width="423" height="411" alt="image" src="https://github.com/user-attachments/assets/d80ade5f-e620-4402-86e2-763cb57814da" />


NB 27:
<img width="429" height="410" alt="image" src="https://github.com/user-attachments/assets/1cdaa920-7e8b-4358-99c0-4c6cfd9698b7" />
