### PR TITLE
Fix StackOverflow Exception when doing ADM audits

### DIFF
--- a/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
+++ b/enterprise/cloud.oracle/src/org/netbeans/modules/cloud/oracle/adm/VulnerabilityWorker.java
@@ -941,9 +941,8 @@ public class VulnerabilityWorker implements ErrorProvider{
                 nonNull(artifact.getArtifactId()),
                 nonNull(artifact.getVersionSpec()))
         );
-        if (artifact.getClassifier() != null) {
-            sb.append(':').append(artifact.getClassifier());
-        }
+        // OCI API cannot accept classifier
+
         return sb.toString();
     }
 


### PR DESCRIPTION
`StackOverflowError` is sometimes thrown when having particular dependencies and doing adm audits