### PR TITLE
Set --sun-misc-unsafe-memory-access=warn (JEP 498)

### DIFF
--- a/nb/ide.launcher/netbeans.conf
+++ b/nb/ide.launcher/netbeans.conf
@@ -66,7 +66,7 @@ netbeans_default_cachedir="${DEFAULT_CACHEDIR_ROOT}/@@metabuild.RawVersion@@"
 # The automatically selected value can be overridden by specifying -J-Xmx
 # here or on the command line.
 #
-netbeans_default_options="-J-XX:+UseStringDeduplication -J-Xss2m @@metabuild.logcli@@ -J-Djava.lang.Runtime.level=FINE -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.application.appearance=system -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.extbrowser.manual_chrome_plugin_install=yes @@metabuild.jms-flags@@ -J-XX:+IgnoreUnrecognizedVMOptions -J-javaagent:\"${BASEDIR}/ide/netbeans-javaagent.jar\""
+netbeans_default_options="-J-XX:+UseStringDeduplication -J-Xss2m @@metabuild.logcli@@ -J-Djava.lang.Runtime.level=FINE -J--sun-misc-unsafe-memory-access=warn -J-Dguice_custom_class_loading=CHILD -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.application.appearance=system -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.extbrowser.manual_chrome_plugin_install=yes @@metabuild.jms-flags@@ -J-XX:+IgnoreUnrecognizedVMOptions -J-javaagent:\"${BASEDIR}/ide/netbeans-javaagent.jar\""
 
 # Default location of JDK:
 # (set by installer or commented out if launcher should decide)


### PR DESCRIPTION
Set --sun-misc-unsafe-memory-access=warn (JEP 498)
 - JDK 26 will change the default from `warn` it to `deny` and throw on `Unsafe` mem access method usage, this sets it back
 - gives us more time to update the dependencies (till JDK 27)

note: as of 26b23, this isn't implemented yet

set `-J-Dguice_custom_class_loading=CHILD`
  - this will lead guice to code paths which don't use `Unsafe` for class definition
    (e.g it won't use `com.google.inject.internal.aop.HiddenClassDefiner`)
  - maven 4 uses the same trick (https://github.com/apache/maven/pull/11002)

meta issue https://github.com/apache/netbeans/issues/8259