### PR TITLE
Use `absolutize_paths` to make userdir and path absolute

### DIFF
--- a/nb/ide.launcher/unix/netbeans
+++ b/nb/ide.launcher/unix/netbeans
@@ -57,6 +57,16 @@ case "`uname -s -m`" in
         ;;
 esac
 
+absolutize_paths() {
+    while read path; do
+        if [ -d "$path" ]; then
+            (cd "$path" 2>/dev/null && pwd)
+        else
+            echo "$path"
+        fi
+    done
+}
+
 # $HOME can be used as it is present on mac OS and
 BASEDIR=$basedir
 
@@ -73,7 +83,7 @@ export DEFAULT_USERDIR_ROOT
 
 if ! [ "$NETBEANS_USERDIR" = "IGNORE" ]; then
     # make sure own launcher directory is on PATH as a fallback
-    PATH=$PATH:$progdir
+    PATH=$PATH:`echo $progdir | absolutize_paths`
 fi
 
 # #68373: look for userdir, but do not modify "$@"
@@ -123,16 +133,6 @@ readClusters() {
     done
 }
 
-absolutize_paths() {
-    while read path; do
-        if [ -d "$path" ]; then
-            (cd "$path" 2>/dev/null && pwd)
-        else
-            echo "$path"
-        fi
-    done
-}
-
 netbeans_clusters=`readClusters | absolutize_paths | tr '\012' ':'`
 
 if [ ! -z "$netbeans_extraclusters" ] ; then
@@ -153,7 +153,7 @@ launchNbexec() {
     then
         sh=/bin/bash
     fi
-    NETBEANS_USERDIR=${userdir}
+    NETBEANS_USERDIR=`echo ${userdir} | absolutize_paths`
     export NETBEANS_USERDIR
     if [ "${founduserdir}" = "yes" ]; then
         exec $sh "$nbexec" "$@"


### PR DESCRIPTION
If you invoke the launcher with a relative path, that relative path is set to `NETBEANS_USERDIR`. The moment you change the local directory in the terminal this invalidates the reference as now the relative path resolves to a different directory. 
On Linux invoked as `./nbbuild/netbeans/bin/netbeans --userdir x` we used to get:

<img width="532" height="99" alt="Image" src="https://github.com/user-attachments/assets/21c404b8-7956-475e-9c9a-7755d4304011" />

This PR "absolutizes" both paths. The `NETBEANS_USERDIR` as well as the path to the `bin` directory. 

<img width="531" height="110" alt="absolute path" src="https://github.com/user-attachments/assets/de611dfa-52b1-4acb-99db-579aa08dd86c" />

Gets printed in the NetBeans terminal window now. 