### PR TITLE
TreeUtilities: fix record span computation

### DIFF
--- a/java/spi.java.hints/src/org/netbeans/spi/java/hints/ErrorDescriptionFactory.java
+++ b/java/spi.java.hints/src/org/netbeans/spi/java/hints/ErrorDescriptionFactory.java
@@ -49,8 +49,6 @@ import javax.swing.SwingUtilities;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.java.source.GeneratorUtilities;
-import org.netbeans.api.java.source.JavaSource;
-import org.netbeans.api.java.source.JavaSource.Phase;
 import org.netbeans.api.java.source.TreePathHandle;
 import org.netbeans.api.java.source.WorkingCopy;
 import org.netbeans.api.lexer.TokenSequence;
@@ -172,7 +170,7 @@ public class ErrorDescriptionFactory {
             case METHOD -> {
                 return info.getTreeUtilities().findNameSpan((MethodTree) tree);
             }
-            case ANNOTATION_TYPE, CLASS, ENUM, INTERFACE -> {
+            case ANNOTATION_TYPE, CLASS, ENUM, RECORD, INTERFACE -> {
                 return info.getTreeUtilities().findNameSpan((ClassTree) tree);
             }
             case VARIABLE -> {
@@ -488,6 +486,7 @@ public class ErrorDescriptionFactory {
             return NbBundle.getMessage(ErrorDescriptionFactory.class, "LBL_FIX_Suppress_Waning",  keyNames.toString() );  // NOI18N
         }
 
+        @Override
         public void performRewrite(TransformationContext ctx) throws IOException {
             WorkingCopy copy = ctx.getWorkingCopy();
             TreePath path = ctx.getPath();


### PR DESCRIPTION
`ErrorDescriptionFactory` can now compute spans for record declarations. This allows hints like Unused to correctly highlight hints on records.

`TreeUtilities`: use compact Collections and minor cleanup.

note: `record` is parsed as an identifier token since it is no reserved keyword, that is why this needs special casing.

before:
<img width="397" height="190" alt="image" src="https://github.com/user-attachments/assets/62414010-1b32-4a7f-8a84-bd102cae3e04" />

after:
<img width="402" height="193" alt="image" src="https://github.com/user-attachments/assets/4380fcd0-75c5-4d5b-8ed2-1d4d2dc34867" />
