### PR TITLE
Fixes a NPE in CreateElementUtilities::computeLambdaReturn

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElementUtilities.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElementUtilities.java
@@ -95,6 +95,7 @@ public final class CreateElementUtilities {
 
     private CreateElementUtilities() {}
 
+    // TODO rewrite so that it returns List.of() instead of null. Both states (null and .isEmpty()) are handled interchangeably atm.
     public static List<? extends TypeMirror> resolveType(Set<ElementKind> types, CompilationInfo info, TreePath currentPath, Tree unresolved, int offset, TypeMirror[] typeParameterBound, int[] numTypeParameters) {
         switch (currentPath.getLeaf().getKind()) {
             case METHOD:
@@ -562,8 +563,13 @@ public final class CreateElementUtilities {
             return null;
         }
 
+        List<? extends TypeMirror> resolved = resolveType(types, info, parent.getParentPath(), let, offset, null, null);
+        if (resolved == null || resolved.isEmpty()) {
+            return null;
+        }
+
         List<TypeMirror> result = new ArrayList<>();
-        for (TypeMirror target : resolveType(types, info, parent.getParentPath(), let, offset, null, null)) {
+        for (TypeMirror target : resolved) {
             if (!org.netbeans.modules.java.hints.errors.Utilities.isValidType(target) ||
                 target.getKind() != TypeKind.DECLARED) {
                 continue;

--- a/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/CreatorBasedLazyFixList.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/CreatorBasedLazyFixList.java
@@ -28,6 +28,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.modules.java.hints.spi.ErrorRule;
 import org.netbeans.modules.java.hints.spi.ErrorRule.Data;
@@ -125,7 +127,15 @@ public class CreatorBasedLazyFixList implements LazyFixList {
                     data.setData(diagnosticMessage);
                 }
                 
-                List<Fix> currentRuleFixes = rule.run(info, diagnosticKey, offset, path, data);
+                List<Fix> currentRuleFixes;
+                
+                try {
+                    currentRuleFixes = rule.run(info, diagnosticKey, offset, path, data);
+                } catch (Exception ex) {
+                    Logger.getLogger(CreatorBasedLazyFixList.class.getName())
+                            .log(Level.WARNING, rule.getDisplayName()+ " rule failed", ex);
+                    continue;
+                }
                 
                 if (currentRuleFixes == CANCELLED) {
                     cancelled.set(true);


### PR DESCRIPTION
 - hotfix for regression (since https://github.com/apache/netbeans/pull/8713).
 - updated loop to log `Exceptions` and continue computing the remaining `ErrorRules` in the queue

Would be good to refactor the utility to return non-null values in future, usages seem to treat empty list and null the same.

```
java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because the return value of "org.netbeans.modules.java.hints.errors.CreateElementUtilities.resolveType(java.util.Set, org.netbeans.api.java.source.CompilationInfo, com.sun.source.util.TreePath, com.sun.source.tree.Tree, int, javax.lang.model.type.TypeMirror[], int[])" is null
	at org.netbeans.modules.java.hints.errors.CreateElementUtilities.computeLambdaReturn(CreateElementUtilities.java:566)
	at org.netbeans.modules.java.hints.errors.CreateElementUtilities.resolveType(CreateElementUtilities.java:216)
	at org.netbeans.modules.java.hints.errors.CreateElement.analyzeImpl(CreateElement.java:333)
	at org.netbeans.modules.java.hints.errors.CreateElement.analyze(CreateElement.java:131)
	at org.netbeans.modules.java.hints.errors.CreateElement.run(CreateElement.java:116)
	at org.netbeans.modules.java.hints.infrastructure.CreatorBasedLazyFixList.compute(CreatorBasedLazyFixList.java:128)
	at org.netbeans.modules.java.hints.infrastructure.LazyHintComputation.run(LazyHintComputation.java:87)
	at org.netbeans.modules.java.hints.infrastructure.LazyHintComputation.run(LazyHintComputation.java:33)
[catch] at org.netbeans.modules.java.source.JavaSourceAccessor$CancelableTaskWrapper.run(JavaSourceAccessor.java:273)
	at org.netbeans.modules.parsing.impl.TaskProcessor.callParserResultTask(TaskProcessor.java:561)
	at org.netbeans.modules.parsing.impl.TaskProcessor$RequestPerformer.run(TaskProcessor.java:786)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:288)
	at org.netbeans.modules.parsing.impl.TaskProcessor$RequestPerformer.execute(TaskProcessor.java:702)
	at org.netbeans.modules.parsing.impl.TaskProcessor$CompilationJob.run(TaskProcessor.java:663)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1403)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2018)
```

reproducer taken from a different/unrelated issue (https://github.com/apache/netbeans/issues/4668):

<details>


```java
package testapp;

import java.util.stream.Collectors;
import java.util.stream.Stream;

public class Main {
    static String letterGrade(Student s) {
        int percent = 0; //s.getPercent();
        if (percent > 90)
            return "A";
        if (percent > 80)
            return "B";
        if (percent > 70)
            return "C";
        return "D";
    }

    public static void main(String[] args) {
        
        Stream.of(new Student(null, null))
                .collect(Collectors.groupingBy(s -> letterGrade(s), Collectors.mapping(s -> )))
    }

}

class Student {

    private String name;
    private int percent;

    public Student(String name, int percent) {
        this.name = name;
        this.percent = percent;
    }

}
```

</details>