### PR TITLE
Form Designer: set listener generator style to LAMBDAS by default

### DIFF
--- a/java/form/src/org/netbeans/modules/form/FormLoaderSettings.java
+++ b/java/form/src/org/netbeans/modules/form/FormLoaderSettings.java
@@ -137,7 +137,7 @@ public class FormLoaderSettings implements HelpCtx.Provider   {
      * @return listener generation style.
      */
     public int getListenerGenerationStyle() {
-        return getPreferences().getInt(PROP_LISTENER_GENERATION_STYLE, 0);
+        return getPreferences().getInt(PROP_LISTENER_GENERATION_STYLE, JavaCodeGenerator.LAMBDAS);
     }
 
     /**


### PR DESCRIPTION
 - https://github.com/apache/netbeans/pull/6150 was added in NB 19 and it is working pretty well.
 - generates less code (only affects newly created forms)

<img width="795" height="650" alt="image" src="https://github.com/user-attachments/assets/c927cfde-9cff-4db5-a130-5b75df9cf0d8" />
