### PR TITLE
Replaced codicons in Change Method refactoring UI with Unicode characters

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/ui/ChangeMethodParameters.html
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/ui/ChangeMethodParameters.html
@@ -26,7 +26,6 @@
     <meta http-equiv="Content-Security-Policy" content="default-src http: 'unsafe-inline' 'unsafe-eval'">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="refactoring.css">
-    <link rel="stylesheet" href="codicon.css">
     <title>Refactor: Change Method Parameters...</title>
 </head>
 
@@ -57,13 +56,16 @@
         <div class="flex row">
             <input type="text" data-bind="textInput: type" class="flex-grow">
             <input type="text" data-bind="textInput: name" class="flex-grow">
-            <button class="action-button codicon codicon-arrow-up" data-bind="click: $root.moveUpParameter"></button>
-            <button class="action-button codicon codicon-arrow-down" data-bind="click: $root.moveDownParameter"></button>
-            <button class="action-button codicon codicon-trash" data-bind="click: $root.removeParameter"></button>
+            <button class="action-button" title="Move up" data-bind="click: $root.moveUpParameter">&#9650;</button>
+            <button class="action-button" title="Move down" data-bind="click: $root.moveDownParameter">&#9660;</button>
+            <button class="action-button" title="Remove parameter" data-bind="click: $root.removeParameter">&#10006;</button>
         </div>
     </div>
+
     <div class="add-param flex">
-        <button id="addParam" class="silent-button codicon codicon-add full-width flex-grow" data-bind="click: addParameter"><span class="button-text vscode-font"> Add Parameter</span></button>
+        <button id="addParam" class="silent-button flex-grow" data-bind="click: addParameter">
+            &#10010; <span class="button-text vscode-font">Add Parameter</span>
+        </button>
     </div>
     <div class="section">
         <label>Signature preview:</label>


### PR DESCRIPTION
Codicons were removed in https://github.com/apache/netbeans/pull/4040, but `ChangeMethodParameters.html` still used them.
Since the VS Code extension doesn’t include codicon assets, the icons failed to load. It is only packaged as a dev-dependency.

Replaced Codicons with suitable Unicode symbols for consistent UI without extra dependencies.
New UI:

<img width="552" height="494" alt="Screenshot 2025-10-24 at 7 40 59 PM" src="https://github.com/user-attachments/assets/81cf5a02-9662-4c2c-b702-7d2def79d9e2" />
