### PR TITLE
mavenembedder asm fix

### DIFF
--- a/java/maven.embedder/checkembedded.sh
+++ b/java/maven.embedder/checkembedded.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+EXTERNALFILE=external/binariesembedded-list
+
+while read -r LINE ; do
+   if [[ $LINE =~ ^# ]]; then continue; fi
+   if [[ -z $LINE ]]; then continue; fi
+     printf 'checking dependency %s\n' "$LINE"
+     artifact=`echo $LINE | cut -d ";" -f 2`
+     groupId=`echo ${artifact} | cut  -d ":" -f 1`
+     artifactId=`echo ${artifact} | cut -d ":" -f 2`
+     version=`echo ${artifact} | cut -d ":" -f 3`
+     mvn dependency:get -DgroupId=${groupId} -DartifactId=${artifactId} -Dversion=${version} | grep 'BUILD FAILURE'
+done <  "$EXTERNALFILE"

--- a/java/maven.embedder/external/binariesembedded-list
+++ b/java/maven.embedder/external/binariesembedded-list
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-DC19ECB3F7889B7860697215CAE99C0F9B6F6B4B;aopalliance:asm:9.8
+DC19ECB3F7889B7860697215CAE99C0F9B6F6B4B;org.ow2.asm:asm:9.8
 0235BA8B489512805AC13A8F9EA77A1CA5EBE3E8;aopalliance:aopalliance:1.0
 1194890E6F56EC29177673F2F12D0B8E627DEC98;org.apache.httpcomponents:httpclient:4.5.14
 51CF043C87253C9F58B539C9F7E44C8894223850;org.apache.httpcomponents:httpcore:4.4.16


### PR DESCRIPTION
fix dependencies for asm. it shoud be org.ow2.asm:asm:9.8

added a bash script to try downloading artifacts, only display failure. 