### PR TITLE
Partial handling of module imports

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/OrganizeImports.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/OrganizeImports.java
@@ -37,6 +37,7 @@ import javax.tools.Diagnostic;
 
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.ImportTree;
 import com.sun.source.tree.MemberSelectTree;
@@ -160,10 +161,11 @@ public class OrganizeImports {
             }
         }
         final CodeStyle cs = CodeStyle.getDefault(copy.getFileObject());
-        Set<Element> starImports = new HashSet<Element>();
-        Set<Element> staticStarImports = new HashSet<Element>();
-        Set<Element> toImport = getUsedElements(copy, cu, starImports, staticStarImports);
-        List<ImportTree> imps = new LinkedList<ImportTree>();  
+        final Set<Element> starImports = new HashSet<>();
+        final Set<Element> staticStarImports = new HashSet<>();
+        final Set<Element> moduleImports = new HashSet<>();
+        Set<Element> toImport = getUsedElements(copy, cu, starImports, staticStarImports, moduleImports);
+        final List<ImportTree> imps = new LinkedList<>();  
         TreeMaker maker = copy.getTreeMaker();
         
         if (addImports != null) {
@@ -181,13 +183,13 @@ public class OrganizeImports {
                     Element importedScope = trees.getElement(TreePath.getPath(cu, ((MemberSelectTree)qualIdent).getExpression()));
                     
                     if (importTree.isStatic()) {
-                        if (staticStarImports != null && 
+                        if (!staticStarImports.isEmpty() && 
                             staticStarImports.contains(importedScope) &&
                             !starImportScopes.contains(importedScope)) {
                             imp = maker.Import(qualIdent, true);
                         }
                     } else {
-                        if (starImports != null && 
+                        if (!starImports.isEmpty() && 
                             starImports.contains(importedScope) &&
                             !starImportScopes.contains(importedScope)) {
                             imp = maker.Import(qualIdent, false);
@@ -196,6 +198,14 @@ public class OrganizeImports {
                     if (imp != null) {
                         starImportScopes.add(importedScope);
                         imps.add(imp);
+                    }
+                } else if (importTree.isModule()) {
+                    Element importedScope = copy.getElements().getModuleElement(qualIdent.toString());
+                    if ((qualIdent instanceof ExpressionTree) &&
+                        !moduleImports.isEmpty() &&
+                        moduleImports.contains(importedScope) &&
+                        !starImportScopes.contains(importedScope)) {
+                        imps.add(maker.ImportModule((ExpressionTree)qualIdent));
                     }
                 }
             }
@@ -213,21 +223,27 @@ public class OrganizeImports {
                         return 0;
                     String s1 = o1.getQualifiedIdentifier().toString();
                     String s2 = o2.getQualifiedIdentifier().toString();
-                    int bal = groups.getGroupId(s1, o1.isStatic()) - groups.getGroupId(s2, o2.isStatic());
+                    int bal;
+                    if (o1.isModule()) bal = o2.isModule() ? 0 : 1; // Place module imports last
+                    else if (o2.isModule()) bal = -1;               // Place module imports last
+                    else bal = groups.getGroupId(s1, o1.isStatic()) - groups.getGroupId(s2, o2.isStatic());
                     return bal == 0 ? s1.compareTo(s2) : bal;
                 }
             });
         }
         CompilationUnitTree cut = maker.CompilationUnit(cu.getPackageAnnotations(), cu.getPackageName(), imps, cu.getTypeDecls(), cu.getSourceFile());
         ((JCCompilationUnit)cut).packge = ((JCCompilationUnit)cu).packge;
-        if (starImports != null || staticStarImports != null) {
+        if (!starImports.isEmpty() || !staticStarImports.isEmpty()) {
             ((JCCompilationUnit)cut).starImportScope = ((JCCompilationUnit)cu).starImportScope;
+        }
+        if (!moduleImports.isEmpty()) {
+            ((JCCompilationUnit)cut).moduleImportScope = ((JCCompilationUnit)cu).moduleImportScope;
         }
         CompilationUnitTree ncu = toImport.isEmpty() ? cut : GeneratorUtilities.get(copy).addImports(cut, toImport);
         copy.rewrite(cu, ncu);
     }
 
-    private static Set<Element> getUsedElements(final CompilationInfo info, final CompilationUnitTree cut, final Set<Element> starImports, final Set<Element> staticStarImports) {
+    private static Set<Element> getUsedElements(final CompilationInfo info, final CompilationUnitTree cut, final Set<Element> starImports, final Set<Element> staticStarImports, final Set<Element> moduleImports) {
         final Set<Element> ret = new HashSet<Element>();
         final Trees trees = info.getTrees();
         final Types types = info.getTypes();
@@ -273,7 +289,7 @@ public class OrganizeImports {
                         case FIELD:
                         case METHOD:
                             if (element.getModifiers().contains(Modifier.STATIC)) {
-                                Element glob = global(element, staticStarImports);
+                                Element glob = global(element, staticStarImports, moduleImports);
                                 if (glob != null)
                                     ret.add(glob);
                             }
@@ -283,14 +299,14 @@ public class OrganizeImports {
                         case RECORD:
                         case ENUM:
                         case INTERFACE:
-                            Element glob = global(element, starImports);
+                            Element glob = global(element, starImports, moduleImports);
                             if (glob != null)
                                 ret.add(glob);
                     }
                 }
             }
 
-            private Element global(Element element, Set<Element> stars) {
+            private Element global(Element element, Set<Element> stars, Set<Element> modules) {
                 for (Symbol sym : ((JCCompilationUnit)cut).namedImportScope.getSymbolsByName((Name)element.getSimpleName())) {
                     if (element == sym || element.asType().getKind() == TypeKind.ERROR && element.getKind() == sym.getKind())
                         return sym;
@@ -303,6 +319,14 @@ public class OrganizeImports {
                     if (element == sym || element.asType().getKind() == TypeKind.ERROR && element.getKind() == sym.getKind()) {
                         if (stars != null) {
                             stars.add(sym.owner);
+                        }
+                        return sym;
+                    }
+                }
+                for (Symbol sym : ((JCCompilationUnit)cut).moduleImportScope.getSymbolsByName((Name)element.getSimpleName())) {
+                    if (element == sym || element.asType().getKind() == TypeKind.ERROR && element.getKind() == sym.getKind()) {
+                        if (modules != null) {
+                            modules.add(sym.packge().modle);
                         }
                         return sym;
                     }

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/OrganizeImportsTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/OrganizeImportsTest.java
@@ -72,4 +72,200 @@ public class OrganizeImportsTest extends NbTestCase {
                               "     Button b;\n" +
                               "}\n");
     }
+    
+    public void testModuleSimple() throws Exception {
+        HintTest.create()
+                .sourceLevel(25)
+                .input("""
+                       package test;
+                       import module java.base;
+                       import java.util.ArrayList;
+                       public class Test {
+                            List l = new ArrayList();
+                       }
+                       """)
+                .run(OrganizeImports.class)
+                .findWarning("2:0-2:27:verifier:MSG_OragnizeImports")
+                .applyFix()
+                .assertOutput("""
+                              package test;
+                              import module java.base;
+                              public class Test {
+                                   List l = new ArrayList();
+                              }
+                              """);
+    }
+    
+    public void testModuleSimpleAllNamed() throws Exception {
+        HintTest.create()
+                .sourceLevel(25)
+                .input("""
+                       package test;
+                       import java.util.List;
+                       import module java.base;
+                       import java.util.ArrayList;
+                       public class Test {
+                            List l = new ArrayList();
+                       }
+                       """)
+                .run(OrganizeImports.class)
+                .findWarning("1:0-1:22:verifier:MSG_OragnizeImports")
+                .applyFix()
+                .assertOutput("""
+                              package test;
+                              import java.util.ArrayList;
+                              import java.util.List;
+                              public class Test {
+                                   List l = new ArrayList();
+                              }
+                              """);
+    }
+    
+    public void testModuleSimpleAllStar() throws Exception {
+        HintTest.create()
+                .sourceLevel(25)
+                .input("""
+                       package test;
+                       import java.util.List;
+                       import module java.base;
+                       import java.util.*;
+                       public class Test {
+                            List l = new ArrayList();
+                       }
+                       """)
+                .run(OrganizeImports.class)
+                .findWarning("1:0-1:22:verifier:MSG_OragnizeImports")
+                .applyFix()
+                .assertOutput("""
+                              package test;
+                              import java.util.*;
+                              public class Test {
+                                   List l = new ArrayList();
+                              }
+                              """);
+    }
+
+    public void testModuleSimpleWithStar() throws Exception {
+        HintTest.create()
+                .sourceLevel(25)
+                .input("""
+                       package test;
+                       import java.util.List;
+                       import module java.base;
+                       import java.util.*;
+                       public class Test {
+                            Consumer<String> print = System.out::println;
+                            List<String> l = new ArrayList<>();
+                            private void printAll() { l.forEach(print); }
+                       }
+                       """)
+                .run(OrganizeImports.class)
+                .findWarning("1:0-1:22:verifier:MSG_OragnizeImports")
+                .applyFix()
+                .assertOutput("""
+                              package test;
+                              import java.util.*;
+                              import module java.base;
+                              public class Test {
+                                   Consumer<String> print = System.out::println;
+                                   List<String> l = new ArrayList<>();
+                                   private void printAll() { l.forEach(print); }
+                              }
+                              """);
+    }
+
+    public void testModuleSimpleWithStarAndStatic() throws Exception {
+        HintTest.create()
+                .sourceLevel(25)
+                .input("""
+                       package test;
+                       import java.util.List;
+                       import module java.base;
+                       import static java.util.List.of;
+                       import java.util.*;
+                       public class Test {
+                            Consumer<String> print = System.out::println;
+                            List<String> l = new ArrayList<>();
+                            private void printAll() { of("abc","def").forEach(print); }
+                       }
+                       """)
+                .run(OrganizeImports.class)
+                .findWarning("1:0-1:22:verifier:MSG_OragnizeImports")
+                .applyFix()
+                .assertOutput("""
+                              package test;
+                              import java.util.*;
+                              import static java.util.List.of;
+                              import module java.base;
+                              public class Test {
+                                   Consumer<String> print = System.out::println;
+                                   List<String> l = new ArrayList<>();
+                                   private void printAll() { of("abc","def").forEach(print); }
+                              }
+                              """);
+    }
+
+    public void testModuleClashing() throws Exception {
+        HintTest.create()
+                .sourceLevel(25)
+                .input("""
+                       package test;
+                       import module java.desktop;
+                       import java.util.List;
+                       import module java.base;
+                       public class Test {
+                            List l = new ArrayList();
+                            Button b;
+                       }
+                       """)
+                .run(OrganizeImports.class)
+                .findWarning("1:0-1:27:verifier:MSG_OragnizeImports")
+                .applyFix()
+                .assertOutput("""
+                              package test;
+                              import java.util.List;
+                              import module java.base;
+                              import module java.desktop;
+                              public class Test {
+                                   List l = new ArrayList();
+                                   Button b;
+                              }
+                              """);
+    }
+
+    public void testModuleClashing2() throws Exception {
+        HintTest.create()
+                .sourceLevel(25)
+                .input("""
+                       package test;
+                       import module java.desktop;
+                       import java.util.List;
+                       import static java.util.List.of;
+                       import module java.base;
+                       public class Test {
+                           List<String> l = new ArrayList<>(of("abc", "xyz", "def"));
+                           Button b;
+                           public Test() {
+                               l.sort(Comparator.naturalOrder());
+                           }
+                       }
+                       """)
+                .run(OrganizeImports.class)
+                .findWarning("1:0-1:27:verifier:MSG_OragnizeImports")
+                .applyFix()
+                .assertOutput("""
+                              package test;
+                              import java.util.List;
+                              import static java.util.List.of;
+                              import module java.base;
+                              import module java.desktop;
+                              public class Test {
+                                  List<String> l = new ArrayList<>(of("abc", "xyz", "def"));
+                                  Button b;
+                                  public Test() {
+                                      l.sort(Comparator.naturalOrder());
+                                  }
+                              }
+                              """);
+    }
 }

--- a/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
@@ -83,6 +83,7 @@ import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -93,6 +94,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
@@ -1088,15 +1090,20 @@ public final class GeneratorUtilities {
     }
 
     private CompilationUnitTree addImports(CompilationUnitTree cut, List<? extends ImportTree> cutImports, Set<? extends Element> toImport) {
-        assert cut != null && toImport != null && toImport.size() > 0;
+        assert cut != null && toImport != null && !toImport.isEmpty();
 
-        ArrayList<Element> elementsToImport = new ArrayList<Element>(toImport.size());
-        Set<String> staticImportNames = new HashSet<String>();
+        ArrayList<Element> elementsToImport = new ArrayList<>(toImport.size());
+        Set<ModuleElement> modulesToImport = new LinkedHashSet<>();
+        Set<String> staticImportNames = new HashSet<>();
         for (Element e : toImport) {
             if (e == null) {
                 continue;
             }
             switch (e.getKind()) {
+                case MODULE:
+                    modulesToImport.add((ModuleElement)e);
+                    elementsToImport.add(e);
+                    break;
                 case METHOD:
                 case ENUM_CONSTANT:
                 case FIELD:
@@ -1117,7 +1124,7 @@ public final class GeneratorUtilities {
         // check weather any conversions to star imports are needed
         int treshold = cs.useSingleClassImport() ? cs.countForUsingStarImport() : 1;
         int staticTreshold = cs.countForUsingStaticStarImport();        
-        Map<PackageElement, Integer> pkgCounts = new LinkedHashMap<PackageElement, Integer>();
+        Map<PackageElement, Integer> pkgCounts = new LinkedHashMap<>();
         PackageElement pkg = elements.getPackageElement("java.lang"); //NOI18N
         if (pkg != null) {
             pkgCounts.put(pkg, -2);
@@ -1131,17 +1138,22 @@ public final class GeneratorUtilities {
             pkg = elements.getPackageElement(elements.getName("")); //NOI18N
         }
         pkgCounts.put(pkg, -2);
-        Map<TypeElement, Integer> typeCounts = new LinkedHashMap<TypeElement, Integer>();
+        Map<TypeElement, Integer> typeCounts = new LinkedHashMap<>();
         // initially the import scope has no symbols. We must fill it in by:
-        // existing CUT named imports, package members AND then star imports, in this specific order
+        // existing CUT named imports, package members AND then star imports AND then module imports, in this specific order
         JCCompilationUnit jcut = (JCCompilationUnit)cut;
         StarImportScope importScope = new StarImportScope((Symbol)pkg);
+        if (jcut.moduleImportScope != null) {
+            importScope.prependSubScope(((JCCompilationUnit)cut).moduleImportScope);
+        }
         if (jcut.starImportScope != null) {
             importScope.prependSubScope(((JCCompilationUnit)cut).starImportScope);
         }
         if (jcut.packge != null) {
             importScope.prependSubScope(jcut.packge.members_field);
         }
+        // capture module counts if module imports are present
+        Map<ModuleElement, Integer> modCounts = jcut.moduleImportScope != null || !modulesToImport.isEmpty() ? new LinkedHashMap<>() : null;
         for (Element e : elementsToImport) {
             boolean isStatic = false;
             Element el = null;
@@ -1162,6 +1174,10 @@ public final class GeneratorUtilities {
                 case FIELD:
                     isStatic = true;
                     el = e.getEnclosingElement();
+                    break;
+                case MODULE:
+                    if (modCounts != null)
+                        modCounts.merge((ModuleElement)e, 1, Integer::sum);
                     break;
                 default:
                     assert false : "Illegal element kind: " + e.getKind(); //NOI18N
@@ -1187,11 +1203,29 @@ public final class GeneratorUtilities {
                     typeCounts.put((TypeElement)el, cnt);
                 } else {
                     pkgCounts.put((PackageElement)el, cnt);
+                    if (cnt >= -1 && modCounts != null) {
+                        ModuleElement ml = elements.getModuleOf(e);
+                        if (ml != null) {
+                            modCounts.merge(ml, 1, Integer::sum);
+                        }
+                    }
                 }
             }
         }
-        List<ImportTree> imports = new ArrayList<ImportTree>(cutImports);
+        List<ImportTree> imports = new ArrayList<>(cutImports);
         for (ImportTree imp : imports) {
+            if (imp.isModule()) {
+                // For module imports, no conversion thresholds to be checked, unlike star imports.
+                // The module imports should be retained, if in use; 
+                // even when the current usage is covered by existing named/star imports, 
+                // because more module classes may be used in the future.
+                if (modCounts != null) {
+                    ModuleElement m = elements.getModuleElement(imp.getQualifiedIdentifier().toString());
+                    if (m != null) modCounts.replace(m, -2); // -2 = do not touch the module import
+                    modulesToImport.remove(m);
+                    continue;
+                }
+            }
             Element e = getImportedElement(cut, imp);
             if (!elementsToImport.contains(e)) {
                 if (imp.isStatic()) {
@@ -1253,6 +1287,16 @@ public final class GeneratorUtilities {
         // remove those star imports that do not satisfy the thresholds
         for (Iterator<ImportTree> ii = imports.iterator(); ii.hasNext();) {
             ImportTree imp = ii.next();
+            if (imp.isModule()) {
+                if (modCounts != null) {
+                    // remove module imports if they are unused
+                    ModuleElement m = elements.getModuleElement(imp.getQualifiedIdentifier().toString());
+                    if (m != null && !modCounts.containsKey(m)) {
+                        ii.remove();
+                    }
+                }
+                continue;
+            }
             if (!isStarImport(imp)) {
                 continue;
             }
@@ -1268,8 +1312,21 @@ public final class GeneratorUtilities {
             }
         }
         
-        // check for possible name clashes originating from adding the package imports
-        Set<Element> explicitNamedImports = new HashSet<Element>();
+        // Add modulesToImport to the importScope, to check name clashes, if any
+        if (!modulesToImport.isEmpty()) {
+            for (ModuleElement m : modulesToImport) {
+                for (Element e : m.getEnclosedElements()) {
+                    if (e instanceof Symbol p) {
+                        importScope.appendSubScope(p.members());
+                    }
+                }
+                if (modCounts != null) {
+                    modCounts.replace(m, -1);
+                }
+            }
+        }        
+        // check for possible name clashes originating from adding the package or module imports
+        Set<Element> explicitNamedImports = new HashSet<>();
         for (Element element : elementsToImport) {
             if (element.getEnclosingElement() != pkg && (element.getKind().isClass() || element.getKind().isInterface())) {
                 for (Symbol sym : importScope.getSymbolsByName((com.sun.tools.javac.util.Name)element.getSimpleName())) {
@@ -1355,13 +1412,32 @@ public final class GeneratorUtilities {
                     el = currentToImportElement.getEnclosingElement();
                     break;
             }
-            Integer cnt = el == null ? Integer.valueOf(0) : isStatic ? typeCounts.get((TypeElement)el) : pkgCounts.get((PackageElement)el);
-            if (explicitNamedImports.contains(currentToImportElement))
+            final int cnt;
+            if (explicitNamedImports.contains(currentToImportElement)) {
                 cnt = 0;
+            } else {
+                Integer enclosingStarCnt = el == null ? null : isStatic ? typeCounts.get((TypeElement)el) :  pkgCounts.get((PackageElement)el);
+                if (isStatic) {
+                    cnt = enclosingStarCnt == null ? 0 : enclosingStarCnt;
+                } else {
+                    int modCount = 0;
+                    if (modCounts != null) {
+                        ModuleElement m = elements.getModuleOf(currentToImportElement);
+                        Integer mc = m == null ? null : modCounts.get(m);
+                        if (mc != null && mc < 0) {
+                            // No need to add an import unless a self import
+                            modCount = mc == -1 && m == currentToImportElement ? -1 : -2;
+                            if (el != null) pkgCounts.replace((PackageElement)el, -2);
+                        }
+                    }
+                    cnt = modCount < 0 ? modCount : enclosingStarCnt == null ? 0 : enclosingStarCnt;
+                }
+            }
+
             if (cnt == -2) {
                 currentToImport--;
             } else {
-                if (cnt == -1) {
+                if (cnt == -1 && el != null) {
                     currentToImportElement = el;
                     if (isStatic) {
                         typeCounts.put((TypeElement)el, -2);
@@ -1375,7 +1451,7 @@ public final class GeneratorUtilities {
                 if (isStar) {
                     qualIdent = make.MemberSelect(qualIdent, elements.getName("*")); //NOI18N
                 }
-                ImportTree nImport = make.Import(qualIdent, isStatic);
+                ImportTree nImport = currentToImportElement.getKind() == ElementKind.MODULE ? make.ImportModule(qualIdent) : make.Import(qualIdent, isStatic);
                 while (currentExisting >= 0) {
                     ImportTree imp = imports.get(currentExisting);
                     Element impElement = getImportedElement(cut, imp);
@@ -1903,7 +1979,9 @@ public final class GeneratorUtilities {
     
     private ExpressionTree qualIdentFor(Element e) {
         TreeMaker tm = copy.getTreeMaker();
-        if (e.getKind() == ElementKind.PACKAGE) {
+        if (e.getKind() == ElementKind.MODULE) {
+            return qualIdentFor(((ModuleElement)e).getQualifiedName().toString());
+        } else if (e.getKind() == ElementKind.PACKAGE) {
             String name = ((PackageElement)e).getQualifiedName().toString();
             if (e instanceof Symbol) {
                 int lastDot = name.lastIndexOf('.');
@@ -2124,12 +2202,13 @@ public final class GeneratorUtilities {
                 return 0;
             
             boolean isStatic1 = false;
+            boolean isModule1 = false;
             StringBuilder sb1 = new StringBuilder();
-            if (o1 instanceof ImportTree) {
-                isStatic1 = ((ImportTree)o1).isStatic();
-                sb1.append(((ImportTree)o1).getQualifiedIdentifier().toString());
-            } else if (o1 instanceof Element) {
-                Element e1 = (Element)o1;
+            if (o1 instanceof ImportTree it1) {
+                isStatic1 = it1.isStatic();
+                isModule1 = it1.isModule();
+                sb1.append(it1.getQualifiedIdentifier().toString());
+            } else if (o1 instanceof Element e1) {
                 if (e1.getKind().isField() || e1.getKind() == ElementKind.METHOD) {
                     sb1.append('.').append(e1.getSimpleName());
                     e1 = e1.getEnclosingElement();
@@ -2139,17 +2218,21 @@ public final class GeneratorUtilities {
                     sb1.insert(0, ((TypeElement)e1).getQualifiedName());
                 } else if (e1.getKind() == ElementKind.PACKAGE) {
                     sb1.insert(0, ((PackageElement)e1).getQualifiedName());
+                } else if (e1.getKind() == ElementKind.MODULE) {
+                    isModule1 = true;
+                    sb1.insert(0, ((ModuleElement)e1).getQualifiedName());
                 }
             }
             String s1 = sb1.toString();
                 
             boolean isStatic2 = false;
+            boolean isModule2 = false;
             StringBuilder sb2 = new StringBuilder();
-            if (o2 instanceof ImportTree) {
-                isStatic2 = ((ImportTree)o2).isStatic();
-                sb2.append(((ImportTree)o2).getQualifiedIdentifier().toString());
-            } else if (o2 instanceof Element) {
-                Element e2 = (Element)o2;
+            if (o2 instanceof ImportTree it2) {
+                isStatic2 = it2.isStatic();
+                isModule2 = it2.isModule();
+                sb2.append(it2.getQualifiedIdentifier().toString());
+            } else if (o2 instanceof Element e2) {
                 if (e2.getKind().isField() || e2.getKind() == ElementKind.METHOD) {
                     sb2.append('.').append(e2.getSimpleName());
                     e2 = e2.getEnclosingElement();
@@ -2159,11 +2242,17 @@ public final class GeneratorUtilities {
                     sb2.insert(0, ((TypeElement)e2).getQualifiedName());
                 } else if (e2.getKind() == ElementKind.PACKAGE) {
                     sb2.insert(0, ((PackageElement)e2).getQualifiedName());
+                } else if (e2.getKind() == ElementKind.MODULE) {
+                    isModule2 = true;
+                    sb2.insert(0, ((ModuleElement)e2).getQualifiedName());
                 }
             }
             String s2 = sb2.toString();
 
-            int bal = groups.getGroupId(s1, isStatic1) - groups.getGroupId(s2, isStatic2);
+            int bal;
+            if (isModule1) bal = isModule2 ? 0 : 1;     // Place module imports last
+            else if (isModule2) bal = -1;               // Place module imports last
+            else bal = groups.getGroupId(s1, isStatic1) - groups.getGroupId(s2, isStatic2);
 
             return bal == 0 ? s1.compareTo(s2) : bal;
         }

--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
@@ -100,6 +100,7 @@ import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
 import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
 import com.sun.tools.javac.tree.JCTree.JCModifiers;
 import com.sun.tools.javac.tree.JCTree.JCModuleDecl;
+import com.sun.tools.javac.tree.JCTree.JCModuleImport;
 import com.sun.tools.javac.tree.JCTree.JCNewArray;
 import com.sun.tools.javac.tree.JCTree.JCNewClass;
 import com.sun.tools.javac.tree.JCTree.JCOpens;
@@ -934,6 +935,18 @@ public class CasualDiff {
                 printer.print("static ");
             }
         }
+        localPointer = diffTree(oldT.getQualifiedIdentifier(), newT.getQualifiedIdentifier(), qualBounds);
+        copyTo(localPointer, bounds[1]);
+
+        return bounds[1];
+    }
+
+    protected int diffModuleImport(JCModuleImport oldT, JCModuleImport newT, int[] bounds) {
+        int localPointer = bounds[0];
+
+        int[] qualBounds = getBounds(oldT.getQualifiedIdentifier());
+        assert oldT.isModule() == newT.isModule();
+        copyTo(localPointer, qualBounds[0]);
         localPointer = diffTree(oldT.getQualifiedIdentifier(), newT.getQualifiedIdentifier(), qualBounds);
         copyTo(localPointer, bounds[1]);
 
@@ -3287,6 +3300,8 @@ public class CasualDiff {
               return ((JCCompilationUnit)t1).sourcefile.equals(((JCCompilationUnit)t2).sourcefile);
           case IMPORT:
               return matchImport((JCImport)t1, (JCImport)t2);
+          case MODULEIMPORT:
+              return matchModuleImport((JCModuleImport)t1, (JCModuleImport)t2);
           case CLASSDEF:
               return ((JCClassDecl)t1).sym == ((JCClassDecl)t2).sym;
           case METHODDEF:
@@ -5676,6 +5691,9 @@ public class CasualDiff {
           case IMPORT:
               retVal = diffImport((JCImport)oldT, (JCImport)newT, elementBounds);
               break;
+          case MODULEIMPORT:
+              retVal = diffModuleImport((JCModuleImport)oldT, (JCModuleImport)newT, elementBounds);
+              break;
           case CLASSDEF:
               retVal = diffClassDef((JCClassDecl)oldT, (JCClassDecl)newT, elementBounds);
               break;
@@ -5976,6 +5994,10 @@ public class CasualDiff {
 
     private boolean matchImport(JCImport t1, JCImport t2) {
         return t1.staticImport == t2.staticImport && treesMatch(t1.qualid, t2.qualid);
+    }
+
+    private boolean matchModuleImport(JCModuleImport t1, JCModuleImport t2) {
+        return treesMatch(t1.getQualifiedIdentifier(), t2.getQualifiedIdentifier());
     }
 
     private boolean matchBlock(JCBlock t1, JCBlock t2) {

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/GeneratorUtilitiesTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/GeneratorUtilitiesTest.java
@@ -610,6 +610,88 @@ public class GeneratorUtilitiesTest extends NbTestCase {
         }, false);
     }
 
+    public void testAddImportsWithModule1() throws Exception {
+        performTest("test/Process.java", "package test;\nimport java.util.Collections;\npublic class Process {\npublic static void main(String... args) {\n" +
+        "Collections.singleton(Process.class).forEach(System.out::println);\n}\n}", "25", new AddImportsTask(false, List.of("java.base"), "test.Process"), new Validator() {
+            public void validate(CompilationInfo info) {
+                assertEquals(0, info.getDiagnostics().size());
+                List<? extends ImportTree> imports = info.getCompilationUnit().getImports();
+                assertEquals(2, imports.size());
+                assertEquals("java.util.Collections", imports.get(0).getQualifiedIdentifier().toString());
+                assertTrue(imports.get(1).isModule());
+                assertEquals("java.base", imports.get(1).getQualifiedIdentifier().toString());
+            }
+        }, false);
+    }
+
+    public void testAddImportsWithModule2() throws Exception {
+        performTest("package test;\nimport java.util.List;\nimport javax.swing.JLabel;\npublic class Test { }\n", "25", new AddImportsTask(false, List.of("java.base", "java.desktop"), "javax.swing.JTable", "java.util.ArrayList"), new Validator() {
+            public void validate(CompilationInfo info) {
+                assertEquals(0, info.getDiagnostics().size());
+                List<? extends ImportTree> imports = info.getCompilationUnit().getImports();
+                assertEquals(4, imports.size());
+                assertEquals("java.util.List", imports.get(0).getQualifiedIdentifier().toString());
+                assertEquals("javax.swing.JLabel", imports.get(1).getQualifiedIdentifier().toString());
+                assertTrue(imports.get(2).isModule());
+                assertEquals("java.base", imports.get(2).getQualifiedIdentifier().toString());
+                assertTrue(imports.get(3).isModule());
+                assertEquals("java.desktop", imports.get(3).getQualifiedIdentifier().toString());
+            }
+        }, false);
+    }
+
+    public void testAddImportsWithModule3() throws Exception {
+        performTest("package test;\nimport javax.swing.JLabel;\nimport module java.base;\npublic class Test { }\n", "25", new AddImportsTask(false, List.of("java.base", "java.desktop"), "java.util.List", "java.util.ArrayList"), new Validator() {
+            public void validate(CompilationInfo info) {
+                assertEquals(0, info.getDiagnostics().size());
+                List<? extends ImportTree> imports = info.getCompilationUnit().getImports();
+                assertEquals(4, imports.size());
+                assertEquals("java.util.List", imports.get(0).getQualifiedIdentifier().toString());
+                assertEquals("javax.swing.JLabel", imports.get(1).getQualifiedIdentifier().toString());
+                assertTrue(imports.get(2).isModule());
+                assertEquals("java.base", imports.get(2).getQualifiedIdentifier().toString());
+                assertTrue(imports.get(3).isModule());
+                assertEquals("java.desktop", imports.get(3).getQualifiedIdentifier().toString());
+            }
+        }, false);
+    }
+
+    public void testAddImportsWithModule4() throws Exception {
+        Preferences preferences = MimeLookup.getLookup(JavaTokenId.language().mimeType()).lookup(Preferences.class);
+        preferences.putBoolean("allowConvertToStarImport", true);
+        performTest("package test;\nimport java.awt.*;\nimport java.util.List;\nimport module java.base;\npublic class Test {\nprivate void op(List list) {\nint size = list.size();\n}\n}\n", "25", new AddImportsTask("java.util.AbstractList", "java.util.ArrayList", "java.util.Collection", "java.util.Collections"), new Validator() {
+            public void validate(CompilationInfo info) {
+                assertEquals(0, info.getDiagnostics().size());
+                List<? extends ImportTree> imports = info.getCompilationUnit().getImports();
+                assertEquals(3, imports.size());
+                assertEquals("java.awt.*", imports.get(0).getQualifiedIdentifier().toString());
+                assertEquals("java.util.List", imports.get(1).getQualifiedIdentifier().toString());
+                assertTrue(imports.get(2).isModule());
+                assertEquals("java.base", imports.get(2).getQualifiedIdentifier().toString());
+            }
+        }, false);
+        preferences.putBoolean("allowConvertToStarImport", false);
+    }
+
+    public void testAddImportsWithModule5() throws Exception {
+        Preferences preferences = MimeLookup.getLookup(JavaTokenId.language().mimeType()).lookup(Preferences.class);
+        preferences.putBoolean("allowConvertToStarImport", true);
+        performTest("package test;\nimport java.util.List;\npublic class Test {\nprivate List l = new ArrayList<>();\nprivate Button b;\n private void op(List list) {\nint size = list.size();\n}\n}\n", "25", new AddImportsTask(false, List.of("java.desktop", "java.base"), "java.awt.Button", "java.util.AbstractList", "java.util.ArrayList", "java.util.Collection", "java.util.Collections"), new Validator() {
+            public void validate(CompilationInfo info) {
+                assertEquals(0, info.getDiagnostics().size());
+                List<? extends ImportTree> imports = info.getCompilationUnit().getImports();
+                assertEquals(3, imports.size());
+                assertEquals("java.util.List", imports.get(0).getQualifiedIdentifier().toString());
+                assertTrue(imports.get(1).isModule());
+                assertEquals("java.base", imports.get(1).getQualifiedIdentifier().toString());
+                assertTrue(imports.get(2).isModule());
+                assertEquals("java.desktop", imports.get(2).getQualifiedIdentifier().toString());
+            }
+        }, false);
+        preferences.putBoolean("allowConvertToStarImport", false);
+    }
+
+
     public void testGetterNamingConvention0() throws Exception {//#165241
         performTest("package test;\npublic class Test {\nprivate int eMai;\npublic Test(){\n}\n }\n", new GetterSetterTask(34, false), new Validator() {
 
@@ -1156,6 +1238,7 @@ public class GeneratorUtilitiesTest extends NbTestCase {
 
         private final boolean incremental;
         private String[] toImport;
+        private List<String> toImportModules;
         
         public AddImportsTask(String... toImport) {
             this(false, toImport);
@@ -1164,6 +1247,13 @@ public class GeneratorUtilitiesTest extends NbTestCase {
         public AddImportsTask(boolean incremental, String... toImport) {
             this.incremental = incremental;
             this.toImport = toImport;
+            this.toImportModules = List.of();
+        }
+
+        public AddImportsTask(boolean incremental, List<String> toImportModules, String... toImport) {
+            this.incremental = incremental;
+            this.toImport = toImport;
+            this.toImportModules = toImportModules == null ? List.of() : toImportModules;
         }
 
         public void cancel() {
@@ -1202,6 +1292,12 @@ public class GeneratorUtilitiesTest extends NbTestCase {
                 if (incremental) {
                     newCut = utilities.addImports(newCut, Collections.singleton(el));
                 } else {
+                    imports.add(el);
+                }
+            }
+            for (String imp : toImportModules) {
+                Element el = elements.getModuleElement(imp);
+                if (el != null) {
                     imports.add(el);
                 }
             }


### PR DESCRIPTION
Added further handling and support for module imports, especially with regards to `OrganizeImports`.

1. Enhanced support for module imports in java.source/CasualDiff to allow re-ordering of imports.
2. Enhanced java.hints/OrganizeImports to support the presence of module imports in checking for usage, and, transferring the module import scope. Also included sort comparison for module imports, adding them as the last group.
    - This avoids removal of module imports from java source files, especially due if the setting is enabled to organize imports on save.
4. Enhanced java.source/GeneratorUtilities.addImports() to support the writing of existing module imports in the compilation unit, as well as, the addition of module imports if needed in the future by any hint/completion. This includes:
    - checking for the usage of a module import.
    - checking for simple name clashes in the consolidated import scope which includes module imports now, for adding as named imports.
    - sorting comparison for module imports (added as the last group).



---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [ ] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [ ] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [ ] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [ ] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>