### PR TITLE
Fix for issue 9018: Javadoc viewer shows HTML comments

### DIFF
--- a/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementJavadoc.java
+++ b/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementJavadoc.java
@@ -123,8 +123,6 @@ import com.sun.source.util.JavacTask;
 import com.vladsch.flexmark.ext.tables.TablesExtension;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
-import com.vladsch.flexmark.util.data.DataHolder;
-import com.vladsch.flexmark.util.data.MutableDataSet;
 import javax.lang.model.element.RecordComponentElement;
 import org.netbeans.api.java.queries.SourceLevelQuery;
 import org.netbeans.api.java.queries.SourceLevelQuery.Profile;
@@ -191,7 +189,7 @@ public class ElementJavadoc {
     }
     
     /** Creates an object describing the Javadoc of given element. The object
-     * is capable of getting the text formated into HTML, resolve the links,
+     * is capable of getting the text formatted into HTML, resolve the links,
      * jump to external javadoc.
      * 
      * @param compilationInfo CompilationInfo
@@ -203,7 +201,7 @@ public class ElementJavadoc {
     }
 
     /** Creates an object describing the Javadoc of given element. The object
-     * is capable of getting the text formated into HTML, resolve the links,
+     * is capable of getting the text formatted into HTML, resolve the links,
      * jump to external javadoc.
      *
      * @param compilationInfo CompilationInfo
@@ -216,7 +214,7 @@ public class ElementJavadoc {
         return new ElementJavadoc(compilationInfo, element, null, cancel);
     }
     
-    /** Gets the javadoc comment formated as HTML.      
+    /** Gets the javadoc comment formatted as HTML.
      * @return HTML text of the javadoc
      */
     public String getText() {
@@ -228,7 +226,7 @@ public class ElementJavadoc {
         }
     }
 
-    /** Gets the javadoc comment formated as HTML.
+    /** Gets the javadoc comment formatted as HTML.
      * @return {@link Future} of HTML text of the javadoc
      * @since 1.20
      */
@@ -237,7 +235,7 @@ public class ElementJavadoc {
     }
 
     /** Gets URL of the external javadoc.
-     * @return Text of the Javadoc comment formated as HTML
+     * @return Text of the Javadoc comment formatted as HTML
      */ 
     public URL getURL() {
         return docURL;
@@ -422,7 +420,7 @@ public class ElementJavadoc {
             return;
         }
         try {
-            //Optimisitic no http
+            //Optimistic no http
             CharSequence doc = getElementDoc(element, compilationInfo, header, url, true);
             if (doc == null) {
                 computeDocURL(Collections.emptyList(), true, cancel);
@@ -1391,6 +1389,8 @@ public class ElementJavadoc {
                     sb.append("<code>"); //NOI18N
                     sb.append(systemPropTag.getPropertyName());
                     sb.append("</code>"); //NOI18N
+                    break;
+                case COMMENT:
                     break;
                 default:
                     sb.append("<code>"); //NOI18N

--- a/java/java.sourceui/test/unit/src/org/netbeans/api/java/source/ui/ElementJavadocTest.java
+++ b/java/java.sourceui/test/unit/src/org/netbeans/api/java/source/ui/ElementJavadocTest.java
@@ -157,8 +157,27 @@ public class ElementJavadocTest extends NbTestCase {
         String expectedJavadoc = "<pre>public class <b>Test</b><br>extends <a href='*0'>Object</a></pre><p>Hello!\n" +
                                  "\n" +
                                  "<p>";
-
+        
         assertEquals(expectedJavadoc, actualJavadoc);
     }
 
+    /**
+     * Test for issue 9018: Javadoc viewer shows HTML comments
+     * @throws Exception 
+     */
+    public void testHiddenTagInDoc() throws Exception {
+        prepareTest("test/Test.java", "/**\n" +
+                    " * Next commented text is not expected to be in output document\n" +
+                    " * <!-- This text not expected to be in output document -->\n" +
+                    " */\n" +
+                    "public class Te<caret>st {}");
+        String actualJavadoc = ElementJavadoc.create(info, selectedElement).getText();
+        String expectedJavadoc = "<pre>public class <b>Test</b><br>extends <a href='*0'>Object</a></pre><p>Next commented text is not expected to be in output document\n" +
+
+                                 "<p>";
+        assertEquals(expectedJavadoc, actualJavadoc);
+    }
+    
+    
+    
 }


### PR DESCRIPTION
Fix for #9018 

Given html tag passed to default section of inlineTags method and thus changes opening bracket convered to 'lt' entity
I add extra case 'COMMENT' to bupass this DocTree tag processing

Add test to check this 

---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>