### PR TITLE
Prevent NPE inside GradleTestProgressListener

### DIFF
--- a/java/gradle.test/src/org/netbeans/modules/gradle/test/GradleTestProgressListener.java
+++ b/java/gradle.test/src/org/netbeans/modules/gradle/test/GradleTestProgressListener.java
@@ -365,6 +365,7 @@ public final class GradleTestProgressListener implements ProgressListener, Gradl
 
         String relativePath = null;
         for (Map.Entry<ClasspathInfo, Path> ci : classpathInfo.entrySet()) {
+            if (ci.getKey() == null) continue;
             FileObject fo = SourceUtils.getFile(ElementHandle.createTypeElementHandle(ElementKind.CLASS, className), ci.getKey());
             if (fo != null) {
                 relativePath = ci.getValue().relativize(FileUtil.toFile(fo).toPath()).toString();


### PR DESCRIPTION
SourceUtil.getFile will throw NullPointerException [here](https://github.com/apache/netbeans/blob/d21c96133591332a5537d70d7c5d6bdbf8059e00/java/gradle.test/src/org/netbeans/modules/gradle/test/GradleTestProgressListener.java#L368) when ci.getKey() is null 