### PR TITLE
cleanup: remove deprecated TheadGroup methods

### DIFF
--- a/platform/core.execution/src/org/netbeans/core/execution/DefaultSysProcess.java
+++ b/platform/core.execution/src/org/netbeans/core/execution/DefaultSysProcess.java
@@ -101,35 +101,4 @@ final class DefaultSysProcess extends ExecutorTask {
     public String getName() {
         return name;
     }
-    
-    /** destroy the thread group this process was handled from. Not that simple
-     * as it seems, since the ThreadGroup can't be destroyed from inside.
-     */
-    void destroyThreadGroup(ThreadGroup base) {
-        new Thread(base, new Destroyer(group)).start();
-    }
-    private static class Destroyer implements Runnable {
-        private final ThreadGroup group;
-        Destroyer(ThreadGroup group) {
-            this.group = group;
-        }
-        @Override public void run() {
-            try {
-                while (group.activeCount() > 0) {
-                    Thread.sleep(1000);
-                }
-            }
-            catch (InterruptedException e) {
-                Exceptions.printStackTrace(e);
-            }
-            if (!group.isDestroyed()) {
-                try {
-                    group.destroy();
-                } catch (IllegalThreadStateException x) {
-                    // #165302: destroyed some other way?
-                }
-            }
-        }
-    }
-
 }

--- a/platform/openide.util/src/org/openide/util/RequestProcessor.java
+++ b/platform/openide.util/src/org/openide/util/RequestProcessor.java
@@ -1892,19 +1892,13 @@ outer:  do {
                             return proc;
                         }
                     } else {
-                        assert checkAccess(TOP_GROUP.getTopLevelThreadGroup());
                         Processor proc = POOL.pop();
                         proc.idle = false;
-
                         return proc;
                     }
                 }
                 newP = new Processor();
             }
-        }
-        private static boolean checkAccess(ThreadGroup g) throws SecurityException {
-            g.checkAccess();
-            return true;
         }
 
         /** A way of returning a Processor to the inactive pool.


### PR DESCRIPTION
desc: The ThreadGroup class is an artifact of by-gone days. The ability to destroy a thread group and the concept of a destroyed thread group no longer exists. Several of the methods are null functions as well as marked for removal. This cleans up the usage of these methods.





---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>