### PR TITLE
Tooltip which shows variable value during debugging no longer hides automatically after variable loses focus

### DIFF
--- a/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/ToolTipUI.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/ToolTipUI.java
@@ -73,7 +73,7 @@ public final class ToolTipUI {
         EditorUI eui = Utilities.getEditorUI(editorPane);
         if (eui != null) {
             ToolTipSupport toolTipSupport = eui.getToolTipSupport();
-            toolTipSupports.setToolTip(
+            toolTipSupport.setToolTip(
                     et,
                     PopupManager.ViewPortBounds,
                     PopupManager.AbovePreferred,


### PR DESCRIPTION
**Tooltip which shows variable value during debugging no longer hides automatically after variable loses focus**

When you are in debug mode and want to see value for some variable you can find this in "variables" view. Alternatively you can hover over a variable and tooltip is displayed. Which is more convenient for some quick checks. However, if the variable is not of primitive type you need to click "expand" icon in tooltip to see any data. For example, if you variable is instance of a class - you will see has code in popup and to see any property defined for this class instance you need to click that expand icon.

Unfortunately in NetBeans sometimes it is quite tricky to put your mouse into popup before it is automatically closed. This popup is automatically closed when variable for which it is display looses focus. See attached video.
https://github.com/user-attachments/assets/ef11db79-794b-4788-bc75-7c9cb03cfa3f
Sometimes this behavior is really annoying because you can't catch popup before it is closed.
This change makes popup "heavy" or "sticky" so it does not close automatically depending on focus or mouse movement. There are two ways to close it:
* press "esc" on keyboard
* click somewhere outside of popup in code editor window.

As for me this behavior is much more convenient. I've checked idea ide - and they have very similar behavior.
Also this behavior is aligned with other "mode" of this popup - when you expend popup to see details - there is popup window which also does not close depending on focus or mouse movement - but closes if you "click outside" or press "esc".

Video with behavior after the change:
https://github.com/user-attachments/assets/185b0ca7-9356-4a9e-baee-377883d82844

So as for me this is a good change - imho it makes this functionality more convenient to use and it makes it consistent with other "mode" for same popup.
</details>