### PR TITLE
Fixes git DeleteBranchAction activation logic.

### DIFF
--- a/ide/git/src/org/netbeans/modules/git/ui/branch/Bundle.properties
+++ b/ide/git/src/org/netbeans/modules/git/ui/branch/Bundle.properties
@@ -32,8 +32,9 @@ LBL_DeleteBranchAction.progressName=Deleting Branch {0}
 LBL_DeleteBranchAction.notMerged=Branch Not Fully Merged
 MSG_DeleteBranchAction.notMerged=Branch {0} has not been fully merged yet.\n\
 Do you still want to delete the branch?
+MSG_DeleteBranchAction.noOtherBranches=Repository does not have any other branches
 LBL_DeleteBranchAction.confirmation=Delete Branch
-MSG_DeleteBranchAction.confirmation=Do you really want to delete branch {0}
+MSG_DeleteBranchAction.confirmation=Do you really want to delete branch {0}?
 CreateBranchPanel.cbCheckoutBranch.text=Check&out Created Branch
 CreateBranchPanel.cbCheckoutBranch.TTtext=Checkout the branch right after it is created
 

--- a/ide/git/src/org/netbeans/modules/git/ui/branch/DeleteBranchAction.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/branch/DeleteBranchAction.java
@@ -22,7 +22,6 @@ import org.netbeans.libs.git.GitException.NotMergedException;
 import org.netbeans.modules.git.client.GitClientExceptionHandler;
 import java.io.File;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.libs.git.GitBranch;
@@ -38,7 +37,6 @@ import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionRegistration;
-import org.openide.nodes.Node;
 import org.openide.util.NbBundle;
 
 /**
@@ -58,6 +56,9 @@ public class DeleteBranchAction extends SingleRepositoryAction {
         branches.remove(info.getActiveBranch().getName());
 
         if (branches.isEmpty()) {
+            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(
+                    NbBundle.getMessage(DeleteBranchAction.class, "MSG_DeleteBranchAction.noOtherBranches")
+            ));
             return;
         }
 
@@ -65,23 +66,6 @@ public class DeleteBranchAction extends SingleRepositoryAction {
         if (selector.open()) {
             deleteBranch(repository, selector.getSelectedBranch());
         }
-    }
-
-    @Override
-    protected boolean enable(Node[] activatedNodes) {
-        if (!super.enable(activatedNodes)) {
-            return false;
-        }
-
-        // require 2+ branches
-        Map.Entry<File, File[]> actionRoots = getActionRoots(getCurrentContext(activatedNodes));
-        if (actionRoots != null) {
-            RepositoryInfo info = RepositoryInfo.getInstance(actionRoots.getKey());
-
-            return info != null && info.getBranches().size() > 1;
-        }
-
-        return false;
     }
 
     public void deleteBranch(final File repository, final String branchName) {

--- a/ide/git/src/org/netbeans/modules/git/utils/GitUtils.java
+++ b/ide/git/src/org/netbeans/modules/git/utils/GitUtils.java
@@ -417,9 +417,8 @@ public final class GitUtils {
     }
 
     /**
-     *
-     * @param ctx
-     * @return
+     * Returns the repository and its roots. May open a selection dialog if
+     * there is more than one repository in the provided context.
      */
     public static HashMap.SimpleImmutableEntry<File, File[]> getActionRoots(VCSContext ctx) {
         Set<File> rootsSet = ctx.getRootFiles();


### PR DESCRIPTION
`GitUtils.getActionRoots()` may open dialogs and is not suited for checks inside action `enabled()` methods.

Action is now always enabled, the `performAction()` logic handles the edge cases.

fixes #8933