### PR TITLE
Refactoring: Improve listClassPathHints() performance

### DIFF
--- a/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintRegistry.java
+++ b/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintRegistry.java
@@ -106,7 +106,7 @@ public class DeclarativeHintRegistry implements HintProvider, ClassPathBasedHint
     }
 
     public static Collection<? extends HintDescription> join(Map<HintMetadata, Collection<? extends HintDescription>> hints) {
-        List<HintDescription> descs = new LinkedList<>();
+        List<HintDescription> descs = new ArrayList<>();
 
         for (Collection<? extends HintDescription> c : hints.values()) {
             descs.addAll(c);


### PR DESCRIPTION
The binary class path Set has the tendency to have duplicated roots. The added deduplication pass ensures that `findSourceRoots2` isn't called more often than necessary.

This can significantly improve the performance during code inspect and transform actions, esp when many projects are open.

relative time spent in `listClassPathHints()` during inspect/transform dialog open.

before:
<img width="1544" height="940" alt="image" src="https://github.com/user-attachments/assets/a21841e7-0776-4899-ad74-dc056bf37f7d" />

after:
<img width="1544" height="940" alt="image" src="https://github.com/user-attachments/assets/298a1d4d-2a55-4478-913c-11b84e1a4989" />




benchmark was a project wide code inspection run with all 856 NetBeans modules open.
`listClassPathHints()` execution time in ms

before:
```
  17375 cold
   6177 warm
```

after:
```
  3648 cold
  1299 warm
```

the number of entries was reduced from 154997 to 1258 in that use case.