### PR TITLE
JavaScript: Detect duplicate private class elements and invalid constructors

### DIFF
--- a/webcommon/libs.nashorn/nbproject/project.properties
+++ b/webcommon/libs.nashorn/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 

--- a/webcommon/libs.nashorn/src/com/oracle/js/parser/resources/Messages.properties
+++ b/webcommon/libs.nashorn/src/com/oracle/js/parser/resources/Messages.properties
@@ -101,6 +101,8 @@ parser.error.expected.import=expected ImportClause or ModuleSpecifier
 parser.error.expected.as=expected 'as'
 parser.error.expected.binding.identifier=expected BindingIdentifier
 parser.error.expected.from=expected 'from'
+parser.error.constructor.nonplain=Constructor must be a plain, non-static, public method
+parser.error.private.multiplebindings=Multiple bindings for private class element found
 
 # ES7 mode error messages
 parser.error.decorator.method.only=decorators may be used on methods only

--- a/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/ParserTest.java
+++ b/webcommon/libs.nashorn/test/unit/src/com/oracle/js/parser/ParserTest.java
@@ -126,6 +126,116 @@ public class ParserTest {
     }
 
     @Test
+    public void testConstructor() {
+        assertParses("""
+            class T {
+                constructor() {}
+            }
+        """);
+        // Parser should reject multiple constructors
+        assertParsesNot(Integer.MAX_VALUE, """
+            class T {
+                constructor() {}
+                constructor() {}
+            }
+        """);
+        // Parser should reject private constructors
+        assertParsesNot(Integer.MAX_VALUE, """
+            class T {
+                #constructor() {}
+            }
+        """);
+        // Parser should reject fields with name constructor
+        assertParsesNot(Integer.MAX_VALUE, """
+            class T {
+                constructor = X
+            }
+        """);
+        // Parser should reject generator function as constructor
+        assertParsesNot(Integer.MAX_VALUE, """
+            class T {
+                *constructor() {}
+            }
+        """);
+        // Parser should reject getter function as constructor
+        assertParsesNot(Integer.MAX_VALUE, """
+            class T {
+                get constructor() {}
+            }
+        """);
+        // Parser should reject getter function as constructor
+        assertParsesNot(Integer.MAX_VALUE, """
+            class T {
+                set constructor(value) {}
+            }
+        """);
+    }
+
+    @Test
+    public void testRejectDuplicatePrivateMembers() {
+        assertParses(Integer.MAX_VALUE, """
+            class T {
+                get #X() {};
+                set #X(value) {};
+            }
+        """);
+        // Plain field and getter should be rejected
+        assertParsesNot(Integer.MAX_VALUE, """
+            class T {
+                #X;
+                get #X() {};
+            }
+        """);
+        assertParsesNot(Integer.MAX_VALUE, """
+            class T {
+                #X = 1;
+                get #X() {};
+            }
+        """);
+        // Plain field and setter should be rejected
+        assertParsesNot(Integer.MAX_VALUE, """
+            class T {
+                #X;
+                set #X() {};
+            }
+        """);
+        assertParsesNot(Integer.MAX_VALUE, """
+            class T {
+                #X = 1;
+                set #X() {};
+            }
+        """);
+        // Plain field and method should be rejected
+        assertParsesNot(Integer.MAX_VALUE, """
+            class T {
+                #X;
+                #X() {};
+            }
+        """);
+        // Duplicate method should be rejected
+        assertParsesNot(Integer.MAX_VALUE, """
+            class T {
+                #X() {};
+                #X() {};
+            }
+        """);
+        // Duplicate fields should be rejected
+        assertParsesNot(Integer.MAX_VALUE, """
+            class T {
+                #X;
+                #X;
+            }
+        """);
+        // Mixed static declarations should be rejected
+       assertParsesNot(Integer.MAX_VALUE, """
+            class T {
+                get #X() {};
+                static set #X(value) {};
+            }
+        """);
+    }
+
+    @Test
     public void testNullishCoalesce() {
         assertParses("let a = b ?? 3");
         assertParsesNot( 10, "let a = b ?? 3");
@@ -390,7 +500,6 @@ public class ParserTest {
             assertNull("Parsing should have failed", fn);
         } else {
             assertNotNull("Parser did not yield result", fn);
-            dumpTree(fn);
         }
     }
 


### PR DESCRIPTION
The JS parser should invalid constructs such as:

- Multiple declarations of constructor:
  ```javascript
    class T {
        constructor() {}
        constructor() {}
    }
  ```
- Private constructors:
  ```javascript
    class T {
        #constructor() {}
    }
  ```
- Fields that are named constructor:
  ```javascript
    class T {
        constructor = X
    }
  ```
- Generators named constructor:
  ```javascript
    class T {
        *constructor() {}
    }
  ```
- Accessors named constructor:
  ```javascript
    class S {
        get constructor() {}
    }

    class T {
        set constructor(value) {}
    }
  ```

Private element must be declared only once:

- Accessor pair should be accepted
  ```javascript
    class T {
        get #X() {};
        set #X(value) {};
    }
  ```
- Reject plain field and and accessor
  ```javascript
    class T {
        #X = 1;
        get #X() {};
    }
  ```
  ```javascript
    class T {
        #X = 1;
        set #X() {};
    }
  ```
- Plain field and method should be rejected
  ```javascript
    class T {
        #X;
        #X() {};
    }
  ```
- Duplicate method should be rejected
  ```javascript
    class T {
        #X() {};
        #X() {};
    }
  ```
- Duplicate fields should be rejected
  ```javascript
    class T {
        #X;
        #X;
    }
  ```
- Mixed static declarations should be rejected
  ```javascript
    class T {
        get #X() {};
        static set #X(value) {};
    }
  ```

Closes: #8953
