### PR TITLE
When the last annotation attribute is removed, removing also the '()'.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
@@ -3052,6 +3052,11 @@ public class CasualDiff {
         localPointer = diffTree(oldT.annotationType, newT.annotationType, annotationBounds);
         JavaTokenId[] parens = null;
         if (oldT.args.nonEmpty()) {
+            if (newT.args.isEmpty()) {
+                //non-empty to empty:
+                copyTo(localPointer, annotationBounds[1]);
+                return endPos(oldT);
+            }
             copyTo(localPointer, localPointer = getOldPos(oldT.args.head));
         } else {
             // check, if there are already written parenthesis

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/AnnotationTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/AnnotationTest.java
@@ -20,6 +20,7 @@ package org.netbeans.api.java.source.gen;
 
 import com.sun.source.tree.*;
 import com.sun.source.util.SourcePositions;
+import com.sun.source.util.TreePathScanner;
 import org.netbeans.api.java.source.support.ErrorAwareTreePathScanner;
 import org.netbeans.api.java.source.support.ErrorAwareTreeScanner;
 import java.io.File;
@@ -1132,6 +1133,96 @@ public class AnnotationTest extends GeneratorTestBase {
                              "public enum Test {\n" +
                              "    A();\n" +
                              "}\n");
+    }
+
+    public void testAnnotationRemoveLastAttribute1() throws Exception {
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile,
+            "package hierbas.del.litoral;\n" +
+            "\n" +
+            "@Ann( 1 )\n" +
+            "public class Test {\n" +
+            "}\n" +
+            "public @interface Ann {\n" +
+            "    public int value() default 0;\n" +
+            "}\n"
+            );
+        String golden =
+            "package hierbas.del.litoral;\n" +
+            "\n" +
+            "@Ann\n" +
+            "public class Test {\n" +
+            "}\n" +
+            "public @interface Ann {\n" +
+            "    public int value() default 0;\n" +
+            "}\n";
+
+        JavaSource src = getJavaSource(testFile);
+        Task task = new Task<WorkingCopy>() {
+
+            public void run(WorkingCopy workingCopy) throws IOException {
+                workingCopy.toPhase(Phase.RESOLVED);
+                TreeMaker make = workingCopy.getTreeMaker();
+                CompilationUnitTree cut = workingCopy.getCompilationUnit();
+                new TreePathScanner<Void, Void>() {
+                    @Override
+                    public Void visitAnnotation(AnnotationTree node, Void p) {
+                        workingCopy.rewrite(node,
+                                            make.Annotation(node.getAnnotationType(), List.of()));
+                        return null;
+                    }
+                }.scan(cut, null);
+            }
+        };
+        src.runModificationTask(task).commit();
+        String res = TestUtilities.copyFileToString(testFile);
+        //System.err.println(res);
+        assertEquals(golden, res);
+    }
+
+    public void testAnnotationRemoveLastAttribute2() throws Exception {
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile,
+            "package hierbas.del.litoral;\n" +
+            "\n" +
+            "@Ann( value = 1 )\n" +
+            "public class Test {\n" +
+            "}\n" +
+            "public @interface Ann {\n" +
+            "    public int value() default 0;\n" +
+            "}\n"
+            );
+        String golden =
+            "package hierbas.del.litoral;\n" +
+            "\n" +
+            "@Ann\n" +
+            "public class Test {\n" +
+            "}\n" +
+            "public @interface Ann {\n" +
+            "    public int value() default 0;\n" +
+            "}\n";
+
+        JavaSource src = getJavaSource(testFile);
+        Task task = new Task<WorkingCopy>() {
+
+            public void run(WorkingCopy workingCopy) throws IOException {
+                workingCopy.toPhase(Phase.RESOLVED);
+                TreeMaker make = workingCopy.getTreeMaker();
+                CompilationUnitTree cut = workingCopy.getCompilationUnit();
+                new TreePathScanner<Void, Void>() {
+                    @Override
+                    public Void visitAnnotation(AnnotationTree node, Void p) {
+                        workingCopy.rewrite(node,
+                                            make.Annotation(node.getAnnotationType(), List.of()));
+                        return null;
+                    }
+                }.scan(cut, null);
+            }
+        };
+        src.runModificationTask(task).commit();
+        String res = TestUtilities.copyFileToString(testFile);
+        //System.err.println(res);
+        assertEquals(golden, res);
     }
 
     String getGoldenPckg() {


### PR DESCRIPTION
Having:
```
@Ann(1)
```

and removing the `1`, currently the outcome is:
```
@Ann()
```

It would be better to produce `@Ann`, without the `()`, which is what this PR is trying to do.


---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [ ] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [ ] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [ ] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [ ] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>