### PR TITLE
Added missing Faces 4 EL implicit objects

### DIFF
--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/el/FaceletsELPlugin.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/el/FaceletsELPlugin.java
@@ -82,7 +82,7 @@ public class FaceletsELPlugin extends ELPlugin {
         }
 
         if(implObjects == null) {
-            List<ImplicitObject> implObjectsBuilder = new ArrayList<>(9);
+            List<ImplicitObject> implObjectsBuilder = new ArrayList<>(20);
 
             implObjectsBuilder.addAll(getScopeObjects());
 
@@ -105,14 +105,16 @@ public class FaceletsELPlugin extends ELPlugin {
             implObjects = Collections.unmodifiableCollection(implObjectsBuilder);
 
 
-            List<ImplicitObject> implObjectsJakartaBuilder = new ArrayList<>(9);
+            List<ImplicitObject> implObjectsJakartaBuilder = new ArrayList<>(22);
 
             implObjectsJakartaBuilder.addAll(getScopeObjects());
 
             implObjectsJakartaBuilder.add(new JsfImplicitObject("facesContext", "jakarta.faces.context.FacesContext", OBJECT_TYPE)); //NOI18N
+            implObjectsJakartaBuilder.add(new JsfImplicitObject("externalContext", "jakarta.faces.context.ExternalContext", OBJECT_TYPE));
             implObjectsJakartaBuilder.add(new JsfImplicitObject("application",  "jakarta.servlet.ServletContext", OBJECT_TYPE)); //NOI18N
             implObjectsJakartaBuilder.add(new JsfImplicitObject("component", "jakarta.faces.component.UIComponent", OBJECT_TYPE)); //NOI18N
             implObjectsJakartaBuilder.add(new JsfImplicitObject("flash", "jakarta.faces.context.Flash", OBJECT_TYPE)); //NOI18N
+            implObjectsJakartaBuilder.add(new JsfImplicitObject("flow", "jakarta.faces.flow.Flow", OBJECT_TYPE));
             implObjectsJakartaBuilder.add(new JsfImplicitObject("resource", "jakarta.faces.application.ResourceHandler", OBJECT_TYPE)); //NOI18N
             implObjectsJakartaBuilder.add(new JsfImplicitObject("session", "jakarta.servlet.http.HttpSession", OBJECT_TYPE)); //NOI18N
             implObjectsJakartaBuilder.add(new JsfImplicitObject("view", "jakarta.faces.component.UIViewRoot", OBJECT_TYPE)); //NOI18N


### PR DESCRIPTION
`#{externalContext}` has been added in Faces 4.0, `#{flow}` in Faces 4.1

Specification: https://jakarta.ee/specifications/faces/4.1/jakarta-faces-4.1#a2830




---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>