### PR TITLE
Revert dark color profile change for local variable declarations.

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-Java-tokenColorings.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-Java-tokenColorings.xml
@@ -48,7 +48,7 @@
     <fontcolor name="mod-interface" default="identifier"/>
     <fontcolor name="mod-interface-declaration" default="identifier"><font style="bold"/></fontcolor>
     <fontcolor name="mod-local-variable" default="identifier"/>
-    <fontcolor name="mod-local-variable-declaration" default="identifier"><font style="bold"/></fontcolor>
+    <fontcolor name="mod-local-variable-declaration" default="identifier"/>
     <fontcolor name="mod-method" default="method"/>
     <fontcolor name="mod-method-declaration" default="method" foreColor="ffffc66d"/>
     <fontcolor name="mod-package-private"/>


### PR DESCRIPTION
Was added by mistake. Local variable declarations should not be rendered in bold, all others should (like with light theme).

reverts a line from e00777c3 / https://github.com/apache/netbeans/pull/8733