### PR TITLE
Java ConvertToARM fix: Fix case where existing variable (without declaration) is guarded and other variables are used outside the new block

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToARM.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToARM.java
@@ -612,12 +612,16 @@ public class ConvertToARM {
             final List<StatementTree> statements = new ArrayList<StatementTree>(originalStatements.size());
             int state = var != null ? 0 : 1;  //0 - ordinary,1 - replace by try, 2 - remove 
             final Set<Tree> toRemove = new HashSet<Tree>(oldStms);
+            boolean preVarDeclsWritten = false;
             for (StatementTree statement : originalStatements) {
                 if (removeStms.contains(statement)) {
                     continue;
                 }
                 if (var == statement) {
-                    statements.addAll(preVarDecls);
+                    if (!preVarDeclsWritten) {
+                        preVarDeclsWritten = true;
+                        statements.addAll(preVarDecls);
+                    }
                     if (var.getKind() == Kind.TRY) {
                         gen.copyComments(statement, newTry, true);
                         gen.copyComments(statement, newTry, false);
@@ -658,6 +662,10 @@ public class ConvertToARM {
                             gen.copyComments(tt.getFinallyBlock(), nt, false);
                         }
                     }
+                    if (!preVarDeclsWritten) {
+                        preVarDeclsWritten = true;
+                        statements.addAll(preVarDecls);
+                    }
                     statement = newTry;
                 } else if (state == 2) {
                     if (!toRemove.contains(statement)) {
@@ -667,6 +675,7 @@ public class ConvertToARM {
                 }
                 statements.add(statement);
             }
+
             return tm.Block(statements, false);
         }
         


### PR DESCRIPTION
Example:

```java
import java.io.ByteArrayOutputStream;
import java.io.InputStream;

public class Test {

    public static byte[] test(InputStream input) throws Exception {
        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
        int len;

        byte[] buffer = new byte[1024];

        while ((len = input.read(buffer)) != -1) {
            outStream.write(buffer, 0, len);
        }
        input.close();

        return outStream.toByteArray();
    }
}
```

Rewrite result before fix:

```java
import java.io.ByteArrayOutputStream;
import java.io.InputStream;

public class Test {

    public static byte[] test(InputStream input) throws Exception {
        try (input) {
            outStream = new ByteArrayOutputStream();
            int len;
            byte[] buffer = new byte[1024];
            while ((len = input.read(buffer)) != -1) {
                outStream.write(buffer, 0, len);
            }
        }

        return outStream.toByteArray();
    }
}
```

Problem is here, that the result variable is used outside the new try block, but the declaration is not written.

Closes: #9046
