### PR TITLE
[GITHUB-9056] Using sharp(er) classpath when rename refactoring.

### DIFF
--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenameRefactoringPlugin.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/RenameRefactoringPlugin.java
@@ -367,23 +367,8 @@ public class RenameRefactoringPlugin extends JavaRefactoringPlugin {
         if (treePathHandle == null && docTreePathHandle == null) {
             return null;
         }
-        switch (p) {
-            case PRECHECK:
-            case FASTCHECKPARAMETERS:
-                return JavaSource.forFileObject(docTreePathHandle != null? docTreePathHandle.getTreePathHandle().getFileObject()
-                                                                         : treePathHandle.getFileObject());
-            case PREPARE:
-            case CHECKPARAMETERS:
-                if(treePathHandle != null && treePathHandle.getKind() == Tree.Kind.LABELED_STATEMENT) {
-                    return JavaSource.forFileObject(treePathHandle.getFileObject());
-                }
-                ClasspathInfo cpInfo = getClasspathInfo(refactoring);
-                JavaSource source = JavaSource.create(cpInfo, docTreePathHandle != null? docTreePathHandle.getTreePathHandle().getFileObject()
-                                                                         : treePathHandle.getFileObject());
-                return source;
-                
-        }
-        throw new IllegalStateException();
+        return JavaSource.forFileObject(docTreePathHandle != null? docTreePathHandle.getTreePathHandle().getFileObject()
+                                                                 : treePathHandle.getFileObject());
     }
 
     @Override
@@ -408,16 +393,10 @@ public class RenameRefactoringPlugin extends JavaRefactoringPlugin {
                 JavaSource source = getJavaSource(Phase.PREPARE);
                 
                 try {
-                    source.runUserActionTask(new CancellableTask<CompilationController>() {
-                        
-                        @Override
-                        public void cancel() {
-                            throw new UnsupportedOperationException("Not supported yet."); // NOI18N
-                        }
-                        
+                    source.runUserActionTask(new Task<CompilationController>() {
                         @Override
                         public void run(CompilationController info) throws Exception {
-                            final ClassIndex idx = info.getClasspathInfo().getClassIndex();
+                            final ClassIndex idx = getClasspathInfo(refactoring).getClassIndex();
                             info.toPhase(JavaSource.Phase.RESOLVED);
                             Element el = docTreePathHandle != null? ((DocTrees)info.getTrees()).getElement(docTreePathHandle.resolve(info))
                                                        : treePathHandle.resolveElement(info);
@@ -631,7 +610,7 @@ public class RenameRefactoringPlugin extends JavaRefactoringPlugin {
         Set<FileObject> a = getRelevantFiles();
         fireProgressListenerStart(AbstractRefactoring.PREPARE, a.size());
         TransformTask transform = new TransformTask(new RenameTransformer(treePathHandle, docTreePathHandle, refactoring, allMethods, recordLinkedDeclarations, refactoring.isSearchInComments()), treePathHandle != null && treePathHandle.getKind() == Tree.Kind.LABELED_STATEMENT ? null : treePathHandle);
-        Problem problem = createAndAddElements(a, transform, elements, refactoring,getClasspathInfo(refactoring));
+        Problem problem = createAndAddElements(a, transform, elements, null);
         fireProgressListenerStop();
         return problem;
     }

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/JavaRefactoringPlugin.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/spi/JavaRefactoringPlugin.java
@@ -268,13 +268,15 @@ public abstract class JavaRefactoringPlugin extends ProgressProviderAdapter impl
         return results;
     }
 
-    private void processFiles(Map<FileObject, List<FileObject>> work, ClasspathInfo info, boolean modification, Collection<ModificationResult> results, CancellableTask<? extends CompilationController> task) throws IOException, IllegalArgumentException {
+    //the meaning of overrideInfo (used to be info) is very unclear, and is suspicious. Possibly, it should be eliminated:
+    private void processFiles(Map<FileObject, List<FileObject>> work, ClasspathInfo overrideInfo, boolean modification, Collection<ModificationResult> results, CancellableTask<? extends CompilationController> task) throws IOException, IllegalArgumentException {
         for (Map.Entry<FileObject, List<FileObject>> entry : work.entrySet()) {
             if (cancelRequested.get()) {
                 results.clear();
                 return;
             }
             final FileObject root = entry.getKey();
+            ClasspathInfo info = overrideInfo;
             if (info == null) {
                 ClassPath bootPath = ClassPath.getClassPath(root, ClassPath.BOOT);
                 if (bootPath == null) {

--- a/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/plugins/Bundle_test.properties
+++ b/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/plugins/Bundle_test.properties
@@ -109,3 +109,4 @@ ERR_InvertMethodInInterface=ERR_InvertMethodInInterface
 ERR_VarNotInBlockOrMethod=ERR_VarNotInBlockOrMethod
 WRN_Implements=WRN_Implements
 ERR_ReferencesFound=ERR_ReferencesFound
+ERR_Overrides=ERR_Overrides

--- a/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ComplexProjectHierarchyTest.java
+++ b/java/refactoring.java/test/unit/src/org/netbeans/modules/refactoring/java/test/ComplexProjectHierarchyTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.refactoring.java.test;
+
+import com.sun.source.util.TreePath;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import org.netbeans.api.java.source.CompilationController;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.TreePathHandle;
+import org.netbeans.modules.refactoring.api.Problem;
+import org.netbeans.modules.refactoring.api.RefactoringSession;
+import org.netbeans.modules.refactoring.api.RenameRefactoring;
+import org.netbeans.modules.refactoring.java.ui.JavaRenameProperties;
+import org.openide.filesystems.FileObject;
+import org.openide.util.lookup.Lookups;
+
+public class ComplexProjectHierarchyTest extends RefactoringTestBase {
+
+    private final ProjectDesc side = new ProjectDesc("side");
+    private final ProjectDesc base = new ProjectDesc("base");
+    private final ProjectDesc main = new ProjectDesc("main", side, base);
+
+    public ComplexProjectHierarchyTest(String name) {
+        super(name, "17");
+    }
+
+    public void testComplexRename1() throws Exception {
+        writeFilesAndWaitForScan(getSource(side),
+                new File("side/Side.java",
+                         """
+                         package side;
+                         public class Side {}
+                         """));
+
+        String baseCode = """
+                          package base;
+                          public class Base<T> {
+                              public void te|st(T t) {}
+                          }
+                          """;
+        int pos = baseCode.indexOf('|');
+
+        writeFilesAndWaitForScan(getSource(base),
+                new File("base/Base.java",
+                         baseCode.substring(0, pos) + baseCode.substring(pos + 1)));
+
+        writeFilesAndWaitForScan(getSource(main),
+                new File("main/Main.java",
+                         """
+                         package main;
+                         import base.Base;
+                         import side.Side;
+                         public class Main extends Base<Side> {
+                             public void test(Side t) {}
+                             public void test(String t) {}
+                             public void run() {
+                                 test(new Side());
+                             }
+                         }
+                         """));
+        performRename(getSource(base).getFileObject("base/Base.java"), pos, "test2", null, false);
+        verifyContent(getSource(main),
+                new File("main/Main.java",
+                         """
+                         package main;
+                         import base.Base;
+                         import side.Side;
+                         public class Main extends Base<Side> {
+                             public void test2(Side t) {}
+                             public void test(String t) {}
+                             public void run() {
+                                 test2(new Side());
+                             }
+                         }
+                         """));
+    }
+
+    public void testComplexRename2() throws Exception {
+        writeFilesAndWaitForScan(getSource(side),
+                new File("side/Side.java",
+                         """
+                         package side;
+                         public class Side {}
+                         """));
+        writeFilesAndWaitForScan(getSource(base),
+                new File("base/Base.java",
+                         """
+                         package base;
+                         public class Base<T> {
+                             public void test(T t) {}
+                         }
+                         """));
+
+        String mainCode = """
+                          package main;
+                          import base.Base;
+                          import side.Side;
+                          public class Main extends Base<Side> {
+                              public void test(Side t) {}
+                              public void test(String t) {}
+                              public void run() {
+                                  te|st(new Side());
+                              }
+                          }
+                          """;
+
+        int pos = mainCode.indexOf('|');
+
+        writeFilesAndWaitForScan(getSource(main),
+                new File("main/Main.java",
+                         mainCode.substring(0, pos) + mainCode.substring(pos + 1)));
+        performRename(getSource(main).getFileObject("main/Main.java"), pos, "test2", null, false, new Problem(false, "ERR_Overrides"));
+        verifyContent(getSource(main),
+                new File("main/Main.java",
+                         """
+                         package main;
+                         import base.Base;
+                         import side.Side;
+                         public class Main extends Base<Side> {
+                             public void test2(Side t) {}
+                             public void test(String t) {}
+                             public void run() {
+                                 test2(new Side());
+                             }
+                         }
+                         """));
+    }
+
+    @Override
+    protected List<ProjectDesc> projects() {
+        return List.of(main, base, side);
+    }
+
+    private void performRename(FileObject source, final int absPos, final String newname, final JavaRenameProperties props, final boolean searchInComments, Problem... expectedProblems) throws Exception {
+        final RenameRefactoring[] r = new RenameRefactoring[1];
+        JavaSource.forFileObject(source)
+                  .runUserActionTask(javac -> {
+                      javac.toPhase(JavaSource.Phase.RESOLVED);
+                      TreePath tp = javac.getTreeUtilities().pathFor(absPos);
+
+                      r[0] = new RenameRefactoring(Lookups.singleton(TreePathHandle.create(tp, javac)));
+                      r[0].setNewName(newname);
+                      r[0].setSearchInComments(searchInComments);
+                      if(props != null) {
+                          r[0].getContext().add(props);
+                      }
+        }, true);
+
+        RefactoringSession rs = RefactoringSession.create("Rename");
+        List<Problem> problems = new LinkedList<>();
+
+        addAllProblems(problems, r[0].preCheck());
+        if (!problemIsFatal(problems)) {
+            addAllProblems(problems, r[0].prepare(rs));
+        }
+        if (!problemIsFatal(problems)) {
+            addAllProblems(problems, rs.doRefactoring(true));
+        }
+
+        assertProblems(Arrays.asList(expectedProblems), problems);
+    }
+}


### PR DESCRIPTION
The Java refactoring is sometimes using class path (`ClasspathInfo`) that is, to me, extremely weird. In the specific case of https://github.com/apache/netbeans/issues/9056, the `ClasspathInfo` used to process `GspIndenter` does not in some cases contain the `lexer` module, while the `groovy/groovy.gsp` definitely lists it as a dependency.

The consequence of that is that there are compile-time errors in the file(s) with this broken class path. Sometimes, it may lead to "catastrophic" failures like:
https://bugs.openjdk.org/browse/JDK-8373094

but even if it does not, wrong class path is likely to lead to weird effects. Like, in the test for the PR, `testComplexRename1`, inside `main.Main`, not only `test(Side)` will be renamed, but also `test(String)` will be renamed with the current state, as the classpath when analyzing `main.main` does not contain `side`.

The goal of this PR is to use class path that is more sensible for the rename refactoring.


---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>