### PR TITLE
Upgrade nb-javac to JDK 26b27

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1456,10 +1456,10 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java: [ '17', '25' ]
+        java: [ '17', '26-ea' ]
         config: [ 'batch1', 'batch2' ]
         exclude:
-          - java: ${{ github.event_name == 'pull_request' && 'nothing' || '25' }}
+          - java: ${{ github.event_name == 'pull_request' && 'nothing' || '26-ea' }}
       fail-fast: false
     steps:
 

--- a/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
+++ b/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
@@ -763,7 +763,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
         String headerText = controller.getText().substring(startPos, offset);
         int idx = headerText.indexOf('{'); //NOI18N
         //see JDK-8364015, unclear how reliable this will be:
-        boolean isImplicitlyDeclaredClass = sourcePositions.getEndPosition(root, cls) == (-1);
+        boolean isImplicitlyDeclaredClass = env.getController().getTreeUtilities().isImplicitlyDeclaredClass(cls);
         if (idx >= 0 || isImplicitlyDeclaredClass) {
             addKeywordsForClassBody(env);
             addClassTypes(env, null);

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/Utilities.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/Utilities.java
@@ -1919,7 +1919,7 @@ public class Utilities {
         Log.DiagnosticHandler discardHandler = log.new DiscardDiagnosticHandler() {
             private Diagnostic.Kind f = filter == null ? Diagnostic.Kind.ERROR : filter;
             @Override
-            public void report(JCDiagnostic diag) {
+            public void reportReady(JCDiagnostic diag) {
                 if (diag.getKind().compareTo(f) >= 0) {
                     errors.add(diag);
                 }

--- a/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testOverrideAnnotation.pass
+++ b/java/java.hints/test/unit/data/goldenfiles/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest/testOverrideAnnotation.pass
@@ -1,1 +1,1 @@
-3:4-3:13:error:method does not override or implement a method from a supertype
+3:4-3:13:error:t() in TestOverrideAnnotation does not override or implement a method from a supertype

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/infrastructure/ErrorHintsProviderTest.java
@@ -249,9 +249,7 @@ public class ErrorHintsProviderTest extends NbTestCase {
                                }
                                """,
                                "21",
-                               //TODO: can this comment be now removed?
-                               //TODO: needs to be adjusted when the error in javac is fixed:
-                               "0:0-0:13::Test.java:1:1: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.implicit.classes), 21, " + SourceVersion.latest().ordinal());
+                               "0:0-0:13::Test.java:1:1: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.implicit.classes), 21, 25");
     }
 
     private void performInlinedTest(String name, String code) throws Exception {

--- a/java/java.source.base/nbproject/project.properties
+++ b/java/java.source.base/nbproject/project.properties
@@ -23,7 +23,7 @@ javadoc.name=Java Source Base
 javadoc.title=Java Source Base
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
-spec.version.base=2.81.0
+spec.version.base=2.82.0
 test.qa-functional.cp.extra=${refactoring.java.dir}/modules/ext/nb-javac-api.jar
 test.unit.run.cp.extra=${o.n.core.dir}/core/core.jar:\
     ${o.n.core.dir}/lib/boot.jar:\

--- a/java/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
@@ -34,7 +34,7 @@ import org.openide.modules.OnStart;
  */
 public class NoJavacHelper {
 
-    public static final int REQUIRED_JAVAC_VERSION = 25; // <- TODO: increment on every release
+    public static final int REQUIRED_JAVAC_VERSION = 26; // <- TODO: increment on every release
     private static final boolean HAS_WORKING_JAVAC;
 
     static {

--- a/java/java.source.base/src/org/netbeans/modules/java/source/PostFlowAnalysis.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/PostFlowAnalysis.java
@@ -48,6 +48,7 @@ import javax.tools.JavaFileObject;
 
 import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.util.JCDiagnostic.Error;
+import java.util.Set;
 import org.netbeans.modules.java.source.builder.ElementsService;
 
 /**
@@ -151,7 +152,7 @@ public class PostFlowAnalysis extends TreeScanner {
                         && !type.isErroneous()
                         && types.isSameType(types.erasure(sym.type), type);
                 if (clash) {
-                    log.error(tree.pos(), new Error("compiler", "name.clash.same.erasure", tree.sym, sym)); //NOI18N
+                    log.error(tree.pos(), new Error(Set.of(), "compiler", "name.clash.same.erasure", tree.sym, sym)); //NOI18N
                     return;
                 }
             } catch (AssertionError e) {}
@@ -201,7 +202,7 @@ public class PostFlowAnalysis extends TreeScanner {
         if (checkThis && currentClass != c) {
             List<Pair<TypeSymbol, Symbol>> ots = outerThisStack;
             if (ots.isEmpty()) {
-                log.error(pos, new Error("compiler", "no.encl.instance.of.type.in.scope", c)); //NOI18N
+                log.error(pos, new Error(Set.of(), "compiler", "no.encl.instance.of.type.in.scope", c)); //NOI18N
                 return;
             }
             Pair<TypeSymbol, Symbol> ot = ots.head;
@@ -210,13 +211,13 @@ public class PostFlowAnalysis extends TreeScanner {
                 do {
                     ots = ots.tail;
                     if (ots.isEmpty()) {
-                        log.error(pos, new Error("compiler", "no.encl.instance.of.type.in.scope", c)); //NOI18N
+                        log.error(pos, new Error(Set.of(), "compiler", "no.encl.instance.of.type.in.scope", c)); //NOI18N
                         return;
                     }
                     ot = ots.head;
                 } while (ot.snd != otc);
                 if (otc.owner.kind != Kinds.Kind.PCK && !otc.hasOuterInstance()) {
-                    log.error(pos, new Error("compiler", "cant.ref.before.ctor.called", c)); //NOI18N
+                    log.error(pos, new Error(Set.of(), "compiler", "cant.ref.before.ctor.called", c)); //NOI18N
                     return;
                 }
                 otc = ot.fst;
@@ -233,7 +234,7 @@ public class PostFlowAnalysis extends TreeScanner {
     private static final int MAX_STRING_LENGTH = 65535;
     private void checkStringConstant(DiagnosticPosition pos, Object constValue) {
         if (constValue instanceof String && ((String)constValue).length() >= MAX_STRING_LENGTH)
-            log.error(pos, new Error("compiler", "limit.string")); //NOI18N
+            log.error(pos, new Error(Set.of(), "compiler", "limit.string")); //NOI18N
     }
 
 }

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/VanillaPartialReparser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/VanillaPartialReparser.java
@@ -348,23 +348,11 @@ public class VanillaPartialReparser implements PartialReparser {
         }
         return new NBParserFactory.NBJavacParser(parserFactory, lexer, true, false, true, false, cancelService) {
             @Override protected com.sun.tools.javac.parser.JavacParser.AbstractEndPosTable newEndPosTable(boolean keepEndPositions) {
-                return new com.sun.tools.javac.parser.JavacParser.AbstractEndPosTable(this) {
+                return new com.sun.tools.javac.parser.JavacParser.AbstractEndPosTable() {
 
                     @Override
-                    public void storeEnd(JCTree tree, int endpos) {
-                        ((NBParserFactory.NBJavacParser.EndPosTableImpl)endPos).storeEnd(tree, endpos);
-                    }
-
-                    @Override
-                    protected <T extends JCTree> T to(T t) {
-                        storeEnd(t, token.endPos);
-                        return t;
-                    }
-
-                    @Override
-                    protected <T extends JCTree> T toP(T t) {
-                        storeEnd(t, S.prevToken().endPos);
-                        return t;
+                    public <T extends JCTree> T storeEnd(T tree, int endpos) {
+                        return ((NBParserFactory.NBJavacParser.EndPosTableImpl)endPos).storeEnd(tree, endpos);
                     }
 
                     @Override
@@ -410,7 +398,7 @@ public class VanillaPartialReparser implements PartialReparser {
                 // in enum constructors, except in the compiler
                 // generated one.
                 log.error(tree.body.stats.head.pos(),
-                          new JCDiagnostic.Error("compiler",
+                          new JCDiagnostic.Error(Set.of(), "compiler",
                                     "call.to.super.not.allowed.in.enum.ctor",
                                     env.enclClass.sym));
                     }

--- a/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
@@ -2902,13 +2902,14 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
         }
     }
     
-    private static final String[] flagLowerCaseNames = new String[Flag.values().length];
+    private static final String[] flagLowerCaseNames = new String[FlagsEnum.values().length];
     
     static {
-        for (Flag flag : Flag.values()) {
+        for (FlagsEnum flag : FlagsEnum.values()) {
             flagLowerCaseNames[flag.ordinal()] = flag.name().toLowerCase(Locale.ENGLISH);
         }
-        flagLowerCaseNames[Flag.NON_SEALED.ordinal()] = "non-sealed";
+        flagLowerCaseNames[FlagsEnum.NON_SEALED.ordinal()] = "non-sealed";
+        flagLowerCaseNames[FlagsEnum.TRANSIENT_OR_ACC_VARARGS.ordinal()] = "transient"; //TODO: there should be a test in java.source.base for this
     }
     
     /**
@@ -2922,7 +2923,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
         flags = flags & Flags.ExtendedStandardFlags;
         StringBuilder buf = new StringBuilder();
         String sep = ""; // NOI18N
-        for (Flag flag : Flags.asFlagSet(flags)) {
+        for (FlagsEnum flag : Flags.asFlagSet(flags)) {
             buf.append(sep);
             String fname = flagLowerCaseNames[flag.ordinal()];
             buf.append(fname);

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
@@ -2502,13 +2502,12 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
             public Data get(ErrorKind kind, Range range, String message) {
                 return new Data(kind, Pair.of(Pair.of(range.start().line(),
                                                       range.start().column()),
-                                              range.end() != null ? Pair.of(range.end().line(),
-                                                                               range.end().column())
-                                                                     : null));
+                                              Pair.of(range.end().line(),
+                                                      range.end().column())));
             }
         });
         assertEquals(List.of(new Data(ErrorKind.WARNING, Pair.of(Pair.of(4, 9), Pair.of(4, 19))),
-                             new Data(ErrorKind.WARNING, Pair.of(Pair.of(4, 17), null))),
+                             new Data(ErrorKind.WARNING, Pair.of(Pair.of(4, 17), Pair.of(4, 17)))),
                      errors);
     }
 

--- a/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBClassFinder.java
+++ b/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBClassFinder.java
@@ -35,6 +35,7 @@ import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.util.Names;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -107,7 +108,7 @@ public class NBClassFinder extends ClassFinder {
                             Constructor<CompletionFailure> constr = CompletionFailure.class.getDeclaredConstructor(Symbol.class, Supplier.class, dcfhClass);
                             Object dcfh = dcfhClass.getDeclaredMethod("instance", Context.class).invoke(null, context);
                             throw constr.newInstance(sym, (Supplier<JCDiagnostic>) () -> {
-                                return diagFactory.create(log.currentSource(), new SimpleDiagnosticPosition(0), DiagnosticInfo.of(DiagnosticType.ERROR, "compiler", "cant.resolve", "package", "java.lang"));
+                                return diagFactory.create(log.currentSource(), new SimpleDiagnosticPosition(0), DiagnosticInfo.of(DiagnosticType.ERROR, Set.of(), "compiler", "cant.resolve", "package", "java.lang"));
                             }, dcfh);
                         } catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | InstantiationException ex) {
                             Logger.getLogger(NBClassFinder.class.getName()).log(Level.FINE, null, ex);

--- a/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBParserFactory.java
+++ b/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBParserFactory.java
@@ -100,7 +100,7 @@ public class NBParserFactory extends ParserFactory {
 
             if (!unit.getTypeDecls().isEmpty() && unit.getTypeDecls().get(0).getKind() == Kind.CLASS) {
                 JCClassDecl firstClass = (JCClassDecl) unit.getTypeDecls().get(0);
-                if ((firstClass.mods.flags & Flags.IMPLICIT_CLASS) != 0 && getEndPos(unit) == Position.NOPOS) {
+                if ((firstClass.mods.flags & Flags.IMPLICIT_CLASS) != 0) {
                     if (pack[0] != null) {
                         unit.defs = unit.defs.prepend(pack[0]);
                     }
@@ -115,7 +115,6 @@ public class NBParserFactory extends ParserFactory {
                     }
 
                     firstClass.pos = newPos;
-                    endPosTable.storeEnd(unit, token.endPos);
                 }
             }
             return unit;
@@ -188,12 +187,9 @@ public class NBParserFactory extends ParserFactory {
 
         public final class EndPosTableImpl extends AbstractEndPosTable {
             
-            private final Lexer lexer;
             private final SimpleEndPosTable delegate;
 
             private EndPosTableImpl(Lexer lexer, JavacParser parser, SimpleEndPosTable delegate) {
-                super(parser);
-                this.lexer = lexer;
                 this.delegate = delegate;
             }
             
@@ -202,9 +198,11 @@ public class NBParserFactory extends ParserFactory {
                 errorEndPos = delegate.errorEndPos;
             }
             
-            @Override public void storeEnd(JCTree tree, int endpos) {
+            @Override
+            public <T extends JCTree> T storeEnd(T tree, int endpos) {
                 if (endpos >= 0)
-                    delegate.storeEnd(tree, endpos);
+                    return delegate.storeEnd(tree, endpos);
+                return null;
             }
 
             public void setEnd(JCTree tree, int endpos) {
@@ -223,18 +221,6 @@ public class NBParserFactory extends ParserFactory {
             public void setErrorEndPos(int errPos) {
                 delegate.setErrorEndPos(errPos);
                 errorEndPos = delegate.errorEndPos;
-            }
-
-            @Override
-            protected <T extends JCTree> T to(T t) {
-                storeEnd(t, parser.token().endPos);
-                return t;
-            }
-
-            @Override
-            protected <T extends JCTree> T toP(T t) {
-                storeEnd(t, lexer.prevToken().endPos);
-                return t;
             }
 
             @Override

--- a/java/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/NBParserFactoryTest.java
+++ b/java/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/NBParserFactoryTest.java
@@ -54,7 +54,7 @@ public class NBParserFactoryTest extends NbTestCase {
         SourcePositions sp = Trees.instance(parsed.first()).getSourcePositions();
 
         assertEquals(0, sp.getStartPosition(parsed.second(), ct));
-        assertEquals(-1, sp.getEndPosition(parsed.second(), ct));
+        assertEquals(14, sp.getEndPosition(parsed.second(), ct));
     }
 
     public void testImplicitClassPositions() throws Exception {
@@ -74,9 +74,9 @@ public class NBParserFactoryTest extends NbTestCase {
         SourcePositions sp = Trees.instance(parsed.first()).getSourcePositions();
 
         assertEquals(19, sp.getStartPosition(parsed.second(), ct));
-        assertEquals(-1, sp.getEndPosition(parsed.second(), ct));
+        assertEquals(46, sp.getEndPosition(parsed.second(), ct));
         assertEquals(0, sp.getStartPosition(parsed.second(), parsed.second()));
-        assertEquals(code.length(), sp.getEndPosition(parsed.second(), parsed.second()));
+        assertEquals(46, sp.getEndPosition(parsed.second(), parsed.second()));
     }
 
     public void testErrorRecoveryCompactSourceFilePackage() throws Exception {
@@ -126,7 +126,7 @@ public class NBParserFactoryTest extends NbTestCase {
         Context context = new Context();
         NBParserFactory.preRegister(context);
         NBTreeMaker.preRegister(context);
-        final JavacTaskImpl ct = (JavacTaskImpl) ((JavacTool)tool).getTask(null, std, null, Arrays.asList("-source", "21"), null, Arrays.asList(new MyFileObject(code)), context);
+        final JavacTaskImpl ct = (JavacTaskImpl) ((JavacTool)tool).getTask(null, std, null, Arrays.asList("-source", "25"), null, Arrays.asList(new MyFileObject(code)), context);
 
         CompilationUnitTree cut = ct.parse().iterator().next();
 

--- a/java/libs.javacapi/external/binaries-list
+++ b/java/libs.javacapi/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-CD9EA8DDE23DF41A129D563A51C9A2E502BD85BF com.dukescript.nbjavac:nb-javac:jdk-25+31.1
-183E5391BCCC0A27AE0F5014A3A9FA7F93214911 com.dukescript.nbjavac:nb-javac:jdk-25+31.1:api
+162196CDF0DAE37B7D3AD7991DE4310B78AFA30F com.dukescript.nbjavac:nb-javac:jdk-26+27
+F9B91950111918341594B7B5641B3731CA8CCF80 com.dukescript.nbjavac:nb-javac:jdk-26+27:api

--- a/java/libs.javacapi/external/nb-javac-jdk-26+27-license.txt
+++ b/java/libs.javacapi/external/nb-javac-jdk-26+27-license.txt
@@ -1,7 +1,7 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Version: 25+31.1
-Files: nb-javac-jdk-25+31.1-api.jar nb-javac-jdk-25+31.1.jar
+Version: 26+27
+Files: nb-javac-jdk-26+27-api.jar nb-javac-jdk-26+27.jar
 License: GPL-2-CP
 Origin: OpenJDK (https://github.com/openjdk/jdk)
 Source: https://github.com/openjdk/jdk

--- a/java/libs.javacapi/nbproject/project.xml
+++ b/java/libs.javacapi/nbproject/project.xml
@@ -40,11 +40,11 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-jdk-25+31.1-api.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-26+27-api.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-jdk-25+31.1.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-26+27.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/libs.nbjavacapi/external/binaries-list
+++ b/java/libs.nbjavacapi/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-CD9EA8DDE23DF41A129D563A51C9A2E502BD85BF com.dukescript.nbjavac:nb-javac:jdk-25+31.1
-183E5391BCCC0A27AE0F5014A3A9FA7F93214911 com.dukescript.nbjavac:nb-javac:jdk-25+31.1:api
+162196CDF0DAE37B7D3AD7991DE4310B78AFA30F com.dukescript.nbjavac:nb-javac:jdk-26+27
+F9B91950111918341594B7B5641B3731CA8CCF80 com.dukescript.nbjavac:nb-javac:jdk-26+27:api

--- a/java/libs.nbjavacapi/external/nb-javac-jdk-26+27-license.txt
+++ b/java/libs.nbjavacapi/external/nb-javac-jdk-26+27-license.txt
@@ -1,7 +1,7 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Version: 25+31.1
-Files: nb-javac-jdk-25+31.1-api.jar nb-javac-jdk-25+31.1.jar
+Version: 26+27
+Files: nb-javac-jdk-26+27-api.jar nb-javac-jdk-26+27.jar
 License: GPL-2-CP
 Origin: OpenJDK (https://github.com/openjdk/jdk)
 Source: https://github.com/openjdk/jdk

--- a/java/libs.nbjavacapi/nbproject/project.properties
+++ b/java/libs.nbjavacapi/nbproject/project.properties
@@ -18,8 +18,8 @@
 javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 license.file.override=${nb_all}/nbbuild/licenses/GPL-2-CP
-release.external/nb-javac-jdk-25+31.1-api.jar=modules/ext/nb-javac-jdk-25-31.1-api.jar
-release.external/nb-javac-jdk-25+31.1.jar=modules/ext/nb-javac-jdk-25-31.1.jar
+release.external/nb-javac-jdk-26+27-api.jar=modules/ext/nb-javac-jdk-26-27-api.jar
+release.external/nb-javac-jdk-26+27.jar=modules/ext/nb-javac-jdk-26-27.jar
 
 # for tests
 requires.nb.javac=true

--- a/java/libs.nbjavacapi/nbproject/project.xml
+++ b/java/libs.nbjavacapi/nbproject/project.xml
@@ -45,12 +45,12 @@
             </test-dependencies>
             <public-packages/>
             <class-path-extension>
-                <runtime-relative-path>ext/nb-javac-jdk-25-31.1-api.jar</runtime-relative-path>
-                <binary-origin>external/nb-javac-jdk-25+31.1-api.jar</binary-origin>
+                <runtime-relative-path>ext/nb-javac-jdk-26-27-api.jar</runtime-relative-path>
+                <binary-origin>external/nb-javac-jdk-26+27-api.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/nb-javac-jdk-25-31.1.jar</runtime-relative-path>
-                <binary-origin>external/nb-javac-jdk-25+31.1.jar</binary-origin>
+                <runtime-relative-path>ext/nb-javac-jdk-26-27.jar</runtime-relative-path>
+                <binary-origin>external/nb-javac-jdk-26+27.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/libs.nbjavacapi/src/org/netbeans/modules/nbjavac/api/Bundle.properties
+++ b/java/libs.nbjavacapi/src/org/netbeans/modules/nbjavac/api/Bundle.properties
@@ -18,6 +18,6 @@
 OpenIDE-Module-Display-Category=Java
 OpenIDE-Module-Long-Description=\
     This library provides a Java language parser for the IDE. \
-    Supports JDK-25 features.
+    Supports JDK-26 features.
 OpenIDE-Module-Name=The nb-javac Java editing support library
 OpenIDE-Module-Short-Description=The nb-javac Java editing support library

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
@@ -579,7 +579,7 @@ public class Utilities {
         JavaFileObject prev = compiler.log.useSource(new DummyJFO());
         Log.DiagnosticHandler discardHandler = compiler.log.new DiscardDiagnosticHandler() {
             @Override
-            public void report(JCDiagnostic diag) {
+            public void reportReady(JCDiagnostic diag) {
                 errors.add(diag);
             }            
         };
@@ -606,7 +606,7 @@ public class Utilities {
         JavaFileObject prev = compiler.log.useSource(new DummyJFO());
         Log.DiagnosticHandler discardHandler = compiler.log.new DiscardDiagnosticHandler() {
             @Override
-            public void report(JCDiagnostic diag) {
+            public void reportReady(JCDiagnostic diag) {
                 errors.add(diag);
             }            
         };
@@ -637,7 +637,7 @@ public class Utilities {
         JavaFileObject prev = log.useSource(new DummyJFO());
         Log.DiagnosticHandler discardHandler = log.new DiscardDiagnosticHandler() {
             @Override
-            public void report(JCDiagnostic diag) {
+            public void reportReady(JCDiagnostic diag) {
                 errors.add(diag);
             }            
         };
@@ -1569,12 +1569,17 @@ public class Utilities {
 
         @Override
         public long getEndPosition() {
-            if (delegate instanceof JCDiagnostic dImpl) {
-                return dImpl.getDiagnosticPosition().getEndPosition(new EndPosTable() {
+            if (delegate instanceof JCDiagnostic jcDiag) {
+                return jcDiag.getDiagnosticPosition().getEndPosition(new EndPosTable() {
                     @Override public int getEndPos(JCTree tree) {
                         return (int) sp.getEndPosition(null, tree);
                     }
-                    @Override public void storeEnd(JCTree tree, int endpos) {
+                    @Override
+                    public <T extends JCTree> T storeEnd(T tree, int endpos) {
+                        throw new UnsupportedOperationException("Not supported yet.");
+                    }
+                    @Override
+                    public void setErrorEndPos(int errpos) {
                         throw new UnsupportedOperationException("Not supported yet.");
                     }
                     @Override public int replaceTree(JCTree oldtree, JCTree newtree) {

--- a/java/whitelist/nbproject/project.properties
+++ b/java/whitelist/nbproject/project.properties
@@ -22,6 +22,3 @@ javadoc.apichanges=${basedir}/apichanges.xml
 requires.nb.javac=true
 
 test.config.stableBTD.includes=**/*Test.class
-
-# for JDK 11+
-test.bootclasspath.prepend.args=-Dno.netbeans.bootclasspath.prepend.needed=true

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -92,8 +92,8 @@ nb/ide.launcher/external/launcher-external-binaries-4-8e2bc77e581e.zip platform/
 nb/ide.launcher/external/launcher-external-binaries-4-8e2bc77e581e.zip harness/apisupport.harness/external/launcher-external-binaries-4-8e2bc77e581e.zip
 
 # only one is part of the product:
-java/libs.javacapi/external/nb-javac-jdk-25+31.1-api.jar java/libs.nbjavacapi/external/nb-javac-jdk-25+31.1-api.jar
-java/libs.javacapi/external/nb-javac-jdk-25+31.1.jar java/libs.nbjavacapi/external/nb-javac-jdk-25+31.1.jar
+java/libs.javacapi/external/nb-javac-jdk-26+27-api.jar java/libs.nbjavacapi/external/nb-javac-jdk-26+27-api.jar
+java/libs.javacapi/external/nb-javac-jdk-26+27.jar java/libs.nbjavacapi/external/nb-javac-jdk-26+27.jar
 
 # Used only in unittests for mysql db specific tests
 ide/db.metadata.model/external/mysql-connector-j-8.0.31.jar ide/db.mysql/external/mysql-connector-j-8.0.31.jar


### PR DESCRIPTION
Upgrades the javac integration to nb-javac based on JDK 26b27.

This PR is based on a copy of the valhalla javac experiment https://github.com/apache/netbeans/pull/8995 but swaps the nb-javac dependency against staged nb-javac 26b26 based on https://github.com/lahodaj/nb-javac/commits/upgrade-jdk26/. ~It will be later updated to a nb-javac release from maven central.~ done

manual testing:
 - [x] indexer smoke test
 - [x] check https://github.com/orgs/apache/projects/536/views/1 to verify/link issues
 - [x] nb-javac stack traces have line numbers

closes https://github.com/apache/netbeans/issues/4470
closes https://github.com/apache/netbeans/issues/6822
closes https://github.com/apache/netbeans/issues/8722
