### PR TITLE
Add dlight.nativeexecution tests to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -587,6 +587,9 @@ jobs:
       - name: ide/db.sql.editor
         run: ant $OPTS -f ide/db.sql.editor test
 
+      - name: ide/dlight.nativeexecution
+        run: ant $OPTS -f ide/dlight.nativeexecution test
+
       - name: ide/docker.api
         run: ant $OPTS -f ide/docker.api test
 

--- a/ide/dlight.nativeexecution/nbproject/project.properties
+++ b/ide/dlight.nativeexecution/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=11
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 project.license=apache20-asf
@@ -23,22 +23,10 @@ nbm.executable.files=bin/nativeexecution/**
 jnlp.indirect.files=bin/nativeexecution/**
 spec.version.base=1.69.0
 
-test.config.stableBTD.includes=**/*Test.class
-test.config.stableBTD.excludes=\
-    **/ConnectionManagerTest.class,\
-    **/DerbyDatabasesTest.class,\
-    **/DerbyOptionsTest.class,\
-    **/EnvironmentTest.class,\
-    **/HostInfoUtilsTest.class,\
-    **/MacroExpanderFactoryTest.class,\
-    **/NativeProcessBuilderTest.class,\
-    **/NativeProcessTest.class,\
-    **/NativeTaskTest.class,\
-    **/RedirectErrorTest.class,\
-    **/RegisterDerbyTest.class,\
-    **/ShellSessionTest.class,\
-    **/TerminalConfigurationProviderTest.class,\
-    **/WindowsSupportTest.class
+test.config.default.includes=**/*Test.class
+test.config.default.excludes=\
+    **/SolarisPrivilegesSupportTest.class,\
+    **/ConnectionManagerTest.class
 
 release.external/exechlp-1.2.zip!/Linux-aarch64/process_start   = bin/nativeexecution/Linux-aarch64/process_start
 release.external/exechlp-1.2.zip!/Linux-aarch64/pty             = bin/nativeexecution/Linux-aarch64/pty

--- a/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/SolarisPrivilegesSupport.java
+++ b/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/SolarisPrivilegesSupport.java
@@ -40,6 +40,7 @@ import org.netbeans.modules.nativeexecution.api.util.ConnectionManager.Cancellat
  * but is never stored. So the password is asked for every new execution session.
  *
  */
+@Deprecated(forRemoval = true)
 public interface SolarisPrivilegesSupport {
 
     /**

--- a/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/SolarisPrivilegesSupportProvider.java
+++ b/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/SolarisPrivilegesSupportProvider.java
@@ -27,6 +27,7 @@ import org.netbeans.modules.nativeexecution.sps.impl.SPSLocalImpl;
 import org.netbeans.modules.nativeexecution.sps.impl.SPSRemoteImpl;
 import org.netbeans.modules.nativeexecution.support.Logger;
 
+@Deprecated(forRemoval = true)
 public final class SolarisPrivilegesSupportProvider {
 
     private static final ConcurrentHashMap<ExecutionEnvironment, SolarisPrivilegesSupport> instances =


### PR DESCRIPTION
 - add to CI
 - deprecate Solaris impl for removal
 - pump module lang level to 11 to unlock the for-removal deprecation field
