### PR TITLE
Improve LazyProject initialization performance

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/LazyProject.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/LazyProject.java
@@ -23,7 +23,6 @@ import java.beans.PropertyChangeListener;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import javax.swing.Action;
 import javax.swing.Icon;
 import org.netbeans.api.project.Project;
@@ -34,7 +33,6 @@ import org.netbeans.spi.project.ui.support.CommonProjectActions;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
-import org.openide.loaders.DataObject;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
@@ -55,6 +53,7 @@ Project, ProjectInformation, LogicalViewProvider, RecommendedTemplates {
     URL url;
     String displayName;
     ExtIcon icon;
+    private FileObject fo;
 
     public LazyProject(URL url, String displayName, ExtIcon icon) {
         super();
@@ -65,7 +64,10 @@ Project, ProjectInformation, LogicalViewProvider, RecommendedTemplates {
 
     @Override
     public FileObject getProjectDirectory() {
-        FileObject fo = URLMapper.findFileObject(url);
+        if (fo != null) {
+            return fo;
+        }
+        fo = URLMapper.findFileObject(url);
         if (fo == null) {
             OpenProjectList.LOGGER.warning("Project dir with " + url + " not found!");
             fo = FileUtil.createMemoryFileSystem().getRoot();

--- a/ide/projectui/src/org/netbeans/modules/project/ui/ProjectsRootNode.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/ProjectsRootNode.java
@@ -412,19 +412,16 @@ public class ProjectsRootNode extends AbstractNode {
         // PropertyChangeListener & NodeListener impl -----------------------------------------
         
         @Override
-        public void propertyChange( PropertyChangeEvent e ) {
-            if ( OpenProjectList.PROPERTY_OPEN_PROJECTS.equals( e.getPropertyName() ) ) {
-                RP.post(new Runnable() {
-                    public @Override void run() {
-                        setKeys(getKeys());
-                    }
-                });
-            } else if( PROP_DISPLAY_NAME.equals(e.getPropertyName()) ) {
-                RP.schedule(new Runnable() {
-                    public @Override void run() {
-                        setKeys( getKeys() );
-                    }
-                }, 500, TimeUnit.MILLISECONDS);
+        public void propertyChange(PropertyChangeEvent e) {
+            String prop = e.getPropertyName();
+            if (prop == null) {
+                return;
+            }
+            switch (prop) {
+                case OpenProjectList.PROPERTY_OPEN_PROJECTS -> 
+                    RP.post(() -> setKeys(getKeys()));
+                case PROP_DISPLAY_NAME -> 
+                    RP.schedule(() -> setKeys(getKeys()), 500, TimeUnit.MILLISECONDS);
             }
         }
         
@@ -627,10 +624,14 @@ public class ProjectsRootNode extends AbstractNode {
             this.ch = ch;
             this.pair = p;
             this.logicalView = logicalView;
-            OpenProjectList.log(Level.FINER, "BadgingNode init {0}", toStringForLog()); // NOI18N
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.log(Level.FINER, "BadgingNode init {0}", toStringForLog()); // NOI18N
+            }
             OpenProjectList.getDefault().addPropertyChangeListener(WeakListeners.propertyChange(this, OpenProjectList.getDefault()));
             setProjectFilesAsynch();
-            OpenProjectList.log(Level.FINER, "BadgingNode finished {0}", toStringForLog()); // NOI18N
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.log(Level.FINER, "BadgingNode finished {0}", toStringForLog()); // NOI18N
+            }
             AnnotationListener annotationListener = new AnnotationListener(this);
             annotationListener.init();
             result.addLookupListener(annotationListener);
@@ -655,18 +656,25 @@ public class ProjectsRootNode extends AbstractNode {
                     if (newProj == pair.project) {
                         return;
                     }
-                } catch (IOException ex) {
-                    OpenProjectList.log(Level.INFO, "No project for " + pair.fo, ex); // NOI18N
-                } catch (IllegalArgumentException ex) {
-                    OpenProjectList.log(Level.INFO, "No project for " + pair.fo, ex); // NOI18N
+                } catch (IOException | IllegalArgumentException ex) {
+                    OpenProjectList.LOGGER.log(Level.INFO, "No project for " + pair.fo, ex); // NOI18N
                 }
-
             }
-            
-            OpenProjectList.log(Level.FINER, "replacing for {0}", toStringForLog());
+
+            // fast path before lookup. This method can be hot during startup.
+            if (newProj != null && !pair.fo.equals(newProj.getProjectDirectory())) {
+                return;
+            }
+
+            if (OpenProjectList.LOGGER.isLoggable(Level.FINER)) {
+                OpenProjectList.log(Level.FINER, "replacing for {0}", toStringForLog());
+            }
+
             Project p = getLookup().lookup(Project.class);
             if (p == null) {
-                OpenProjectList.log(Level.FINE, "no project in lookup {0}", toStringForLog());
+                if (OpenProjectList.LOGGER.isLoggable(Level.FINE)) {
+                    OpenProjectList.log(Level.FINE, "no project in lookup {0}", toStringForLog());
+                }
                 return;
             }
             FileObject fo = p.getProjectDirectory();
@@ -696,33 +704,35 @@ public class ProjectsRootNode extends AbstractNode {
                         n = Node.EMPTY;
                     }
                 }
-                OpenProjectList.log(Level.FINER, "change original: {0}", n);
-                OpenProjectList.log(Level.FINER, "children before change original: {0}", getChildren());
-                OpenProjectList.log(Level.FINER, "delegate children before change original: {0}", getOriginal().getChildren());
+                if (OpenProjectList.LOGGER.isLoggable(Level.FINER)) {
+                    OpenProjectList.log(Level.FINER, "change original: {0}", n);
+                    OpenProjectList.log(Level.FINER, "children before change original: {0}", getChildren());
+                    OpenProjectList.log(Level.FINER, "delegate children before change original: {0}", getOriginal().getChildren());
+                }
                 changeOriginal(n, true);
-                OpenProjectList.log(Level.FINER, "delegate after change original: {0}", getOriginal());
-                OpenProjectList.log(Level.FINER, "name after change original: {0}", getName());
-                OpenProjectList.log(Level.FINER, "children after change original: {0}", getChildren());
-                OpenProjectList.log(Level.FINER, "delegate children after change original: {0}", getOriginal().getChildren());
+                if (OpenProjectList.LOGGER.isLoggable(Level.FINER)) {
+                    OpenProjectList.log(Level.FINER, "delegate after change original: {0}", getOriginal());
+                    OpenProjectList.log(Level.FINER, "name after change original: {0}", getName());
+                    OpenProjectList.log(Level.FINER, "children after change original: {0}", getChildren());
+                    OpenProjectList.log(Level.FINER, "delegate children after change original: {0}", getOriginal().getChildren());
+                }
                 BadgingLookup bl = (BadgingLookup) getLookup();
                 bl.setMyLookups(n.getLookup());
-                OpenProjectList.log(Level.FINER, "done {0}", toStringForLog());
+                if (OpenProjectList.LOGGER.isLoggable(Level.FINER)) {
+                    OpenProjectList.log(Level.FINER, "done {0}", toStringForLog());
+                }
                 setProjectFilesAsynch();
             } else {
-                FileObject newDir;
-                if (newProj != null) {
-                    newDir = newProj.getProjectDirectory();
-                } else {
-                    newDir = null;
+                if (newProj == null) {
                     //#228790 use RP instead of EventQueue.invokeLater, job can block on project write mutex
-                    RP.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            OpenProjectList.getDefault().close(new Project[] { pair.project }, false);
-                        }
+                    RP.post(() -> {
+                        OpenProjectList.getDefault().close(new Project[] { pair.project }, false);
                     });
                 }
-                OpenProjectList.log(Level.FINER, "wrong directories. current: " + fo + " new " + newDir);
+                if (OpenProjectList.LOGGER.isLoggable(Level.FINER)) {
+                    OpenProjectList.log(Level.FINER, "wrong directories. current: " + fo
+                            + " new " + (newProj != null ? newProj.getProjectDirectory() : null));
+                }
             }
         }
 
@@ -925,16 +935,18 @@ public class ProjectsRootNode extends AbstractNode {
         }
 
         @Override
-        public void propertyChange( PropertyChangeEvent e ) {
-            if ( OpenProjectList.PROPERTY_MAIN_PROJECT.equals( e.getPropertyName() ) ) {
-                mainCache = null;
-                fireDisplayNameChange( null, null );
+        public void propertyChange(PropertyChangeEvent e) {
+            String prop = e.getPropertyName();
+            if (prop == null) {
+                return;
             }
-            if ( OpenProjectList.PROPERTY_REPLACE.equals(e.getPropertyName())) {
-                replaceProject((Project)e.getNewValue());
-            }
-            if (SourceGroup.PROP_CONTAINERSHIP.equals(e.getPropertyName())) {
-                setProjectFilesAsynch();
+            switch (prop) {
+                case OpenProjectList.PROPERTY_MAIN_PROJECT -> {
+                    mainCache = null;
+                    fireDisplayNameChange(null, null);
+                }
+                case OpenProjectList.PROPERTY_REPLACE -> replaceProject((Project)e.getNewValue());
+                case SourceGroup.PROP_CONTAINERSHIP -> setProjectFilesAsynch();
             }
         }
 

--- a/ide/projectui/src/org/netbeans/modules/project/ui/actions/MainProjectAction.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/actions/MainProjectAction.java
@@ -29,7 +29,6 @@ import javax.swing.SwingUtilities;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.modules.project.ui.OpenProjectList;
-import static org.netbeans.modules.project.ui.actions.Bundle.*;
 import org.netbeans.spi.project.ui.support.ProjectActionPerformer;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
@@ -39,6 +38,10 @@ import org.openide.util.Lookup;
 import org.openide.util.Mutex;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.WeakListeners;
+
+import static org.netbeans.modules.project.ui.actions.Bundle.*;
+import static org.netbeans.modules.project.ui.OpenProjectList.PROPERTY_MAIN_PROJECT;
+import static org.netbeans.modules.project.ui.OpenProjectList.PROPERTY_OPEN_PROJECTS;
 
 /**
  * Similar to {@link ProjectAction} but has a different selection model.
@@ -134,10 +137,14 @@ public class MainProjectAction extends LookupSensitiveAction implements Property
         }
     }
 
-    public @Override void propertyChange( PropertyChangeEvent evt ) {
-        if (OpenProjectList.PROPERTY_MAIN_PROJECT.equals(evt.getPropertyName()) ||
-            OpenProjectList.PROPERTY_OPEN_PROJECTS.equals(evt.getPropertyName())) {
-            refreshView(null, false);
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        String prop = evt.getPropertyName();
+        if (prop == null) {
+            return;
+        }
+        switch (prop) {
+            case PROPERTY_MAIN_PROJECT, PROPERTY_OPEN_PROJECTS -> refreshView(null, false);
         }
     }
 

--- a/ide/projectui/src/org/netbeans/modules/project/ui/actions/MainProjectActionWithHistory.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/actions/MainProjectActionWithHistory.java
@@ -19,11 +19,7 @@
 package org.netbeans.modules.project.ui.actions;
 
 import java.awt.Component;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.List;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
@@ -32,7 +28,6 @@ import javax.swing.JComponent;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
-import javax.swing.MenuElement;
 import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 import org.netbeans.spi.project.ui.support.BuildExecutionSupport;
@@ -71,25 +66,19 @@ public class MainProjectActionWithHistory extends MainProjectAction implements P
             final JMenuItem item = new JMenuItem(org.openide.awt.Actions.cutAmpersand((String) getValue("menuText")));
             item.setEnabled(isEnabled());
 
-            addPropertyChangeListener(new PropertyChangeListener() {
-                @Override
-                public void propertyChange(PropertyChangeEvent evt) {
-                    String propName = evt.getPropertyName();
-                    if ("enabled".equals(propName)) {
-                        item.setEnabled((Boolean) evt.getNewValue());
-                    } else if ("menuText".equals(propName)) {
-                        item.setText(org.openide.awt.Actions.cutAmpersand((String) evt.getNewValue()));
-                    }
+            addPropertyChangeListener(evt -> {
+                String prop = evt.getPropertyName();
+                if (prop == null) {
+                    return;
+                }
+                switch (prop) {
+                    case "enabled" -> item.setEnabled((Boolean) evt.getNewValue());
+                    case "menuText" -> item.setText(org.openide.awt.Actions.cutAmpersand((String) evt.getNewValue()));
                 }
             });
 
             menu.add(item);
-            item.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    MainProjectActionWithHistory.this.actionPerformed(e);
-                }
-            });
+            item.addActionListener(MainProjectActionWithHistory.this::actionPerformed);
            
             org.openide.awt.Actions.connect(button, this);
             menu.addPopupMenuListener(this);
@@ -116,17 +105,9 @@ public class MainProjectActionWithHistory extends MainProjectAction implements P
                 JMenuItem item = new JMenuItem(bai.getDisplayName());
                 item.putClientProperty("aaa", "aaa");
                 menu.add(item);
-                item.addActionListener(new ActionListener() {
-                    @Override
-                    public void actionPerformed(ActionEvent e) {
-                        RequestProcessor.getDefault().post(new Runnable() {
-                            @Override
-                            public void run() {
-                                bai.repeatExecution();
-                            }
-                        });
-                    }
-                });
+                item.addActionListener(evt -> 
+                    RequestProcessor.getDefault().post(bai::repeatExecution)
+                );
             }
         }
     }

--- a/ide/projectui/src/org/netbeans/modules/project/ui/actions/NewFile.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/actions/NewFile.java
@@ -22,8 +22,6 @@ package org.netbeans.modules.project.ui.actions;
 import java.awt.EventQueue;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -61,7 +59,6 @@ import org.openide.util.Mutex;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.Pair;
 import org.openide.util.RequestProcessor;
-import org.openide.util.WeakListeners;
 import org.openide.util.actions.Presenter.Popup;
 
 /** Action for invoking the project sensitive NewFile Wizard
@@ -71,7 +68,7 @@ import org.openide.util.actions.Presenter.Popup;
     "LBL_NewFileAction_PopupName=New",
     "# {0} - Name of the template", "LBL_NewFileAction_Template_PopupName={0}..."
 })
-public class NewFile extends ProjectAction implements PropertyChangeListener, Popup {
+public class NewFile extends ProjectAction implements Popup {
 
     private static final RequestProcessor RP = new RequestProcessor(NewFile.class);
     private static final RequestProcessor INSTANTIATE_RP = new RequestProcessor(NewFile.class.getName() + ".INSTANTIATE_RP", 5);
@@ -88,7 +85,6 @@ public class NewFile extends ProjectAction implements PropertyChangeListener, Po
         super((String) null, LBL_NewFileAction_Name(), null, context);
         putValue("iconBase","org/netbeans/modules/project/ui/resources/newFile.png"); //NOI18N
         putValue(SHORT_DESCRIPTION, LBL_NewFileAction_Tooltip());
-        OpenProjectList.getDefault().addPropertyChangeListener( WeakListeners.propertyChange( this, OpenProjectList.getDefault() ) );
         refresh(getLookup(), true);
     }
 
@@ -279,11 +275,6 @@ public class NewFile extends ProjectAction implements PropertyChangeListener, Po
 
         LOG.log(Level.FINE, "#210919: found preselected folder {0} for {1}", new Object[] {preselectedFolder, context});
         return preselectedFolder;
-    }
-
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        refresh(Lookup.EMPTY, false);
     }
 
     private static final String TEMPLATE_PROPERTY = "org.netbeans.modules.project.ui.actions.NewFile.Template"; // NOI18N

--- a/ide/projectui/src/org/netbeans/modules/project/ui/actions/RecentProjects.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/actions/RecentProjects.java
@@ -184,22 +184,17 @@ public class RecentProjects extends AbstractAction implements Presenter.Menu, Pr
     // Implementation of change listener ---------------------------------------
     
     
-    @Override public void propertyChange(PropertyChangeEvent e) {
-        
-        if ( OpenProjectList.PROPERTY_RECENT_PROJECTS.equals( e.getPropertyName() ) ) {
-            final boolean en = !OpenProjectList.getDefault().isRecentProjectsEmpty();
-            SwingUtilities.invokeLater(new Runnable() {
-                @Override
-                public void run() {
-                    createMainSubMenu();
-                    subMenu.setEnabled( en );
-                    recreate = true;
-                }
+    @Override
+    public void propertyChange(PropertyChangeEvent e) {
+        if (OpenProjectList.PROPERTY_RECENT_PROJECTS.equals(e.getPropertyName())) {
+            boolean enable = !OpenProjectList.getDefault().isRecentProjectsEmpty();
+            SwingUtilities.invokeLater(() -> {
+                createMainSubMenu();
+                subMenu.setEnabled(enable);
+                recreate = true;
             });
         }
-        
     }
-    
     
     
     // Innerclasses ------------------------------------------------------------

--- a/ide/projectui/src/org/netbeans/modules/project/ui/actions/SetMainProject.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/actions/SetMainProject.java
@@ -252,13 +252,13 @@ public class SetMainProject extends ProjectAction implements PropertyChangeListe
                 if (project == null) {
                     noneItem = (JRadioButtonMenuItem) jmi;
                 }
-                if ( jmi instanceof JRadioButtonMenuItem ) {
+                if (jmi instanceof JRadioButtonMenuItem radio) {
                     if ( OpenProjectList.getDefault().isMainProject( project ) ) {
-                        ((JRadioButtonMenuItem)jmi).setSelected( true );
+                        radio.setSelected(true);
                         prjSelected = true;
                     }
                     else {
-                        ((JRadioButtonMenuItem)jmi).setSelected( false );
+                        radio.setSelected(false);
                     }
                 }
             }
@@ -270,11 +270,10 @@ public class SetMainProject extends ProjectAction implements PropertyChangeListe
     }
     
     private void checkProjectNames() {
-        for(Component componentIter : subMenu.getMenuComponents()) {
-            if(componentIter instanceof JRadioButtonMenuItem) {
-                JRadioButtonMenuItem menuItem = (JRadioButtonMenuItem) componentIter;
+        for (Component componentIter : subMenu.getMenuComponents()) {
+            if (componentIter instanceof JRadioButtonMenuItem menuItem) {
                 Project projectIter = getItemProject(menuItem);
-                if(projectIter != null && !ProjectUtils.getInformation(projectIter).getDisplayName().equals(menuItem.getText())) {
+                if (projectIter != null && !ProjectUtils.getInformation(projectIter).getDisplayName().equals(menuItem.getText())) {
                     menuItem.setText(ProjectUtils.getInformation(projectIter).getDisplayName());
                 }
             }
@@ -284,40 +283,30 @@ public class SetMainProject extends ProjectAction implements PropertyChangeListe
     // Implementation of change listener ---------------------------------------
     
     
-    @Override public void propertyChange(PropertyChangeEvent e) {
-        
-        if ( OpenProjectList.PROPERTY_OPEN_PROJECTS.equals( e.getPropertyName() )) {
-            final Project projects[] = OpenProjectList.getDefault().getOpenProjects();
-            SwingUtilities.invokeLater(new Runnable() {
-                @Override
-                public void run() {
-                   createSubMenu(projects);
-                }
-            });
-            
-        } else if ( ProjectInformation.PROP_DISPLAY_NAME.equals( e.getPropertyName() )) {
-            SwingUtilities.invokeLater(new Runnable() {
-                @Override
-                public void run() {
-                    if (subMenu != null) {
-                        checkProjectNames();
-                    }
-                }
-            });
-            
-        } else if ( OpenProjectList.PROPERTY_MAIN_PROJECT.equals( e.getPropertyName() )) {
-            SwingUtilities.invokeLater(new Runnable() {
-                @Override
-                public void run() {
-                    if (subMenu != null) {
-                        selectMainProject();
-                    }
-                }
-            });            
-            
+    @Override
+    public void propertyChange(PropertyChangeEvent e) {
+        String prop = e.getPropertyName();
+        if (prop == null) {
+            return;
         }
-        
-        
+        switch (prop) {
+            case OpenProjectList.PROPERTY_OPEN_PROJECTS -> {
+                Project[] projects = OpenProjectList.getDefault().getOpenProjects();
+                SwingUtilities.invokeLater(() -> {
+                    createSubMenu(projects);
+                });
+            }
+            case ProjectInformation.PROP_DISPLAY_NAME -> SwingUtilities.invokeLater(() -> {
+                if (subMenu != null) {
+                    checkProjectNames();
+                }
+            });
+            case OpenProjectList.PROPERTY_MAIN_PROJECT -> SwingUtilities.invokeLater(() -> {
+                if (subMenu != null) {
+                    selectMainProject();
+                }
+            });
+        }
     }
     
     /**
@@ -352,17 +341,10 @@ public class SetMainProject extends ProjectAction implements PropertyChangeListe
     private static class MenuItemActionListener implements ActionListener {
         
         @Override public void actionPerformed(ActionEvent e) {
-            
-            if ( e.getSource() instanceof JMenuItem ) {
-                JMenuItem jmi = (JMenuItem)e.getSource();
+            if (e.getSource() instanceof JMenuItem jmi) {
                 final Project project = getItemProject(jmi);
                 prefs().putBoolean(CONTEXT_MENU_ITEM_ENABLED, project != null);
-                RP.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        OpenProjectList.getDefault().setMainProject(project);
-                    }
-                });   
+                RP.post(() -> OpenProjectList.getDefault().setMainProject(project));   
             }            
         }   
     }       


### PR DESCRIPTION
Added fast paths to hot methods and all property change listeners which are active during the "opening projects" phase.

Avoid calling `findFileObject()` or using the `Lookup` in event handlers if possible.

NewFile (action): remove `PropertyChangeListener` since the `refresh()` which was called from the handler method isn't doing much anymore beside locking.

(The event handlers were called almost 1.5m times during the second project group which is why fast paths make such a difference there)

results:

speeds up post-launch "opening projects" phase by up to 30% when big project groups are loaded without making the code more complex (I tried also other tricks but they weren't worth their complexity).

`loadInBackground()` timings:

for 40 maven projects:
```
before: 7806
after: 6033
```

for 850 NetBeans ant projects:
```
before: 32476
after: 21462
```

no flame graphs this time since I overwrote the baseline graph by accident