### PR TITLE
Set end position for implicit  class declaration tree part of a compact source file 

### DIFF
--- a/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
+++ b/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementOpen.java
@@ -573,6 +573,11 @@ public final class ElementOpen {
         int[] span = null;
         switch(forTree.getKind()) {
             case CLASS:
+                if ((int) target[1] >= 0 && (int) target[2] == -1) {
+                    // Compact Source file (JEP 512)  issue implicit class end position not found in code 
+                    // see JDK-8364015
+                    target[2] = (int) info.getTrees().getSourcePositions().getEndPosition(cu, cu);
+                }
             case INTERFACE:
             case ENUM:
             case ANNOTATION_TYPE:


### PR DESCRIPTION
## Issue : End position not found for implicit class scaffolding compact source file (JEP 512)

**Context** 

- Compact source file allow top level methods and fields. 
- Internally the fields and methods are treated as part of a implicit final class. 
- As the class in not explicitly declared in code the IDE when trying to find end position for the corresponding java element fails.
- This change defaults to using the end position of the compilation unit tree (which is computed correctly) when for a class element source position is found but no end position is found. 
- Visible effect of this issue was missing outline view for the compact source file in the Java VSCode Extension.


Debugging output  for reference 

<img width="1512" height="982" alt="Screenshot 2025-09-22 at 5 46 25 PM" src="https://github.com/user-attachments/assets/2be6c3cb-b6bc-4e49-8b9d-c6ba1f1a142a" />



---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>