### PR TITLE
Private members are never inherited, and package-private members are only sometimes inherited, the Java import analysis needs to account for that.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/pretty/ImportAnalysis2.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/pretty/ImportAnalysis2.java
@@ -187,7 +187,7 @@ public class ImportAnalysis2 {
 
     public void enterVisibleThroughClasses(ClassTree clazz) {
         Set<Element> visible = visibleThroughClasses.getFirst();
-        visible.addAll(overlay.getAllVisibleThrough(model, elements, currentFQN.getFQN(), clazz, modle));
+        visible.addAll(overlay.getAllVisibleThrough(model, elements, currentFQN.getFQN(), clazz, pack, modle));
     }
 
     public void classLeft() {
@@ -367,7 +367,7 @@ public class ImportAnalysis2 {
             return make.Identifier(element.getSimpleName());
         }
 
-        if (getPackageOf(element) != null && getPackageOf(element).isUnnamed()) {
+        if (overlay.packageOf(element) != null && overlay.packageOf(element).isUnnamed()) {
             if (orig.getExpression().getKind() == Kind.MEMBER_SELECT) {
                 return make.MemberSelect(resolveImport((MemberSelectTree) orig.getExpression(), element.getEnclosingElement()),
                                          element.getSimpleName());
@@ -450,12 +450,6 @@ public class ImportAnalysis2 {
             }           
         }
         return false;
-    }
-
-    private PackageElement getPackageOf(Element el) {
-        while ((el != null) && (el.getKind() != ElementKind.PACKAGE)) el = el.getEnclosingElement();
-
-        return (PackageElement) el;
     }
 
     private Map<String, Element> getUsedImplicitlyImportedClasses() {

--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/ElementOverlay.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/ElementOverlay.java
@@ -389,7 +389,7 @@ public class ElementOverlay {
                this.packages.size();
     }
 
-    public Collection<? extends Element> getAllVisibleThrough(ASTService ast, Elements elements, String what, ClassTree tree, ModuleElement modle) {
+    public Collection<? extends Element> getAllVisibleThrough(ASTService ast, Elements elements, String what, ClassTree tree, Element currentPackage, ModuleElement modle) {
         Collection<Element> result = new ArrayList<Element>();
         Element current = what != null ? resolve(ast, elements, what, modle) : null;
 
@@ -408,30 +408,50 @@ public class ElementOverlay {
                 }
             }
         } else {
-            result.addAll(getAllMembers(ast, elements, current));
+            result.addAll(getAllMembers(ast, elements, current, currentPackage, false));
         }
 
         return result;
     }
 
-    private Collection<? extends Element> getAllMembers(ASTService ast, Elements elements, Element el) {
+    private Collection<? extends Element> getAllMembers(ASTService ast, Elements elements, Element el, Element currentPackage, boolean inherited) {
         List<Element> result = new ArrayList<Element>();
 
-        result.addAll(el.getEnclosedElements());
+        el.getEnclosedElements()
+          .stream()
+          .filter(encl -> !inherited || //include all members from the current class
+                          encl.getModifiers().contains(Modifier.PUBLIC) || //public members are inherited
+                          encl.getModifiers().contains(Modifier.PROTECTED) || //protected memebers are inherited
+                          (!encl.getModifiers().contains(Modifier.PRIVATE) && //private member are never inherited
+                           resolvedPackageOf(ast, elements, encl) == currentPackage)) //package-private members are inherited only inside the same package
+          .forEach(result::add);
 
         for (Element parent : getAllSuperElements(ast, elements, el)) {
             if (!el.equals(parent)) {
-                result.addAll(getAllMembers(ast, elements, parent));
+                result.addAll(getAllMembers(ast, elements, parent, currentPackage, true));
             }
         }
 
         return result;
     }
 
+    private Element resolvedPackageOf(ASTService ast, Elements elements, Element el) {
+        ModuleElement modle = moduleOf(elements, el);
+        PackageElement pack = packageOf(el);
+
+        return resolve(ast, elements, pack.getQualifiedName().toString(), modle);
+    }
+
     public PackageElement unnamedPackage(ASTService ast, Elements elements, ModuleElement modle) {
         return (PackageElement) resolve(ast, elements, "", modle);
     }
     
+    public PackageElement packageOf(Element el) {
+        while ((el != null) && (el.getKind() != ElementKind.PACKAGE)) el = el.getEnclosingElement();
+
+        return (PackageElement) el;
+    }
+
     public ModuleElement moduleOf(Elements elements, Element el) {
         if (el instanceof TypeElementWrapper)
             return moduleOf(elements, ((TypeElementWrapper) el).delegateTo);


### PR DESCRIPTION
Consider these files:
```java
package api;
public class A {
    public static void test() {}
    public static void test(int i) {}
}

package hierbas.del.litoral;
import static api.A.*;
public class Test extends Base {
    public static void t() {
    }
}
class Base {
    private static void test() {}
    private static void test(int i) {}
}
```

And now consider a piece of code that tries to add (using `QualIdent`s) calls to `A.test()`/`A.test(0)` inside `Test.t()`. Given the methods are accessible using simple names, this should produce just:
```
test();
test(0);
```

But import analysis sees the `test` methods in the superclass, thinks there's a clash and uses `A.test()`/`A.test(0)`. There's no clash, of course, as the `private` members are not inherited.

This PR tries to resolve that, but considering the modifiers of the members from supertypes.

---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>