### PR TITLE
[NETBEANS-6573] remove extra spaces for record compact constructor erroneously added by reformatter task

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
@@ -1516,7 +1516,9 @@ public class Reformatter implements ReformatTask {
                     }
                     try {
                         spaces(cs.spaceWithinMethodDeclParens() ? 1 : 0, true);
-                        wrapList(cs.wrapMethodParams(), cs.alignMultilineMethodParams(), false, COMMA, params);
+                        if (!isSynthetic(getCurrentPath().getCompilationUnit(), node)) {
+                            wrapList(cs.wrapMethodParams(), cs.alignMultilineMethodParams(), false, COMMA, params);
+                        }
                     } finally {
                         indent = oldIndent;
                         lastIndent = oldLastIndent;
@@ -5612,8 +5614,9 @@ public class Reformatter implements ReformatTask {
             if (tree.pos == (-1))
                 return true;
             if (leaf.getKind() == Tree.Kind.METHOD) {
-                //check for synthetic constructor:
-                return (((JCMethodDecl)leaf).mods.flags & Flags.GENERATEDCONSTR) != 0L;
+                //check for synthetic constructor and compact record constuctor
+                return (((JCMethodDecl)leaf).mods.flags & Flags.GENERATEDCONSTR) != 0L
+                  || (((JCMethodDecl)leaf).mods.flags & Flags.COMPACT_RECORD_CONSTRUCTOR) != 0L;
             }
             //check for synthetic superconstructor call:
             if (leaf.getKind() == Tree.Kind.EXPRESSION_STATEMENT) {

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
@@ -6753,6 +6753,35 @@ public class FormatingTest extends NbTestCase {
                 + "}\n";
         reformat(doc, content, golden);
     }
+    
+    // #6573
+    public void testRecordConstructorReformat() throws Exception {
+        sourceLevel="16";
+        JavacParser.DISABLE_SOURCE_LEVEL_DOWNGRADE = true;
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile, "");
+        FileObject testSourceFO = FileUtil.toFileObject(testFile);
+        DataObject testSourceDO = DataObject.find(testSourceFO);
+        EditorCookie ec = testSourceDO.getLookup().lookup(EditorCookie.class);
+        final Document doc = ec.openDocument();
+        doc.putProperty(Language.class, JavaTokenId.language());
+        String content = 
+                """
+                package hierbas.del.litoral;
+                
+                public class Test {
+                
+                    public record Rec(int a, int b) {
+                
+                        public Rec { // add no space for synthetic params
+                        }
+                    }
+                }
+                """;
+        String golden = content;
+                
+        reformat(doc, content, golden);
+    }    
 
     // verify closing '}' position during record formatting
     public void testRecordClosingBrace7043() throws Exception {


### PR DESCRIPTION
see https://github.com/apache/netbeans/issues/6573
