### PR TITLE
Update ssh key FileChooser filter

### DIFF
--- a/ide/dlight.nativeexecution.nb/nbproject/project.properties
+++ b/ide/dlight.nativeexecution.nb/nbproject/project.properties
@@ -16,5 +16,5 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
+javac.release=11
 javac.compilerargs=-Xlint -Xlint:-serial


### PR DESCRIPTION
key FileChooser (e.g terminal remote connection) will now also show openssh keys which have a longer key header

found this issue while testing https://github.com/apache/netbeans/pull/8848 and noticed that the file chooser didn't list my keys (both RSA and EC, created using OpenSSH)