### PR TITLE
Add tooltips to Projects, Files and Favorites tabs

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/Bundle.properties
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/Bundle.properties
@@ -32,11 +32,17 @@ ACSN_BrowseFolders_Select_Option=Select Folder
 ACSD_BrowseFolders_Select_Option=N/A
 LBL_BrowseFolders_jLabel1=&Folders\:
 LBL_BrowseFolders_Dialog=Browse Folders
+
 # ProjectTab
 LBL_projectTab_tc=Files
 LBL_projectTabLogical_tc=Projects
+TT_projectTab_tc=Open Projects - Physical View\n({0}) to select editor file in view
+TT_projectTabLogical_tc=Open Projects - Logical View\n({0}) to select editor file in view
+
 # {0} - display name of currently selected group
 LBL_projectTabLogical_tc_with_group=Projects - {0}
+TT_projectTab_tc_with_group=Open Projects [{1}] - Physical View\n({0}) to select editor file in view
+TT_projectTabLogical_tc_with_group=Open Projects [{1}] - Logical View\n({0}) to select editor file in view
 
 LBL_ProjectMode=Projects
 

--- a/ide/projectui/src/org/netbeans/modules/project/ui/ProjectTab.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/ProjectTab.java
@@ -59,6 +59,7 @@ import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
+import javax.swing.KeyStroke;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
@@ -82,6 +83,7 @@ import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
 import org.openide.awt.ActionRegistration;
+import org.openide.awt.Actions;
 import org.openide.awt.StatusDisplayer;
 import org.openide.awt.UndoRedo;
 import org.openide.explorer.ExplorerManager;
@@ -133,7 +135,7 @@ public class ProjectTab extends TopComponent
 
     private static final Logger LOG = Logger.getLogger(ProjectTab.class.getName());
 
-    private static Map<String, ProjectTab> tabs = new HashMap<String, ProjectTab>();                            
+    private static Map<String, ProjectTab> tabs = new HashMap<>();                            
                             
     private final transient ExplorerManager manager;
     private transient Node rootNode;
@@ -214,14 +216,29 @@ public class ProjectTab extends TopComponent
     public void setGroup(Group g) {
         if (id.equals(ID_LOGICAL)) {
             if (g != null) {
-                setName(NbBundle.getMessage(ProjectTab.class, "LBL_projectTabLogical_tc_with_group", g.getName()));
+                setName(NbBundle.getMessage(ProjectTab.class, "LBL_projectTabLogical_tc_with_group", g.getName())); // NOI18N
+                setToolTipText(NbBundle.getMessage(ProjectTab.class, "TT_projectTabLogical_tc_with_group", g.getName(), getKeyStrokeString())); // NOI18N
             } else {
-                setName(NbBundle.getMessage(ProjectTab.class, "LBL_projectTabLogical_tc"));
+                setName(NbBundle.getMessage(ProjectTab.class, "LBL_projectTabLogical_tc")); // NOI18N
+                setToolTipText(NbBundle.getMessage(ProjectTab.class, "TT_projectTabLogical_tc", getKeyStrokeString())); // NOI18N
             }
         } else {
-            setName(NbBundle.getMessage(ProjectTab.class, "LBL_projectTab_tc"));
+            setName(NbBundle.getMessage(ProjectTab.class, "LBL_projectTab_tc")); // NOI18N
+            if (g != null) {
+                setToolTipText(NbBundle.getMessage(ProjectTab.class, "TT_projectTab_tc_with_group", g.getName(), getKeyStrokeString())); // NOI18N
+            } else {
+                setToolTipText(NbBundle.getMessage(ProjectTab.class, "TT_projectTab_tc", getKeyStrokeString())); // NOI18N
+            }
         }
-        // Seems to be useless: setToolTipText(getName());
+    }
+
+    private String getKeyStrokeString() {
+        Action action = id.equals(ID_LOGICAL)
+                ? Actions.forID("Window/SelectDocumentNode", "org.netbeans.modules.project.ui.SelectInProjects") // NOI18N
+                : Actions.forID("Window/SelectDocumentNode", "org.netbeans.modules.project.ui.SelectInFiles"); // NOI18N
+        return action != null && action.getValue(Action.ACCELERATOR_KEY) instanceof KeyStroke ks
+                ? Actions.keyStrokeToString(ks)
+                : ""; // NOI18N
     }
 
     private void initValues() {
@@ -240,7 +257,7 @@ public class ProjectTab extends TopComponent
         }
         manager.setRootContext( rootNode );
     }
-            
+
     /** Explorer manager implementation 
      */
     @Override
@@ -386,7 +403,7 @@ public class ProjectTab extends TopComponent
         id = (String)in.readObject();
         rootNode = ((Node.Handle)in.readObject()).getNode();
         final List<String[]> exPaths = NbCollections.checkedListByCopy((List<?>) in.readObject(), String[].class, true);
-        final List<String[]> selPaths = new ArrayList<String[]>();
+        final List<String[]> selPaths = new ArrayList<>();
         try {
             selPaths.addAll(NbCollections.checkedListByCopy((List<?>) in.readObject(), String[].class, true));
         }
@@ -435,7 +452,7 @@ public class ProjectTab extends TopComponent
             LOG.log(Level.FINE, "{0}: expanding paths", id);
             btv.expandNodes(exPaths);
             LOG.log(Level.FINE, "{0}: selecting paths", id);
-            final List<Node> selectedNodes = new ArrayList<Node>();
+            final List<Node> selectedNodes = new ArrayList<>();
             Node root = manager.getRootContext();
             for (String[] sp : selPaths) {
                 LOG.log(Level.FINE, "{0}: selecting {1}", new Object[] {id, Arrays.asList(sp)});
@@ -453,7 +470,7 @@ public class ProjectTab extends TopComponent
                 EventQueue.invokeLater(new Runnable() {
                     @Override public void run() {
                         try {
-                            manager.setSelectedNodes(selectedNodes.toArray(new Node[0]));
+                            manager.setSelectedNodes(selectedNodes.toArray(Node[]::new));
                         } catch (PropertyVetoException x) {
                             LOG.log(Level.FINE, null, x);
                         }
@@ -649,7 +666,7 @@ public class ProjectTab extends TopComponent
     }
     
     private List<String[]> getSelectedPaths() {
-        List<String[]> result = new ArrayList<String[]>();
+        List<String[]> result = new ArrayList<>();
         Node root = manager.getRootContext();
         for (Node n : manager.getSelectedNodes()) {
             String[] path = NodeOp.createPath(n, root);
@@ -728,7 +745,7 @@ public class ProjectTab extends TopComponent
                         
         public List<String[]> getExpandedPaths() { 
 
-            List<String[]> result = new ArrayList<String[]>();
+            List<String[]> result = new ArrayList<>();
             
             TreeNode rtn = Visualizer.findVisualizer( rootNode );
             TreePath tp = new TreePath( rtn ); // Get the root
@@ -831,7 +848,7 @@ public class ProjectTab extends TopComponent
     // showing popup on right click in projects tab when label <No Project Open> is shown
     private class LabelPopupDisplayer extends MouseAdapter {
 
-        private Component component;
+        private final Component component;
 
         public LabelPopupDisplayer(Component comp) {
             component = comp;

--- a/ide/projectui/src/org/netbeans/modules/project/ui/groups/Group.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/groups/Group.java
@@ -450,6 +450,7 @@ public abstract class Group {
             EventQueue.invokeLater(new Runnable() {
                 @Override public void run() {
                     ProjectTab.findDefault(ProjectTab.ID_LOGICAL).setGroup(Group.this);
+                    ProjectTab.findDefault(ProjectTab.ID_PHYSICAL).setGroup(Group.this);
                 }
             });
         }
@@ -549,6 +550,7 @@ public abstract class Group {
         EventQueue.invokeLater(new Runnable() {
             @Override public void run() {
                 ProjectTab.findDefault(ProjectTab.ID_LOGICAL).setGroup(g);
+                ProjectTab.findDefault(ProjectTab.ID_PHYSICAL).setGroup(g);
             }
         });
         String handleLabel;

--- a/platform/favorites/nbproject/project.properties
+++ b/platform/favorites/nbproject/project.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint:all -Xlint:-serial -Xlint:-options -Werror
-javac.source=1.8
+javac.release=17

--- a/platform/favorites/src/org/netbeans/modules/favorites/Bundle.properties
+++ b/platform/favorites/src/org/netbeans/modules/favorites/Bundle.properties
@@ -22,6 +22,7 @@ ACT_View=Fa&vorites
 ACT_Select_Main_Menu=Select in F&avorites
 
 Favorites=Favorites
+TT_Favorites=Favorite Files and Locations \n({0}) to select editor file in view
 
 #name [display name]
 CTL_DisplayNameTemplate ={0} [{1}]

--- a/platform/favorites/src/org/netbeans/modules/favorites/Tab.java
+++ b/platform/favorites/src/org/netbeans/modules/favorites/Tab.java
@@ -31,8 +31,10 @@ import java.util.Collections;
 import java.util.Stack;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.swing.Action;
 import javax.swing.ActionMap;
 import javax.swing.JFileChooser;
+import javax.swing.KeyStroke;
 import javax.swing.text.DefaultEditorKit;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeModel;
@@ -112,7 +114,7 @@ implements Runnable, ExplorerManager.Provider {
     public HelpCtx getHelpCtx () {
         return new HelpCtx(Tab.HELP_ID);
     }
-    
+
     @Override
     public ExplorerManager getExplorerManager() {
         return manager;
@@ -232,7 +234,12 @@ implements Runnable, ExplorerManager.Provider {
     * obtained from specified root context node */
     private void initializeWithRootContext (Node rc) {
         // update TC's attributes
-        setToolTipText(rc.getDisplayName());
+        String hotkey = ""; // NOI18N
+        Action action = org.openide.awt.Actions.forID("Window/SelectDocumentNode", "org.netbeans.modules.favorites.Select"); // NOI18N
+        if (action != null && action.getValue(Action.ACCELERATOR_KEY) instanceof KeyStroke ks) {
+            hotkey = org.openide.awt.Actions.keyStrokeToString(ks);
+        }
+        setToolTipText(NbBundle.getMessage(Tab.class, "TT_Favorites", hotkey)); //NOI18N
         setName(rc.getDisplayName());
         updateTitle();
         // attach listener
@@ -521,8 +528,8 @@ implements Runnable, ExplorerManager.Provider {
         File chooserSelection = null;
         JFileChooser chooser = new JFileChooser ();
         chooser.setFileSelectionMode( JFileChooser.FILES_AND_DIRECTORIES );
-        chooser.setDialogTitle(NbBundle.getBundle(Actions.class).getString ("CTL_DialogTitle"));
-        chooser.setApproveButtonText(NbBundle.getBundle(Actions.class).getString ("CTL_ApproveButtonText"));
+        chooser.setDialogTitle(NbBundle.getMessage(Actions.class, "CTL_DialogTitle"));
+        chooser.setApproveButtonText(NbBundle.getMessage(Actions.class, "CTL_ApproveButtonText"));
         chooser.setSelectedFile(FileUtil.toFile(file));
         int option = chooser.showOpenDialog( WindowManager.getDefault().getMainWindow() ); // Show the chooser
         if ( option == JFileChooser.APPROVE_OPTION ) {
@@ -562,8 +569,8 @@ implements Runnable, ExplorerManager.Provider {
         final Node[] selection = getExplorerManager().getSelectedNodes();
         if( null == selection || selection.length < 1 )
             return;
-        if( view instanceof MyBeanTreeView ) {
-            ((MyBeanTreeView)view).scrollNodeToVisible(selection[0]);
+        if( view instanceof MyBeanTreeView myBeanTreeView ) {
+            myBeanTreeView.scrollNodeToVisible(selection[0]);
         }
     }
 


### PR DESCRIPTION
 - Project tab tooltips (Projects and Files) will show up as logical and physical view and also display the active project group
 - Favorites tab will simply say "Favorite Files and Locations"

mouse pointer is over `Projects` tab:

<img width="472" height="233" alt="image" src="https://github.com/user-attachments/assets/fba7df77-496c-4d6a-ab5a-9fbed165886e" />

mouse over `Files`:

<img width="512" height="204" alt="image" src="https://github.com/user-attachments/assets/3b2285b4-8d18-4f64-9d34-239069917377" />


`Favorites` tab:

<img width="515" height="212" alt="image" src="https://github.com/user-attachments/assets/82ef96e9-5936-4b1f-8f1a-93ddfee25f77" />

