### PR TITLE
Fix parameter field buttons in Change Method Parameters UI in Language Server

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/ui/ChangeMethodParameters.html
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/ui/ChangeMethodParameters.html
@@ -63,7 +63,7 @@
         </div>
     </div>
     <div class="add-param flex">
-        <button id="addParam" class="silent-button codicon codicon-add full-width flex-grow" data-bind="click: addParameter"><span class="button-text vscode-font">Add Parameter</span></button>
+        <button id="addParam" class="silent-button codicon codicon-add full-width flex-grow" data-bind="click: addParameter"><span class="button-text vscode-font"> Add Parameter</span></button>
     </div>
     <div class="section">
         <label>Signature preview:</label>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/ui/refactoring.css
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/ui/refactoring.css
@@ -115,19 +115,22 @@ label {
 }
 .action-button {
     border: none;
-    border-radius: 4px;
-	padding: 2px;
-	margin: 3px 0px;
+    padding: 4px 10px 4px 10px;
+    margin: 2px;
     color: var(--vscode-input-foreground);
-    background-color: transparent;
+    background-color: var(--vscode-list-hoverBackground);
 }
+
 .action-button:hover {
-	background-color: var(--vscode-list-inactiveSelectionBackground);
+    color: var(--vscode-button-foreground);
+    background-color: var(--vscode-button-hoverBackground);
 }
+
 .action-button:focus, .action-button:hover:focus {
     color: var(--vscode-button-foreground);
     background-color: var(--vscode-button-hoverBackground);
-    outline: none;
+    outline: 1px solid var(--vscode-button-hoverBackground);
+    outline-offset: 2px;
 }
 .checkbox-label {
     align-self: center;


### PR DESCRIPTION
This PR fixes the issue where the parameter field buttons (move up, move down, delete) in the "Change Method Parameters" refactoring UI show no text or icon.

Existing UI:
<img width="577" height="376" alt="Screenshot 2025-09-15 at 4 40 24 PM" src="https://github.com/user-attachments/assets/1afe742d-c2f5-4986-b289-c272013202f2" />

Updated UI:
<img width="579" height="414" alt="Screenshot 2025-09-15 at 4 31 58 PM" src="https://github.com/user-attachments/assets/1f9a2a5e-983a-4427-ba26-80e1d73ebfcd" />
