### PR TITLE
Make sure netbeans in embedded terminal means itself

### DIFF
--- a/harness/apisupport.harness/windows-launcher-src/applauncher.cpp
+++ b/harness/apisupport.harness/windows-launcher-src/applauncher.cpp
@@ -74,6 +74,10 @@ bool AppLauncher::initBaseNames() {
     return true;
 }
 
+const char* AppLauncher::findUserDirViaEnvVar() {
+    return "IGNORE";
+}
+
 bool AppLauncher::findUserDir(const char *str) {
     logMsg("AppLauncher::findUserDir()");
     if (!NbLauncher::findUserDir(str)) {    // will set userDir and possibly userHome.

--- a/harness/apisupport.harness/windows-launcher-src/applauncher.h
+++ b/harness/apisupport.harness/windows-launcher-src/applauncher.h
@@ -51,6 +51,7 @@ protected:
     virtual void adjustHeapSize();
     virtual bool findUserDir(const char *str);
     virtual bool findCacheDir(const char *str);
+    virtual const char* findUserDirViaEnvVar();
     virtual const char * getDefUserDirOptName();
     virtual const char * getDefCacheDirOptName();
     virtual const char * getDefOptionsOptName();

--- a/ide/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/TerminalSupportImpl.java
+++ b/ide/dlight.terminal/src/org/netbeans/modules/dlight/terminal/action/TerminalSupportImpl.java
@@ -72,6 +72,7 @@ import org.openide.windows.OutputListener;
 import org.openide.windows.OutputWriter;
 
 import static org.netbeans.lib.terminalemulator.Term.ExternalCommandsConstants.*;
+import org.netbeans.modules.nativeexecution.api.util.MacroMap;
 
 /**
  *
@@ -270,14 +271,14 @@ public final class TerminalSupportImpl {
                         term.setEmulation("xterm"); // NOI18N
 
                         NativeProcessBuilder npb = NativeProcessBuilder.newProcessBuilder(env);
+                        final MacroMap envVars = npb.getEnvironment();
                         // clear env modified by NB. Let it be initialized by started shell process
-                        npb.getEnvironment().put("LD_LIBRARY_PATH", "");// NOI18N
-                        npb.getEnvironment().put("DYLD_LIBRARY_PATH", "");// NOI18N
-
+                        envVars.put("LD_LIBRARY_PATH", "");// NOI18N
+                        envVars.put("DYLD_LIBRARY_PATH", "");// NOI18N
                         if (hostInfo.getOSFamily() == HostInfo.OSFamily.WINDOWS) {
                             // /etc/profile changes directory to ${HOME} if this
                             // variable is not set.
-                            npb.getEnvironment().put("CHERE_INVOKING", "1");// NOI18N
+                            envVars.put("CHERE_INVOKING", "1");// NOI18N
                         }
 
                         final TerminalPinSupport support = TerminalPinSupport.getDefault();
@@ -308,8 +309,8 @@ public final class TerminalSupportImpl {
                             final String promptCommand = "printf \"\033]3;${PWD}\007\"; " // NOI18N
                                     + IDE_OPEN + "() { printf \"\033]10;" + COMMAND_PREFIX + IDE_OPEN + " $*;\007\"; printf \"Opening $# file(s) ...\n\";}";   // NOI18N
                             final String commandName = "PROMPT_COMMAND";                                    // NOI18N
-                            String usrPrompt = npb.getEnvironment().get(commandName);
-                            npb.getEnvironment().put(commandName,
+                            String usrPrompt = envVars.get(commandName);
+                            envVars.put(commandName,
                                     (usrPrompt == null)
                                             ? promptCommand
                                             : promptCommand + ';' + usrPrompt

--- a/nb/ide.launcher/unix/netbeans
+++ b/nb/ide.launcher/unix/netbeans
@@ -38,11 +38,17 @@ cd "$progdir"/..
 basedir=`pwd`
 cd "$old"
 
-case "`uname`" in
+case "`uname -s -m`" in
     Darwin*)
         # set default userdir and cachedir on Mac OS X
         DEFAULT_USERDIR_ROOT="${HOME}/Library/Application Support/NetBeans"
         DEFAULT_CACHEDIR_ROOT=${HOME}/Library/Caches/NetBeans
+        ;;
+    CYGWIN*_64)
+        exec "$progdir/netbeans64.exe" "$@"
+        ;;
+    CYGWIN*)
+        exec "$progdir/netbeans.exe" "$@"
         ;;
     *) 
         # set default userdir and cachedir on unix systems
@@ -65,8 +71,17 @@ fi
 
 export DEFAULT_USERDIR_ROOT
 
+if ! [ "$NETBEANS_USERDIR" = "IGNORE" ]; then
+    # make sure own launcher directory is on PATH as a fallback
+    PATH=$PATH:$progdir
+fi
+
 # #68373: look for userdir, but do not modify "$@"
-userdir="${netbeans_default_userdir}"
+if [ -z "$NETBEANS_USERDIR" ]; then
+    userdir="${netbeans_default_userdir}"
+else
+    userdir="$NETBEANS_USERDIR"
+fi
 cachedir="${netbeans_default_cachedir}"
 
 founduserdir=""
@@ -138,6 +153,8 @@ launchNbexec() {
     then
         sh=/bin/bash
     fi
+    NETBEANS_USERDIR=${userdir}
+    export NETBEANS_USERDIR
     if [ "${founduserdir}" = "yes" ]; then
         exec $sh "$nbexec" "$@"
     else

--- a/nb/ide.launcher/windows/nblauncher.h
+++ b/nb/ide.launcher/windows/nblauncher.h
@@ -66,6 +66,7 @@ protected:
     virtual bool initBaseNames();
     virtual void addSpecificOptions(CmdArgs &args);
     virtual bool findUserDir(const char *str);
+    virtual const char* findUserDirViaEnvVar();
     virtual bool findCacheDir(const char *str);
     virtual const char * getAppName();
     virtual const char * getDefUserDirOptName();
@@ -80,7 +81,7 @@ private:
     NbLauncher(const NbLauncher& orig);
     bool readClusterFile();
     bool parseArgs(int argc, char *argv[]);
-    bool parseConfigFile(const char* path);    
+    bool parseConfigFile(const char* path, const bool searchUserDir);
     bool getOption(char *&str, const char *opt);
     void addCluster(const char *cl);
     void addExtraClusters();

--- a/nb/ide.launcher/windows/netbeans.exe.manifest
+++ b/nb/ide.launcher/windows/netbeans.exe.manifest
@@ -20,7 +20,7 @@
 
 -->
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-<assemblyIdentity version="101.3.0.0"
+<assemblyIdentity version="101.4.0.0"
    processorArchitecture="x86"
    name="netbeans.exe"
    type="win32"/>

--- a/nb/ide.launcher/windows/netbeans64.exe.manifest
+++ b/nb/ide.launcher/windows/netbeans64.exe.manifest
@@ -22,7 +22,7 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
 <!-- Use processorArchitecture="x86", which is the value used by the 64-bit
      javaw.exe on Java 10.0.2 and Java 11ea. -->
-<assemblyIdentity version="101.3.0.0"
+<assemblyIdentity version="101.4.0.0"
    processorArchitecture="x86"
    name="netbeans64.exe"
    type="win32"/>

--- a/nb/ide.launcher/windows/version.h
+++ b/nb/ide.launcher/windows/version.h
@@ -19,9 +19,9 @@
 
 #define COMPANY ""
 #define COMPONENT "Apache NetBeans IDE Launcher"
-#define VER "101.3.0.0"
-#define FVER 101,3,0,0
-#define BUILD_ID "101300"
+#define VER "101.4.0.0"
+#define FVER 101,4,0,0
+#define BUILD_ID "101400"
 #define INTERNAL_NAME "netbeans"
 #define COPYRIGHT "Based on Apache NetBeans from the Apache Software Foundation and is licensed under Apache License Version 2.0"
 #define NAME "Apache NetBeans IDE Launcher"

--- a/nb/o.n.upgrader/arch.xml
+++ b/nb/o.n.upgrader/arch.xml
@@ -621,6 +621,43 @@
         clusters' fully qualified paths separated by path.separator (semicolon on Windows, colon on Unices)
      </api></li>
   </ul>
+  <p>
+      When the <code>netbeans</code> launcher starts, it also manipulates
+      (reads and writes) following properties:
+  </p>
+  <ul>
+     <li><api name="NETBEANS_USERDIR" category="devel" group="property" type="export">
+         <p>
+         If this <em>environment variable</em> is set to a valid value,
+         then its value is used as default user dir 
+         instead of <code>netbeans_default_userdir</code> read from
+         the config file.
+         </p>
+         <p>
+         When the value of user dir is finally determined by the launcher
+         (by considering default values, value of this environment variable
+         and <code>--userdir</code> CLI switch, etc.) the launcher sets
+         <code>NETBEANS_USERDIR</code> environment variable for itself 
+         and its subprocesses.
+         </p>
+         <p>
+         That way executing <code>netbeans</code> in the NetBeans internal
+         terminal will know what's the userdir of the surrouding NetBeans
+         and will open files in the same instance just as 
+         <a href="https://github.com/apache/netbeans/pull/8756">#8756 illustrates</a>.
+         </p>
+         <p>
+         The launcher also modifies the <code>PATH</code> variable
+         by appending its own diretory - making sure typing <code>netbeans</code>
+         gets handled in the internal NetBeans terminal at all.
+         In the unusual and rare cases when <b>opt-out</b> of this
+         behavior maybe needed, just
+         set the environment variable to <code>IGNORE</code> to instruct
+         the launcher to avoid these environment variable modifications.
+         </p>
+    </api>
+     </li>
+  </ul>
  </answer>
 
 


### PR DESCRIPTION
- since I am working with VSCode I admire its integration with its embedded terminal
- I'd like NetBeans terminal integration to be as good
- one thing I like a lot is ability to open a file from the terminal

<img width="852" height="471" alt="image" src="https://github.com/user-attachments/assets/b206f541-6bda-4606-b542-df42560aadb3" />

- e.g. typing `netbeans pom.xml` in the embedded terminal would open the file in the IDE the terminal is embedded into
- I had such a setup locally for years, but:
   - it doesn't work with other than default `--userdir` well
   - not everyone is capable to set it up
- thus I've created this PR to provide such a support for everyone
