### PR TITLE
Improving handling of broken bootpaths with an implicit hardcoded --release

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
@@ -1034,9 +1034,12 @@ public class JavacParser extends Parser {
             options.add("-proc:none"); // NOI18N, Disable annotation processors
         }
         if (compilerOptions != null) {
-            for (String compilerOption : validateCompilerOptions(compilerOptions.getArguments(), validatedSourceLevel)) {
-                options.add(compilerOption);
-            }
+            options.addAll(
+                validateCompilerOptions(
+                    compilerOptions.getArguments(),
+                    useRelease != null ? com.sun.tools.javac.code.Source.lookup(useRelease) : validatedSourceLevel
+                )
+            );
         }
         if (!additionalModules.isEmpty()) {
             options.add("--add-modules");       //NOI18N
@@ -1098,8 +1101,12 @@ public class JavacParser extends Parser {
         if (validatedSourceLevel.equals(sourceLevel)) {
             return null;
         }
-        if (sourceLevel.compareTo(com.sun.tools.javac.code.Source.JDK7) <= 0) {
-            sourceLevel = com.sun.tools.javac.code.Source.JDK7;
+        if (!sourceLevel.isSupported()) {
+            for (com.sun.tools.javac.code.Source searchForSupported : com.sun.tools.javac.code.Source.values()) {
+                if (searchForSupported.isSupported()) {
+                    sourceLevel = searchForSupported;
+                }
+            }
         }
         return sourceLevel.isSupported() ? sourceLevel.requiredTarget().multiReleaseValue() : null;
     }


### PR DESCRIPTION
When a project sends broken bootclasspath/system module path, NetBeans' `JavacParser` will fall back to an implicit `--release`. while I may have some reservations about it, it does help in some cases.
There are two problems with that however:
- when compiler options are validated, they are validated against the validated source level, not against the release version javac will use in the end. In practice, this means options like `--limit-modules` are usually filtered-out, as the validated source level is something extremely old (like `1.3`). If we use the implicit `--release`, we should validate against it.
- if the source level is very old (older that 1.7), we use 1.7 instead. And then check if the source level is "supported" - but 1.7 is not supported anymore, so `--release` won't be used when very old source level is used. The proposal herein is to simply use the oldest supported source level.

---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [ ] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [ ] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [ ] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [ ] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>