### PR TITLE
Add code templates for compact main methods

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/java/editor/resources/DefaultAbbrevs.xml
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/resources/DefaultAbbrevs.xml
@@ -293,6 +293,24 @@
         <![CDATA[${TYPE default="Object"} ${OBJ newVarName default="obj"} = new ${TYPE}(${cursor});]]>
         </code>
     </codetemplate>
+
+    <codetemplate abbreviation="vm" contexts="CLASS">
+        <code>
+<![CDATA[void main() {
+    ${cursor}
+}
+]]>
+        </code>
+    </codetemplate>
+
+    <codetemplate abbreviation="svm" contexts="CLASS">
+        <code>
+<![CDATA[static void main() {
+    ${cursor}
+}
+]]>
+        </code>
+    </codetemplate>
         
     <codetemplate abbreviation="psvm" contexts="CLASS">
         <code>


### PR DESCRIPTION
Both `psvm` and `main` abbreviations generate the classic main method.

This adds `vm` and `svm` to generate the compact variants ~and changes `main` to generate the most basic (`void main() {}`).~ 

~Feedback appreciated. I changed the `main` template too mostly from the onboarding/new-to-java perspective, since it is the abbreviation with the highest probability to be discovered just by typing something and hitting auto completion.~

current:
-  `psvm`/`main` -> `public static void main(String[] args) {}`

new:
-  `svm` -> `static void main() {}`
-  `vm` -> `void main() {}`

