### PR TITLE
[GITHUB-8749] Preventing an NPE when mimeType is not available (yet).

### DIFF
--- a/ide/editor.lib2/src/org/netbeans/spi/editor/highlighting/support/HighlightsContainers.java
+++ b/ide/editor.lib2/src/org/netbeans/spi/editor/highlighting/support/HighlightsContainers.java
@@ -38,6 +38,9 @@ public class HighlightsContainers {
 
             public InlineHintsSettingsAwareContainer() {
                 String mimeType = DocumentUtilities.getMimeType(doc);
+                if (mimeType == null) {
+                    mimeType = "";
+                }
                 prefs = MimeLookup.getLookup(mimeType).lookup(Preferences.class);
                 prefs.addPreferenceChangeListener(WeakListeners.create(PreferenceChangeListener.class, this, prefs));
                 inlineSettingChanged();


### PR DESCRIPTION
If the Document does not have a mimeType, lets use root. (From my testing, it seems the method is called again with a properly set-up Document anyway.)

closes #8749

---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>