### PR TITLE
Remove remaining Integer constructor calls in custom form code and String literal

### DIFF
--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/project/templateWizardIterator.javx
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/project/templateWizardIterator.javx
@@ -136,7 +136,7 @@ public class ${TEMPLATENAME}WizardIterator implements WizardDescriptor./*Progres
                 JComponent jc = (JComponent) c;
                 // Step #.
                 // TODO if using org.openide.dialogs >= 7.8, can use WizardDescriptor.PROP_*:
-                jc.putClientProperty("WizardPanel_contentSelectedIndex", new Integer(i));
+                jc.putClientProperty("WizardPanel_contentSelectedIndex", i);
                 // Step name (actually the whole list for reference).
                 jc.putClientProperty("WizardPanel_contentData", steps);
             }
@@ -152,7 +152,7 @@ public class ${TEMPLATENAME}WizardIterator implements WizardDescriptor./*Progres
 
     public String name() {
         return MessageFormat.format("{0} of {1}",
-            new Object[] {new Integer(index + 1), new Integer(panels.length)});
+            new Object[] {index + 1, panels.length});
     }
 
     public boolean hasNext() {

--- a/enterprise/web.core/src/org/netbeans/modules/web/core/palette/items/ChooseCustomizer.form
+++ b/enterprise/web.core/src/org/netbeans/modules/web/core/palette/items/ChooseCustomizer.form
@@ -30,6 +30,7 @@
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
@@ -75,7 +76,7 @@
           <Connection code="new JSpinner.NumberEditor(jSpinner1, &quot;#&quot;)" type="code"/>
         </Property>
         <Property name="value" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-          <Connection code="new Integer(Choose.DEFAULT_WHENS)" type="code"/>
+          <Connection code="Choose.DEFAULT_WHENS" type="code"/>
         </Property>
       </Properties>
       <Constraints>

--- a/ide/html/src/org/netbeans/modules/html/palette/items/OLCustomizer.form
+++ b/ide/html/src/org/netbeans/modules/html/palette/items/OLCustomizer.form
@@ -254,7 +254,7 @@
           <Connection code="new NumberEditor(jSpinner1, &quot;#&quot;)" type="code"/>
         </Property>
         <Property name="value" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-          <Connection code="new Integer(ol.getCount())" type="code"/>
+          <Connection code="Integer.valueOf(ol.getCount())" type="code"/>
         </Property>
       </Properties>
       <AccessibilityProperties>

--- a/ide/html/src/org/netbeans/modules/html/palette/items/SELECTCustomizer.form
+++ b/ide/html/src/org/netbeans/modules/html/palette/items/SELECTCustomizer.form
@@ -205,7 +205,7 @@
           <Connection code="new JSpinner.NumberEditor(jSpinner1, &quot;#&quot;)" type="code"/>
         </Property>
         <Property name="value" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-          <Connection code="new Integer(select.getOptions())" type="code"/>
+          <Connection code="Integer.valueOf(select.getOptions())" type="code"/>
         </Property>
       </Properties>
       <AccessibilityProperties>
@@ -251,7 +251,7 @@
           <Connection code="new JSpinner.NumberEditor(jSpinner2, &quot;#&quot;)" type="code"/>
         </Property>
         <Property name="value" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-          <Connection code="new Integer(select.getOptionsVisible())" type="code"/>
+          <Connection code="Integer.valueOf(select.getOptionsVisible())" type="code"/>
         </Property>
       </Properties>
       <AccessibilityProperties>

--- a/ide/html/src/org/netbeans/modules/html/palette/items/TABLECustomizer.form
+++ b/ide/html/src/org/netbeans/modules/html/palette/items/TABLECustomizer.form
@@ -165,7 +165,7 @@
           <Connection code="new JSpinner.NumberEditor(jSpinner1, &quot;#&quot;)" type="code"/>
         </Property>
         <Property name="value" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-          <Connection code="new Integer(table.getRows())" type="code"/>
+          <Connection code="Integer.valueOf(table.getRows())" type="code"/>
         </Property>
       </Properties>
       <AccessibilityProperties>
@@ -189,7 +189,7 @@
           <Connection code="new JSpinner.NumberEditor(jSpinner2, &quot;#&quot;)" type="code"/>
         </Property>
         <Property name="value" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-          <Connection code="new Integer(table.getCols())" type="code"/>
+          <Connection code="Integer.valueOf(table.getCols())" type="code"/>
         </Property>
       </Properties>
       <AccessibilityProperties>
@@ -315,7 +315,7 @@
           <Connection code="new JSpinner.NumberEditor(jSpinner3, &quot;#&quot;)" type="code"/>
         </Property>
         <Property name="value" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-          <Connection code="new Integer(table.getBorder())" type="code"/>
+          <Connection code="Integer.valueOf(table.getBorder())" type="code"/>
         </Property>
       </Properties>
       <AccessibilityProperties>
@@ -336,7 +336,7 @@
           <Connection code="new JSpinner.NumberEditor(jSpinner4, &quot;#&quot;)" type="code"/>
         </Property>
         <Property name="value" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-          <Connection code="new Integer(table.getCspac())" type="code"/>
+          <Connection code="Integer.valueOf(table.getCspac())" type="code"/>
         </Property>
       </Properties>
       <AccessibilityProperties>
@@ -357,7 +357,7 @@
           <Connection code="new JSpinner.NumberEditor(jSpinner5, &quot;#&quot;)" type="code"/>
         </Property>
         <Property name="value" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-          <Connection code="new Integer(table.getCpadd())" type="code"/>
+          <Connection code="Integer.valueOf(table.getCpadd())" type="code"/>
         </Property>
       </Properties>
       <AccessibilityProperties>
@@ -378,7 +378,7 @@
           <Connection code="new JSpinner.NumberEditor(widthSpinner, &quot;#&quot;)" type="code"/>
         </Property>
         <Property name="value" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-          <Connection code="new Integer(table.getWidth())" type="code"/>
+          <Connection code="Integer.valueOf(table.getWidth())" type="code"/>
         </Property>
       </Properties>
       <AccessibilityProperties>

--- a/ide/html/src/org/netbeans/modules/html/palette/items/TEXTAREACustomizer.form
+++ b/ide/html/src/org/netbeans/modules/html/palette/items/TEXTAREACustomizer.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
 
@@ -198,7 +198,7 @@
           <Connection code="new JSpinner.NumberEditor(jSpinner1, &quot;#&quot;)" type="code"/>
         </Property>
         <Property name="value" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-          <Connection code="new Integer(textArea.getRows())" type="code"/>
+          <Connection code="Integer.valueOf(textArea.getRows())" type="code"/>
         </Property>
       </Properties>
       <AccessibilityProperties>
@@ -224,7 +224,7 @@
           <Connection code="new JSpinner.NumberEditor(jSpinner2, &quot;#&quot;)" type="code"/>
         </Property>
         <Property name="value" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-          <Connection code="new Integer(textArea.getCols())" type="code"/>
+          <Connection code="Integer.valueOf(textArea.getCols())" type="code"/>
         </Property>
       </Properties>
       <AccessibilityProperties>

--- a/ide/html/src/org/netbeans/modules/html/palette/items/ULCustomizer.form
+++ b/ide/html/src/org/netbeans/modules/html/palette/items/ULCustomizer.form
@@ -219,7 +219,7 @@
           <Connection code="new NumberEditor(jSpinner1, &quot;#&quot;)" type="code"/>
         </Property>
         <Property name="value" type="java.lang.Object" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-          <Connection code="new Integer(ul.getCount())" type="code"/>
+          <Connection code="Integer.valueOf(ul.getCount())" type="code"/>
         </Property>
       </Properties>
       <AccessibilityProperties>

--- a/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectCopyPanel.form
+++ b/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectCopyPanel.form
@@ -25,7 +25,7 @@
   <AccessibilityProperties>
     <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
       <ResourceString bundle="org/netbeans/modules/project/uiapi/Bundle.properties" key="ACSD_Copy_Move_Panel" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;, {arguments})">
-        <Argument index="0" javacode="new Integer(isMove ? 1 : 0)"/>
+        <Argument index="0" javacode="Integer.valueOf(isMove ? 1 : 0)"/>
       </ResourceString>
     </Property>
   </AccessibilityProperties>
@@ -35,6 +35,7 @@
     <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_layoutCodeTarget" type="java.lang.Integer" value="1"/>
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
@@ -47,7 +48,7 @@
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/project/uiapi/Bundle.properties" key="LBL_Copy_Move_Dialog_Text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;, {arguments})">
-            <Argument index="0" javacode="new Integer(isMove ? 1 : 0)"/>
+            <Argument index="0" javacode="Integer.valueOf(isMove ? 1 : 0)"/>
             <Argument index="1" javacode="ProjectUtils.getInformation(project).getDisplayName()"/>
           </ResourceString>
         </Property>
@@ -161,8 +162,8 @@
     </Component>
     <Component class="javax.swing.JTextField" name="projectFolder">
       <Properties>
-        <Property name="columns" type="int" value="30"/>
         <Property name="editable" type="boolean" value="false"/>
+        <Property name="columns" type="int" value="30"/>
       </Properties>
       <AccessibilityProperties>
         <Property name="AccessibleContext.accessibleName" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
@@ -233,7 +234,7 @@
               <Properties>
                 <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
                   <ResourceString bundle="org/netbeans/modules/project/uiapi/Bundle.properties" key="LBL_Copying_Moving" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;, {arguments})">
-                    <Argument index="0" javacode="isMove ? new Integer(1) : new Integer(0)"/>
+                    <Argument index="0" javacode="isMove ? Integer.valueOf(1) : Integer.valueOf(0)"/>
                   </ResourceString>
                 </Property>
               </Properties>
@@ -261,8 +262,8 @@
     </Container>
     <Component class="javax.swing.JTextArea" name="warningTextArea">
       <Properties>
-        <Property name="columns" type="int" value="20"/>
         <Property name="editable" type="boolean" value="false"/>
+        <Property name="columns" type="int" value="20"/>
         <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
           <Connection code="UIManager.getColor(&quot;nb.errorForeground&quot;)" type="code"/>
         </Property>

--- a/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectCopyPanel.java
+++ b/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectCopyPanel.java
@@ -177,8 +177,8 @@ public class ProjectCopyPanel extends javax.swing.JPanel implements DocumentList
         gridBagConstraints.insets = new java.awt.Insets(6, 0, 0, 12);
         add(jLabel4, gridBagConstraints);
 
-        projectFolder.setColumns(30);
         projectFolder.setEditable(false);
+        projectFolder.setColumns(30);
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 3;
@@ -240,8 +240,8 @@ public class ProjectCopyPanel extends javax.swing.JPanel implements DocumentList
         gridBagConstraints.insets = new java.awt.Insets(8, 0, 0, 0);
         add(progress, gridBagConstraints);
 
-        warningTextArea.setColumns(20);
         warningTextArea.setEditable(false);
+        warningTextArea.setColumns(20);
         warningTextArea.setForeground(UIManager.getColor("nb.errorForeground"));
         warningTextArea.setLineWrap(true);
         warningTextArea.setRows(5);

--- a/platform/o.n.core/src/org/netbeans/beaninfo/editors/ListImageEditor.java
+++ b/platform/o.n.core/src/org/netbeans/beaninfo/editors/ListImageEditor.java
@@ -152,7 +152,7 @@ public class ListImageEditor extends PropertyEditorSupport implements ExProperty
 
     @Override
     public String getJavaInitializationString () {
-        return "new Integer(" + getValue () + ")"; // NOI18N
+        return "Integer.valueOf(" + getValue () + ")"; // NOI18N
     }
     
     private Object findObject (Object [] objs, int i) {


### PR DESCRIPTION
https://github.com/apache/netbeans/pull/8391 missed some hidden occurrences since it mostly used jackpot driven code inspection.

 - some generated form code got updated at some point without updating the form files (editing the form would have reverted the changes again)
 - string literal in `ListImageEditor` used for code generation
 - `templateWizardIterator.javx` project template

part of https://github.com/apache/netbeans/issues/8257