### PR TITLE
cleanup: cleanup usage of getSecurityManager()

### DIFF
--- a/enterprise/performance.scripting/test/qa-functional/src/org/netbeans/performance/languages/actions/CountingSecurityManager.java
+++ b/enterprise/performance.scripting/test/qa-functional/src/org/netbeans/performance/languages/actions/CountingSecurityManager.java
@@ -51,11 +51,10 @@ public final class CountingSecurityManager extends SecurityManager {
     public static void initialize(String prefix) {
         Assert.assertNotNull(prefix);
         
-        if (! (System.getSecurityManager() instanceof CountingSecurityManager)) {
-            setAllowedReplace(true);
-            System.setSecurityManager(new CountingSecurityManager());
-            setAllowedReplace(false);
-        }
+        setAllowedReplace(true);
+        System.setSecurityManager(new CountingSecurityManager());
+        setAllowedReplace(false);
+
         if (!System.getSecurityManager().getClass().getName().equals(CountingSecurityManager.class.getName())) {
             throw new IllegalStateException("Wrong security manager: " + System.getSecurityManager());
         }

--- a/ide/ide.kit/test/qa-functional/src/org/netbeans/test/ide/CountingSecurityManager.java
+++ b/ide/ide.kit/test/qa-functional/src/org/netbeans/test/ide/CountingSecurityManager.java
@@ -90,11 +90,7 @@ final class CountingSecurityManager extends SecurityManager implements Callable<
     public static void initialize(String prefix, Mode mode, Set<String> allowedFiles) {
         System.setProperty("counting.security.disabled", "true");
 
-        if (System.getSecurityManager() instanceof CountingSecurityManager) {
-            // ok
-        } else {
-            System.setSecurityManager(new CountingSecurityManager());
-        }
+        System.setSecurityManager(new CountingSecurityManager());
         setCnt(0);
         msgs = new StringWriter();
         pw = new PrintWriter(msgs);
@@ -113,7 +109,6 @@ final class CountingSecurityManager extends SecurityManager implements Callable<
     static void assertReflection(int maxCount, String whitelist) {
         System.setProperty("counting.reflection.whitelist", whitelist);
         RuntimePermission checkMemberAccessPermission = new RuntimePermission("accessDeclaredMembers");
-        System.getSecurityManager().checkPermission(checkMemberAccessPermission);
         System.getProperties().remove("counting.reflection.whitelist");
     }
 
@@ -127,7 +122,7 @@ final class CountingSecurityManager extends SecurityManager implements Callable<
     }
 
     public static boolean isEnabled() {
-        return System.getSecurityManager() instanceof Callable<?>;
+        return false;
     }
     
     public static void assertCounts(String msg, int expectedCnt) throws Exception {

--- a/ide/projectui/src/org/netbeans/modules/project/ui/groups/CheckBoxRenderrer.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/groups/CheckBoxRenderrer.java
@@ -49,19 +49,11 @@ public class CheckBoxRenderrer extends JCheckBox implements ListCellRenderer, Se
 
     private Border getNoFocusBorder () {
         Border border = UIManager.getBorder("List.cellNoFocusBorder");
-        if (System.getSecurityManager () != null) {
-            if (border != null) {
-                return border;
-            }
-            return SAFE_NO_FOCUS_BORDER;
-        } else {
-            if (border != null &&
-                (noFocusBorder == null ||
-                noFocusBorder == DEFAULT_NO_FOCUS_BORDER)) {
-                return border;
-            }
-            return noFocusBorder;
+        if (border != null &&
+            (noFocusBorder == null || noFocusBorder == DEFAULT_NO_FOCUS_BORDER)) {
+            return border;
         }
+        return noFocusBorder;
     }
 
     public Component getListCellRendererComponent (

--- a/ide/spellchecker/src/org/netbeans/modules/spellchecker/options/CheckBoxRenderrer.java
+++ b/ide/spellchecker/src/org/netbeans/modules/spellchecker/options/CheckBoxRenderrer.java
@@ -49,19 +49,11 @@ public class CheckBoxRenderrer extends JCheckBox implements ListCellRenderer, Se
 
     private Border getNoFocusBorder () {
         Border border = UIManager.getBorder("List.cellNoFocusBorder");
-        if (System.getSecurityManager () != null) {
-            if (border != null) {
-                return border;
-            }
-            return SAFE_NO_FOCUS_BORDER;
-        } else {
-            if (border != null &&
-                (noFocusBorder == null ||
-                noFocusBorder == DEFAULT_NO_FOCUS_BORDER)) {
-                return border;
-            }
-            return noFocusBorder;
+        if (border != null &&
+            (noFocusBorder == null || noFocusBorder == DEFAULT_NO_FOCUS_BORDER)) {
+            return border;
         }
+        return noFocusBorder;
     }
 
     public Component getListCellRendererComponent (

--- a/ide/versioning/test/unit/src/org/netbeans/modules/versioning/GetOwnerTest.java
+++ b/ide/versioning/test/unit/src/org/netbeans/modules/versioning/GetOwnerTest.java
@@ -37,7 +37,6 @@ public class GetOwnerTest extends NbTestCase {
     
     protected File dataRootDir;
     private StatFiles accessMonitor;
-    private SecurityManager defaultSecurityManager;
     protected File versionedFolder;
     protected File unversionedFolder;
 
@@ -69,9 +68,6 @@ public class GetOwnerTest extends NbTestCase {
         userdir.mkdirs();
         System.setProperty("netbeans.user", userdir.getAbsolutePath());
         if(accessMonitor != null) {
-            if(defaultSecurityManager == null) {
-                defaultSecurityManager = System.getSecurityManager();
-            }
             System.setSecurityManager(accessMonitor);
         }
     }
@@ -80,7 +76,8 @@ public class GetOwnerTest extends NbTestCase {
     protected void tearDown() throws Exception {
         super.tearDown();
         if(accessMonitor != null) {
-            System.setSecurityManager(defaultSecurityManager);
+            // FIXME - throws UnsupportedOperationException unconditionally, regardless of arg.
+            System.setSecurityManager(null);
         }
     }
      

--- a/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyserCellRenderer.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/AnalyserCellRenderer.java
@@ -42,17 +42,11 @@ class AnalyserCellRenderer extends DefaultListCellRenderer {
 
     private Border getNoFocusBorder() {
         Border border = UIManager.getBorder("List.cellNoFocusBorder");
-        if (System.getSecurityManager() != null) {
-            if (border != null) return border;
-            return SAFE_NO_FOCUS_BORDER;
-        } else {
-            if (border != null &&
-                    (noFocusBorder == null ||
-                    noFocusBorder == DEFAULT_NO_FOCUS_BORDER)) {
-                return border;
-            }
-            return noFocusBorder;
+        if (border != null &&
+            (noFocusBorder == null || noFocusBorder == DEFAULT_NO_FOCUS_BORDER)) {
+            return border;
         }
+        return noFocusBorder;
     }
 
 

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TreePathHandleTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TreePathHandleTest.java
@@ -184,13 +184,12 @@ public class TreePathHandleTest extends NbTestCase {
                 
                 TypeElement string = parameter.getElements().getTypeElement("test.test2");
                 
-                SecurityManager old = System.getSecurityManager();
-                
                 System.setSecurityManager(new SecMan());
                 
                 TreePathHandle.create(string, parameter);
-                
-                System.setSecurityManager(old);
+
+                // FIXME - throws UnsupportedOperationException unconditionally, regardless of arg.
+		System.setSecurityManager(null);
             }
         }, true);
     }

--- a/java/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CountingSecurityManager.java
+++ b/java/performance.java/test/qa-functional/src/org/netbeans/performance/j2se/actions/CountingSecurityManager.java
@@ -50,14 +50,10 @@ public final class CountingSecurityManager extends SecurityManager {
     public static void initialize(String prefix) {
         Assert.assertNotNull(prefix);
         
-        if (! (System.getSecurityManager() instanceof CountingSecurityManager)) {
-            setAllowedReplace(true);
-            System.setSecurityManager(new CountingSecurityManager());
-            setAllowedReplace(false);
-        }
-        if (!System.getSecurityManager().getClass().getName().equals(CountingSecurityManager.class.getName())) {
-            throw new IllegalStateException("Wrong security manager: " + System.getSecurityManager());
-        }
+        setAllowedReplace(true);
+        System.setSecurityManager(new CountingSecurityManager());
+        setAllowedReplace(false);
+
         cnt = 0;
         msgs = new StringWriter();
         pw = new PrintWriter(msgs);

--- a/java/performance/test/qa-functional/src/org/netbeans/test/ide/PerfCountingSecurityManager.java
+++ b/java/performance/test/qa-functional/src/org/netbeans/test/ide/PerfCountingSecurityManager.java
@@ -91,11 +91,7 @@ final class PerfCountingSecurityManager extends SecurityManager implements Calla
     public static void initialize(String prefix, PerfCountingSecurityManager.Mode mode, Set<String> allowedFiles) {
         System.setProperty("counting.security.disabled", "true");
 
-        if (System.getSecurityManager() instanceof PerfCountingSecurityManager) {
-            // ok
-        } else {
-            System.setSecurityManager(new PerfCountingSecurityManager());
-        }
+        System.setSecurityManager(new PerfCountingSecurityManager());
         setCnt(0);
         msgs = new StringWriter();
         pw = new PrintWriter(msgs);
@@ -113,7 +109,6 @@ final class PerfCountingSecurityManager extends SecurityManager implements Calla
 
     static void assertReflection(int maxCount, String whitelist) {
         System.setProperty("counting.reflection.whitelist", whitelist);
-        System.getSecurityManager().checkPermission( SecurityConstants.CHECK_MEMBER_ACCESS_PERMISSION); 
         System.getProperties().remove("counting.reflection.whitelist");
     }
 
@@ -127,7 +122,7 @@ final class PerfCountingSecurityManager extends SecurityManager implements Calla
     }
 
     public static boolean isEnabled() {
-        return System.getSecurityManager() instanceof Callable<?>;
+        return false;
     }
     
     public static void assertCounts(String msg, int expectedCnt) throws Exception {

--- a/java/performance/test/unit/src/org/netbeans/performance/scalability/CountingSecurityManager.java
+++ b/java/performance/test/unit/src/org/netbeans/performance/scalability/CountingSecurityManager.java
@@ -51,14 +51,10 @@ public final class CountingSecurityManager extends SecurityManager {
     public static void initialize(String prefix) {
         Assert.assertNotNull(prefix);
         
-        if (! (System.getSecurityManager() instanceof CountingSecurityManager)) {
-            setAllowedReplace(true);
-            System.setSecurityManager(new CountingSecurityManager());
-            setAllowedReplace(false);
-        }
-        if (!System.getSecurityManager().getClass().getName().equals(CountingSecurityManager.class.getName())) {
-            throw new IllegalStateException("Wrong security manager: " + System.getSecurityManager());
-        }
+        setAllowedReplace(true);
+        System.setSecurityManager(new CountingSecurityManager());
+        setAllowedReplace(false);
+
         cnt = 0;
         msgs = new StringWriter();
         pw = new PrintWriter(msgs);

--- a/platform/core.startup/test/unit/src/org/netbeans/core/startup/CountingSecurityManager.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/core/startup/CountingSecurityManager.java
@@ -36,11 +36,7 @@ final class CountingSecurityManager extends SecurityManager {
     private static String prefix;
     
     public static void initialize(String prefix) {
-        if (System.getSecurityManager() instanceof CountingSecurityManager) {
-            // ok
-        } else {
-            System.setSecurityManager(new CountingSecurityManager());
-        }
+        System.setSecurityManager(new CountingSecurityManager());
         cnt = 0;
         msgs = new StringWriter();
         pw = new PrintWriter(msgs);

--- a/platform/core.startup/test/unit/src/org/netbeans/core/startup/IsDirCntSecurityManager.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/core/startup/IsDirCntSecurityManager.java
@@ -32,9 +32,7 @@ public class IsDirCntSecurityManager extends SecurityManager {
     private static StringBuffer sb;
 
     public static void initialize() {
-        if (!(System.getSecurityManager() instanceof IsDirCntSecurityManager)) {
-            System.setSecurityManager(new IsDirCntSecurityManager());
-        }
+        System.setSecurityManager(new IsDirCntSecurityManager());
         cnt = 0;
         sb = new StringBuffer();
     }

--- a/platform/core.startup/test/unit/src/org/netbeans/core/startup/layers/CountingSecurityManager.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/core/startup/layers/CountingSecurityManager.java
@@ -67,11 +67,7 @@ final class CountingSecurityManager extends SecurityManager implements Callable<
         System.setProperty("counting.security.disabled", "true");
         inSubtree("", "");
 
-        if (System.getSecurityManager() instanceof CountingSecurityManager) {
-            // ok
-        } else {
-            System.setSecurityManager(new CountingSecurityManager());
-        }
+        System.setSecurityManager(new CountingSecurityManager());
         setCnt(0);
         msgs = new StringWriter();
         pw = new PrintWriter(msgs);
@@ -86,7 +82,6 @@ final class CountingSecurityManager extends SecurityManager implements Callable<
 
     static void assertReflection(int maxCount, String whitelist) {
         System.setProperty("counting.reflection.whitelist", whitelist);
-        System.getSecurityManager().checkPermission(new MaxCountCheck(maxCount, "MaxCountCheck"));
         System.getProperties().remove("counting.reflection.whitelist");
     }
 
@@ -129,7 +124,7 @@ final class CountingSecurityManager extends SecurityManager implements Callable<
     }
 
     public static boolean isEnabled() {
-        return System.getSecurityManager() instanceof Callable<?>;
+        return false;
     }
     
     public static void assertCounts(String msg, int expectedCnt) throws Exception {

--- a/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/CountingSecurityManager.java
+++ b/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/CountingSecurityManager.java
@@ -60,11 +60,7 @@ final class CountingSecurityManager extends SecurityManager implements Callable<
     public static void initialize(String prefix, Mode mode, Set<String> allowedFiles) {
         System.setProperty("counting.security.disabled", "true");
 
-        if (System.getSecurityManager() instanceof CountingSecurityManager) {
-            // ok
-        } else {
-            System.setSecurityManager(new CountingSecurityManager());
-        }
+        System.setSecurityManager(new CountingSecurityManager());
         setCnt(0);
         msgs = new StringWriter();
         pw = new PrintWriter(msgs);
@@ -79,7 +75,6 @@ final class CountingSecurityManager extends SecurityManager implements Callable<
 
     static void assertReflection(int maxCount, String whitelist) {
         System.setProperty("counting.reflection.whitelist", whitelist);
-        System.getSecurityManager().checkPermission(new MaxCountPerm(maxCount));
         System.getProperties().remove("counting.reflection.whitelist");
     }
 
@@ -124,7 +119,7 @@ final class CountingSecurityManager extends SecurityManager implements Callable<
     }
 
     public static boolean isEnabled() {
-        return System.getSecurityManager() instanceof Callable<?>;
+        return false;
     }
     
     public static void assertCounts(String msg, int expectedCnt) throws Exception {

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/CountingSecurityManager.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/CountingSecurityManager.java
@@ -36,11 +36,7 @@ final class CountingSecurityManager extends SecurityManager {
     private static String prefix;
     
     public static void initialize(String prefix) {
-        if (System.getSecurityManager() instanceof CountingSecurityManager) {
-            // ok
-        } else {
-            System.setSecurityManager(new CountingSecurityManager());
-        }
+        System.setSecurityManager(new CountingSecurityManager());
         cnt = 0;
         msgs = new StringWriter();
         pw = new PrintWriter(msgs);

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/JarClassLoaderTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/JarClassLoaderTest.java
@@ -407,11 +407,7 @@ public class JarClassLoaderTest extends NbTestCase {
         public static void initialize(String path, Semaphore sync) {
             BlockingSecurityManager.path = path;
             BlockingSecurityManager.sync = sync;
-            if (System.getSecurityManager() instanceof BlockingSecurityManager) {
-            // ok
-            } else {
-                System.setSecurityManager(new BlockingSecurityManager());
-            }
+            System.setSecurityManager(new BlockingSecurityManager());
         }
     
         public @Override void checkRead(String file) {

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/TestBaseHid.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/TestBaseHid.java
@@ -76,9 +76,6 @@ public abstract class TestBaseHid extends MultiThreadedTestCaseHid {
         if (allTestedFS != null) testedFS = allTestedFS[0];
         // If not null, file accesses are counted through custom SecurityManager.
         if(accessMonitor != null) {
-            if(defaultSecurityManager == null) {
-                defaultSecurityManager = System.getSecurityManager();
-            }
             System.setSecurityManager(accessMonitor);
         }
     }

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/test/StatFiles.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/test/StatFiles.java
@@ -40,23 +40,17 @@ public class StatFiles extends SecurityManager {
     public static final int DELETE = 3;
     private Results results;
     private Monitor monitor;
-    private SecurityManager defaultSecurityManager;
 
     public StatFiles() {
         reset();
     }
 
     public void register() {
-        if (defaultSecurityManager == null) {
-            defaultSecurityManager = System.getSecurityManager();
-        }
         System.setSecurityManager(this);
     }
     
     public void unregister() {
-        if (defaultSecurityManager == null) {
-            System.setSecurityManager(defaultSecurityManager);
-        }
+        System.setSecurityManager(null);
     }
     
     public void reset() {

--- a/platform/openide.util.ui/test/unit/src/org/openide/xml/XMLUtilReflectionTest.java
+++ b/platform/openide.util.ui/test/unit/src/org/openide/xml/XMLUtilReflectionTest.java
@@ -97,11 +97,7 @@ public class XMLUtilReflectionTest extends org.netbeans.junit.NbTestCase {
     
     static final class CountingSecurityManager extends SecurityManager {
         public static void initialize() {
-            if (System.getSecurityManager() instanceof CountingSecurityManager) {
-                // ok
-            } else {
-                System.setSecurityManager(new CountingSecurityManager());
-            }
+            System.setSecurityManager(new CountingSecurityManager());
             members.clear();
         }
 


### PR DESCRIPTION
cleanup: cleanup usage of getSecurityManager()

desc: getSecurityManager() is deprecated and marked for imminent removal. In addition as of JDK 24, getSecurityManager() returns null.

This change removes getSecurityManager() from various places that have minimal impact.





---

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>