### PR TITLE
Resolves #4710 a Close Right feature in menu

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/actions/ActionUtils.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/actions/ActionUtils.java
@@ -79,6 +79,10 @@ public abstract class ActionUtils {
                     allBut.setEnabled(false);
                 }
                 actions.add(allBut);
+                //close all right of this
+                int index = mode.getTopComponentTabPosition(tc);
+                CloseAllRightOfThisAction allRight = new CloseAllRightOfThisAction(index);
+                actions.add(allRight);
             }
             
             actions.add(null); // Separator
@@ -499,6 +503,18 @@ public abstract class ActionUtils {
             closeAll(tcs);
         });
     }
+    
+    /** 
+     * Closes all documents after given index, according to isContext flag
+     */
+    public static void closeRight(int index) {
+        // See closeAllDocuments.
+        SwingUtilities.invokeLater(() -> {
+            List<TopComponent> tcs = new ArrayList<>(getOpened(TopComponent.getRegistry().getActivated()));
+            closeAll(tcs.subList(index + 1, tcs.size()));
+        });
+    }
+    
 
     private static void closeAll( Iterable<TopComponent> tcs ) {
         for (TopComponent curTC : tcs) {

--- a/platform/core.windows/src/org/netbeans/core/windows/actions/Bundle.properties
+++ b/platform/core.windows/src/org/netbeans/core/windows/actions/Bundle.properties
@@ -29,6 +29,9 @@ CTL_SwitchToRecentDocumentAction=&Editor
 
 CTL_CloseAllDocumentsAction=Close &All Documents
 
+CTL_CloseAllRightOfThisAction=Close Right
+CTL_CloseAllRightOfThisAction_MainMenu=Close All Documents Right Of This
+
 # UndockAction
 CTL_UndockWindowAction=&Float
 CTL_UndockWindowAction_Dock=Doc&k

--- a/platform/core.windows/src/org/netbeans/core/windows/actions/CloseAllRightOfThisAction.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/actions/CloseAllRightOfThisAction.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.core.windows.actions;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import static javax.swing.Action.NAME;
+import org.netbeans.core.windows.WindowManagerImpl;
+import org.openide.util.NbBundle;
+import org.openide.windows.TopComponent;
+
+/**
+ *
+ * @author davidwolf
+ */
+public class CloseAllRightOfThisAction extends AbstractAction {
+
+    /**
+     * TopComponent index to mark after which tab should all subsequent tabs be
+     * closed or -1 for the instance used in the Menu Bar
+     */
+    private int index;
+
+    /**
+     * Constructor used in Menu Bar menu called "Window" in the "Close All
+     * Documents Right Of This" option
+     */
+    public CloseAllRightOfThisAction() {
+        this(-1);
+    }
+
+    /**
+     * Constructor used by right clicking on an opened file.
+     *
+     * @param index
+     */
+    public CloseAllRightOfThisAction(int index) {
+        this.index = index;
+        String key = index == -1 ? "CTL_CloseAllRightOfThisAction_MainMenu" : "CTL_CloseAllRightOfThisAction";
+        putValue(NAME, NbBundle.getMessage(CloseAllRightOfThisAction.class, key));
+    }
+
+    @Override
+    public void actionPerformed(java.awt.event.ActionEvent ev) {
+        // index CANNOT be reassigned because this class is used in Menu Bar where the instance is not regenerated
+        if (index == -1) {
+            ActionUtils.closeRight(TopComponent.getRegistry().getActivated().getTabPosition());
+        } else {
+            ActionUtils.closeRight(index);
+        }
+    }
+
+    /**
+     * Overriden to share accelerator with
+     * org.netbeans.core.windows.actions.ActionUtils.CloseAllRightOfThisAction
+     */
+    @Override
+    public void putValue(String key, Object newValue) {
+        if (Action.ACCELERATOR_KEY.equals(key)) {
+            ActionUtils.putSharedAccelerator("CloseAllRightOfThisAction", newValue); //NOI18N
+        } else {
+            super.putValue(key, newValue);
+        }
+    }
+
+    /**
+     * Overriden to share accelerator with
+     * org.netbeans.core.windows.actions.ActionUtils.CloseAllRightOfThisAction
+     */
+    @Override
+    public Object getValue(String key) {
+        if (Action.ACCELERATOR_KEY.equals(key)) {
+            return ActionUtils.getSharedAccelerator("CloseAllRightOfThisAction"); //NOI18N
+        } else {
+            return super.getValue(key);
+        }
+    }
+    
+    @Override
+    public boolean isEnabled() {
+        WindowManagerImpl wmi = WindowManagerImpl.getInstance();
+        TopComponent tc = TopComponent.getRegistry().getActivated();
+        if (!wmi.isOpenedEditorTopComponent(tc)) {
+            return false;
+        }
+        int i = index == -1 ? tc.getTabPosition() : index;
+        return i != wmi.getEditorTopComponents().length - 1;
+    }
+
+}

--- a/platform/core.windows/src/org/netbeans/core/windows/resources/layer.xml
+++ b/platform/core.windows/src/org/netbeans/core/windows/resources/layer.xml
@@ -64,6 +64,7 @@
             <file name="org-netbeans-core-windows-actions-NextTabAction.instance"/>
             <file name="org-netbeans-core-windows-actions-PreviousTabAction.instance"/>
             <file name="org-netbeans-core-windows-actions-CloseAllButThisAction.instance"/>
+            <file name="org-netbeans-core-windows-actions-CloseAllRightOfThisAction.instance"/>
             <file name="org-netbeans-core-windows-actions-ToggleFullScreenAction.instance"/>
             <file name="org-netbeans-core-windows-actions-UndockWindowAction.instance"/>
             <file name="org-netbeans-core-windows-actions-DockWindowAction.instance"/>
@@ -256,6 +257,10 @@
             <file name="CloseAllButThisAction.shadow">
                 <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseAllButThisAction.instance"/>
                 <attr name="position" intvalue="20600"/>
+            </file>
+            <file name="CloseAllRightOfThisAction.shadow">
+                <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-windows-actions-CloseAllRightOfThisAction.instance"/>
+                <attr name="position" intvalue="20625"/>
             </file>
             <file name="GroupsMenuAction.shadow">
                 <attr name="originalFile" stringvalue="Actions/Window/GroupsMenuAction.instance"/>

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/TabbedHandler.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/TabbedHandler.java
@@ -30,11 +30,9 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-
 import org.netbeans.core.windows.Constants;
 import org.netbeans.core.windows.ModeImpl;
 import org.netbeans.core.windows.Switches;
@@ -329,7 +327,10 @@ public final class TabbedHandler implements ChangeListener, ActionListener {
             } else if (TabbedContainer.COMMAND_CLOSE_ALL_BUT_THIS == cmd) {
                 TopComponent tc = tabbed.getTopComponentAt(tae.getTabIndex());
                 ActionUtils.closeAllExcept(tc, true);
-            //Pin button handling here
+            } else if (TabbedContainer.COMMAND_CLOSE_RIGHT.equals(cmd)) {
+                TopComponent tc = tabbed.getTopComponentAt(tae.getTabIndex());
+                ActionUtils.closeRight(tc.getTabPosition());
+                //Pin button handling here
             } else if (TabbedContainer.COMMAND_ENABLE_AUTO_HIDE.equals(cmd)) {
                 if( Switches.isTopComponentSlidingEnabled() && tabbed.getComponent().isShowing() ) {
                     TopComponent tc = tabbed.getTopComponentAt(tae.getTabIndex());

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabbedContainer.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/TabbedContainer.java
@@ -19,11 +19,6 @@
 
 package org.netbeans.swing.tabcontrol;
 
-import javax.accessibility.Accessible;
-import org.netbeans.swing.tabcontrol.event.TabActionEvent;
-import org.netbeans.swing.tabcontrol.plaf.DefaultTabbedContainerUI;
-
-import javax.swing.*;
 import java.awt.*;
 import java.awt.event.AWTEventListener;
 import java.awt.event.ActionListener;
@@ -32,8 +27,12 @@ import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import javax.accessibility.Accessible;
 import javax.accessibility.AccessibleRole;
+import javax.swing.*;
 import javax.swing.JComponent.AccessibleJComponent;
+import org.netbeans.swing.tabcontrol.event.TabActionEvent;
+import org.netbeans.swing.tabcontrol.plaf.DefaultTabbedContainerUI;
 import org.openide.util.NbBundle;
 
 
@@ -192,6 +191,8 @@ public class TabbedContainer extends JComponent implements Accessible {
     public static final String COMMAND_CLOSE_ALL = "closeAll"; //NOI18N
 
     public static final String COMMAND_CLOSE_ALL_BUT_THIS = "closeAllButThis"; //NOI18N
+    
+    public static final String COMMAND_CLOSE_RIGHT = "closeRight"; //NOI18N
 
     public static final String COMMAND_ENABLE_AUTO_HIDE = "enableAutoHide"; //NOI18N
 


### PR DESCRIPTION
An implementation of https://github.com/apache/netbeans/issues/4710
Implements an Action seen in the popup shown when right-clicking an opened file and a button in the Menu Bar. (see screenshot) 

<img width="711" height="568" alt="screenshot" src="https://github.com/user-attachments/assets/9921aaf2-69be-499f-b30c-22407a9f5e7b" />

The Menu button is disabled when a different menu is selected.

## IMPORTANT
I also implemented the feature in https://github.com/wolftxt/netbeans/commit/ee5dff62c5502a3180efbe867f4c4832189acfac#diff-71678d0b96847081e80dbff752c8f8fbd5ddb104b0aca14c5f647b0d5577a890R330-R332 
and in
https://github.com/wolftxt/netbeans/commit/ee5dff62c5502a3180efbe867f4c4832189acfac#diff-bcff9302585f23230582eec38b02969456405f636b6c490c3e9c10e8c8c83e23R195
(Classes TabbedHandler and TabbedContainer)

Even through i don't think this part of the code does anything, but I implemented close right here as well just in case. I do not believe that this part of the code does anything because I was not able to reproduce any other string values of the cmd variable other than "select" or "popup".

Therefore I think that this part (along with all other parts of this method that depend on the variable cmd being any different than "select" or "popup") should be removed.
