### PR TITLE
apidoc font linked to main site

### DIFF
--- a/nbbuild/javadoctools/export2html.xsl
+++ b/nbbuild/javadoctools/export2html.xsl
@@ -47,10 +47,8 @@
                     <xsl:text>API List</xsl:text>
                 </xsl:element>
                 <link rel="stylesheet" href="netbeans.css" type="text/css"/>
-                <link rel="icon" type="image/png" sizes="32x32" href="//netbeans.apache.org/favicon-32x32.png" /> 
-                <link rel="icon" type="image/png" sizes="16x16" href="//netbeans.apache.org/favicon-16x16.png" />
-          
-
+                <link rel="icon" type="image/png" sizes="32x32" href="https://netbeans.apache.org/favicon-32x32.png" />
+                <link rel="icon" type="image/png" sizes="16x16" href="https://netbeans.apache.org/favicon-16x16.png" />
             </head>
 
             <body>

--- a/nbbuild/javadoctools/javadoc-generic.css
+++ b/nbbuild/javadoctools/javadoc-generic.css
@@ -20,7 +20,7 @@
  * Javadoc style sheet
  */
 
-@import url('fonts/dejavu.css');
+@import url('https://netbeans.apache.org/_/css/font-dejavu.css');
 /*
  * These CSS custom properties (variables) define the core color and font
  * properties used in this stylesheet.

--- a/nbbuild/javadoctools/jsonhelp.xsl
+++ b/nbbuild/javadoctools/jsonhelp.xsl
@@ -169,6 +169,7 @@ committed to the repository for legal reasons. You need to download it:
         </div>
     </xsl:template>
     <xsl:template name="htmlfooter">
+        <script src="https://netbeans.apache.org/_/js/vendor/jquery.min.js"></script>
         <script>
             $('.modulesclasslist').hide();
             
@@ -233,9 +234,8 @@ committed to the repository for legal reasons. You need to download it:
             <meta name="msapplication-TileColor" content="#ffc40d" />
             <meta name="theme-color" content="#ffffff"/>
             <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-            <link rel="icon" type="image/png" sizes="32x32" href="//netbeans.apache.org/favicon-32x32.png" />
-            <link rel="icon" type="image/png" sizes="16x16" href="//netbeans.apache.org/favicon-16x16.png" />
-            <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+            <link rel="icon" type="image/png" sizes="32x32" href="https://netbeans.apache.org/favicon-32x32.png" />
+            <link rel="icon" type="image/png" sizes="16x16" href="https://netbeans.apache.org/favicon-16x16.png" />
         </head>
     </xsl:template>
     <xsl:template name="htmlmainmenu">


### PR DESCRIPTION
Small adjustement to use full url + jquery we use on main site to not depend on google.
Link to dejavu font that could be on main website.

linked to https://github.com/apache/netbeans-antora-ui/pull/103
