### PR TITLE
Better handling of local class when creating local variable-like elements.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeType.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeType.java
@@ -168,7 +168,7 @@ public final class ChangeType implements ErrorRule<Void> {
                     return null;
                 }
                 //anonymous class?
-                expressionType[0] = org.netbeans.modules.java.hints.errors.Utilities.convertIfAnonymous(expressionType[0]);
+                expressionType[0] = org.netbeans.modules.java.hints.errors.Utilities.convertIfAnonymous(expressionType[0], true);
 
                 result.add(new ChangeTypeFix(info, treePath,
                         ((VariableTree) leaf[0]).getName().toString(), 

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeTypeFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/ChangeTypeFix.java
@@ -61,7 +61,7 @@ final class ChangeTypeFix extends JavaFix {
         ChangeType.computeType(working, position, tm, expressionType, leaf);
 
         //anonymous class?
-        expressionType[0] = Utilities.convertIfAnonymous(expressionType[0]);
+        expressionType[0] = Utilities.convertIfAnonymous(expressionType[0], true);
 
         if (leaf[0] instanceof VariableTree) {
             VariableTree oldVariableTree = ((VariableTree)leaf[0]);

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElement.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElement.java
@@ -358,6 +358,7 @@ public final class CreateElement implements ErrorRule<Void> {
         if (!ErrorFixesFakeHint.enabled(info.getFileObject(), FixKind.CREATE_LOCAL_VARIABLE)) {
             fixTypes.remove(ElementKind.LOCAL_VARIABLE);
         }
+        TypeMirror localType;
         final TypeMirror type;
         
         if (types != null && !types.isEmpty()) {
@@ -376,13 +377,15 @@ public final class CreateElement implements ErrorRule<Void> {
                 i++;
             }
             //XXX: should reasonably consider all the found type candidates, not only the one:
-            type = types.get(0);
+            localType = Utilities.convertIfAnonymous(types.get(0), true);
+            type = Utilities.convertIfAnonymous(types.get(0), false);
             
             if (superType[0] == null) {
                 // the type must be already un-captured.
                 superType[0] = type;
             }
         } else {
+            localType = null;
             type = null;
         }
 
@@ -500,11 +503,11 @@ public final class CreateElement implements ErrorRule<Void> {
             if (ee != null && fixTypes.contains(ElementKind.PARAMETER) && !Utilities.isMethodHeaderInsideGuardedBlock(info, (MethodTree) firstMethod.getLeaf()))
                 result.add(new AddParameterOrLocalFix(info, type, simpleName, ElementKind.PARAMETER, identifierPos).toEditorFix());
             if ((firstMethod != null || firstInitializer != null || firstLambda != null) && fixTypes.contains(ElementKind.LOCAL_VARIABLE) && ErrorFixesFakeHint.enabled(ErrorFixesFakeHint.FixKind.CREATE_LOCAL_VARIABLE))
-                result.add(new AddParameterOrLocalFix(info, type, simpleName, ElementKind.LOCAL_VARIABLE, identifierPos).toEditorFix());
+                result.add(new AddParameterOrLocalFix(info, localType, simpleName, ElementKind.LOCAL_VARIABLE, identifierPos).toEditorFix());
             if (fixTypes.contains(ElementKind.RESOURCE_VARIABLE))
-                result.add(new AddParameterOrLocalFix(info, type, simpleName, ElementKind.RESOURCE_VARIABLE, identifierPos).toEditorFix());
+                result.add(new AddParameterOrLocalFix(info, localType, simpleName, ElementKind.RESOURCE_VARIABLE, identifierPos).toEditorFix());
             if (fixTypes.contains(ElementKind.OTHER))
-                result.add(new AddParameterOrLocalFix(info, type, simpleName, ElementKind.OTHER, identifierPos).toEditorFix());
+                result.add(new AddParameterOrLocalFix(info, localType, simpleName, ElementKind.OTHER, identifierPos).toEditorFix());
         }
 
         return result;

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElementUtilities.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/CreateElementUtilities.java
@@ -390,9 +390,6 @@ public final class CreateElementUtilities {
             type = info.getTrees().getTypeMirror(new TreePath(parent, at.getExpression()));
 
             if (type != null) {
-                //anonymous class?
-                type = org.netbeans.modules.java.hints.errors.Utilities.convertIfAnonymous(type);
-
                 if (type.getKind() == TypeKind.EXECUTABLE) {
                     //TODO: does not actualy work, attempt to solve situations like:
                     //t = Collections.emptyList()

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/Utilities.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/Utilities.java
@@ -656,13 +656,13 @@ public class Utilities {
      * 
      * @return typemirror of supertype/iface, initial tm if not anonymous
      */
-    public static TypeMirror convertIfAnonymous(TypeMirror tm) {
+    public static TypeMirror convertIfAnonymous(TypeMirror tm, boolean keepLocal) {
         //anonymous class?
         Set<ElementKind> fm = EnumSet.of(ElementKind.METHOD, ElementKind.FIELD);
         if (tm instanceof DeclaredType) {
             Element el = ((DeclaredType) tm).asElement();
             //XXX: the null check is needed for lambda type, not covered by test:
-            if (el != null && (el.getSimpleName().length() == 0 || fm.contains(el.getEnclosingElement().getKind()))) {
+            if (el != null && (el.getSimpleName().length() == 0 || (!keepLocal && fm.contains(el.getEnclosingElement().getKind())))) {
                 List<? extends TypeMirror> interfaces = ((TypeElement) el).getInterfaces();
                 if (interfaces.isEmpty()) {
                     tm = ((TypeElement) el).getSuperclass();
@@ -1156,7 +1156,7 @@ public class Utilities {
             TypeMirror tm = info.getTrees().getTypeMirror(argPath);
 
             //anonymous class?
-            tm = Utilities.convertIfAnonymous(tm);
+            tm = Utilities.convertIfAnonymous(tm, false);
 
             if (tm == null || tm.getKind() == TypeKind.NONE || containsErrorsRecursively(tm)) {
                 return null;

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/InstanceRefFinder.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/InstanceRefFinder.java
@@ -67,7 +67,6 @@ public class InstanceRefFinder extends ErrorAwareTreePathScanner {
      * Immediate enclosing element
      */
     private Element                 enclosingElement;
-    private TreePath                enclosingElementPath;
     private TypeElement             enclosingType;
     
     private Set<TypeElement>        superReferences = Collections.<TypeElement>emptySet();
@@ -135,8 +134,7 @@ public class InstanceRefFinder extends ErrorAwareTreePathScanner {
                 case INTERFACE:
                 case RECORD:
                 case NEW_CLASS:
-                    enclosingElementPath = path;
-                    enclosingElement = ci.getTrees().getElement(enclosingElementPath);
+                    enclosingElement = ci.getTrees().getElement(path);
                     if (enclosingElement == null) {
                         return;
                     }
@@ -152,9 +150,6 @@ public class InstanceRefFinder extends ErrorAwareTreePathScanner {
     }
     
     private void addLocalReference(TypeElement el) {
-        if (this.enclosingElement != el.getEnclosingElement()) {
-            return;
-        }
         if (localReferences.isEmpty()) {
             localReferences = new HashSet<TypeElement>();
         }

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceExpressionBasedMethodFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceExpressionBasedMethodFix.java
@@ -233,7 +233,7 @@ final class IntroduceExpressionBasedMethodFix extends IntroduceFixBase implement
                 if (expression == null || returnType == null) {
                     return; //TODO...
                 }
-                returnType = Utilities.convertIfAnonymous(Utilities.resolveTypeForDeclaration(copy, returnType));
+                returnType = Utilities.convertIfAnonymous(Utilities.resolveTypeForDeclaration(copy, returnType), false);
                 final TreeMaker make = copy.getTreeMaker();
                 Tree returnTypeTree = make.Type(returnType);
                 copy.tag(returnTypeTree, TYPE_TAG);

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceFieldFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceFieldFix.java
@@ -284,7 +284,7 @@ class IntroduceFieldFix extends IntroduceFixBase implements Fix {
             if (tm == null) {
                 return; //TODO...
             }
-            tm = Utilities.convertIfAnonymous(Utilities.resolveTypeForDeclaration(parameter, tm));
+            tm = Utilities.convertIfAnonymous(Utilities.resolveTypeForDeclaration(parameter, tm), false);
             TreePath pathToClass = findTargetClass(parameter, resolved);
             if (pathToClass == null) {
                 return; //TODO...

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceVariableFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceVariableFix.java
@@ -169,7 +169,7 @@ final class IntroduceVariableFix extends IntroduceFixBase implements Fix {
                 if (tm == null) {
                     return; //TODO...
                 }
-                tm = Utilities.convertIfAnonymous(Utilities.resolveTypeForDeclaration(parameter, tm));
+                tm = Utilities.convertIfAnonymous(Utilities.resolveTypeForDeclaration(parameter, tm), true);
                 if (!Utilities.isValidType(tm)) {
                     return; // TODO...
                 }

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AddParameterOrLocalFixTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/AddParameterOrLocalFixTest.java
@@ -666,6 +666,102 @@ public class AddParameterOrLocalFixTest extends ErrorHintsTestBase {
                 """.replaceAll("[ \t\n]+", " "));
     }
 
+    public void testLocalClass1() throws Exception {
+        sourceLevel = "17";
+        performAnalysisTest("test/Test.java",
+                """
+                package test;
+                public class Test {
+                    private void t() {
+                        record R(int i) {}
+                        r|r = new R(0);
+                    }
+                }
+                """,
+                "AddParameterOrLocalFix:rr:java.lang.Record:PARAMETER",
+                "AddParameterOrLocalFix:rr:R:LOCAL_VARIABLE");
+    }
+
+    public void testLocalClass2() throws Exception {
+        sourceLevel = "17";
+        performFixTest("test/Test.java",
+                """
+                package test;
+                public class Test {
+                    private void t() {
+                        record R(int i) {}
+                        r|r = new R(0);
+                    }
+                }
+                """,
+                "AddParameterOrLocalFix:rr:R:LOCAL_VARIABLE",
+                """
+                package test;
+                public class Test {
+                    private void t() {
+                        record R(int i) {}
+                        R rr = new R(0);
+                    }
+                }
+                """.replaceAll("[ \t\n]+", " "));
+                
+    }
+
+    public void testTWRLocalClass() throws Exception {
+        sourceLevel = "17";
+        performFixTest("test/Test.java",
+                """
+                package test;
+                public class Test {
+                    private void t() {
+                        class Impl implements AutoCloseable {
+                            public void close() {}
+                        }
+                        try (|impl = new Impl()) {
+                        }
+                    }
+                }
+                """,
+                "AddParameterOrLocalFix:impl:Impl:RESOURCE_VARIABLE",
+                """
+                package test;
+                public class Test {
+                    private void t() {
+                        class Impl implements AutoCloseable {
+                            public void close() {}
+                        }
+                        try (Impl impl = new Impl()) {
+                        }
+                    }
+                }
+                """.replaceAll("[ \t\n]+", " "));
+    }
+
+    public void testLocalClassForInit() throws Exception {
+        sourceLevel = "17";
+        performFixTest("test/Test.java",
+                """
+                package test;
+                public class Test {
+                    private void t() {
+                        record R(int i) {}
+                        for (r|r = new R(0); ;) {}
+                    }
+                }
+                """,
+                "AddParameterOrLocalFix:rr:R:OTHER",
+                """
+                package test;
+                public class Test {
+                    private void t() {
+                        record R(int i) {}
+                        for (R rr = new R(0); ;) {}
+                    }
+                }
+                """.replaceAll("[ \t\n]+", " "));
+                
+    }
+
     @Override
     protected List<Fix> computeFixes(CompilationInfo info, String diagnosticCode, int pos, TreePath path) throws Exception {
         List<Fix> fixes = super.computeFixes(info, diagnosticCode, pos, path);

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ChangeTypeTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ChangeTypeTest.java
@@ -199,6 +199,31 @@ public class ChangeTypeTest extends ErrorHintsTestBase {
              "}").replaceAll("\\s+", " "));
     }
 
+    public void testLocalClass() throws Exception {
+        sourceLevel = "17";
+        performFixTest("test/Test.java",
+            """
+            package test;
+            public class Test {
+                private void test() {
+                    record R(int i) {}
+                    String str = new R(0);
+                }
+            }
+            """,
+            -1,
+            "Change type of str to R",
+            """
+            package test;
+            public class Test {
+                private void test() {
+                    record R(int i) {}
+                    R str = new R(0);
+                }
+            }
+            """.replaceAll("\\s+", " "));
+    }
+
 
     protected List<Fix> computeFixes(CompilationInfo info, int pos, TreePath path) {
         return new ChangeType().run(info, null, pos, path, null);

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/introduce/IntroduceHintTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/introduce/IntroduceHintTest.java
@@ -2618,6 +2618,87 @@ public class IntroduceHintTest extends NbTestCase {
                        1, 0);
     }
     
+    public void testLocalType1() throws Exception {
+        sourceLevel = "17";
+        performCheckFixesTest(
+                """
+                package test;
+                public class Test {
+                    public static void test() {
+                        record R(int i) {}
+                        |new R(0)|;
+                    }
+                }
+                """,
+                "[IntroduceFix:r:1:CREATE_VARIABLE]",
+                "[IntroduceField:r:1:true:false:[3, 3]]");
+    }
+
+    public void testLocalType2() throws Exception {
+        sourceLevel = "17";
+        performCheckFixesTest(
+                """
+                package test;
+                public class Test {
+                    public static void test() {
+                        record R(int i) {}
+                        R r = |new R(0)|;
+                    }
+                }
+                """,
+                "[IntroduceFix:r1:1:CREATE_VARIABLE]",
+                "[IntroduceField:r:1:true:false:[3, 3]]");
+    }
+
+    public void testIntroduceVariableLocalType() throws Exception {
+        sourceLevel = "17";
+        performFixTest("""
+                       package test;
+                       public class Test {
+                           public static void test() {
+                               record R(int i) {}
+                               |new R(0)|;
+                           }
+                       }
+                       """,
+                       """
+                       package test;
+                       public class Test {
+                           public static void test() {
+                               record R(int i) {}
+                               R name = new R(0);
+                           }
+                       }
+                       """.replaceAll("[ \t\n]+", " "),
+                       new DialogDisplayerImpl("name", false, false, true),
+                       2, 0);
+    }
+
+    public void testIntroduceFieldLocalType() throws Exception {
+        sourceLevel = "17";
+        performFixTest("""
+                       package test;
+                       public class Test {
+                           public static void test() {
+                               record R(int i) {}
+                               |new R(0)|;
+                           }
+                       }
+                       """,
+                       """
+                       package test;
+                       public class Test {
+                           private static Record name;
+                           public static void test() {
+                               record R(int i) {}
+                               name = new R(0);
+                           }
+                       }
+                       """.replaceAll("[ \t\n]+", " "),
+                       new DialogDisplayerImpl("name", false, false, true),
+                       2, 1);
+    }
+
     protected void prepareTest(String code) throws Exception {
         clearWorkDir();
 


### PR DESCRIPTION
Consider code like:
```
void test() {
    record R(int i) {}
    r = new R(0);
}
```

there's an error on the `r = new R(0);` line, as `r` is not defined. There's a fix available for that, but if that's used, the type of the variable will be `Record`. That's not ideal - `R` would be much better.

Given that, with the introduction of record, local classes might be more common than before, this PR's goal is to improve handling of local classes in hints that generate variables.

For introduce hint, this PR will detect some variants would not work well, and does not offer them to the user.

What do you think?



---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>