### PR TITLE
apidoc css simplification

### DIFF
--- a/apisupport/apisupport.project/apichanges.xml
+++ b/apisupport/apisupport.project/apichanges.xml
@@ -277,7 +277,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Database Explorer API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/enterprise/api.web.webmodule/apichanges.xml
+++ b/enterprise/api.web.webmodule/apichanges.xml
@@ -243,7 +243,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the WebModule API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/enterprise/j2ee.api.ejbmodule/apichanges.xml
+++ b/enterprise/j2ee.api.ejbmodule/apichanges.xml
@@ -212,7 +212,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the EjbJar API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/enterprise/j2ee.common/apichanges.xml
+++ b/enterprise/j2ee.common/apichanges.xml
@@ -279,7 +279,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the EjbJar API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/enterprise/j2ee.dd.webservice/apichanges.xml
+++ b/enterprise/j2ee.dd.webservice/apichanges.xml
@@ -101,7 +101,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Web Services Deployment Descriptor API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/enterprise/j2ee.dd/apichanges.xml
+++ b/enterprise/j2ee.dd/apichanges.xml
@@ -136,7 +136,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the J2EE Deployment Descriptor API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/enterprise/j2ee.dd/doc/ddapi_architecture.html
+++ b/enterprise/j2ee.dd/doc/ddapi_architecture.html
@@ -21,7 +21,6 @@
 <html>
 <head>
 <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<link rel="Stylesheet" href="../prose.css" type='text/css'>
 <title>Architecture Document for Deployment Descriptor API</title>
 </head>
 <body>

--- a/enterprise/j2ee.dd/doc/usage.html
+++ b/enterprise/j2ee.dd/doc/usage.html
@@ -22,7 +22,6 @@
 <HTML>
 <head>
 <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<link rel="Stylesheet" href="../prose.css" type='text/css'>
 <title>DD API Usage</title>
 </head>
 <BODY>

--- a/enterprise/j2ee.ejbjarproject/apichanges.xml
+++ b/enterprise/j2ee.ejbjarproject/apichanges.xml
@@ -115,7 +115,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the EjbJarProject API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/enterprise/j2eeserver/apichanges.xml
+++ b/enterprise/j2eeserver/apichanges.xml
@@ -1598,7 +1598,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the J2EE Server API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/enterprise/web.core.syntax/apichanges.xml
+++ b/enterprise/web.core.syntax/apichanges.xml
@@ -120,7 +120,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the JSP Editor API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/enterprise/web.core/apichanges.xml
+++ b/enterprise/web.core/apichanges.xml
@@ -120,7 +120,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the JSP Core API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/enterprise/web.jspparser/apichanges.xml
+++ b/enterprise/web.jspparser/apichanges.xml
@@ -142,7 +142,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the JSP Parser API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -740,7 +740,6 @@ is the proper place.
         -->
         <head>
             <title>Change History for the Gradle Project API</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
 

--- a/extide/o.apache.tools.ant.module/apichanges.xml
+++ b/extide/o.apache.tools.ant.module/apichanges.xml
@@ -662,7 +662,6 @@ is the proper place.
 -->
     <head>
       <title>NetBeans Ant module API Changes by Date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
       <meta name="CATEGORY" content="OtherDevelopmentDoc"/>
       <meta name="DESCRIPTION" content="A cross-indexed list of all changes made to the NetBeans Ant module APIs."/>
     </head>

--- a/groovy/groovy.editor/apichanges.xml
+++ b/groovy/groovy.editor/apichanges.xml
@@ -181,7 +181,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Input/Output API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/groovy/groovy.support/apichanges.xml
+++ b/groovy/groovy.support/apichanges.xml
@@ -114,7 +114,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Input/Output API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/harness/nbjunit/apichanges.xml
+++ b/harness/nbjunit/apichanges.xml
@@ -500,7 +500,6 @@
     <htmlcontents>
     <head>
       <title>Change History for the NetBeans JUnit Extensions API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/api.debugger/apichanges.xml
+++ b/ide/api.debugger/apichanges.xml
@@ -546,7 +546,6 @@
 -->
     <head>
       <title>Debugger Core API changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/api.java.classpath/apichanges.xml
+++ b/ide/api.java.classpath/apichanges.xml
@@ -367,7 +367,6 @@
 -->
     <head>
       <title>ClassPath API changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/api.lsp/apichanges.xml
+++ b/ide/api.lsp/apichanges.xml
@@ -354,7 +354,6 @@
 -->
     <head>
       <title>LSP API changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/api.xml/apichanges.xml
+++ b/ide/api.xml/apichanges.xml
@@ -376,7 +376,6 @@ is the proper place.
 -->
     <head>
       <title>XML Tools API Changes by Date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
       <meta name="CATEGORY" content="OtherDevelopmentDoc"/>
       <meta name="DESCRIPTION" content="A cross-indexed list of all changes made to the NetBeans XML tools APIs."/>
     </head>

--- a/ide/bugtracking/apichanges.xml
+++ b/ide/bugtracking/apichanges.xml
@@ -130,7 +130,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Bugtracking SPI and API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/core.ide/apichanges.xml
+++ b/ide/core.ide/apichanges.xml
@@ -52,7 +52,6 @@
         <!-- Generated from apichanges.xml -->
         <head>
             <title>Change History for the Core IDE API</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
 

--- a/ide/csl.api/apichanges.xml
+++ b/ide/csl.api/apichanges.xml
@@ -314,7 +314,6 @@
 <htmlcontents>
 <head>
     <title>Change History for the Common Scripting Language API</title>
-    <link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
     <standard-changelists module-code-name="org.netbeans.modules.csl.api"/>

--- a/ide/csl.types/apichanges.xml
+++ b/ide/csl.types/apichanges.xml
@@ -121,7 +121,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Common CSL types</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/db.core/apichanges.xml
+++ b/ide/db.core/apichanges.xml
@@ -49,7 +49,6 @@
     <htmlcontents>
         <head>
             <title>Change History for the DB Core API</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
 

--- a/ide/db.metadata.model/apichanges.xml
+++ b/ide/db.metadata.model/apichanges.xml
@@ -50,7 +50,6 @@
     <htmlcontents>
         <head>
             <title>Change History for the DB Metadata Model API</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
 

--- a/ide/db/apichanges.xml
+++ b/ide/db/apichanges.xml
@@ -394,7 +394,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Database Explorer API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/diff/apichanges.xml
+++ b/ide/diff/apichanges.xml
@@ -218,7 +218,6 @@ is the proper place.
 -->
     <head>
       <title>Diff API Changes by Date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/editor.bracesmatching/apichanges.xml
+++ b/ide/editor.bracesmatching/apichanges.xml
@@ -197,7 +197,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the Braces Matching SPI</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/editor.codetemplates/apichanges.xml
+++ b/ide/editor.codetemplates/apichanges.xml
@@ -156,7 +156,6 @@ is the proper place.
     <htmlcontents>
     <head>
       <title>Change History for the Editor Code Templates API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/editor.completion/apichanges.xml
+++ b/ide/editor.completion/apichanges.xml
@@ -268,7 +268,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Editor Code Completion API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/editor.document/apichanges.xml
+++ b/ide/editor.document/apichanges.xml
@@ -170,7 +170,6 @@ is the proper place.
 -->
     <head>
       <title>Editor Document API Changes by Date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
       <meta name="CATEGORY" content="OtherDevelopmentDoc"/>
       <meta name="DESCRIPTION" content="A cross-indexed list of all changes made to the Editor Document API."/>
     </head>

--- a/ide/editor.fold/apichanges.xml
+++ b/ide/editor.fold/apichanges.xml
@@ -180,7 +180,6 @@ is the proper place.
 -->
     <head>
       <title>Fold API Changes by Date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
       <meta name="CATEGORY" content="OtherDevelopmentDoc"/>
       <meta name="DESCRIPTION" content="A cross-indexed list of all changes made to the Fold API."/>
     </head>

--- a/ide/editor.guards/apichanges.xml
+++ b/ide/editor.guards/apichanges.xml
@@ -175,7 +175,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Editor Guarded Sections API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/editor.indent.project/apichanges.xml
+++ b/ide/editor.indent.project/apichanges.xml
@@ -103,7 +103,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History of Editor Indentation for Projects API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/editor.indent.support/apichanges.xml
+++ b/ide/editor.indent.support/apichanges.xml
@@ -113,7 +113,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History of Editor Indentation API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/editor.indent/apichanges.xml
+++ b/ide/editor.indent/apichanges.xml
@@ -285,7 +285,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History of Editor Indentation API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/editor.lib/apichanges.xml
+++ b/ide/editor.lib/apichanges.xml
@@ -1150,7 +1150,6 @@ duplicate messages suppressed: 14
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the Editor Library API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/editor.lib2/apichanges.xml
+++ b/ide/editor.lib2/apichanges.xml
@@ -618,7 +618,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the Editor Library 2 API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/editor.plain/apichanges.xml
+++ b/ide/editor.plain/apichanges.xml
@@ -104,7 +104,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the Editor Library API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/editor.settings.storage/apichanges.xml
+++ b/ide/editor.settings.storage/apichanges.xml
@@ -306,7 +306,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Editor Settings Storage API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/editor.settings/apichanges.xml
+++ b/ide/editor.settings/apichanges.xml
@@ -426,7 +426,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Editor Settings API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/editor.util/apichanges.xml
+++ b/ide/editor.util/apichanges.xml
@@ -449,7 +449,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Editor Utilities API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/editor/apichanges.xml
+++ b/ide/editor/apichanges.xml
@@ -458,7 +458,6 @@ org.netbeans.modules.editor.NbEditorKit:method public java.util.List&lt;javax.sw
 -->
     <head>
       <title>Change History for the Editor API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/extexecution.base/apichanges.xml
+++ b/ide/extexecution.base/apichanges.xml
@@ -145,7 +145,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the External Execution Base API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/extexecution/apichanges.xml
+++ b/ide/extexecution/apichanges.xml
@@ -316,7 +316,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the External Execution API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/gototest/apichanges.xml
+++ b/ide/gototest/apichanges.xml
@@ -74,7 +74,6 @@
 -->
     <head>
       <title>Navigate To Test API changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/gsf.testrunner.ui/apichanges.xml
+++ b/ide/gsf.testrunner.ui/apichanges.xml
@@ -163,7 +163,6 @@
 	-->
 	<head>
 	    <title>Options Dialog API changes by date</title>
-	    <link rel="stylesheet" href="prose.css" type="text/css"/>
 	</head>
 	<body>
 

--- a/ide/gsf.testrunner/apichanges.xml
+++ b/ide/gsf.testrunner/apichanges.xml
@@ -179,7 +179,6 @@
 	-->
 	<head>
 	    <title>Options Dialog API changes by date</title>
-	    <link rel="stylesheet" href="prose.css" type="text/css"/>
 	</head>
 	<body>
 

--- a/ide/jumpto/apichanges.xml
+++ b/ide/jumpto/apichanges.xml
@@ -327,7 +327,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Jump to API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/lexer.antlr4/apichanges.xml
+++ b/ide/lexer.antlr4/apichanges.xml
@@ -118,7 +118,6 @@ is the proper place.
         -->
         <head>
             <title>Change History for the ANTLR4 Lexer Bridge</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
 

--- a/ide/lexer/apichanges.xml
+++ b/ide/lexer/apichanges.xml
@@ -612,7 +612,6 @@ is the proper place.
 -->
     <head>
       <title>Lexer API Changes by Date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
       <meta name="CATEGORY" content="OtherDevelopmentDoc"/>
       <meta name="DESCRIPTION" content="A cross-indexed list of all changes made to the Lexer API."/>
     </head>

--- a/ide/lib.terminalemulator/apichanges.xml
+++ b/ide/lib.terminalemulator/apichanges.xml
@@ -141,7 +141,6 @@ For details see:
 -->
     <head>
       <title>Debugger Core API changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/lib.terminalemulator/doc-files/func_spec.html
+++ b/ide/lib.terminalemulator/doc-files/func_spec.html
@@ -22,7 +22,6 @@
 <html>
 <head>
 <title>High level functional description of a Terminal Emulator, Term</title>
-<LINK REL="Stylesheet" HREF="../../../../../prose.css" TYPE="text/css" TITLE="NetBeans OpenSource Style">
 
 </head>
 <body>

--- a/ide/lib.terminalemulator/doc-files/interpreter.html
+++ b/ide/lib.terminalemulator/doc-files/interpreter.html
@@ -22,7 +22,6 @@
 <html>
 <head>
 <title>Term interpreter construction</title>
-<LINK REL="Stylesheet" HREF="../../../../../prose.css" TYPE="text/css">
 
 </head>
 

--- a/ide/lib.terminalemulator/doc-files/properties.html
+++ b/ide/lib.terminalemulator/doc-files/properties.html
@@ -21,7 +21,6 @@
 
 <html>
 <head>
-<LINK REL="Stylesheet" HREF="../../../../../prose.css" TYPE="text/css">
 </head>
 <body>
 	<h1>Current properties for Term</h1>

--- a/ide/libs.git/apichanges.xml
+++ b/ide/libs.git/apichanges.xml
@@ -398,7 +398,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Git Library API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/libs.graalsdk.system/apichanges.xml
+++ b/ide/libs.graalsdk.system/apichanges.xml
@@ -65,7 +65,6 @@
 -->
     <head>
       <title>Change History for the Progress API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/libs.graalsdk/apichanges.xml
+++ b/ide/libs.graalsdk/apichanges.xml
@@ -65,7 +65,6 @@
 -->
     <head>
       <title>Change History for the Progress API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/lsp.client/apichanges.xml
+++ b/ide/lsp.client/apichanges.xml
@@ -53,7 +53,6 @@
 <htmlcontents>
 <head>
 <title>Change History for the LSP Client API</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/ide/o.openidex.util/apichanges.xml
+++ b/ide/o.openidex.util/apichanges.xml
@@ -281,7 +281,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Search API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/options.editor/apichanges.xml
+++ b/ide/options.editor/apichanges.xml
@@ -227,7 +227,6 @@ is the proper place.
 -->
     <head>
       <title>Lexer API Changes by Date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
       <meta name="CATEGORY" content="OtherDevelopmentDoc"/>
       <meta name="DESCRIPTION" content="A cross-indexed list of all changes made to the Lexer API."/>
     </head>

--- a/ide/parsing.api/apichanges.xml
+++ b/ide/parsing.api/apichanges.xml
@@ -820,7 +820,6 @@ is the proper place.
 -->
     <head>
         <title>Change History for the Parsing &amp; Indexing API</title>
-        <link rel="stylesheet" href="prose.css" type="text/css"/>
         <meta name="CATEGORY" content="OtherDevelopmentDoc"/>
         <meta name="DESCRIPTION" content="A cross-indexed list of all changes made to the Parsing &amp; Indexing API."/>
     </head>

--- a/ide/parsing.indexing/apichanges.xml
+++ b/ide/parsing.indexing/apichanges.xml
@@ -210,7 +210,6 @@ is the proper place.
 -->
     <head>
         <title>Change History for the Indexing API</title>
-        <link rel="stylesheet" href="prose.css" type="text/css"/>
         <meta name="CATEGORY" content="OtherDevelopmentDoc"/>
         <meta name="DESCRIPTION" content="A cross-indexed list of all changes made to the Parsing &amp; Indexing API."/>
     </head>

--- a/ide/parsing.lucene/apichanges.xml
+++ b/ide/parsing.lucene/apichanges.xml
@@ -396,7 +396,6 @@ is the proper place.
 -->
     <head>
         <title>Change History for the Parsing Lucene Support Friend API</title>
-        <link rel="stylesheet" href="prose.css" type="text/css"/>
         <meta name="CATEGORY" content="OtherDevelopmentDoc"/>
         <meta name="DESCRIPTION" content="A cross-indexed list of all changes made to the  Parsing Lucene Support Friend API."/>
     </head>

--- a/ide/parsing.nb/apichanges.xml
+++ b/ide/parsing.nb/apichanges.xml
@@ -128,7 +128,6 @@ is the proper place.
 -->
     <head>
         <title>Change History for the Parsing &amp; Indexing API</title>
-        <link rel="stylesheet" href="prose.css" type="text/css"/>
         <meta name="CATEGORY" content="OtherDevelopmentDoc"/>
         <meta name="DESCRIPTION" content="A cross-indexed list of all changes made to the Parsing &amp; Indexing API."/>
     </head>

--- a/ide/project.ant.ui/apichanges.xml
+++ b/ide/project.ant.ui/apichanges.xml
@@ -130,7 +130,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Ant Project Support UI</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/project.ant/apichanges.xml
+++ b/ide/project.ant/apichanges.xml
@@ -630,7 +630,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Ant Project API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/project.libraries.ui/apichanges.xml
+++ b/ide/project.libraries.ui/apichanges.xml
@@ -112,7 +112,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Project Libraries API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/project.libraries/apichanges.xml
+++ b/ide/project.libraries/apichanges.xml
@@ -336,7 +336,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Project Libraries API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/projectapi/apichanges.xml
+++ b/ide/projectapi/apichanges.xml
@@ -692,7 +692,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Project API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/projectapi/src/org/netbeans/spi/project/doc-files/configurations.html
+++ b/ide/projectapi/src/org/netbeans/spi/project/doc-files/configurations.html
@@ -22,7 +22,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title>Project Configurations</title>
-<link rel="stylesheet" type="text/css" href="../../../../../prose.css"/>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
 <meta name="topic" content="projects"/>
 <meta name="type" content="proposal"/>

--- a/ide/projectui/apichanges.xml
+++ b/ide/projectui/apichanges.xml
@@ -174,7 +174,6 @@
         <!-- Generated from apichanges.xml -->
         <head>
             <title>Change History for the Project UI</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
 

--- a/ide/projectuiapi.base/apichanges.xml
+++ b/ide/projectuiapi.base/apichanges.xml
@@ -232,7 +232,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Project UI API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/projectuiapi/apichanges.xml
+++ b/ide/projectuiapi/apichanges.xml
@@ -1033,7 +1033,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Project UI API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/properties/apichanges.xml
+++ b/ide/properties/apichanges.xml
@@ -224,7 +224,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Search API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/refactoring.api/apichanges.xml
+++ b/ide/refactoring.api/apichanges.xml
@@ -232,7 +232,6 @@
     <htmlcontents>
         <head>
             <title>Change History for the Refactoing API</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
             <p class="overviewlink"><a href="overview-summary.html">Overview</a></p>

--- a/ide/server/apichanges.xml
+++ b/ide/server/apichanges.xml
@@ -179,7 +179,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Common Server API/SPI</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/spi.debugger.ui/apichanges.xml
+++ b/ide/spi.debugger.ui/apichanges.xml
@@ -328,7 +328,6 @@
 -->
     <head>
       <title>Debugger Core UI SPI changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/spi.editor.hints.projects/apichanges.xml
+++ b/ide/spi.editor.hints.projects/apichanges.xml
@@ -106,7 +106,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the Editor Hints SPI</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/spi.editor.hints/apichanges.xml
+++ b/ide/spi.editor.hints/apichanges.xml
@@ -217,7 +217,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the Editor Hints SPI</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/spi.navigator/apichanges.xml
+++ b/ide/spi.navigator/apichanges.xml
@@ -231,7 +231,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Progress API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/spi.palette/apichanges.xml
+++ b/ide/spi.palette/apichanges.xml
@@ -410,7 +410,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Progress API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/spi.tasklist/apichanges.xml
+++ b/ide/spi.tasklist/apichanges.xml
@@ -131,7 +131,6 @@
 -->
     <head>
       <title>Options Dialog API changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/spi.viewmodel/apichanges.xml
+++ b/ide/spi.viewmodel/apichanges.xml
@@ -444,7 +444,6 @@
 -->
     <head>
       <title>View Model API changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/textmate.lexer/apichanges.xml
+++ b/ide/textmate.lexer/apichanges.xml
@@ -97,7 +97,6 @@
 -->
     <head>
       <title>Options Dialog API changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/versioning/apichanges.xml
+++ b/ide/versioning/apichanges.xml
@@ -332,7 +332,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Versioning SPI</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/web.common/apichanges.xml
+++ b/ide/web.common/apichanges.xml
@@ -54,7 +54,6 @@
   <htmlcontents>
     <head>
       <title>Change History for the Friend Core APIs</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/xml.catalog/apichanges.xml
+++ b/ide/xml.catalog/apichanges.xml
@@ -122,7 +122,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the XML Entity Catalog</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/xml.core/apichanges.xml
+++ b/ide/xml.core/apichanges.xml
@@ -116,7 +116,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the XML Core module API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/xml.lexer/apichanges.xml
+++ b/ide/xml.lexer/apichanges.xml
@@ -104,7 +104,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the XML Text Editor API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/xml.multiview/apichanges.xml
+++ b/ide/xml.multiview/apichanges.xml
@@ -86,7 +86,6 @@
 -->
     <head>
       <title>XML Multiview Editor changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/xml.schema.model/apichanges.xml
+++ b/ide/xml.schema.model/apichanges.xml
@@ -104,7 +104,6 @@ is the proper place.
         <!-- Generated from apichanges.xml -->
         <head>
             <title>Change History for the Schema Model API</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
             <p class="overviewlink">

--- a/ide/xml.text/apichanges.xml
+++ b/ide/xml.text/apichanges.xml
@@ -176,7 +176,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the XML Text Editor API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/ide/xml.xam/apichanges.xml
+++ b/ide/xml.xam/apichanges.xml
@@ -148,7 +148,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the Extansible Abstract Model (XAM)</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/ant.freeform/apichanges.xml
+++ b/java/ant.freeform/apichanges.xml
@@ -222,7 +222,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the Ant Freeform SPI</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/api.debugger.jpda/apichanges.xml
+++ b/java/api.debugger.jpda/apichanges.xml
@@ -1007,7 +1007,6 @@ These are mainly class and thread filters and hit counts.
 -->
     <head>
       <title>Debugger JPDA API changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/api.java/apichanges.xml
+++ b/java/api.java/apichanges.xml
@@ -612,7 +612,6 @@
 -->
     <head>
       <title>Java Support API changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/api.maven/apichanges.xml
+++ b/java/api.maven/apichanges.xml
@@ -135,7 +135,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for Maven Archetype</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/classfile/apichanges.xml
+++ b/java/classfile/apichanges.xml
@@ -213,7 +213,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Classfile API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/gradle.java/apichanges.xml
+++ b/java/gradle.java/apichanges.xml
@@ -237,7 +237,6 @@ is the proper place.
         -->
         <head>
             <title>Change History for the Gradle Java Project API</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
 

--- a/java/j2ee.metadata/apichanges.xml
+++ b/java/j2ee.metadata/apichanges.xml
@@ -130,7 +130,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Java EE Metadata module</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/j2ee.persistenceapi/apichanges.xml
+++ b/java/j2ee.persistenceapi/apichanges.xml
@@ -113,7 +113,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Database Explorer API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/java.api.common/apichanges.xml
+++ b/java/java.api.common/apichanges.xml
@@ -702,7 +702,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Java Common API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/java.editor.lib/apichanges.xml
+++ b/java/java.editor.lib/apichanges.xml
@@ -121,7 +121,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the Java Editor Library API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/java.freeform/apichanges.xml
+++ b/java/java.freeform/apichanges.xml
@@ -80,7 +80,6 @@
 -->
     <head>
       <title>Change History for the Java Freeform SPI</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/java.hints.test/apichanges.xml
+++ b/java/java.hints.test/apichanges.xml
@@ -160,7 +160,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the Editor Hints SPI</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/java.j2seplatform/apichanges.xml
+++ b/java/java.j2seplatform/apichanges.xml
@@ -116,7 +116,6 @@ is the proper place.
     <!-- Generated from apichanges.xml -->
     <head>
         <title>Change History for the Java SE Platforms and Libraries</title>
-        <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
         <p class="overviewlink"><a href="@TOP@/overview-summary.html">Overview</a></p>

--- a/java/java.j2seproject/apichanges.xml
+++ b/java/java.j2seproject/apichanges.xml
@@ -224,7 +224,6 @@ is the proper place.
     <!-- Generated from apichanges.xml -->
     <head>
         <title>Change History for the Java SE Projects API</title>
-        <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
         <p class="overviewlink"><a href="@TOP@/overview-summary.html">Overview</a></p>

--- a/java/java.lexer/apichanges.xml
+++ b/java/java.lexer/apichanges.xml
@@ -162,7 +162,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Java Lexer API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/java.platform.ui/apichanges.xml
+++ b/java/java.platform.ui/apichanges.xml
@@ -132,7 +132,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Java Platform API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/java.platform/apichanges.xml
+++ b/java/java.platform/apichanges.xml
@@ -253,7 +253,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Java Platform API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/java.preprocessorbridge/apichanges.xml
+++ b/java/java.preprocessorbridge/apichanges.xml
@@ -114,7 +114,6 @@
 -->
     <head>
       <title>Java Source Friend API changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/java.project.ui/apichanges.xml
+++ b/java/java.project.ui/apichanges.xml
@@ -179,7 +179,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Java Project API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/java.project/apichanges.xml
+++ b/java/java.project/apichanges.xml
@@ -755,7 +755,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Java Project API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/java.source.base/apichanges.xml
+++ b/java/java.source.base/apichanges.xml
@@ -491,7 +491,6 @@
 <htmlcontents>
 <head>
 <title>Change History for the Base Java Source API</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/java/java.source.queries/apichanges.xml
+++ b/java/java.source.queries/apichanges.xml
@@ -148,7 +148,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Java Source Queries API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/java.source/apichanges.xml
+++ b/java/java.source/apichanges.xml
@@ -1115,7 +1115,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Java Source API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/java.sourceui/apichanges.xml
+++ b/java/java.sourceui/apichanges.xml
@@ -251,7 +251,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Java Source UI API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/junit/apichanges.xml
+++ b/java/junit/apichanges.xml
@@ -98,7 +98,6 @@
 -->
     <head>
       <title>JUnit API changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/maven.embedder/apichanges.xml
+++ b/java/maven.embedder/apichanges.xml
@@ -130,7 +130,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Maven Embedder API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/maven/apichanges.xml
+++ b/java/maven/apichanges.xml
@@ -388,7 +388,6 @@ is the proper place.
         -->
         <head>
             <title>Change History for the Maven Project API</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
 

--- a/java/refactoring.java/apichanges.xml
+++ b/java/refactoring.java/apichanges.xml
@@ -238,7 +238,6 @@
     <htmlcontents>
         <head>
             <title>Change History for the Java Refactoring API</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
             <p class="overviewlink">

--- a/java/spi.debugger.jpda.ui/apichanges.xml
+++ b/java/spi.debugger.jpda.ui/apichanges.xml
@@ -86,7 +86,6 @@
 -->
     <head>
       <title>Debugger JPDA UI SPI changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/java/spi.java.hints/apichanges.xml
+++ b/java/spi.java.hints/apichanges.xml
@@ -191,7 +191,6 @@
     <htmlcontents>
         <head>
             <title>Change History for the Java Hints SPI</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
             <p class="overviewlink">

--- a/java/whitelist/apichanges.xml
+++ b/java/whitelist/apichanges.xml
@@ -121,7 +121,6 @@
 -->
     <head>
       <title>White List API changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/nbbuild/javadoctools/apichanges-empty.xml
+++ b/nbbuild/javadoctools/apichanges-empty.xml
@@ -27,7 +27,6 @@
     <htmlcontents>
         <head>
             <title>No Change History</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
             <p class="overviewlink"><a href="overview-summary.html">Overview</a></p>

--- a/nbbuild/javadoctools/apichanges-template.xml
+++ b/nbbuild/javadoctools/apichanges-template.xml
@@ -95,7 +95,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the CHANGEME API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/nbbuild/javadoctools/javadoc-generic.css
+++ b/nbbuild/javadoctools/javadoc-generic.css
@@ -934,7 +934,7 @@ li.ui-static-link a, li.ui-static-link a:visited {
     padding-bottom: 5px;
 }
 input[type="text"] {
-    background-image:url('glass.png');
+    background-image:url('glass.svg');
     background-size:13px;
     background-repeat:no-repeat;
     background-position:2px 3px;
@@ -963,7 +963,7 @@ input.filter-input {
 }
 input#reset-search, input.reset-filter {
     background-color: transparent;
-    background-image:url('x.png');
+    background-image:url('x.svg');
     background-repeat:no-repeat;
     background-size:contain;
     border:0;

--- a/nbbuild/javadoctools/netbeans-lite.css
+++ b/nbbuild/javadoctools/netbeans-lite.css
@@ -124,6 +124,7 @@ table.tableapigroup {
    border-spacing: 4px;
    border-collapse: collapse;
    border: 4px solid var(--selected-background-color);
+   overflow-wrap: break-word;
 }
 
 table.tableapigroup caption {

--- a/nbbuild/javadoctools/template.xml
+++ b/nbbuild/javadoctools/template.xml
@@ -173,7 +173,7 @@ cause it to fail.
         <delete file="${javadoc.overview}" />
 
         <property file="${export.interfaces}/properties/all.properties" />
-        <arch xsl="exportOverview.xsl" answers="${javadoc.arch}" output="${javadoc.overview}" stylesheet="prose.css"
+        <arch xsl="exportOverview.xsl" answers="${javadoc.arch}" output="${javadoc.overview}"
               apichanges="${javadoc.apichanges}" project="${javadoc.project}"
         >
             <!--
@@ -277,7 +277,7 @@ cause it to fail.
         
         <replace dir="${javadoc.out.dir}" >
             <include name="**/javadoc*.css"/>
-            <include name="nb-docs-stability.css"/>
+            <include name="**/nb-docs-stability.css"/>
             <replacefilter token="@CSS_TIMESTAMP@" value="Built on ${TODAY}. Copyright 2017-${YEAR} The Apache Software Foundation. All Rights Reserved." />
             <replacefilter token="@nb-docs-css@" value="${nb-docs.css}"/>
             <replacefilter token="@api-stability-image@" value="${stability.image}"/>
@@ -289,7 +289,10 @@ cause it to fail.
         <!-- JDK 25+ uses svgs -->
         <copy file="${javadoc.out.dir}/resource-files/glass.svg" todir="${javadoc.out.dir}/resource-files/resources" if:true="${javadoc25.or.later}" />
         <copy file="${javadoc.out.dir}/resource-files/x.svg" todir="${javadoc.out.dir}/resource-files/resources" if:true="${javadoc25.or.later}" />
-        <copy todir="${javadoc.out.dir}/resources">
+        <copy todir="${javadoc.out.dir}/resource-files/resources" if:true="${javadoc25.or.later}" >
+            <fileset refid="javadoc.resources.files"/>
+        </copy>
+        <copy todir="${javadoc.out.dir}/resources" if:blank="${javadoc25.or.later}" >
             <fileset refid="javadoc.resources.files"/>
         </copy>
     </target>
@@ -418,7 +421,6 @@ cause it to fail.
         <available file="${javadoc.out.dir}/deprecated-list.html" property="hasdeprecated"/>
         <arch answers="${javadoc.arch}"
               output="${javadoc.out.dir}/architecture-summary.html"
-              stylesheet="prose.css"
               overviewlink="overview-summary.html"
               footer="@FOOTER@"
               project="${javadoc.project}"
@@ -437,7 +439,7 @@ cause it to fail.
         <property name="arch.warn" value="true"/>
         <property name="arch.target" value="${javadoc.name}" />
         <mkdir dir="${export.interfaces}"/>
-        <arch xsl="exportInterfaces.xsl" answers="${javadoc.arch}" output="${export.interfaces}/architecture-summary.html" stylesheet="prose.css"/>
+        <arch xsl="exportInterfaces.xsl" answers="${javadoc.arch}" output="${export.interfaces}/architecture-summary.html"/>
         <move file="${export.interfaces}/architecture-summary.html" tofile="${export.interfaces}/${javadoc.name}" />
         <mkdir dir="${export.interfaces}/properties" />
         <xslt style="exportInterfaceProperties.xsl" in="${export.interfaces}/${javadoc.name}" out="${export.interfaces}/properties/${javadoc.name}" >

--- a/platform/api.annotations.common/apichanges.xml
+++ b/platform/api.annotations.common/apichanges.xml
@@ -161,7 +161,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Common Annotations API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/api.htmlui/apichanges.xml
+++ b/platform/api.htmlui/apichanges.xml
@@ -124,7 +124,6 @@
 <htmlcontents>
 <head>
 <title>Change History for the HTML for Java and NetBeans API</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/platform/api.io/apichanges.xml
+++ b/platform/api.io/apichanges.xml
@@ -182,7 +182,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Input/Output API and SPI</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/api.progress.nb/apichanges.xml
+++ b/platform/api.progress.nb/apichanges.xml
@@ -130,7 +130,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Progress API - Swing</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/api.progress/apichanges.xml
+++ b/platform/api.progress/apichanges.xml
@@ -379,7 +379,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Progress API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/api.scripting/apichanges.xml
+++ b/platform/api.scripting/apichanges.xml
@@ -87,7 +87,6 @@
 -->
     <head>
       <title>Change History for the Progress API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/api.search/apichanges.xml
+++ b/platform/api.search/apichanges.xml
@@ -302,7 +302,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the Search in Projects API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/api.templates/apichanges.xml
+++ b/platform/api.templates/apichanges.xml
@@ -204,7 +204,6 @@ page()</a>
 -->
     <head>
       <title>Change History for the Templates API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/api.visual/apichanges.xml
+++ b/platform/api.visual/apichanges.xml
@@ -788,7 +788,6 @@
     <htmlcontents>
     <head>
       <title>Change History for the Visual Library API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/api.visual/src/org/netbeans/api/visual/widget/doc-files/documentation.html
+++ b/platform/api.visual/src/org/netbeans/api/visual/widget/doc-files/documentation.html
@@ -23,7 +23,6 @@
 <head>
 <meta http-equiv="content-type" content="text/html; charset=ISO-8859-1">
 <meta name="author" content="david.kaspar@sun.com">
-<link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css">
 <title>netbeans.org : NetBeans Visual Library 2.0 - Documentation</title>
 <style type="text/css"><!--
 pre {

--- a/platform/autoupdate.services/apichanges.xml
+++ b/platform/autoupdate.services/apichanges.xml
@@ -336,7 +336,6 @@
 -->
     <head>
       <title>Change History for the Autoupdate Services API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/autoupdate.ui/apichanges.xml
+++ b/platform/autoupdate.ui/apichanges.xml
@@ -90,7 +90,6 @@
 -->
     <head>
       <title>Change History for the Autoupdate UI API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/core.multiview/apichanges.xml
+++ b/platform/core.multiview/apichanges.xml
@@ -238,7 +238,6 @@ Adding a marker interface for <code>MultiViewDescription</code> instances that a
 -->
     <head>
       <title>Change History for the MultiView API/SPI</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/core.netigso/apichanges.xml
+++ b/platform/core.netigso/apichanges.xml
@@ -131,7 +131,6 @@
 <htmlcontents>
 <head>
 <title>Change History for the Netigso SPI</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/platform/core.network/apichanges.xml
+++ b/platform/core.network/apichanges.xml
@@ -52,7 +52,6 @@
   <htmlcontents>
     <head>
       <title>Change History for the Friend Network Core APIs</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/core.startup/apichanges.xml
+++ b/platform/core.startup/apichanges.xml
@@ -236,7 +236,6 @@
   <htmlcontents>
     <head>
       <title>Change History for the Friend Core APIs</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/core.windows/apichanges.xml
+++ b/platform/core.windows/apichanges.xml
@@ -155,7 +155,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Window System Implementation</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/editor.mimelookup/apichanges.xml
+++ b/platform/editor.mimelookup/apichanges.xml
@@ -162,7 +162,6 @@ is the proper place.
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the Editor Library 2 API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/javahelp/apichanges.xml
+++ b/platform/javahelp/apichanges.xml
@@ -165,7 +165,6 @@ is the proper place.
 -->
     <head>
       <title>NetBeans JavaHelp module API Changes by Date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
       <meta name="CATEGORY" content="OtherDevelopmentDoc"/>
       <meta name="DESCRIPTION" content="A cross-indexed list of all changes made to the NetBeans JavaHelp module APIs."/>
     </head>

--- a/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/api.html
+++ b/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/api.html
@@ -22,7 +22,6 @@
 <html>
 <head>
 <title>NetBeans JavaHelp Integration API</title>
-<link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css">
 </head>
 
 <body>

--- a/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/help-guide.html
+++ b/platform/javahelp/src/org/netbeans/api/javahelp/doc-files/help-guide.html
@@ -22,7 +22,6 @@
 <html>
 <head>
 <title>Connecting Help in NetBeans: From Help Set Installation to Hooking up Context-Sensitive Help</title>
-<link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css">
 </head>
 
 <body>

--- a/platform/keyring/apichanges.xml
+++ b/platform/keyring/apichanges.xml
@@ -81,7 +81,6 @@
 <!-- Generated from apichanges.xml -->
     <head>
       <title>Change History for the Keyring API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 <p class="overviewlink"><a href="@TOP@/overview-summary.html">Overview</a></p>

--- a/platform/lib.uihandler/apichanges.xml
+++ b/platform/lib.uihandler/apichanges.xml
@@ -114,7 +114,6 @@
 <htmlcontents>
 <head>
 <title>Change History for the UI Handler Library</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/platform/masterfs/apichanges.xml
+++ b/platform/masterfs/apichanges.xml
@@ -326,7 +326,6 @@
     <htmlcontents>
         <head>
         <title>Change History for the MasterFileSystem API</title>
-        <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
             <p class="overviewlink">

--- a/platform/o.n.bootstrap/apichanges.xml
+++ b/platform/o.n.bootstrap/apichanges.xml
@@ -153,7 +153,6 @@
   <htmlcontents>
     <head>
       <title>Change History for the Friend Core APIs</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/o.n.core/apichanges.xml
+++ b/platform/o.n.core/apichanges.xml
@@ -90,7 +90,6 @@
   <htmlcontents>
     <head>
       <title>Change History for the Friend Core APIs</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/o.n.swing.outline/apichanges.xml
+++ b/platform/o.n.swing.outline/apichanges.xml
@@ -244,7 +244,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the ETable and Outline API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/o.n.swing.plaf/apichanges.xml
+++ b/platform/o.n.swing.plaf/apichanges.xml
@@ -127,7 +127,6 @@
 <htmlcontents>
 <head>
 <title>Change History for the Look And Feel Customization API</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/platform/o.n.swing.tabcontrol/apichanges.xml
+++ b/platform/o.n.swing.tabcontrol/apichanges.xml
@@ -403,7 +403,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the TabControl API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/openide.actions/apichanges.xml
+++ b/platform/openide.actions/apichanges.xml
@@ -204,7 +204,6 @@
 <htmlcontents>
 <head>
 <title>Change History for the Actions API</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/platform/openide.actions/src/org/openide/actions/doc-files/api.html
+++ b/platform/openide.actions/src/org/openide/actions/doc-files/api.html
@@ -22,7 +22,6 @@
 <html>
 <head>
 <title>Actions API</title>
-<link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css">
 </head>
 <body>
 

--- a/platform/openide.actions/src/org/openide/actions/doc-files/toolbarsAdvanced.html
+++ b/platform/openide.actions/src/org/openide/actions/doc-files/toolbarsAdvanced.html
@@ -21,7 +21,6 @@
 <html>
 <head>
 <title>Actions API - Advanced Toolbar Configuration</title>
-<link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css">
 </head>
 <body>
 <h1>Actions API - Advanced Toolbar Configuration</h1>

--- a/platform/openide.awt/apichanges.xml
+++ b/platform/openide.awt/apichanges.xml
@@ -1072,7 +1072,6 @@
 <htmlcontents>
 <head>
 <title>Change History for the Actions API</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/platform/openide.dialogs/apichanges.xml
+++ b/platform/openide.dialogs/apichanges.xml
@@ -503,7 +503,6 @@
 <htmlcontents>
 <head>
 <title>Change History for the Dialogs API</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/platform/openide.dialogs/src/org/openide/doc-files/wizard-guidebook.html
+++ b/platform/openide.dialogs/src/org/openide/doc-files/wizard-guidebook.html
@@ -24,7 +24,6 @@
 
 <head>
  <title>Wizard guidebook</title>
-    <link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css"/>
     <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
     <meta name="topic" content="openide/dialogs"/>
     <meta name="type" content="article"/>

--- a/platform/openide.execution/apichanges.xml
+++ b/platform/openide.execution/apichanges.xml
@@ -179,7 +179,6 @@
 -->
     <head>
       <title>Change History for the Execution API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/openide.execution/src/org/openide/execution/doc-files/api.html
+++ b/platform/openide.execution/src/org/openide/execution/doc-files/api.html
@@ -22,7 +22,6 @@
 <html>
 <head>
 <title>Execution API</title>
-<link rel="Stylesheet" href="@TOP@/resource-files/prose.css" type="text/css">
 </head>
 <body>
 

--- a/platform/openide.explorer/apichanges.xml
+++ b/platform/openide.explorer/apichanges.xml
@@ -972,7 +972,6 @@ public void removeVetoableChangeListener(VetoableChangeListener l);</pre>
 <htmlcontents>
 <head>
 <title>Change History for the Explorer API</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/platform/openide.explorer/src/org/openide/explorer/doc-files/api.html
+++ b/platform/openide.explorer/src/org/openide/explorer/doc-files/api.html
@@ -22,7 +22,6 @@
 <html>
 <head>
 <title>Explorer API</title>
-<link rel="Stylesheet" href="@TOP@/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </head>
 <body>
 

--- a/platform/openide.explorer/src/org/openide/explorer/doc-files/customExplorerViews.html
+++ b/platform/openide.explorer/src/org/openide/explorer/doc-files/customExplorerViews.html
@@ -22,7 +22,6 @@
 <html>
 <head>
 <title>Creating a New Explorer View</title>
-<link rel="Stylesheet" href="@TOP@/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </head>
 <body>
 

--- a/platform/openide.explorer/src/org/openide/explorer/doc-files/propertySheetReference.html
+++ b/platform/openide.explorer/src/org/openide/explorer/doc-files/propertySheetReference.html
@@ -21,7 +21,6 @@
 <html>
   <head>
     <title>Property Sheet Reference</title>
-    <link rel="Stylesheet" href="@TOP@/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
   </head>
   <body>
 <h1>Property Sheet Reference</h1>

--- a/platform/openide.explorer/src/org/openide/explorer/doc-files/propertyViewCustomization.html
+++ b/platform/openide.explorer/src/org/openide/explorer/doc-files/propertyViewCustomization.html
@@ -22,7 +22,6 @@
 <html>
 <head>
 <title>Customizing how Properties are displayed</title>
-<link rel="Stylesheet" href="@TOP@/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </head>
   <body>
   <h1>Customizing how Properties are displayed</h1>

--- a/platform/openide.filesystems.nb/apichanges.xml
+++ b/platform/openide.filesystems.nb/apichanges.xml
@@ -70,7 +70,6 @@
     <htmlcontents>
         <head>
             <title>Change History for the File Systems API</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
             <p class="overviewlink">

--- a/platform/openide.filesystems/apichanges.xml
+++ b/platform/openide.filesystems/apichanges.xml
@@ -2804,7 +2804,6 @@
     <htmlcontents>
         <head>
             <title>Change History for the File Systems API</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
             <p class="overviewlink">

--- a/platform/openide.filesystems/src/org/openide/filesystems/doc-files/HOWTO-MIME.html
+++ b/platform/openide.filesystems/src/org/openide/filesystems/doc-files/HOWTO-MIME.html
@@ -23,7 +23,6 @@
 
 <HEAD>
 <TITLE>HOW TO: Declarative MIME Type Resolvers</TITLE>
-<LINK REL="Stylesheet" HREF="@TOP@/resource-files/prose.css" TYPE="text/css">
 </HEAD>
 
 <BODY>

--- a/platform/openide.filesystems/src/org/openide/filesystems/doc-files/api.html
+++ b/platform/openide.filesystems/src/org/openide/filesystems/doc-files/api.html
@@ -21,7 +21,6 @@
 
 <html><head>
 <title>Filesystems API</title>
-<link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css">
 </head><body>
 
 <p class="overviewlink"><a href="@TOP@/index.html">Overview</a></p>

--- a/platform/openide.io/apichanges.xml
+++ b/platform/openide.io/apichanges.xml
@@ -390,7 +390,6 @@ encourages to implement the new method.
 -->
     <head>
       <title>Change History for the Input/Output API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/openide.loaders/apichanges.xml
+++ b/platform/openide.loaders/apichanges.xml
@@ -1179,7 +1179,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the Loaders API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/openide.loaders/src/org/openide/loaders/doc-files/api.html
+++ b/platform/openide.loaders/src/org/openide/loaders/doc-files/api.html
@@ -21,7 +21,6 @@
 
 <html><head>
 <title>Datasystems API</title>
-<link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css">
 </head><body>
 
 <p class="overviewlink"><a href="@TOP@/index.html">Overview</a></p>

--- a/platform/openide.modules/apichanges.xml
+++ b/platform/openide.modules/apichanges.xml
@@ -1297,7 +1297,6 @@ OpenIDE-Module-Requires: org.openide.compiler.CompilationEngine,
   <htmlcontents>
     <head>
       <title>Change History for the Modules API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/openide.modules/src/org/openide/modules/doc-files/api.html
+++ b/platform/openide.modules/src/org/openide/modules/doc-files/api.html
@@ -22,7 +22,6 @@
 <html>
 <head>
 <title>Modules API</title>
-<link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css">
 </head>
 <body>
 

--- a/platform/openide.modules/src/org/openide/modules/doc-files/classpath.html
+++ b/platform/openide.modules/src/org/openide/modules/doc-files/classpath.html
@@ -23,7 +23,6 @@
  <head>
   <title>Modules, JARs, Class Loaders, and the "Class Path"</title>
   <!-- Cf. #19961 -->
-  <link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css"/>
  </head>
  <body>
   <p class="overviewlink"><a href="@TOP@/index.html">Overview</a></p>

--- a/platform/openide.modules/src/org/openide/modules/doc-files/i18n-branding.html
+++ b/platform/openide.modules/src/org/openide/modules/doc-files/i18n-branding.html
@@ -22,7 +22,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title>Internationalization, Localization, and Branding of NetBeans</title>
-  <link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink"><a href="@TOP@/index.html">Overview</a></p>

--- a/platform/openide.nodes/apichanges.xml
+++ b/platform/openide.nodes/apichanges.xml
@@ -1033,7 +1033,6 @@ OpenIDE-Module-Requires: org.openide.compiler.CompilationEngine,
 <htmlcontents>
 <head>
 <title>Change History for the Nodes API</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/platform/openide.nodes/src/org/openide/nodes/doc-files/api.html
+++ b/platform/openide.nodes/src/org/openide/nodes/doc-files/api.html
@@ -22,7 +22,6 @@
 <html>
 <head>
 <title>Nodes API</title>
-<link rel="Stylesheet" href=".@TOP@/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </head>
 <body>
 

--- a/platform/openide.text/apichanges.xml
+++ b/platform/openide.text/apichanges.xml
@@ -1027,7 +1027,6 @@
 <htmlcontents>
 <head>
 <title>Change History for the Text API</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/platform/openide.text/src/org/openide/text/doc-files/api.html
+++ b/platform/openide.text/src/org/openide/text/doc-files/api.html
@@ -21,7 +21,6 @@
 
 <html><head>
 <title>Editor API</title>
-<link rel="stylesheet" href="@TOP@/resource-files/prose.css" type="text/css">
 </head><body>
 
 <p class="overviewlink"><a href="@TOP@/index.html">Overview</a></p>

--- a/platform/openide.util.lookup/apichanges.xml
+++ b/platform/openide.util.lookup/apichanges.xml
@@ -587,7 +587,6 @@ for (<a href="@JDK@@JDKMODULE_JAVA_BASE@/java/net/URLStreamHandlerFactory.html">
 <htmlcontents>
 <head>
 <title>Change History for the Lookup API</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/platform/openide.util.lookup/src/org/openide/util/lookup/doc-files/index.html
+++ b/platform/openide.util.lookup/src/org/openide/util/lookup/doc-files/index.html
@@ -22,7 +22,6 @@
 <HTML>
 <HEAD>
 <TITLE>Lookup Library</TITLE>
-<link rel="Stylesheet" href="@TOP@/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </HEAD>
 <BODY>
 <H1>Lookup library HomePage</H1>

--- a/platform/openide.util.lookup/src/org/openide/util/lookup/doc-files/lookup-api.html
+++ b/platform/openide.util.lookup/src/org/openide/util/lookup/doc-files/lookup-api.html
@@ -22,7 +22,6 @@
 <HTML>
 <HEAD>
 <TITLE>Lookup Library API</TITLE>
-<link rel="Stylesheet" href="@TOP@/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </HEAD>
 <BODY>
 <H1>Lookup library API</H1>

--- a/platform/openide.util.lookup/src/org/openide/util/lookup/doc-files/lookup-spi.html
+++ b/platform/openide.util.lookup/src/org/openide/util/lookup/doc-files/lookup-spi.html
@@ -22,7 +22,6 @@
 <HTML>
 <HEAD>
 <TITLE>Lookup Library SPI</TITLE>
-<link rel="Stylesheet" href="@TOP@/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </HEAD>
 <BODY>
 <H1>Lookup library SPI</H1>

--- a/platform/openide.util.ui/apichanges.xml
+++ b/platform/openide.util.ui/apichanges.xml
@@ -2030,7 +2030,6 @@ public void run () {
 <htmlcontents>
 <head>
 <title>Change History for the Utilities API</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/platform/openide.util.ui/src/org/openide/util/doc-files/api.html
+++ b/platform/openide.util.ui/src/org/openide/util/doc-files/api.html
@@ -22,7 +22,6 @@
 <html>
 <head>
 <title>Utility Classes</title>
-<link rel="Stylesheet" href="@TOP@/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </head>
 <body>
 

--- a/platform/openide.util/apichanges.xml
+++ b/platform/openide.util/apichanges.xml
@@ -186,7 +186,6 @@
     <htmlcontents>
         <head>
             <title>Change History for the Base Utilities API</title>
-            <link rel="stylesheet" href="prose.css" type="text/css"/>
         </head>
         <body>
             <p class="overviewlink">

--- a/platform/openide.util/src/org/openide/util/base/doc-files/api.html
+++ b/platform/openide.util/src/org/openide/util/base/doc-files/api.html
@@ -22,7 +22,6 @@
 <html>
 <head>
 <title>Utility Classes</title>
-<link rel="Stylesheet" href="@TOP@/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </head>
 <body>
 

--- a/platform/openide.util/src/org/openide/util/doc-files/api.html
+++ b/platform/openide.util/src/org/openide/util/doc-files/api.html
@@ -22,7 +22,6 @@
 <html>
 <head>
 <title>Utility Classes</title>
-<link rel="Stylesheet" href="@TOP/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </head>
 <body>
 

--- a/platform/openide.windows/apichanges.xml
+++ b/platform/openide.windows/apichanges.xml
@@ -1383,7 +1383,6 @@ OpenIDE-Module-Requires: org.openide.compiler.CompilationEngine,
 <htmlcontents>
 <head>
 <title>Change History for the Window Systems API</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/platform/openide.windows/src/org/openide/windows/doc-files/api.html
+++ b/platform/openide.windows/src/org/openide/windows/doc-files/api.html
@@ -21,7 +21,6 @@
 <html>
 <head>
 <title>Window System API</title>
-<link rel="Stylesheet" href="@TOP@/resource-files/prose.css" type="text/css" title="NetBeans Open APIs Style">
 </head>
 <body>
 

--- a/platform/options.api/apichanges.xml
+++ b/platform/options.api/apichanges.xml
@@ -274,7 +274,6 @@
 -->
     <head>
       <title>Options Dialog API changes by date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/options.keymap/apichanges.xml
+++ b/platform/options.keymap/apichanges.xml
@@ -81,7 +81,6 @@
 -->
     <head>
       <title>Change History for the Keymap Options API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/print/apichanges.xml
+++ b/platform/print/apichanges.xml
@@ -105,7 +105,6 @@ is the proper place.
     -->
     <head>
       <title>Change history for the Print API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
       <p class="overviewlink"><a href="overview-summary.html">Overview</a></p>

--- a/platform/queries/apichanges.xml
+++ b/platform/queries/apichanges.xml
@@ -269,7 +269,6 @@ is the proper place.
 -->
     <head>
       <title>Change History for the General Queries API API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/sampler/apichanges.xml
+++ b/platform/sampler/apichanges.xml
@@ -43,7 +43,6 @@
 <htmlcontents>
 <head>
 <title>Change History for the Sampler API</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/platform/sendopts/apichanges.xml
+++ b/platform/sendopts/apichanges.xml
@@ -192,7 +192,6 @@
 <htmlcontents>
 <head>
 <title>Change History for the SendOpts API and SPI</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/platform/settings/apichanges.xml
+++ b/platform/settings/apichanges.xml
@@ -258,7 +258,6 @@ is the proper place.
 -->
     <head>
       <title>Settings API/SPI Changes by Date</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 <!-- The actual lists of changes, as summaries and details: -->

--- a/platform/spi.quicksearch/apichanges.xml
+++ b/platform/spi.quicksearch/apichanges.xml
@@ -65,7 +65,6 @@
 -->
     <head>
       <title>Change History for the Progress API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/platform/uihandler/src/org/netbeans/modules/uihandler/api/doc-files/ui.html
+++ b/platform/uihandler/src/org/netbeans/modules/uihandler/api/doc-files/ui.html
@@ -23,7 +23,6 @@
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 <title>UI of Gestures Collector</title>
-<link rel="stylesheet" type="text/css" href="../../../../../../prose.css"/>
 </head>
 <body>
 <h1>UI of Gestures Collector</h1>

--- a/webcommon/api.knockout/apichanges.xml
+++ b/webcommon/api.knockout/apichanges.xml
@@ -66,7 +66,6 @@
     <htmlcontents>
     <head>
       <title>Change History for the NetBeans Knockout Integration API</title>
-      <link rel="stylesheet" href="prose.css" type="text/css"/>
     </head>
     <body>
 

--- a/webcommon/lib.chrome_devtools_protocol/apichanges.xml
+++ b/webcommon/lib.chrome_devtools_protocol/apichanges.xml
@@ -30,7 +30,6 @@
 <htmlcontents>
 <head>
 <title>Change History for the Chrome DevTools Protocol Library</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">

--- a/webcommon/lib.v8debug/apichanges.xml
+++ b/webcommon/lib.v8debug/apichanges.xml
@@ -30,7 +30,6 @@
 <htmlcontents>
 <head>
 <title>Change History for the UI Handler Library</title>
-<link rel="stylesheet" href="prose.css" type="text/css"/>
 </head>
 <body>
 <p class="overviewlink">


### PR DESCRIPTION
404 on apidoc were a bit long to sort out but prose.css is leading to lots of error for almost no gain as css can be reached by other means.
Need a localhost as the current bits.netbeans swallow more 404 than expected.

I did a removal on apichanges.xml to avoid putting prose.css.

image for stability are shown again.
