### PR TITLE
Javadoc: enable syntax highlighting for code snippets

### DIFF
--- a/nbbuild/javadoctools/template.xml
+++ b/nbbuild/javadoctools/template.xml
@@ -345,6 +345,7 @@ cause it to fail.
             <arg value="--allow-script-in-comments" if:true="${javadoc23.or.later}" />
             <arg value="--snippet-path ${javadoc.base}/test/unit/src:${javadoc.base}/src" if:true="${javadoc23.or.later}" />
             <arg value="--no-fonts" if:true="${javadoc23.or.later}" />
+            <arg value="--syntax-highlight" if:true="${javadoc25.or.later}" />
         </javadoc>
     </target>
 


### PR DESCRIPTION
This is for the API doc of the NetBeans project.

 - sets `--syntax-highlight` on JDK 25 and later
 - which enables syntax highlighting for code fragments in `{@snippet}` tags and `<pre><code>` elements

API doc for `CharSequences` as example (compare with [NB 27 version](https://bits.netbeans.org/27/javadoc/org-openide-util/org/openide/util/CharSequences.html).):

<img width="842" height="428" alt="image" src="https://github.com/user-attachments/assets/a0beb3c8-b905-41e1-ae62-1b358df5a1ec" />
