### PR TITLE
[NETBEANS-5024] add support for generics angle brackets

### DIFF
--- a/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaBracesMatcherTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaBracesMatcherTest.java
@@ -18,46 +18,129 @@
  */
 package org.netbeans.modules.editor.java;
 
+import java.nio.file.Paths;
 import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
+import org.junit.Test;
 import org.netbeans.api.java.lexer.JavaTokenId;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.SourceUtilsTestUtil;
+import org.netbeans.api.java.source.SourceUtilsTestUtil2;
+import org.netbeans.api.java.source.TestUtilities;
+import org.netbeans.api.lexer.Language;
 import org.netbeans.editor.BaseDocument;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.editor.bracesmatching.api.BracesMatchingTestUtils;
 import org.netbeans.spi.editor.bracesmatching.BracesMatcher;
 import org.netbeans.spi.editor.bracesmatching.BracesMatcherFactory;
 import org.netbeans.spi.editor.bracesmatching.MatcherContext;
+import org.openide.cookies.EditorCookie;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.loaders.DataObject;
 
 /**
  *
  */
 public class JavaBracesMatcherTest extends NbTestCase {
 
+    private volatile int testNumber = 0;
+
     public JavaBracesMatcherTest(String name) {
         super(name);
     }
 
+    @Override
+    protected void setUp() throws Exception {
+        SourceUtilsTestUtil.prepareTest(new String[]{"org/netbeans/modules/java/editor/resources/layer.xml"}, new Object[]{});
+        SourceUtilsTestUtil2.disableArtificalParameterNames();
+    }
+
+    @Test
     public void testStringTemplateBrackets() throws Exception {
         assertMatches2("\"\\^{test^}\"");
     }
 
+    @Test
     public void testMultilineStringBrackets() throws Exception {
         assertMatches2(
-                  "\"\"\"\n"
-                + "^(\n"
-                + "^)\n"
-                + "\"\"\"");
+            "\"\"\"\n"
+            + "^(\n"
+            + "^)\n"
+            + "\"\"\"");
+    }
+
+    @Test
+    public void testAngleBrackets() throws Exception {
+        perfomAngleBracketsTest("Map x = new HashMap^<String, List<String>^>()");
+        perfomAngleBracketsTest("Map x = new HashMap<String, List^<String^>>()");
+        perfomAngleBracketsTest("Map x = new HashMap^<String, Map<Integer,List<String>>^>()");
+        perfomAngleBracketsTest("Map x = new HashMap<String, Map^<Integer,List<String>^>>()");
+        perfomAngleBracketsTest("Map x = new HashMap^<String, Map<Integer,List<String> > ^>()");
+        perfomAngleBracketsTest("Map x = new HashMap<String, Map^<Integer,List<String> ^> >()");
+        perfomAngleBracketsTest("Map x = new HashMap^<String, Map<Integer,List<String> > ^>()");
+        perfomAngleBracketsTest("Map x = new HashMap^<String, Map<Integer,Map<Integer,Map<Integer,List<String>>>>^>()");
+        perfomAngleBracketsTest("Map x = new HashMap<String, Map^<Integer,Map<Integer,Map<Integer,List<String>>>^>>()");
+        perfomAngleBracketsTest("Map x = new HashMap<String, Map<Integer,Map^<Integer,Map<Integer,List<String>>^>>>()");
+        perfomAngleBracketsTest("Map x = new HashMap<String, Map<Integer,Map<Integer,Map^<Integer,List<String>^>>>>()");
+        perfomAngleBracketsTest("""
+            Map<Integer,List<String>> x = new HashMap<Integer,List<String>>()
+            Object a = x.^<HashMap<Integer,List<String>>^>get(0)
+        """);
+    }
+
+    private String makeTestClass(String angleStr) {
+        String ret = "package text;\n"
+            + "import java.util.List;\n"
+            + "import java.util.Map;\n"
+            + "import java.util.HashMap;\n"
+            + "public class Test" + testNumber + " {\n"
+            + "public void test() {\n"
+            + angleStr + ";\n"
+            + "}\n"
+            + "}\n";
+
+        return ret;
+    }
+
+    private void perfomAngleBracketsTest(String angleStr) throws Exception {
+        testNumber++;
+        String srcTmp = makeTestClass(angleStr);
+        int caretPos = srcTmp.indexOf('^');
+        String sourceCode = srcTmp.substring(0, caretPos) + srcTmp.substring(caretPos + 1);
+        int matchingCaretPos = sourceCode.indexOf('^');
+        sourceCode = sourceCode.substring(0, matchingCaretPos) + sourceCode.substring(matchingCaretPos + 1);
+        FileObject wd = FileUtil.toFileObject(getWorkDir());
+        FileObject sourceDir = FileUtil.createFolder(wd, "src");
+        FileObject buildDir = FileUtil.createFolder(wd, "build");
+        FileObject cacheFolder = FileUtil.createFolder(wd, "cache");
+        Paths.get(cacheFolder.toURI()).toFile().mkdirs();
+        FileObject testFO = FileUtil.createData(sourceDir, "test/Test" + testNumber + ".java");
+        TestUtilities.copyStringToFile(testFO, sourceCode);
+        SourceUtilsTestUtil.prepareTest(sourceDir, buildDir, cacheFolder);
+        JavaSource source = JavaSource.forFileObject(testFO);
+        assertNotNull(source);
+        DataObject od = DataObject.find(testFO);
+        EditorCookie ec = od.getCookie(EditorCookie.class);
+        Document doc = ec.openDocument();
+        doc.putProperty(Language.class, JavaTokenId.language());
+        doc.putProperty("mimeType", JavaKit.JAVA_MIME_TYPE);
+        computeAndAssertMatches(doc, caretPos, false, matchingCaretPos);
+        computeAndAssertMatches(doc, caretPos + 1, true, matchingCaretPos);
+        computeAndAssertMatches(doc, matchingCaretPos, false, caretPos);
+        computeAndAssertMatches(doc, matchingCaretPos + 1, true, caretPos);
     }
 
     //from CslTestBase:
     protected void assertMatches2(String original) throws Exception {
         int caretPos = original.indexOf('^');
-        original = original.substring(0, caretPos) + original.substring(caretPos+1);
+        original = original.substring(0, caretPos) + original.substring(caretPos + 1);
 
         int matchingCaretPos = original.indexOf('^');
 
-        original = original.substring(0, matchingCaretPos) + original.substring(matchingCaretPos+1);
+        original = original.substring(0, matchingCaretPos) + original.substring(matchingCaretPos + 1);
 
         BaseDocument doc = getDocument(original);
 
@@ -67,7 +150,7 @@ public class JavaBracesMatcherTest extends NbTestCase {
         computeAndAssertMatches(doc, matchingCaretPos + 1, true, caretPos);
     }
 
-    private void computeAndAssertMatches(BaseDocument doc, int pos, boolean backwards, int matchingPos) throws BadLocationException, InterruptedException {
+    private void computeAndAssertMatches(Document doc, int pos, boolean backwards, int matchingPos) throws BadLocationException, InterruptedException {
         BracesMatcherFactory factory = new JavaBracesMatcher();
         MatcherContext context = BracesMatchingTestUtils.createMatcherContext(doc, pos, backwards, 1);
         BracesMatcher matcher = factory.createMatcher(context);
@@ -86,13 +169,11 @@ public class JavaBracesMatcherTest extends NbTestCase {
     }
 
     private BaseDocument getDocument(String content) throws Exception {
-        BaseDocument doc = new BaseDocument(true, "text/x-java") {
+        BaseDocument doc = new BaseDocument(true, JavaKit.JAVA_MIME_TYPE) {
         };
-
         doc.putProperty(org.netbeans.api.lexer.Language.class, JavaTokenId.language());
-
         doc.insertString(0, content, null);
-
         return doc;
     }
+
 }


### PR DESCRIPTION
Original issue https://github.com/apache/netbeans/issues/5024

This fixes a generics angle bracket highlighting. It works for a multichar token like GTGT and GTGTGT.  It ignores logic and arithmetic operators. As we need to distinguish between these two cases,  java parser is used for this check. 
I added also unit tests.
There is a similar commit https://github.com/apache/netbeans/pull/8500 but I don't think it can work in this way and there  is no other activity since May 2025.