### PR TITLE
Simple implementation of LSP protocol shutdown request and exit notification handlers

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -143,6 +143,7 @@ import org.netbeans.modules.parsing.spi.indexing.Indexable;
 import org.netbeans.modules.progress.spi.InternalHandle;
 import org.netbeans.spi.project.ActionProgress;
 import org.netbeans.spi.project.ActionProvider;
+import org.openide.LifecycleManager;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Lookup;
@@ -463,6 +464,7 @@ public final class Server {
         private final OpenedDocuments openedDocuments = new OpenedDocuments();
         
         private final LspSession lspSession;
+        private boolean shutdownReqReceived = false;
         
         LanguageServerImpl(LspSession session) {
             this.lspSession = session;
@@ -1105,11 +1107,14 @@ public final class Server {
 
         @Override
         public CompletableFuture<Object> shutdown() {
+            shutdownReqReceived = true; 
             return CompletableFuture.completedFuture(null);
         }
 
         @Override
         public void exit() {
+            int exitCode = shutdownReqReceived ? 0 : 1;
+            LifecycleManager.getDefault().exit(exitCode);
         }
 
         @JsonDelegate


### PR DESCRIPTION
### Changes related to Netbeans Java  Language Server
 **Context** 
- LSP Protocol provides the language clients to send messages to the language server to shutdown and exit .
- This allows language clients to control the lifecycle of the language server completely from start to shutdown. [Spec relevant section  : lifeCycleMessages](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#lifeCycleMessages)
#### About the changes made 
-  `Shutdown Request `handler and the `Exit Notification` handler implemented 

**Note** 
As per the LSP Spec about [Shutdown Request ](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#shutdown) the language server should respond with `Invalid Request `error post receiving the shutdown request . That can be done in the future if required but has been deferred for now to keep this change simple .



