### PR TITLE
Open Favorites tab on first project or file open

### DIFF
--- a/platform/favorites/src/org/netbeans/modules/favorites/Tab.java
+++ b/platform/favorites/src/org/netbeans/modules/favorites/Tab.java
@@ -139,6 +139,11 @@ implements Runnable, ExplorerManager.Provider {
         run();
     }
 
+    /// true if this tab has been opened during this session
+    boolean wasOpened() {
+        return view != null;
+    }
+
     /** Initializes gui of this component. Subclasses can override
     * this method to install their own gui.
     * @return Tree view that will serve as main view for this explorer.

--- a/platform/favorites/src/org/netbeans/modules/favorites/resources/favorites.wstcgrp
+++ b/platform/favorites/src/org/netbeans/modules/favorites/resources/favorites.wstcgrp
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<tc-group version="2.0">
+    <module name="org.netbeans.core.ide/1" spec="1.13" />
+    <tc-id id="favorites" />
+    <open-close-behavior open="true" close="false"/>
+</tc-group>

--- a/platform/favorites/src/org/netbeans/modules/favorites/resources/layer.xml
+++ b/platform/favorites/src/org/netbeans/modules/favorites/resources/layer.xml
@@ -21,6 +21,7 @@
 -->
 <!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
 <filesystem>
+
     <folder name="Favorites">
         <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.favorites.Bundle"/>
         <file name="Home.shadow">
@@ -38,4 +39,13 @@
             </file>
         </folder>
     </folder>
+
+    <folder name="Windows2">
+        <folder name="Groups">
+            <folder name="OpenedProjects">
+                <file name="favorites.wstcgrp" url="favorites.wstcgrp"/>
+            </folder>
+        </folder>
+    </folder>
+
 </filesystem>


### PR DESCRIPTION
 - tab group will now contain 4 views: Projects, Files, Favorites and Services
 - will be opened with the already existing on-first-project-open mechanism
 - the very first on-editor-open event will also open the Favorites tab
 - ~made west column 5% smaller [screenshot](https://github.com/apache/netbeans/pull/8908#issuecomment-3399384901)~ too small with 200% scaling

<img width="325" height="246" alt="image" src="https://github.com/user-attachments/assets/45bf5a3c-9036-402e-9a16-6bfa283b555e" />
