### PR TITLE
Update some gradle tests for JDK 21 and enable them in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -925,17 +925,17 @@ jobs:
 #      - name: java/ant.grammar
 #        run: ant $OPTS -f java/ant.grammar test
 
-      # TODO next are JDK 21+ incompatibe steps
+      # TODO next are JDK 21 or 25 incompatibe steps
       - name: java/java.mx.project
-        if: ${{ matrix.java == '17' }}
+        if: ${{ matrix.java == '17' || matrix.java == '21' }}
         run: .github/retry.sh ant $OPTS -f java/java.mx.project test
 
       - name: java/gradle.java
-        if: ${{ matrix.java == '17' }}
+        if: ${{ matrix.java == '17' || matrix.java == '21' }}
         run: .github/retry.sh ant $OPTS -f java/gradle.java test
 
       - name: extide/gradle
-        if: ${{ matrix.java == '17' }}
+        if: ${{ matrix.java == '17' || matrix.java == '21' }}
         run: ant $OPTS -f extide/gradle test
 
       - name: java/gradle.dependencies

--- a/extide/gradle/test/unit/data/buildprops/micronaut/build.gradle
+++ b/extide/gradle/test/unit/data/buildprops/micronaut/build.gradle
@@ -19,7 +19,8 @@
 
 plugins {
     id("com.github.johnrengelman.shadow") version "7.1.2"
-    id("io.micronaut.application") version "3.5.1"
+// ExtensionPropertiesExtractorTest#testTaskListProperty fails with next point release
+    id("io.micronaut.application") version "3.6.5"
 }
 
 version = "0.1"

--- a/extide/gradle/test/unit/data/buildprops/micronaut/gradle/wrapper/gradle-wrapper.properties
+++ b/extide/gradle/test/unit/data/buildprops/micronaut/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/loaders/ExtensionPropertiesExtractorTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/loaders/ExtensionPropertiesExtractorTest.java
@@ -19,15 +19,12 @@
 package org.netbeans.modules.gradle.loaders;
 
 import java.io.File;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
-import static junit.framework.TestCase.assertNotNull;
 import org.gradle.internal.impldep.com.google.common.collect.Streams;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
@@ -116,7 +113,7 @@ public class ExtensionPropertiesExtractorTest extends NbTestCase {
         assertEquals(BuildPropertiesSupport.PropertyKind.STRUCTURE, prop.getKind());
         String s = prop.getStringValue();
         assertNotNull("Paths and directories are convertible to String", s);
-        assertTrue(s.endsWith(Paths.get("micronaut", "build", "distributions").toString()));
+        assertTrue(s.endsWith(Path.of("micronaut", "build", "distributions").toString()));
 
         assertTrue(support.keys(prop).isEmpty());
         assertFalse(support.items(prop, null).iterator().hasNext());
@@ -187,8 +184,8 @@ public class ExtensionPropertiesExtractorTest extends NbTestCase {
         Iterator<BuildPropertiesSupport.Property> iter = it.iterator();
         assertTrue(iter.hasNext());
         
-        List<String> l = Streams.stream(iter).map(BuildPropertiesSupport.Property::getStringValue).collect(Collectors.toList());
-        assertEquals(Arrays.asList("x", "y", "z"), l);
+        List<String> l = Streams.stream(iter).map(BuildPropertiesSupport.Property::getStringValue).toList();
+        assertEquals(List.of("x", "y", "z"), l);
     }
 
     public void testMapExtensionProperty2() throws Exception {
@@ -244,7 +241,7 @@ public class ExtensionPropertiesExtractorTest extends NbTestCase {
         List<String> sorted = new ArrayList<>(keys);
         Collections.sort(sorted);
         
-        assertEquals(Arrays.asList("normalKey", "semi;;key", "semi;\\;key", "semi;key"), sorted);
+        assertEquals(List.of("normalKey", "semi;;key", "semi;\\;key", "semi;key"), sorted);
     }
     
 
@@ -274,7 +271,7 @@ public class ExtensionPropertiesExtractorTest extends NbTestCase {
         assertEquals(BuildPropertiesSupport.PropertyKind.STRUCTURE, prop.getKind());
         String s = prop.getStringValue();
         assertNotNull("Paths and directories are convertible to String", s);
-        assertTrue(s.endsWith(Paths.get("micronaut", "build", "native", "nativeTestCompile").toString()));
+        assertTrue(s.endsWith(Path.of("micronaut", "build", "native", "nativeTestCompile").toString()));
 
         assertTrue(support.keys(prop).isEmpty());
         assertFalse(support.items(prop, null).iterator().hasNext());

--- a/java/gradle.java/test/unit/data/artifacts/shadowed/build.gradle
+++ b/java/gradle.java/test/unit/data/artifacts/shadowed/build.gradle
@@ -13,12 +13,12 @@ run {
 }
 
 task testJar(type: Jar) {
-    classifier = 'tests'
+    archiveClassifier = 'tests'
     from sourceSets.test.output
 }
 
 task testSourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'test-sources'
+    archiveClassifier = 'test-sources'
     from sourceSets.test.allSource
 }
 

--- a/java/gradle.java/test/unit/data/artifacts/shadowed/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle.java/test/unit/data/artifacts/shadowed/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java/gradle.java/test/unit/data/artifacts/withTests/build.gradle
+++ b/java/gradle.java/test/unit/data/artifacts/withTests/build.gradle
@@ -8,12 +8,12 @@ run {
 }
 
 task testJar(type: Jar) {
-    classifier = 'tests'
+    archiveClassifier = 'tests'
     from sourceSets.test.output
 }
 
 task testSourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'test-sources'
+    archiveClassifier = 'test-sources'
     from sourceSets.test.allSource
 }
 

--- a/java/gradle.java/test/unit/data/artifacts/withTests/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle.java/test/unit/data/artifacts/withTests/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java/gradle.java/test/unit/data/dependencies/micronaut/build.gradle
+++ b/java/gradle.java/test/unit/data/dependencies/micronaut/build.gradle
@@ -19,7 +19,7 @@
 
 plugins {
     id("com.github.johnrengelman.shadow") version "7.1.2"
-    id("io.micronaut.application") version "3.5.1"
+    id("io.micronaut.application") version "3.7.10"
 }
 
 version = "0.1"

--- a/java/gradle.java/test/unit/data/dependencies/micronaut/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle.java/test/unit/data/dependencies/micronaut/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/queries/GradleDependenciesImplementationTest.java
+++ b/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/queries/GradleDependenciesImplementationTest.java
@@ -19,11 +19,9 @@
 package org.netbeans.modules.gradle.java.queries;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import static junit.framework.TestCase.assertNotNull;
 import org.netbeans.api.editor.document.LineDocument;
 import org.netbeans.api.editor.document.LineDocumentUtils;
 import org.netbeans.api.project.Project;
@@ -76,7 +74,7 @@ public class GradleDependenciesImplementationTest extends NbTestCase {
         // System.out/err to the IOProvider, and its Trivial implementation will redirect
         // it back to System.err - loop is formed. Initialize IOProvider first, it gets
         // the real System.err/out references.
-        IOProvider p = IOProvider.getDefault();
+        assertNotNull(IOProvider.getDefault());
         System.setProperty("test.reload.sync", "true");
         
         destDirF = getTestNBDestDir();
@@ -259,6 +257,7 @@ public class GradleDependenciesImplementationTest extends NbTestCase {
     }
     
     private void assertContainsDependency(List<Dependency> deps, String groupAndArtifact) {
+        assertFalse("dependency list was empty", deps.isEmpty());
         for (Dependency d : deps) {
             ArtifactSpec a = d.getArtifact();
             if (a != null) {
@@ -271,7 +270,7 @@ public class GradleDependenciesImplementationTest extends NbTestCase {
         fail("Artifact not found: " +  groupAndArtifact);
     }
     
-    private static final List<String> ALL_DEPS =   Arrays.asList(
+    private static final List<String> ALL_DEPS = List.of(
             "io.micronaut:micronaut-http-validation",
             "io.micronaut:micronaut-http-client",
             "io.micronaut:micronaut-jackson-databind",

--- a/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/queries/GradleJarArtifactTest.java
+++ b/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/queries/GradleJarArtifactTest.java
@@ -274,7 +274,7 @@ public class GradleJarArtifactTest extends NbTestCase {
                     "",
                     "",
                     "task sourcesJar(type: Jar) {",
-                    "    classifier = 'sources'",
+                    "    archiveClassifier = 'sources'",
                     "    from sourceSets.main.allSource",
                     "}",
                     "assemble.dependsOn sourcesJar"


### PR DESCRIPTION
attempt to improve the JDK version coverage for the gradle tests slightly

 - only `extide/grade` and `java/gradle`, had no time for the other modules
 - some versions needed to be bumped and builds adjusted
 - enabled `java.mx.project` on JDK 21 too since it appears to be working

part of https://github.com/apache/netbeans/issues/7871

not sure why so many tests projects use the micronaut plugin, this makes them very version sensitive