### PR TITLE
Fixes most layer position warnings and improves logging

### DIFF
--- a/cpplite/cpplite.project/src/org/netbeans/modules/cpplite/project/layer.xml
+++ b/cpplite/cpplite.project/src/org/netbeans/modules/cpplite/project/layer.xml
@@ -24,7 +24,7 @@
     <folder name="Templates">
         <folder name="Project">
             <folder name="Native">
-                <attr name="position" intvalue="650"/>
+                <attr name="position" intvalue="660"/>
                 <attr name="displayName" bundlevalue="org.netbeans.modules.cpplite.project.Bundle#CPPLite_NewProject" />
             </folder>
         </folder>

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/db/MicronautDataEndpointGenerator.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/db/MicronautDataEndpointGenerator.java
@@ -358,7 +358,7 @@ public class MicronautDataEndpointGenerator implements CodeActionProvider, Comma
         return dd;
     }
 
-    @MimeRegistration(mimeType = "text/x-java", service = CodeGenerator.Factory.class)
+    @MimeRegistration(mimeType = "text/x-java", service = CodeGenerator.Factory.class, position = 800)
     public static class Factory implements CodeGenerator.Factory {
 
         @Override

--- a/ide/diff/src/org/netbeans/modules/diff/tree/RecursiveDiffAction.java
+++ b/ide/diff/src/org/netbeans/modules/diff/tree/RecursiveDiffAction.java
@@ -46,7 +46,7 @@ import org.openide.util.actions.NodeAction;
 )
 @ActionReference(
     path = "UI/ToolActions/Files",
-    position = 300
+    position = 250
 )
 @Messages("CTL_RecursiveDiffAction=Tree diff")
 public final class RecursiveDiffAction extends NodeAction implements ActionListener {

--- a/ide/diff/src/org/netbeans/modules/diff/tree/TreeDiffViewerTopComponent.java
+++ b/ide/diff/src/org/netbeans/modules/diff/tree/TreeDiffViewerTopComponent.java
@@ -63,7 +63,8 @@ import org.openide.xml.XMLUtil;
 )
 @TopComponent.Registration(
         mode = "editor",
-        openAtStartup = false
+        openAtStartup = false,
+        position = 0
 )
 @Messages({
     "CTL_TreeDiffViewerTopComponent=Tree diff",

--- a/ide/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/layer.xml
+++ b/ide/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/layer.xml
@@ -36,7 +36,9 @@
     <folder name="Windows2">
         <folder name="Modes">
             <folder name="editor">
-                <file name="CoverageReportTopComponent.wstcref" url="CoverageReportTopComponentWstcref.xml"/>
+                <file name="CoverageReportTopComponent.wstcref" url="CoverageReportTopComponentWstcref.xml">
+                    <attr name="position" intvalue="0"/>
+                </file>
             </folder>
         </folder>
     </folder>

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/CompletionProviderImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/CompletionProviderImpl.java
@@ -87,7 +87,7 @@ import org.openide.xml.XMLUtil;
  *
  * @author lahvac
  */
-@MimeRegistration(mimeType="", service=CompletionProvider.class)
+@MimeRegistration(mimeType="", service=CompletionProvider.class, position = 1000)
 public class CompletionProviderImpl implements CompletionProvider {
 
     private static final Logger LOG = Logger.getLogger(CompletionProviderImpl.class.getName());

--- a/ide/spellchecker.bindings.htmlxml/src/org/netbeans/modules/spellchecker/bindings/htmlxml/layer.xml
+++ b/ide/spellchecker.bindings.htmlxml/src/org/netbeans/modules/spellchecker/bindings/htmlxml/layer.xml
@@ -28,7 +28,9 @@
                     <file name="org-netbeans-modules-spellchecker-bindings-htmlxml-HtmlXmlTokenListProvider.instance" />
                 </folder>
                 <folder name="CompletionProviders">
-                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance"/>
+                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance">
+                        <attr name="position" intvalue="600"/>
+                    </file>
                 </folder>
             </folder>
             <folder name="xhtml">
@@ -36,7 +38,9 @@
                     <file name="org-netbeans-modules-spellchecker-bindings-htmlxml-HtmlXmlTokenListProvider.instance" />
                 </folder>
                 <folder name="CompletionProviders">
-                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance"/>
+                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance">
+                        <attr name="position" intvalue="600"/>
+                    </file>
                 </folder>
             </folder>
             <folder name="x-php5">
@@ -44,7 +48,11 @@
                     <file name="org-netbeans-modules-spellchecker-bindings-htmlxml-HtmlXmlTokenListProvider.instance" />
                 </folder>
                 <folder name="CompletionProviders">
-                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance"/>
+                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance">
+                        <!-- none of the php completion providers have currently a position
+                        <attr name="position" intvalue="600"/>
+                        -->
+                    </file>
                 </folder>
             </folder>
             <folder name="x-jsp">
@@ -52,7 +60,11 @@
                     <file name="org-netbeans-modules-spellchecker-bindings-htmlxml-HtmlXmlTokenListProvider.instance" />
                 </folder>
                 <folder name="CompletionProviders">
-                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance"/>
+                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance">
+                        <!-- none of the enterprise completion providers have currently a position
+                        <attr name="position" intvalue="600"/>
+                        -->
+                    </file>
                 </folder>
             </folder>
             <folder name="x-tag">
@@ -60,7 +72,11 @@
                     <file name="org-netbeans-modules-spellchecker-bindings-htmlxml-HtmlXmlTokenListProvider.instance" />
                 </folder>
                 <folder name="CompletionProviders">
-                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance"/>
+                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance">
+                        <!-- none of the other completion providers have currently a position
+                        <attr name="position" intvalue="600"/>
+                        -->
+                    </file>
                 </folder>
             </folder>
             <folder name="x-gsp">
@@ -68,7 +84,11 @@
                     <file name="org-netbeans-modules-spellchecker-bindings-htmlxml-HtmlXmlTokenListProvider.instance" />
                 </folder>
                 <folder name="CompletionProviders">
-                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance"/>
+                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance">
+                        <!-- none of the other completion providers have currently a position
+                        <attr name="position" intvalue="600"/>
+                        -->
+                    </file>
                 </folder>
             </folder>
             <folder name="xml">
@@ -76,7 +96,9 @@
                     <file name="org-netbeans-modules-spellchecker-bindings-htmlxml-HtmlXmlTokenListProvider.instance" />
                 </folder>
                 <folder name="CompletionProviders">
-                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance"/>
+                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance">
+                        <attr name="position" intvalue="600"/>
+                    </file>
                 </folder>
             </folder>
         </folder>

--- a/ide/spellchecker.bindings.properties/src/org/netbeans/modules/spellchecker/bindings/properties/layer.xml
+++ b/ide/spellchecker.bindings.properties/src/org/netbeans/modules/spellchecker/bindings/properties/layer.xml
@@ -28,7 +28,9 @@
                     <file name="org-netbeans-modules-spellchecker-bindings-properties-PropertiesTokenListProvider.instance" />
                 </folder>
                 <folder name="CompletionProviders">
-                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance"/>
+                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance">
+                        <attr name="position" intvalue="600"/>
+                    </file>
                 </folder>
             </folder>
         </folder>

--- a/ide/texttools/src/org/netbeans/modules/texttools/TextToolsTopComponent.java
+++ b/ide/texttools/src/org/netbeans/modules/texttools/TextToolsTopComponent.java
@@ -70,7 +70,7 @@ import org.openide.windows.WindowManager;
     iconBase="org/netbeans/modules/texttools/accessories-text-editor.png",
     persistenceType = TopComponent.PERSISTENCE_ONLY_OPENED
 )
-@TopComponent.Registration(mode = "output", openAtStartup = false)
+@TopComponent.Registration(mode = "output", openAtStartup = false, position = 3400)
 @Messages({
     "CTL_TextToolsAction=Text Tools",
     "CTL_TextToolsTopComponent=Text Tools Window",

--- a/ide/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/layer.xml
+++ b/ide/xml.schema.completion/src/org/netbeans/modules/xml/schema/completion/layer.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 
     Licensed to the Apache Software Foundation (ASF) under one
@@ -28,7 +27,9 @@
             <folder name="xml">
                 <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.xml.schema.completion.Bundle"/>
                 <folder name="CompletionProviders">
-                    <file name="org-netbeans-modules-xml-schema-completion-SchemaBasedCompletionProvider.instance"/>
+                    <file name="org-netbeans-modules-xml-schema-completion-SchemaBasedCompletionProvider.instance">
+                        <attr name="position" intvalue="800"/>
+                    </file>
                 </folder>
             </folder>
         </folder>

--- a/ide/xml.text/src/org/netbeans/modules/xml/text/completion/XMLCompletionProvider.java
+++ b/ide/xml.text/src/org/netbeans/modules/xml/text/completion/XMLCompletionProvider.java
@@ -47,7 +47,7 @@ import org.openide.util.NbBundle;
  * @author Samaresh (Samaresh.Panda@Sun.Com)
  */
 @MimeRegistrations({
-    @MimeRegistration(mimeType = "text/xml", service = CompletionProvider.class),
+    @MimeRegistration(mimeType = "text/xml", service = CompletionProvider.class, position = 700),
     @MimeRegistration(mimeType = "text/xml-external-parsed-entity", service = CompletionProvider.class),
 })
 public class XMLCompletionProvider implements CompletionProvider {

--- a/java/java.editor/src/org/netbeans/modules/java/editor/resources/layer.xml
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/resources/layer.xml
@@ -411,9 +411,9 @@
                         <folder name="BracesMatchers">
                             <file name="org-netbeans-modules-editor-java-JavaBracesMatcher.shadow">
                                 <attr name="originalFile" stringvalue="Editors/text/x-java/BracesMatchers/org-netbeans-modules-editor-java-JavaBracesMatcher.instance"/>
+                                <attr name="position" intvalue="300"/>
                             </file>
-                        </folder>                
-
+                        </folder>
                     </folder>
                 </folder>
             </folder>
@@ -448,6 +448,7 @@
                 </folder>
             </folder>
             <folder name="InlineHints">
+                <attr name="position" intvalue="0"/>
                 <folder name="text">
                     <folder name="x-java">
                         <file name="JavaInlineHints.instance">

--- a/java/maven/src/org/netbeans/modules/maven/layer.xml
+++ b/java/maven/src/org/netbeans/modules/maven/layer.xml
@@ -53,6 +53,7 @@
                 <file name="settings.xml" url="settings.template.xml">
                     <attr name="javax.script.ScriptEngine" stringvalue="freemarker"/>
                     <attr name="template.openFile" boolvalue="false"/>
+                    <attr name="position" intvalue="110"/>
                 </file>
             </folder>
         </folder>

--- a/platform/openide.filesystems/src/org/openide/filesystems/Ordering.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/Ordering.java
@@ -201,7 +201,7 @@ class Ordering {
                     if (n.contains("ergonomics")) { // NOI18N
                         break IGNORE_ERGO;
                     }
-                    presentNames.add(n);
+                    presentNames.add(n + "@" + cap.position);
                 }
                 LOG.log(
                     Level.WARNING, "Not all children in {0}/ marked with the position attribute: {1}, but some are: {2}",


### PR DESCRIPTION
second round after https://github.com/apache/netbeans/pull/7235

bonus: The warning message will now include the position of the services to make picking a value easier.

Tested activation of all clusters and maven project creation, only one `org.openide.filesystems.Ordering` root '/' warning is left to fix in the log (which I avoided so far since it is a big one).

Might make the layer behave more deterministic in some cases.

**conflict fixes:**

```
same position 300 for both 
UI/ToolActions/Files/org-netbeans-modules-diff-tree-RecursiveDiffAction.shadow and  UI/ToolActions/Files/org-netbeans-modules-favorites-Add.shadow

 -> RecursiveDiffAction = 250
```

```
same position 650 for both Templates/Project/GradleGroovy and Templates/Project/Native

-> Native = 660
```
**ordering fixes:**

```
Not all children in Windows2/Modes/output/ marked with the position attribute:  [TextToolsTopComponent.wstcref], but some are: 
[watchesView.wstcref, NotificationCenterTopComponent.wstcref, ...]

 -> TextToolsTopComponent = 3400
```

```
Not all children in OptionsDialog/Editor/ marked with the position attribute:  
[InlineHints], but some are: 
[CodeCompletion, Formatting, Hints, MarkOccurrences, ...]

 -> InlineHints = 0
```

```
Not all children in Windows2/Modes/editor/ marked with the position attribute:  
[TreeDiffViewerTopComponent.wstcref, CoverageReportTopComponent.wstcref], but some are: 
[DashboardDisplayer.wstcref]

 -> CoverageReportTopComponent = 0
 -> TreeDiffViewerTopComponent = 0
```

```
Not all children in Templates/Project/Maven2/ marked with the position attribute: 
[settings.xml], but some are:
[JavaApp, org-netbeans-modules-maven-j2ee-ui-wizard-EEWizardIterator-createWebAppIterator, ...]

 -> settings.xml = 110
```

```
Not all children in Editors/text/x-java/CodeGenerators/ marked with the position attribute: 
[org-netbeans-modules-micronaut-db-MicronautDataEndpointGenerator$Factory.instance], but some are: 
[org-netbeans-modules-j2ee-ejbcore-ui-logicalview-ejb-action-AddMethodActions$AddBusinessMethodCodeGenerator.instance@10, ...]

 -> MicronautDataEndpointGenerator$Factory = 800
```

```
Not all children in / marked with the position attribute: 
[org-netbeans-modules-editor-java-JavaBracesMatcher.shadow], but some are: 
[org-netbeans-modules-editor-bracesmatching-LegacyEssMatcher.instance@100, org-netbeans-modules-editor-bracesmatching-DefaultMatcher.instance@200]

-> JavaBracesMatcher = 300
```

```
Not all children in / marked with the position attribute:
[org-netbeans-modules-spellchecker-completion-WordCompletion.instance], but some are:
[org-netbeans-modules-lsp-client-bindings-CompletionProviderImpl.instance@1000]

 -> WordCompletion = 600 (across several layer registrations)
```

```
Not all children in / marked with the position attribute:
[org-netbeans-modules-xml-text-completion-XMLCompletionProvider.instance, org-netbeans-modules-xml-schema-completion-SchemaBasedCompletionProvider.instance], but some are:
[org-netbeans-modules-spellchecker-completion-WordCompletion.instance@600, ...]

 -> XMLCompletionProvider = 700 
 -> SchemaBasedCompletionProvider = 800
```

```
Not all children in / marked with the position attribute: 
[org-netbeans-modules-lsp-client-bindings-CompletionProviderImpl.instance], but some are:
[org-netbeans-modules-editor-java-JavaCompletionProvider.instance, ...]

 -> CompletionProviderImpl = 1000
```