### PR TITLE
TreeDiff: remember UI state when browsing through diffs

### DIFF
--- a/ide/diff/src/org/netbeans/modules/diff/tree/TreeDiffViewerTopComponent.java
+++ b/ide/diff/src/org/netbeans/modules/diff/tree/TreeDiffViewerTopComponent.java
@@ -81,6 +81,8 @@ public final class TreeDiffViewerTopComponent extends TopComponent {
     private final JPopupMenu contextMenu;
     private List<ExclusionPattern> filterPatterns = new ArrayList<>();
     private List<TreeEntry> selectedTreeEntries = Collections.emptyList();
+    
+    private DiffController currentDiff = null;
 
     /**
      * @deprecated only for use by NetBeans internals
@@ -331,6 +333,7 @@ public final class TreeDiffViewerTopComponent extends TopComponent {
         if(! selectedTreeEntries.isEmpty()) {
             try {
                 DiffController diff = DiffController.createEnhanced(
+                    currentDiff,
                     FileStreamSource.create(
                             selectedTreeEntries.get(0).getFile1(),
                             selectedTreeEntries.get(0).getBasePath1()
@@ -341,6 +344,7 @@ public final class TreeDiffViewerTopComponent extends TopComponent {
                     )
                 );
                 diffOutput.add(diff.getJComponent());
+                currentDiff = diff;
             } catch (IOException ex) {
                 Exceptions.printStackTrace(ex);
             }
@@ -383,9 +387,7 @@ public final class TreeDiffViewerTopComponent extends TopComponent {
         while (!queue2.isEmpty()) {
             TreeEntry wte = queue2.remove(0);
             wte.removePropertyChangeListener("modified", modifiedListener);
-            for (TreeEntry cte : wte.getChildren()) {
-                queue2.add(cte);
-            }
+            queue2.addAll(wte.getChildren());
         }
     }
 
@@ -395,9 +397,7 @@ public final class TreeDiffViewerTopComponent extends TopComponent {
         while(! queue2.isEmpty()) {
             TreeEntry wte = queue2.remove(0);
             wte.addPropertyChangeListener("modified", modifiedListener);
-            for(TreeEntry cte: wte.getChildren()) {
-                queue2.add(cte);
-            }
+            queue2.addAll(wte.getChildren());
         }
     }
 
@@ -645,10 +645,6 @@ public final class TreeDiffViewerTopComponent extends TopComponent {
     private javax.swing.JLabel targetpathLabel;
     private javax.swing.JLabel targetpathValue;
     // End of variables declaration//GEN-END:variables
-    @Override
-    public void componentOpened() {
-        // TODO add custom code on component opening
-    }
 
     @Override
     public void componentClosed() {

--- a/ide/versioning.ui/nbproject/project.properties
+++ b/ide/versioning.ui/nbproject/project.properties
@@ -17,6 +17,6 @@
 
 is.eager=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.release=17
 
 spec.version.base=1.53.0

--- a/ide/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryDiffView.java
+++ b/ide/versioning.ui/src/org/netbeans/modules/versioning/ui/history/HistoryDiffView.java
@@ -57,7 +57,7 @@ import org.openide.util.lookup.Lookups;
 public class HistoryDiffView implements PropertyChangeListener {
            
     private final HistoryComponent tc;
-    private DiffPanel panel;
+    private final DiffPanel panel;
     private Component diffComponent;
     private DiffController diffView;                
     private DiffTask diffTask;
@@ -262,7 +262,7 @@ public class HistoryDiffView implements PropertyChangeListener {
         }
     }        
 
-    private Map<String, DiffController> views = new ConcurrentHashMap<String, DiffController>();
+    private final Map<String, DiffController> views = new ConcurrentHashMap<>();
     private DiffController getView(HistoryEntry entry, VCSFileProxy file) {
         assert entry != null;
         if(entry == null) {
@@ -471,7 +471,7 @@ public class HistoryDiffView implements PropertyChangeListener {
 
         final DiffController dv;
         try {   
-            dv = DiffController.createEnhanced(ss1, ss2);
+            dv = DiffController.createEnhanced(diffView, ss1, ss2);
         } catch (IOException ioe)  {
             History.LOG.log(Level.SEVERE, null, ioe);
             return null;
@@ -666,7 +666,7 @@ public class HistoryDiffView implements PropertyChangeListener {
         }
         
         private class PreparingDiffHandler extends JPanel implements ActionListener {
-            private JLabel label = new JLabel();
+            private final JLabel label = new JLabel();
             private Component progressComponent;
             private ProgressHandle handle;
             


### PR DESCRIPTION
similar to versioning history, diff mode and divider location should remain the same when a new diff is loaded (e.g file or revision selection changes).

adds a new factory method to `DiffController` which copies the the UI state into the new controller and moved some code from the versioning history into it (originally added in #7128).

Versioning history, single-file history and tree diff windows use now the new factory method.