### PR TITLE
Be able to setup FlatLaf styling for code editor toolbar separately from other toolbars in application

### DIFF
--- a/ide/editor/src/org/netbeans/modules/editor/NbEditorToolBar.java
+++ b/ide/editor/src/org/netbeans/modules/editor/NbEditorToolBar.java
@@ -200,6 +200,9 @@ import org.openide.util.lookup.ProxyLookup;
         
         refreshToolbarButtons();
         setBorderPainted(true);
+
+        // Style editor toolbar separately from main toolbar [style].nb-editor-toolbar   = background: #FFFFFF
+        putClientProperty("FlatLaf.styleClass", "nb-editor-toolbar");
     }
 
     @Override

--- a/platform/core.multiview/src/org/netbeans/core/multiview/TabsComponent.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/TabsComponent.java
@@ -98,6 +98,9 @@ class TabsComponent extends JPanel {
         add(bar, BorderLayout.NORTH);
         startToggling();
         setToolbarBarVisible(toolVis);
+
+        // Style editor toolbar separately from main toolbar [style].nb-editor-toolbar   = background: #FFFFFF
+        bar.putClientProperty("FlatLaf.styleClass", "nb-editor-toolbar");
     }
 
 


### PR DESCRIPTION
Be able to setup FlatFal styling for code editor toolbar separately from other toolbars in application.
Main purpose - provide more flexibility in configuring FlatLaf style for NetBeans.

What this change does - it adds FlatLaf styleClass property for code editor toolbar. This allows to set FlatLaf style for this toolbar separately from other toolbars in the application.

Below are screenshots with example usage of this property. By settings 
```[style].nb-editor-toolbar   = background: #FFFFFF``` in FlatLaf.properties I can make background for code editor toolbar white while keeping other toolbars unchanged. In combination with other FlatLaf properties e.g.
```
Tree.background=#F2F2F2
ScrollBar.track=#F2F2F2
ComboBox.background=#F2F2F2
EditorTab.background=#F2F2F2
EditorTab.activeBackground=#F2F2F2
EditorTab.selectedBackground = #FFFFFF
ViewTab.selectedBackground = #F2F2F2
```
At the moment I can style NetBeans like it is displayed on screenshot except of setting style for code editor toolbar. What I want to achieve in this example is to use white color for "light" LAF only for code editor area including code editor toolbar. While keeping all other panels (see screenshots) light grey.
<img width="2498" height="1508" alt="NetBeans custom LADF properties 1" src="https://github.com/user-attachments/assets/ed95248a-f832-444a-b4d8-7d4b79006142" />

<img width="1682" height="1052" alt="NetBeans custom LADF properties 2" src="https://github.com/user-attachments/assets/08f7823b-2e75-4b47-beaf-8cc00545a7c2" />


This PR is not about all these changes you see on screenshot. PR does not change any default look and feel of NetBeans. PR is about to let people to apply their own styles in which editor toolbar can be styled differently from other toolbars in the application.