### PR TITLE
PHP: Added folding for heredoc and nowdoc

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/csl/PHPFoldingProvider.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/csl/PHPFoldingProvider.java
@@ -44,6 +44,7 @@ public class PHPFoldingProvider implements FoldTypeProvider {
         TYPES.add(FoldingScanner.TYPE_USE);
         TYPES.add(FoldingScanner.TYPE_PHPTAG);
         TYPES.add(FoldingScanner.TYPE_ATTRIBUTES);
+        TYPES.add(FoldingScanner.TYPE_HEREDOC_NOWDOC);
     }
 
     @Override

--- a/php/php.editor/test/unit/data/testfiles/enumerations_01.php.folds
+++ b/php/php.editor/test/unit/data/testfiles/enumerations_01.php.folds
@@ -46,16 +46,16 @@
 |     case C = "C";
 |     case D = "D";
 |     case E = "E" . "E";
-|     case F = <<<F
++     case F = <<<F
 |     Test
 |     Test
 |     Test
-|     F;
-|     case G = <<<'G'
+-     F;
++     case G = <<<'G'
 |     Test
 |     Test
 |     Test
-|     G;
+-     G;
 - }
   
 + enum Impl implements Iface1, Iface2 {

--- a/php/php.editor/test/unit/data/testfiles/foldingHeredocNowdoc.php.folds
+++ b/php/php.editor/test/unit/data/testfiles/foldingHeredocNowdoc.php.folds
@@ -1,0 +1,17 @@
+  <?php
+  
++ echo <<<HEREDOC
+|     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+|     Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+|     Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+|     Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+- HEREDOC;
+  
+  
++ echo <<<'NOWDOC'
+|     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+|     Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+|     Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+|     Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+- NOWDOC;
+

--- a/php/php.editor/test/unit/data/testfiles/parser/foldingHeredocNowdoc.php
+++ b/php/php.editor/test/unit/data/testfiles/parser/foldingHeredocNowdoc.php
@@ -1,0 +1,16 @@
+<?php
+
+echo <<<HEREDOC
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+HEREDOC;
+
+
+echo <<<'NOWDOC'
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+NOWDOC;

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/FoldingTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/FoldingTest.java
@@ -121,4 +121,7 @@ public class FoldingTest extends PHPTestBase {
         checkFolds("testfiles/parser/php81/enumerations_01.php");
     }
 
+    public void testFoldingHeredocNowdoc() throws Exception {
+        checkFolds("testfiles/parser/foldingHeredocNowdoc.php");
+    }
 }


### PR DESCRIPTION
In this PR:

- Added folding for `heredoc` and `nowdoc`
- Fixed test `FoldingTest`
- Added new tests in `FoldingTest`

Example:

```php

<?php

echo <<<HEREDOC
    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
HEREDOC;


echo <<<'NOWDOC'
    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
NOWDOC;
```


Before:
![before](https://github.com/user-attachments/assets/551a668c-847a-4ba6-b37a-d97afe8b6c3a)



After:
<img width="1239" height="324" alt="after" src="https://github.com/user-attachments/assets/dfa73a65-13c4-4b88-b30f-85ddb54a16fb" />

<img width="305" height="134" alt="after_collapsed" src="https://github.com/user-attachments/assets/3217f0ed-edd8-4104-b810-502a35b0aa2f" />
