### PR TITLE
Upgrade FlatLaf from 3.6.1 to 3.6.2

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-18870BCE397936054CE91CFCF41119E0B49060DD com.formdev:flatlaf:3.6.1
+D927E248D29606BE1BDFB5CC29699B0A2A2E7A6C com.formdev:flatlaf:3.6.2

--- a/platform/libs.flatlaf/external/flatlaf-3.6.2-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-3.6.2-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 3.6.1
-Files: flatlaf-3.6.1.jar
+Version: 3.6.2
+Files: flatlaf-3.6.2.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/manifest.mf
+++ b/platform/libs.flatlaf/manifest.mf
@@ -4,4 +4,4 @@ OpenIDE-Module: org.netbeans.libs.flatlaf/1
 OpenIDE-Module-Install: org/netbeans/libs/flatlaf/Installer.class
 OpenIDE-Module-Specification-Version: 1.24
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Implementation-Version: 3.6.1
+OpenIDE-Module-Implementation-Version: 3.6.2

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -31,18 +31,18 @@ spec.version.base.fatal.warning=false
 #
 # So when FlatLaf is updated, the OpenIDE-Module-Implementation-Version entry
 # in manifest.mf needs to be updated to match the new FlatLaf version.
-release.external/flatlaf-3.6.1.jar=modules/ext/flatlaf-3.6.1.jar
+release.external/flatlaf-3.6.2.jar=modules/ext/flatlaf-3.6.2.jar
 # com.formdev.flatlaf.ui intentionally ommitted.
 # rest is equivalent to the "public" packages for friend dependencies as declared in project.xml
 sigtest.public.packages=com.formdev.flatlaf,com.formdev.flatlaf.themes,com.formdev.flatlaf.util
 
-release.external/flatlaf-3.6.1.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
-release.external/flatlaf-3.6.1.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll
-release.external/flatlaf-3.6.1.jar!/com/formdev/flatlaf/natives/flatlaf-windows-arm64.dll=modules/lib/flatlaf-windows-arm64.dll
-release.external/flatlaf-3.6.1.jar!/com/formdev/flatlaf/natives/libflatlaf-macos-arm64.dylib=modules/lib/libflatlaf-macos-arm64.dylib
-release.external/flatlaf-3.6.1.jar!/com/formdev/flatlaf/natives/libflatlaf-macos-x86_64.dylib=modules/lib/libflatlaf-macos-x86_64.dylib
-release.external/flatlaf-3.6.1.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-x86_64.so=modules/lib/libflatlaf-linux-x86_64.so
-release.external/flatlaf-3.6.1.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-arm64.so=modules/lib/libflatlaf-linux-arm64.so
+release.external/flatlaf-3.6.2.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86.dll=modules/lib/flatlaf-windows-x86.dll
+release.external/flatlaf-3.6.2.jar!/com/formdev/flatlaf/natives/flatlaf-windows-x86_64.dll=modules/lib/flatlaf-windows-x86_64.dll
+release.external/flatlaf-3.6.2.jar!/com/formdev/flatlaf/natives/flatlaf-windows-arm64.dll=modules/lib/flatlaf-windows-arm64.dll
+release.external/flatlaf-3.6.2.jar!/com/formdev/flatlaf/natives/libflatlaf-macos-arm64.dylib=modules/lib/libflatlaf-macos-arm64.dylib
+release.external/flatlaf-3.6.2.jar!/com/formdev/flatlaf/natives/libflatlaf-macos-x86_64.dylib=modules/lib/libflatlaf-macos-x86_64.dylib
+release.external/flatlaf-3.6.2.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-x86_64.so=modules/lib/libflatlaf-linux-x86_64.so
+release.external/flatlaf-3.6.2.jar!/com/formdev/flatlaf/natives/libflatlaf-linux-arm64.so=modules/lib/libflatlaf-linux-arm64.so
 jnlp.verify.excludes=\
     modules/lib/flatlaf-windows-x86.dll,\
     modules/lib/flatlaf-windows-x86_64.dll,\

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -49,8 +49,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-3.6.1.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-3.6.1.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-3.6.2.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-3.6.2.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Upgrade FlatLaf from 3.6.1 to 3.6.2.  Fixes some popup / dialog issues with NetBeans on some OS.

Full release notes at https://github.com/JFormDesigner/FlatLaf/releases/tag/3.6.2