### PR TITLE
Fix high CPU load in grid customizer (GH9060)

### DIFF
--- a/java/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GlassPane.java
+++ b/java/form/src/org/netbeans/modules/form/layoutsupport/griddesigner/GlassPane.java
@@ -1501,8 +1501,6 @@ public class GlassPane extends JPanel implements GridActionPerformer {
             if(!noChange(change)) {
                 animChange = change;
                 animLayer.animate();
-            } else {
-                animation = false;
             }
         }
 


### PR DESCRIPTION
Ensure the animation layer paint is called at least once inside paintComponent so that the animation timer is shut down.

This is a minimal fix for #9060.  If a change is made that triggers no change in bounds, then `animation` was set to `false`.  However, if an existing animation was active at that time, the animation layer timer isn't stopped because `animLayer.paint(..)` isn't called during repaint.  This causes a doom loop of repaint requests with excessive CPU usage.  

This whole animation layer code is a little suspect - ideally it would exit cleanly during the timer listener - but it doesn't seem worth doing a full refactor for a little used feature.

Fixes #9060 