### PR TITLE
Make some refactoring warnings messages localisable

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/CodeRefactoring.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/CodeRefactoring.java
@@ -61,6 +61,7 @@ import org.netbeans.modules.refactoring.spi.RefactoringElementImplementation;
 import org.netbeans.modules.refactoring.spi.Transaction;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
+import org.openide.util.NbBundle;
 
 /**
  *
@@ -141,10 +142,16 @@ public abstract class CodeRefactoring extends CodeActionsProvider {
         return p;
     }
 
+    @NbBundle.Messages({
+        "# {0} - problems message",
+        "PROMPT_AskProceedWithRefactoringProblems=Refactoring may lead to following problems: {0}.\nDo you still want to proceed with the refactoring?",
+        "PROMPT_AskProceedWithRefactoringProblems_Yes=Yes",
+        "PROMPT_AskProceedWithRefactoringProblems_No=No",
+    })
     private static ShowMessageRequestParams warningsMessageParams(
             Problem p) {
-        final MessageActionItem yes = new MessageActionItem("Yes");
-        final MessageActionItem no = new MessageActionItem("No");
+        final MessageActionItem yes = new MessageActionItem(Bundle.PROMPT_AskProceedWithRefactoringProblems_Yes());
+        final MessageActionItem no = new MessageActionItem(Bundle.PROMPT_AskProceedWithRefactoringProblems_No());
         ShowMessageRequestParams smrp = new ShowMessageRequestParams(Arrays.asList(yes, no));
         StringBuilder msgs = new StringBuilder();
         while (p != null) {
@@ -152,8 +159,7 @@ public abstract class CodeRefactoring extends CodeActionsProvider {
             msgs.append('\n');
             p = p.getNext();
         }
-        smrp.setMessage(String.format("Refactoring will lead to following problems \n %s ,"
-                + "Do you want to proceed with the problems ?", msgs.toString()));
+        smrp.setMessage(Bundle.PROMPT_AskProceedWithRefactoringProblems(msgs.toString()));
         smrp.setType(MessageType.Warning);
         return smrp;
     }
@@ -161,7 +167,7 @@ public abstract class CodeRefactoring extends CodeActionsProvider {
     private static void showRefactoringWarnings(NbCodeLanguageClient client,AbstractRefactoring refactoring,RefactoringSession session,Problem p) {
         ShowMessageRequestParams smrp = warningsMessageParams(p);
         client.showMessageRequest(smrp).thenAccept(ai -> {
-            if (ai.getTitle().equalsIgnoreCase("Yes")) {
+            if (ai.getTitle().equalsIgnoreCase(Bundle.PROMPT_AskProceedWithRefactoringProblems_Yes())) {
                 try {
                     client.applyEdit(new ApplyWorkspaceEditParams(perform(refactoring, session)));
                 } catch (Exception ex) {


### PR DESCRIPTION

Small change related to recent PR #8968 , adding the new message labels to bundle



<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>