### PR TITLE
Debugger: Only add java specific InlineValueComputerImpl for JPDA sessions

### DIFF
--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/InlineValueComputerImpl.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/InlineValueComputerImpl.java
@@ -97,10 +97,16 @@ public class InlineValueComputerImpl implements PreferenceChangeListener, Proper
     private TaskDescription currentTask;
 
     private InlineValueComputerImpl(Session session) {
-        debugger = (JPDADebuggerImpl) session.lookupFirst(null, JPDADebugger.class);
-        debugger.addPropertyChangeListener(this);
-        prefs = MimeLookup.getLookup("text/x-java").lookup(Preferences.class);
-        prefs.addPreferenceChangeListener(WeakListeners.create(PreferenceChangeListener.class, this, prefs));
+        JPDADebugger jpdaDebugger = session.lookupFirst(null, JPDADebugger.class);
+        if (jpdaDebugger instanceof JPDADebuggerImpl) {
+            debugger = (JPDADebuggerImpl) jpdaDebugger;
+            debugger.addPropertyChangeListener(this);
+            prefs = MimeLookup.getLookup("text/x-java").lookup(Preferences.class);
+            prefs.addPreferenceChangeListener(WeakListeners.create(PreferenceChangeListener.class, this, prefs));
+        } else {
+            debugger = null;
+            prefs = null;
+        }
     }
 
     @Override


### PR DESCRIPTION
Exceptions can be observed with CPPLite and JS debugger. The issue is that the support for showing values for variables inline is registered unconditionally, but the implementation is JPDA only.

```
java.lang.NullPointerException: Cannot invoke "org.netbeans.modules.debugger.jpda.JPDADebuggerImpl.addPropertyChangeListener(java.beans.PropertyChangeListener)" because "this.debugger" is null
	at org.netbeans.modules.debugger.jpda.ui.models.InlineValueComputerImpl.<init>(InlineValueComputerImpl.java:101)
	at org.netbeans.modules.debugger.jpda.ui.models.InlineValueComputerImpl$Init.sessionAdded(InlineValueComputerImpl.java:306)
[catch] at org.netbeans.api.debugger.DebuggerManager.fireSessionAdded(DebuggerManager.java:1324)
	at org.netbeans.api.debugger.DebuggerManager.addSession(DebuggerManager.java:1598)
	at org.netbeans.api.debugger.DebuggerManager.startDebugging(DebuggerManager.java:314)
	at org.netbeans.modules.cpplite.debugger.CPPLiteDebugger.startDebugging(CPPLiteDebugger.java:845)
	at org.netbeans.modules.cpplite.debugger.api.Debugger.startInDebugger(Debugger.java:43)
	at org.netbeans.modules.cpplite.project.ActionProviderImpl.lambda$invokeAction$4(ActionProviderImpl.java:88)
	at org.netbeans.api.extexecution.base.BaseExecutionService$2.call(BaseExecutionService.java:236)
	at org.netbeans.api.extexecution.base.BaseExecutionService$2.call(BaseExecutionService.java:212)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1403)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2018)
```
