### PR TITLE
NotificationCenterManager: Ensure filtered list manipulation is synchronized

### DIFF
--- a/ide/notifications/src/org/netbeans/modules/notifications/center/NotificationCenterManager.java
+++ b/ide/notifications/src/org/netbeans/modules/notifications/center/NotificationCenterManager.java
@@ -72,9 +72,11 @@ public class NotificationCenterManager {
                 notifications.remove(0).clear();
             }
             notifications.add(notification);
-        }
             if (isEnabled(notification)) {
                 filteredNotifications.add(notification);
+            }
+        }
+        if (isEnabled(notification)) {
             firePropertyChange(PROP_NOTIFICATION_ADDED, notification);
         }
         updateTable(capacityFull);
@@ -85,12 +87,12 @@ public class NotificationCenterManager {
             if (!notifications.remove(notification)) {
                 return;
             }
-        }
             if (isEnabled(notification)) {
                 filteredNotifications.remove(notification);
-            if (!notification.isRead()) {
-                firePropertyChange(PROP_NOTIFICATION_READ, notification);
             }
+        }
+        if (isEnabled(notification) && !notification.isRead()) {
+            firePropertyChange(PROP_NOTIFICATION_READ, notification);
         }
         updateTable(false);
     }


### PR DESCRIPTION
Manipulation requests of `filteredNotifications` are only partially covered by synchronization on `notifications`. Manipulations in `add` and `delete` were not protected. This might explain undefined behavior if the list is read while it is being modified.

Closes: #8956