### PR TITLE
More defensive guards against invalid code points in ant Preferences

### DIFF
--- a/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/IntrospectedInfo.java
+++ b/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/api/IntrospectedInfo.java
@@ -683,21 +683,21 @@ public final class IntrospectedInfo {
                         try {
                             v = node.get(k, null);
                         } catch (IllegalArgumentException ex) { // e.g invalid code point JDK-8075156
-                            LOG.log(Level.WARNING, "malformed key: {0}, pref path: {1}, msg: {2}",
-                                    new Object[] {k, node.absolutePath(), ex.getMessage()});
+                            LOG.log(Level.WARNING, "skipping malformed key; pref path: {0}, msg: {1}",
+                                    new Object[] {node.absolutePath(), ex.getMessage()});
                             continue;
                         }
                         assert v != null : k;
                         String[] ss = k.split("\\.", 2);
                         if (ss.length != 2) {
-                            LOG.log(Level.WARNING, "malformed key: {0}, pref path: {1}", new Object[] {k, node.absolutePath()});
+                            LOG.log(Level.WARNING, "skipping malformed key: {0}, pref path: {1}", new Object[] {k, node.absolutePath()});
                             continue;
                         }
                         if (ss[0].equals("class")) {
                             Matcher m = p.matcher(ss[1]);
                             boolean match = m.matches();
                             if (!match) {
-                                LOG.log(Level.WARNING, "malformed key: {0}, pref path: {1}", new Object[] {k, node.absolutePath()});
+                                LOG.log(Level.WARNING, "skipping malformed key: {0}, pref path: {1}", new Object[] {k, node.absolutePath()});
                                 continue;
                             }
                             String c = m.group(1);


### PR DESCRIPTION
followup on https://github.com/apache/netbeans/pull/6094

Once `Preferences` is loaded containing `U+0000` in a key, it can't be used anymore since even removing that key (e.g via clear()) will throw IAE.

What we can do however is to remove and recreate the Preferences node.

example output with this change active:

```
WARNING [org.apache.tools.ant.module.api.IntrospectedInfo]: skipping malformed key; pref path: /org/apache/tools/ant/module/customDefs, msg: Key contains code point U+0000
WARNING [org.apache.tools.ant.module.AntSettings]: recreating preferences node due to code point U+0000
```
tested by corrupting the config file using this script:

```java
    static void main() throws java.io.IOException {
        String path = "netbeans/nbbuild/testuserdir/config/Preferences/org/apache/tools/ant/module/customDefs.properties";
        Files.writeString(
                Path.of(path),
                "\u0000",
                StandardOpenOption.APPEND
        );
    }
```

closes #8941
targets delivery