### PR TITLE
Add NetBeansProjects dir to Favorites tab

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectListSettings.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectListSettings.java
@@ -38,7 +38,7 @@ import org.openide.util.NbPreferences;
  */
 public class OpenProjectListSettings {
 
-    private static OpenProjectListSettings INSTANCE = new OpenProjectListSettings();
+    private static final OpenProjectListSettings INSTANCE = new OpenProjectListSettings();
     
     private static final String RECENT_PROJECTS_DISPLAY_NAMES = "RecentProjectsDisplayNames"; //NOI18N
     private static final String RECENT_PROJECTS_DISPLAY_ICONS = "RecentProjectsIcons"; //NOI18N
@@ -310,8 +310,11 @@ public class OpenProjectListSettings {
         if (result == null || !(new File(result)).exists()) {
             // property for overriding default projects dir location
             String userPrjDir = System.getProperty("netbeans.projects.dir"); // NOI18N
-            if (userPrjDir != null) {
+            if (userPrjDir != null && !userPrjDir.isBlank()) {
                 File f = new File(userPrjDir);
+                if (create && !f.exists()) {
+                    f.mkdirs();
+                }
                 if (f.exists() && f.isDirectory()) {
                     return FileUtil.normalizeFile(f);
                 }

--- a/ide/projectui/src/org/netbeans/modules/project/ui/ProjectUtilities.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/ProjectUtilities.java
@@ -44,7 +44,6 @@ import javax.swing.SwingUtilities;
 import org.netbeans.api.actions.Openable;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectUtils;
-import static org.netbeans.modules.project.ui.Bundle.*;
 import org.netbeans.modules.project.ui.groups.Group;
 import org.netbeans.spi.project.AuxiliaryConfiguration;
 import org.netbeans.spi.project.ui.support.ProjectConvertors;
@@ -60,6 +59,7 @@ import org.openide.util.ContextAwareAction;
 import org.openide.util.Exceptions;
 import org.openide.util.Mutex;
 import org.openide.util.NbBundle.Messages;
+import org.openide.util.Utilities;
 import org.openide.windows.Mode;
 import org.openide.windows.TopComponent;
 import org.openide.windows.WindowManager;
@@ -67,6 +67,8 @@ import org.openide.xml.XMLUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+
+import static org.netbeans.modules.project.ui.Bundle.*;
 
 /** The util methods for projectui module.
  *
@@ -600,6 +602,12 @@ public class ProjectUtilities {
             set.add(url);
         }    
         return new ArrayList<>(set);
+    }
+    
+    // called from (ide.branding) layer.xml on Favorites tab open
+    public static URL getProjectsFolder() throws MalformedURLException {
+        File projectsFolder = OpenProjectListSettings.getInstance().getProjectsFolder(true);
+        return Utilities.toURI(projectsFolder).toURL();
     }
 
     // interface for handling project's documents stored in project private.xml

--- a/nb/ide.branding/src/org/netbeans/modules/ide/branding/layer.xml
+++ b/nb/ide.branding/src/org/netbeans/modules/ide/branding/layer.xml
@@ -38,6 +38,14 @@
       <attr name="currentFontColorProfile" stringvalue="FlatLaf Light" />
     </folder>
 
+    <folder name="Favorites">
+        <file name="NetBeansProjects.shadow">
+            <attr name="originalFile" methodvalue="org.netbeans.modules.project.ui.ProjectUtilities.getProjectsFolder"/>
+            <attr name="originalFileSystem" stringvalue="org.netbeans.modules.masterfs.MasterFileSystem"/>
+            <attr name="position" intvalue="110"/>
+        </file>
+    </folder>
+
     <folder name="Windows2">
       <folder name="Background">
         <attr name="backgroundImage" stringvalue="org/netbeans/modules/ide/branding/apache-netbeans.png" />


### PR DESCRIPTION
 - projects dir is now registered as favorite (after user home)
 - fixed bug: when a custom project dir location is specified by setting  `netbeans.projects.dir`, the dir is now automatically created, instead of falling back to the default dir, which gave the impression that the property isn't working

<img width="281" height="185" alt="image" src="https://github.com/user-attachments/assets/81de5b9a-c653-462e-bfc9-bb8f1f2b8d7d" />
