### PR TITLE
Constructor init of java.lsp.server JavaPlatformProvider override

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractJavaPlatformProviderOverride.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractJavaPlatformProviderOverride.java
@@ -39,6 +39,14 @@ public abstract class AbstractJavaPlatformProviderOverride implements JavaPlatfo
     private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
     private FileObject defaultPlatformOverride;
 
+    public AbstractJavaPlatformProviderOverride() {
+        this(null);
+    }
+
+    protected AbstractJavaPlatformProviderOverride(String defaultPlatformOverride) {
+        this.defaultPlatformOverride = defaultPlatformOverride == null ? null : FileUtil.toFileObject(new File(defaultPlatformOverride));
+    }
+
     @Override
     @SuppressWarnings("ReturnOfCollectionOrArrayField")
     public JavaPlatform[] getInstalledPlatforms() {


### PR DESCRIPTION
1. Added a protected constructor in `AbstractJavaPlatformProviderOverride` to initialize the override value if needed by a subclass.
        - Note that a PropertyChange event is not triggered since it may leak an incompletely initialized instance.
    
~~2. Allowed `LspJavaPlatformProviderOverride` to initialize the override based on the value set for the option "`netbeans.lsp.java.platform.override`" passed as a JVM system property.~~


These changes help users of certain types of Java projects, such as Maven, where the default platform initialization gets cached and not reset when the platform override value is set subsequently.
The project jdkhome value may then be set by the user as a LSP server VM option: `-Dnetbeans.lsp.java.platform.override=<path-to-project-jdk-home>`.

~~3. Finally, the NetBeans VSCode extension is updated to additionally send the `netbeans.project.jdkhome` configuration value to the NBLS via the above system property flag.~~

***Note:*** PR has been edited per review, due to the proposed removal of the extension from this repository.

---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>