### PR TITLE
Switch CI from JDK 25-ea to ga

### DIFF
--- a/.github/scripts/BinariesListUpdates.java
+++ b/.github/scripts/BinariesListUpdates.java
@@ -61,7 +61,7 @@ public class BinariesListUpdates {
 
         Path path = Path.of(args[0]);
         try (Stream<Path> dependencyFiles = Files.find(path, 10, (p, a) -> p.getFileName().toString().equals("binaries-list"));
-             SmoSearchBackend backend = SmoSearchBackendFactory.createDefault()) {
+             SmoSearchBackend backend = SmoSearchBackendFactory.createSmo()) {
             dependencyFiles.sorted().forEach(p -> {
                 try {
                     checkDependencies(p, backend);
@@ -126,7 +126,7 @@ public class BinariesListUpdates {
     }
 
     // reduce concurrency level if needed
-    private final static Semaphore requests = new Semaphore(4);
+    private final static Semaphore requests = new Semaphore(3);
 
     private static String queryLatestVersion(SmoSearchBackend backend, SearchRequest request) throws IOException, InterruptedException {
         requests.acquire();

--- a/.github/workflows/dependency-checks.yml
+++ b/.github/workflows/dependency-checks.yml
@@ -49,13 +49,13 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'zulu'
 
       - name: Check Dependencies
         run: |
-          DEPS=org.apache.maven:maven-artifact:3.9.9,org.apache.maven.indexer:search-backend-smo:7.1.5
-          mvn eu.maveniverse.maven.plugins:toolbox:gav-copy-transitive -Dgav=$DEPS -DsinkSpec="flat(./lib)"
+          DEPS=org.apache.maven:maven-artifact:3.9.11,org.apache.maven.indexer:search-backend-smo:7.1.6
+          mvn eu.maveniverse.maven.plugins:toolbox:0.13.7:gav-resolve-transitive -Dgav=$DEPS -DsinkSpec="flat(./lib)"
           echo "<pre>" >> $GITHUB_STEP_SUMMARY
           java -cp "lib/*" .github/scripts/BinariesListUpdates.java ./ | tee -a $GITHUB_STEP_SUMMARY
           echo "</pre>" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,7 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        java: [ '17', '21', '25-ea' ]
+        java: [ '17', '21', '25' ]
         exclude:
           - java: ${{ github.event_name == 'pull_request' && 'nothing' || '21' }}
       fail-fast: false
@@ -242,7 +242,7 @@ jobs:
         java: [ 17 ]
         include:
           - os: ubuntu-latest
-            java: 25-ea
+            java: 25
       fail-fast: false
     steps:
 
@@ -322,7 +322,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && !cancelled() }}
         uses: actions/setup-java@v5
         with:
-          java-version: 25-ea
+          java-version: 25
           distribution: ${{ env.DEFAULT_JAVA_DISTRIBUTION }}
 
       - name: Check Commit Headers
@@ -446,7 +446,7 @@ jobs:
         if: env.test_javadoc == 'true' && success()
         uses: actions/setup-java@v5
         with:
-          java-version: 25-ea
+          java-version: 25
           distribution: ${{ env.DEFAULT_JAVA_DISTRIBUTION }}
 
       - name: Build javadoc
@@ -843,7 +843,7 @@ jobs:
     timeout-minutes: 50
     strategy:
       matrix:
-        java: [ '17', '21', '25-ea' ]
+        java: [ '17', '21', '25' ]
         exclude:
           - java: ${{ github.event_name == 'pull_request' && 'nothing' || '21' }}
       fail-fast: false
@@ -958,7 +958,7 @@ jobs:
 
 
   platform-modules-test1:
-    name: Platform Modules batch1 on Linux/JDK ${{ matrix.java }} (some on 8)
+    name: Platform Modules batch1 on Linux/JDK ${{ matrix.java }}
     # equals env.test_platform == 'true'
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Platform') || contains(github.event.pull_request.labels.*.name, 'ci:all-tests') || github.event_name != 'pull_request' }}
     needs: base-build
@@ -1450,10 +1450,10 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '17', '25-ea' ]
+        java: [ '17', '25' ]
         config: [ 'batch1', 'batch2' ]
         exclude:
-          - java: ${{ github.event_name == 'pull_request' && 'nothing' || '25-ea' }}
+          - java: ${{ github.event_name == 'pull_request' && 'nothing' || '25' }}
       fail-fast: false
     steps:
 
@@ -1507,7 +1507,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '17', '21', '25-ea' ]
+        java: [ '17', '21', '25' ]
         exclude:
           - java: ${{ github.event_name == 'pull_request' && 'nothing' || '21' }}
       fail-fast: false


### PR DESCRIPTION
JDK 25 builds are now available from nearly all vendors ([list](https://gist.github.com/mbien/7911a1272e2bc77234cd7ffca35cdcb4/69fb7bc6993e27b4cb73f78ec45dc7a4cbb28f92))

dependency checker:

 - updated dependencies of dependency checker and locked toolbox version
 - switched to `gav-resolve-transitive` goal since `gav-copy-transitive` is deprecated
 - `BinariesListUpdates.java`: reduced concurrency level and resolved deprecation warning
