### PR TITLE
PersistenceManager deserialization logging improvement

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/persistence/PersistenceManager.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/persistence/PersistenceManager.java
@@ -22,10 +22,8 @@ package org.netbeans.core.windows.persistence;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InvalidObjectException;
 import java.io.NotSerializableException;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
@@ -395,6 +393,7 @@ public final class PersistenceManager implements PropertyChangeListener {
     
     /** Listens to property changes in InstanceDataObject. Used to clean top component
      * cache when module owning given top component is disabled. */
+    @Override
     public void propertyChange (PropertyChangeEvent evt) {
         if (DataObject.PROP_COOKIE.equals(evt.getPropertyName())) {
             Object obj = evt.getSource();
@@ -521,7 +520,6 @@ public final class PersistenceManager implements PropertyChangeListener {
             return null;
         }
         // search on disk
-        IOException resultExc = null;
         try {
             DataObject dob = findTopComponentDataObject(getComponentsLocalFolder(), stringId);
             if (dob == null) {
@@ -574,7 +572,6 @@ public final class PersistenceManager implements PropertyChangeListener {
                 // not found
                 String excAnnotation = NbBundle.getMessage(PersistenceManager.class,
                         "EXC_FailedLocateTC",  stringId);
-                resultExc = new FileNotFoundException(excAnnotation);
                 LOG.log(warningLevelForDeserTC(stringId),
                     "[PersistenceManager.getTopComponentForID]" // NOI18N
                     + " Problem when deserializing TopComponent for tcID:'" + stringId + "'. Reason: " // NOI18N
@@ -584,48 +581,24 @@ public final class PersistenceManager implements PropertyChangeListener {
 // with new projects should not happen, since projects are not switched in winsys anymore.                
 //                ErrorManager.getDefault().notify(ErrorManager.INFORMATIONAL, resultExc);
             }
-        } catch (NoClassDefFoundError ndfe) { // TEMP>>
+        } catch (DataObjectNotFoundException ex) {
             LOG.log(warningLevelForDeserTC(stringId),
                 "[PersistenceManager.getTopComponentForID]" // NOI18N
                 + " Problem when deserializing TopComponent for tcID:'" + stringId + "'. Reason: " // NOI18N
-                + ndfe.getMessage(), ndfe);
-        } catch (InvalidObjectException ioe) {
+                + ex.getMessage());
+            LOG.log(Level.FINE, "", ex);
+        } catch (NoClassDefFoundError | ClassNotFoundException | ClassCastException | IOException ex) {
             LOG.log(warningLevelForDeserTC(stringId),
                 "[PersistenceManager.getTopComponentForID]" // NOI18N
                 + " Problem when deserializing TopComponent for tcID:'" + stringId + "'. Reason: " // NOI18N
-                + ioe.getMessage(), ioe);
-        } catch (DataObjectNotFoundException dnfe) {
-            LOG.log(warningLevelForDeserTC(stringId),
-                "[PersistenceManager.getTopComponentForID]" // NOI18N
-                + " Problem when deserializing TopComponent for tcID:'" + stringId + "'. Reason: " // NOI18N
-                + " Object not found: " + dnfe.getMessage() // NOI18N
-                + ". It was probably deleted.", dnfe); // NOI18N
-        } catch (ClassNotFoundException exc) {
-            // ignore, will result in IOException fail below, annotate
-            // and turn into IOExc
-            LOG.log(warningLevelForDeserTC(stringId),
-                "[PersistenceManager.getTopComponentForID]" // NOI18N
-                + " Problem when deserializing TopComponent for tcID:'" + stringId + "'. Reason: " // NOI18N
-                + exc.getMessage(), exc);
-        } catch (ClassCastException exc) {
-            // instance is not top component (is broken), annotate and
-            // turn into IOExc
-            LOG.log(warningLevelForDeserTC(stringId),
-                "[PersistenceManager.getTopComponentForID]" // NOI18N
-                + " Problem when deserializing TopComponent for tcID:'" + stringId + "'. Reason: " // NOI18N
-                + exc.getMessage(), exc);
-        } catch (IOException ioe) {
-            LOG.log(warningLevelForDeserTC(stringId),
-                "[PersistenceManager.getTopComponentForID]" // NOI18N
-                + " Problem when deserializing TopComponent for tcID:'" + stringId + "'. Reason: " // NOI18N
-                + ioe.getMessage(), ioe);
+                + ex.getMessage(), ex);
         }
         return null;
     }
-    private final Set<String> warnedIDs = Collections.synchronizedSet(new HashSet<String>());
+    private final Set<String> warnedIDs = Collections.synchronizedSet(new HashSet<>());
     /** Avoid printing dozens of warnings about the same ID in one IDE session. */
     private Level warningLevelForDeserTC(String id) {
-        return warnedIDs.add(id) ? Level.INFO : Level.FINE;
+        return warnedIDs.add(id) ? Level.WARNING : Level.FINE;
     }
     
     /** @return Searches for TopComponent with given string id and returns
@@ -1039,6 +1012,7 @@ public final class PersistenceManager implements PropertyChangeListener {
             parser.setEntityResolver(new EntityResolver () {
                 /** Implementation of entity resolver. Points to the local DTD
                  * for our public ID */
+                @Override
                 public InputSource resolveEntity (String publicId, String systemId)
                 throws SAXException {
                     if (ModeParser.INSTANCE_DTD_ID_1_0.equals(publicId)
@@ -1389,6 +1363,7 @@ public final class PersistenceManager implements PropertyChangeListener {
            this.tcID = tcID;
         }
         
+        @Override
         public void run() {
             removeGlobalTopComponentID(tcID);
         }


### PR DESCRIPTION
Don't dump the serialized form on `DataObjectNotFoundException` when a `TopComponent` can't be deserialized. This is often harmless and happens for example when an opened project moved while NB was closed. A single warning line should be sufficient.

Full exception is logged with `FINE` level.

example log line:
```
WARNING [org.netbeans.core.windows.persistence]: [PersistenceManager.getTopComponentForID] Problem when deserializing TopComponent for tcID:'MultiView-java#002Eso2D0988CFtext#002Ehistory#007C'. Reason: /tmp/mavenproject1/src/main/java/com/mycompany/mavenproject1/Mavenproject1.java@6051f4cb:671b4d0d[invalid]
```
open project -> close NB -> remove project -> start NB


as sidenote:
the original stack dump had several lines which just said "msg". Those were ResourceBundle keys which weren't substituted with the actual message. But substituting it might cause more harm than good (given the key name). I haven't seen this anywhere else so far. My guess is that the mechanism isn't used very often. In any case the hotfix would look like:

<details>

```diff
diff --git a/platform/openide.util/src/org/openide/util/Exceptions.java b/platform/openide.util/src/org/openide/util/Exceptions.java
index 65bdd7c..de07b22 100644
--- a/platform/openide.util/src/org/openide/util/Exceptions.java
+++ b/platform/openide.util/src/org/openide/util/Exceptions.java
@@ -304,10 +304,17 @@
                 return;
             }
             try {
-
                 for (LogRecord log : r) {
-                    if (log.getMessage() != null) {
-                        a.append(log.getMessage()).append("\n");
+                    String msg = log.getMessage();
+                    if (msg != null) {
+                        ResourceBundle rb = log.getResourceBundle();
+                        if (rb != null) {
+                            String localized = rb.getString(msg);
+                            if (localized != null) {
+                                msg = localized;
+                            }
+                        }
+                        a.append(msg).append("\n");
                     }
                     if (log.getThrown() != null) {
                         StringWriter w = new StringWriter();
```

</details>