### PR TITLE
Gradle projects should prefer test class name as NB testsuite name

### DIFF
--- a/java/gradle.test/src/org/netbeans/modules/gradle/test/GradleTestProgressListener.java
+++ b/java/gradle.test/src/org/netbeans/modules/gradle/test/GradleTestProgressListener.java
@@ -206,6 +206,7 @@ public final class GradleTestProgressListener implements ProgressListener, Gradl
         // example the hieararchy can be:
         // - Gradle Test Executor <Number> started
         // - Test class <Class> started
+        // - @ParameterizedTest method name
         // => We flatten the list (suites are registered base on executed
         //    cases (see caseStart)
         TestSuite testSuite = runningSuites.get(session).remove(suiteName);

--- a/java/gradle.test/src/org/netbeans/modules/gradle/test/GradleTestSuite.java
+++ b/java/gradle.test/src/org/netbeans/modules/gradle/test/GradleTestSuite.java
@@ -65,13 +65,22 @@ public final class GradleTestSuite extends TestSuite {
 
     static String suiteName(OperationDescriptor op) {
         assert op != null;
-
-        if (op instanceof JvmTestOperationDescriptor) {
-            JvmTestOperationDescriptor desc = (JvmTestOperationDescriptor)op;
-            return desc.getSuiteName() != null ? desc.getSuiteName() : desc.getClassName();
-        } else {
-            return op.getDisplayName() != null ? op.getDisplayName() : op.getName();
+        String nbSuite = null;
+        if (op instanceof JvmTestOperationDescriptor desc) {
+            // In the NetBeans wording a testsuite is the class grouping multiple
+            // methods (testcase). In the gradle wording a suite can be nested, for
+            // example the hieararchy can be:
+            // - Gradle Test Executor <Number> started
+            // - Test class <Class> started
+            // - @ParameterizedTest method name
+            // So prefer `getClassName()` over `getSuiteName()`, and neither are
+            // guaranteed to be non-null.
+            nbSuite = desc.getClassName() != null ? desc.getClassName() : desc.getSuiteName();
         }
+        if (nbSuite == null) {
+            nbSuite = op.getDisplayName() != null ? op.getDisplayName() : op.getName();
+        }
+        return nbSuite;
     }
 
 }

--- a/java/gradle.test/test/unit/src/org/netbeans/modules/gradle/test/GradleTestSuiteTest.java
+++ b/java/gradle.test/test/unit/src/org/netbeans/modules/gradle/test/GradleTestSuiteTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.test;
+
+import org.gradle.tooling.events.OperationDescriptor;
+import org.gradle.tooling.events.test.JvmTestKind;
+import org.gradle.tooling.events.test.JvmTestOperationDescriptor;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author William Price
+ */
+public class GradleTestSuiteTest {
+
+    @Test
+    public void suiteNameTestDescriptorClassName() {
+      StubTestDescriptor op = new StubTestDescriptor();
+      op.className = this.getClass().getName();
+      assertEquals(this.getClass().getName(), GradleTestSuite.suiteName(op));
+    }
+
+    @Test
+    public void suiteNameTestDescriptorUnknownClass() {
+      StubTestDescriptor op = new StubTestDescriptor();
+      op.className = null;
+      assertEquals(op.suiteName, GradleTestSuite.suiteName(op));
+    }
+
+    @Test
+    public void suiteNameTestDescriptorUnknownClassAndSuite() {
+      StubTestDescriptor op = new StubTestDescriptor();
+      op.className = null;
+      op.suiteName = null;
+      assertEquals(op.displayName, GradleTestSuite.suiteName(op));
+    }
+
+    @Test
+    public void suiteNameNotATestDescriptor() {
+      StubOpDescriptor op = new StubOpDescriptor();
+      assertEquals(op.displayName, GradleTestSuite.suiteName(op));
+    }
+
+    @Test
+    public void suiteNameNotATestDescriptorNoDisplayName() {
+      StubOpDescriptor op = new StubOpDescriptor();
+      op.displayName = null;
+      assertEquals(op.name, GradleTestSuite.suiteName(op));
+    }
+
+    private static class StubOpDescriptor implements OperationDescriptor {
+        String displayName = "display name";
+        String name = "op name";
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        @Override
+        public OperationDescriptor getParent() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class StubTestDescriptor extends StubOpDescriptor implements JvmTestOperationDescriptor {
+        String className = "class name";
+        String suiteName = "suite name";
+
+        @Override
+        public JvmTestKind getJvmTestKind() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getClassName() {
+            return className;
+        }
+
+        @Override
+        public String getSuiteName() {
+            return suiteName;
+        }
+
+        @Override
+        public String getMethodName() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getTestDisplayName() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
Java test support for Gradle was favoring the Gradle test suite name over the test class name, but NB expects that test suites are class names.  In the Gradle model, the suite name can be a method name within the test class, or even a Gradle task name (when a test class is absent for the event).

fixes #8878 

---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>