### PR TITLE
Fix launch.json behavior and hanging issue with multiple main classes

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
@@ -571,7 +571,7 @@ public abstract class NbLaunchDelegate {
             mainSource = false;
         } else {
             FileObject fileRoot = sourceCP != null ? sourceCP.findOwnerRoot(toRun) : null;
-            mainSource = fileRoot != null && UnitTestForSourceQuery.findUnitTests(fileRoot).length > 0;
+            mainSource = fileRoot == null || UnitTestForSourceQuery.findSources(fileRoot).length == 0;
         }
         ActionProvider provider = null;
         String command = null;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
@@ -32,6 +32,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -70,7 +72,7 @@ import org.openide.util.lookup.Lookups;
  * @author martin
  */
 public final class NbLaunchRequestHandler {
-
+    private static final Logger LOG = Logger.getLogger(NbLaunchRequestHandler.class.getName());
     private NbLaunchDelegate activeLaunchHandler;
 
     public CompletableFuture<Void> launch(Map<String, Object> launchArguments, DebugAdapterContext context) {
@@ -148,7 +150,10 @@ public final class NbLaunchRequestHandler {
                         case 1:
                             handleSelectedMainClass.accept(mainClasses.get(0));
                             break;
-                        case 2:
+                        default:
+                            if(mainClasses.size() > 10){
+                                LOG.log(Level.WARNING, "The number of main classes is large :{0}", mainClasses.size());
+                            }
                             List<NotifyDescriptor.QuickPick.Item> mainClassItems =
                                     mainClasses.stream()
                                                .map(eh -> new Item(eh.getQualifiedName(), eh.getQualifiedName()))


### PR DESCRIPTION
- Restore correct source selection when running from `launch.json`:
Previously, after the fix in #8470, a regression was introduced where running a `launch.json` configuration would execute a test source if a non-Java file was opened in the editor. This PR restores the original behavior so that the main source is executed instead of a test source when launching from `launch.json`.

- Fix hanging when multiple main classes exist:
When there are more than two main classes in the project, and `Run and Debug` is triggered without specifying `mainClass` in `launch.json` (or when no file is open in the editor), the launch process used to hang indefinitely. This PR prevents that by handling the ambiguity gracefully, avoiding a hang and prompting the user as needed.