### PR TITLE
Add support for Java SE 26 for Tomcat, TomEE, and GlassFish

### DIFF
--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/JavaSEPlatform.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/JavaSEPlatform.java
@@ -74,7 +74,9 @@ public enum JavaSEPlatform {
     /** JavaSE 24. */
     v24,
     /** JavaSE 25. */
-    v25;
+    v25,
+    /** JavaSE 26. */
+    v26;
 
     // Class attributes                                                       //
     /** GlassFish JavaEE platform enumeration length. */

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/j2ee/TomcatPlatformImpl.java
@@ -555,17 +555,19 @@ public class TomcatPlatformImpl extends J2eePlatformImpl2 {
     public Set<String> getSupportedJavaPlatformVersions() {
         Set<String> versions = new HashSet<>(16);
 
-        // TomEE has different supported Java versions
+        // TomEE has different supported Java versions.
+        // The Java Security Manager (JSM) has been permanently disabled 
+        // as of JDK 24. Only TomEE 10+ will work with Java 24+.
         if (manager.isTomEE()) {
             switch (manager.getTomEEVersion()) {
                 case TOMEE_100:
-                    versions = versionRange(17, 25);
+                    versions = versionRange(17, 26);
                     break;
                 case TOMEE_90:
-                    versions = versionRange(11, 25);
+                    versions = versionRange(11, 23);
                     break;
                 case TOMEE_80:
-                    versions = versionRange(8, 25);
+                    versions = versionRange(8, 23);
                     break;
                 case TOMEE_71:
                 case TOMEE_70:
@@ -582,20 +584,20 @@ public class TomcatPlatformImpl extends J2eePlatformImpl2 {
         } else {
             switch (manager.getTomcatVersion()) {
                 case TOMCAT_110:
-                    versions = versionRange(17, 25);
+                    versions = versionRange(17, 26);
                     break;
                 case TOMCAT_101:
-                    versions = versionRange(11, 25);
+                    versions = versionRange(11, 26);
                     break;
                 case TOMCAT_100:
                 case TOMCAT_90:
-                    versions = versionRange(8, 25);
+                    versions = versionRange(8, 26);
                     break;
                 case TOMCAT_80:
-                    versions = versionRange(7, 25);
+                    versions = versionRange(7, 26);
                     break;
                 case TOMCAT_70:
-                    versions = versionRange(6, 25);
+                    versions = versionRange(6, 26);
                     break;
                 case TOMCAT_60:
                     versions = versionRange(5, 8);


### PR DESCRIPTION
- Tomcat 7-11 runs on Java SE 26
- TomEE 10 runs on Java SE 17 and later
- TomEE 9-8 runs up to Java SE 23
- Add enum for Java SE 26 on GlassFish tooling (currently not supported by GlassFish)

NetBeans Testing:

- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Verify Sigtests
- Verify successful execution of unit tests for modules `glassfish.common`, `glassfish.javaee`, `glassfish.tooling`, `glassfish.eecommon`, and `tomcat5`
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Successfully register Tomcat 7-11 & TomEE 8-10.
  - Create a Jakarta EE 11 maven web app and verify that it works
  - Create a Jakarta EE 11 ant web app and verify that it works.