### PR TITLE
Improve editor tooltip mouse ignore area computation.

### DIFF
--- a/ide/editor.lib/nbproject/project.properties
+++ b/ide/editor.lib/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.release=17
 spec.version.base=4.38.0
 is.autoload=true
 

--- a/ide/editor.lib/src/org/netbeans/editor/ext/ToolTipSupport.java
+++ b/ide/editor.lib/src/org/netbeans/editor/ext/ToolTipSupport.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.editor.ext;
 
-import org.netbeans.api.editor.StickyWindowSupport;
 import java.awt.Color;
 import java.awt.Container;
 import java.awt.Dimension;
@@ -35,6 +34,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
+import java.awt.geom.Rectangle2D;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
@@ -156,7 +156,11 @@ public class ToolTipSupport {
     private static final String HTML_PREFIX_UPPERCASE = "<HTML"; //NOI18N
 
     private static final String LAST_TOOLTIP_POSITION = "ToolTipSupport.lastToolTipPosition"; //NOI18N
+
+    /// Key for ignored area rectangle stored as client property.
+    /// Allowes the mouse pointer to safely enter the tooltip without the risk of it disapearing.
     private static final String MOUSE_MOVE_IGNORED_AREA = "ToolTipSupport.mouseMoveIgnoredArea"; //NOI18N
+
     private static final String MOUSE_LISTENER = "ToolTipSupport.noOpMouseListener"; //NOI18N
 
     private static final Action NO_ACTION = new TextAction("tooltip-no-action") { //NOI18N
@@ -667,8 +671,7 @@ public class ToolTipSupport {
         if (this.status != status) {
             int oldStatus = this.status;
             this.status = status;
-            firePropertyChange(PROP_STATUS,
-                Integer.valueOf(oldStatus), Integer.valueOf(this.status));
+            firePropertyChange(PROP_STATUS, oldStatus, this.status);
         }
     }
 
@@ -799,9 +802,15 @@ public class ToolTipSupport {
                     try {
                         int[] offsets = Utilities.getSelectionOrIdentifierBlock(component, pos);
                         if (offsets != null) {
-                            Rectangle r1 = component.modelToView(offsets[0]);
-                            Rectangle r2 = component.modelToView(offsets[1]);
-                            blockBounds = new Rectangle(r1.x, r1.y, r2.x - r1.x, r1.height);
+                            Rectangle2D r1 = component.modelToView2D(offsets[0]);
+                            Rectangle2D r2 = component.modelToView2D(offsets[1]);
+                            int margin = 6; // additional x-margin for the ignore area, shouldn't be much wider than 1-2 characters
+                            blockBounds = new Rectangle(
+                                    (int) (r1.getX() - margin),
+                                    (int) (r1.getY()),
+                                    (int) (r2.getX() - r1.getX() + margin * 2),
+                                    (int) (r1.getHeight())
+                            );
                         }
                     } catch (BadLocationException ble) {}
                     toolTip.putClientProperty(MOUSE_MOVE_IGNORED_AREA, computeMouseMoveIgnoredArea(
@@ -975,8 +984,7 @@ public class ToolTipSupport {
                     if (parent instanceof JLayeredPane) {
                         parent = parent.getParent();
                     }
-                    if (parent instanceof JViewport) {
-                        JViewport vp = (JViewport)parent;
+                    if (parent instanceof JViewport vp) {
                         p = new Point(vp.getViewPosition().x, p.y);
                     }
                 }

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/ToolTipView.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/ToolTipView.java
@@ -116,7 +116,7 @@ public final class ToolTipView extends JComponent implements org.openide.util.He
 
         private JButton expButton;
         private JButton pinButton;
-        private JComponent textToolTip;
+        private final JComponent textToolTip;
         private boolean widthCheck = true;
         private boolean sizeSet = false;
 
@@ -243,6 +243,23 @@ public final class ToolTipView extends JComponent implements org.openide.util.He
             JTextArea ta = new TextToolTip(wrapLines);
             ta.setText(toolTipText);
             return ta;
+        }
+
+        /**
+         * Adjusts the tooltip location to position the pin button above the cursor.
+         * 
+         * Helps to keep the mouse pointer within the mouse motion ignore area of ext.ToolTipSupport
+         * with the purpose of preventing the tooltip from disappearing while the mouse is moving towards it.
+         */
+        public int getXOffset() {
+            double offset = 0;
+            if (pinButton != null) {
+                offset += pinButton.getPreferredSize().getWidth();
+            }
+            if (expButton != null) {
+                offset += expButton.getPreferredSize().getWidth();
+            }
+            return - (int) (offset / 2 + 2);
         }
 
         private static class TextToolTip extends JTextArea {

--- a/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/ToolTipUI.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/ToolTipUI.java
@@ -72,7 +72,13 @@ public final class ToolTipUI {
     public ToolTipSupport show(JEditorPane editorPane) {
         EditorUI eui = Utilities.getEditorUI(editorPane);
         if (eui != null) {
-            eui.getToolTipSupport().setToolTip(et);
+            eui.getToolTipSupport().setToolTip(
+                    et,
+                    PopupManager.ViewPortBounds,
+                    PopupManager.AbovePreferred,
+                    et.getXOffset(),
+                    0
+            );
             this.editorPane = editorPane;
             return eui.getToolTipSupport();
         } else {


### PR DESCRIPTION
Some editor tooltips are interactive. To be able to enter the tooltip with the mouse, a rectangle is computed which prevents the tooltip to hide, even if the mouse leaves the component (which would hide it instantly).

This improves this mechanism slightly by

 - adding an extra x-margin to the ignored area
 - offsetting the debugger tooltip to further move the buttons into the ignored area (right above the mouse cursor)

other:
 - removed obsolete code in `ToolTipAnnotation` and minor cleanup in that class (no other changes).

debug graphics indicates the ignore area, before:
<img width="966" height="140" alt="debug-tooltip-before" src="https://github.com/user-attachments/assets/b7535552-646c-4a00-a1ce-8141ac425e08" />

after:
<img width="966" height="140" alt="debug-tooltip-after" src="https://github.com/user-attachments/assets/722656a7-0e8f-4d3b-bc74-a97c421f1cd8" />

please note the area is now wider and the tooltip moved even more to the left, I was just too lazy to re-create the screenshot.

also: the code path is shared with some other editor tooltips, e.g ctrl+hover javadoc tooltip

other things I tried:

Why can't it be the entire width of the tooltip? Because this would prevent neighboring components to spawn their own tooltip (see example with `foo,bar,baz` next to each other). I did try to fight this problem by making the ignore area time based - but this made the code even more complicated and harder to maintain.

things I didn't try but could further improve this mechanism:

Use a trapezoid instead of a rectangle (upper part could have the width of the tooltip)

closes https://github.com/apache/netbeans/pull/8961 (alternative proposal)