### PR TITLE
lsp.client: Callers of LSPBindings#getBindingsImpl extect result to be non null

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
@@ -193,7 +193,7 @@ public class LSPBindings {
     }
 
     @SuppressWarnings("AccessingNonPublicFieldOfAnotherObject")
-    public static synchronized List<LSPBindings> getBindingsImpl(Project prj, FileObject file, String mimeType) {
+    public static synchronized @NonNull List<LSPBindings> getBindingsImpl(Project prj, FileObject file, String mimeType) {
         FileObject dir;
 
         if (prj == null) {
@@ -203,7 +203,7 @@ public class LSPBindings {
                 dirFile.getName().startsWith("vcs-") &&
                 dirFile.getAbsolutePath().startsWith(System.getProperty("java.io.tmpdir"))) {
                 //diff dir, don't start servers:
-                return null;
+                return List.of();
             }
         } else {
             dir = prj.getProjectDirectory();
@@ -236,7 +236,7 @@ public class LSPBindings {
     }
 
     @SuppressWarnings({"AccessingNonPublicFieldOfAnotherObject", "ResultOfObjectAllocationIgnored"})
-    private static List<LSPBindings> buildBindings(Project prj, String mt, FileObject dir, URI baseUri) {
+    private static @NonNull List<LSPBindings> buildBindings(Project prj, String mt, FileObject dir, URI baseUri) {
         MimeTypeInfo mimeTypeInfo = new MimeTypeInfo(mt);
         List<LSPBindings> servers = new ArrayList<>();
         Map<LanguageServerProvider, ServerDescription> provider2Description =


### PR DESCRIPTION
Files whose name starts with vcs- and lie inside the java.io.tmpdir will yield `null` for the call to LSPBindings#getBindingsImpl. This is not expected by callers and breaks the contract of that method that declares it to yield non-null values.

This change turns the null into an empty list.