### PR TITLE
Fixes UnsupportedOperationException in maven RunGoalsPanel

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/execute/ui/RunGoalsPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/ui/RunGoalsPanel.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.maven.execute.ui;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -68,7 +69,7 @@ public class RunGoalsPanel extends javax.swing.JPanel {
         RP.post(() -> {
             GoalsProvider provider = Lookup.getDefault().lookup(GoalsProvider.class);
             if (provider != null) {
-                Set<String> strs = provider.getAvailableGoals();
+                Set<String> strs = new HashSet<>(provider.getAvailableGoals());
                 try {
                     List<String> phases = EmbedderFactory.getProjectEmbedder().getLifecyclePhases();
                     strs.addAll(phases);


### PR DESCRIPTION
provider can return an empty collection, e.g when network problems are encountered. This collection is typically immutable.

use defensive copy before adding to it, which is cleaner anyway.

exception:

<details>

```
org.apache.http.client.HttpResponseException: status code: 500, reason phrase: Internal Server Error (500)
	at org.eclipse.aether.transport.http.HttpTransporter.handleStatus(HttpTransporter.java:639)
	at org.eclipse.aether.transport.http.HttpTransporter.execute(HttpTransporter.java:509)
	at org.eclipse.aether.transport.http.HttpTransporter.implGet(HttpTransporter.java:456)
	at org.eclipse.aether.spi.connector.transport.AbstractTransporter.get(AbstractTransporter.java:64)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector$GetTaskRunner.runTask(BasicRepositoryConnector.java:482)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run(BasicRepositoryConnector.java:414)
Caused: org.eclipse.aether.transfer.ArtifactTransferException: Could not transfer artifact org.apache.maven.plugins:maven-clean-plugin:json:cyclonedx:4.0.0-beta-2 from/to central (https://repo.maven.apache.org/maven2/): status code: 500, reason phrase: Internal Server Error (500)
	at org.eclipse.aether.connector.basic.ArtifactTransportListener.transferFailed(ArtifactTransportListener.java:44)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run(BasicRepositoryConnector.java:417)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector.get(BasicRepositoryConnector.java:260)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.performDownloads(DefaultArtifactResolver.java:537)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:449)
Caused: org.eclipse.aether.resolution.ArtifactResolutionException: The following artifacts could not be resolved: org.apache.maven.plugins:maven-clean-plugin:json:cyclonedx:4.0.0-beta-2 (absent): Could not transfer artifact org.apache.maven.plugins:maven-clean-plugin:json:cyclonedx:4.0.0-beta-2 from/to central (https://repo.maven.apache.org/maven2/): status code: 500, reason phrase: Internal Server Error (500)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:473)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts(DefaultArtifactResolver.java:261)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifact(DefaultArtifactResolver.java:243)
	at org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveArtifact(DefaultRepositorySystem.java:278)
	at org.apache.maven.artifact.resolver.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:197)
Caused: org.apache.maven.artifact.resolver.ArtifactResolutionException: The following artifacts could not be resolved: org.apache.maven.plugins:maven-clean-plugin:json:cyclonedx:4.0.0-beta-2 (absent): Could not transfer artifact org.apache.maven.plugins:maven-clean-plugin:json:cyclonedx:4.0.0-beta-2 from/to central (https://repo.maven.apache.org/maven2/): status code: 500, reason phrase: Internal Server Error (500)
  org.apache.maven.plugins:maven-clean-plugin:json:4.0.0-beta-2
from the specified remote repositories:
  central (https://repo.maven.apache.org/maven2/, releases=true, snapshots=true)
	at org.apache.maven.artifact.resolver.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:202)
	at org.apache.maven.artifact.resolver.DefaultArtifactResolver.resolveAlways(DefaultArtifactResolver.java:152)
	at org.netbeans.modules.maven.embedder.MavenEmbedder.resolveArtifact(MavenEmbedder.java:424)
	at org.netbeans.modules.maven.indexer.api.RepositoryUtil.downloadArtifact(RepositoryUtil.java:98)
	at org.netbeans.modules.maven.indexer.api.PluginIndexManager.getPluginGoalNames(PluginIndexManager.java:74)
[catch] at org.netbeans.modules.maven.grammar.GoalsProviderImpl.getAvailableGoals(GoalsProviderImpl.java:41)
	at org.netbeans.modules.maven.execute.ui.RunGoalsPanel.lambda$new$1(RunGoalsPanel.java:71)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1403)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2018)
java.lang.UnsupportedOperationException
	at java.base/java.util.AbstractCollection.add(AbstractCollection.java:253)
	at java.base/java.util.AbstractCollection.addAll(AbstractCollection.java:338)
	at org.netbeans.modules.maven.execute.ui.RunGoalsPanel.lambda$new$1(RunGoalsPanel.java:74)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1403)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2018)
```

</details>
