### PR TITLE
Include apache license on env file module for antlr generated files

### DIFF
--- a/ide/languages.env/src/org/netbeans/modules/languages/env/grammar/antlr4/coloring/EnvAntlrColoringLexer.g4
+++ b/ide/languages.env/src/org/netbeans/modules/languages/env/grammar/antlr4/coloring/EnvAntlrColoringLexer.g4
@@ -18,7 +18,27 @@
  */
 lexer grammar EnvAntlrColoringLexer;
 
-@header{package org.netbeans.modules.languages.env.grammar.antlr4.coloring;}
+@header{
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.languages.env.grammar.antlr4.coloring;}
 
 tokens { 
     NL,

--- a/ide/languages.env/src/org/netbeans/modules/languages/env/grammar/antlr4/parser/EnvAntlrLexer.g4
+++ b/ide/languages.env/src/org/netbeans/modules/languages/env/grammar/antlr4/parser/EnvAntlrLexer.g4
@@ -18,7 +18,28 @@
  */
 lexer grammar EnvAntlrLexer;
 
-@header{package org.netbeans.modules.languages.env.grammar.antlr4.parser;}
+@header{
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.languages.env.grammar.antlr4.parser;
+}
 
 tokens { 
     NL,

--- a/ide/languages.env/src/org/netbeans/modules/languages/env/grammar/antlr4/parser/EnvAntlrParser.g4
+++ b/ide/languages.env/src/org/netbeans/modules/languages/env/grammar/antlr4/parser/EnvAntlrParser.g4
@@ -18,7 +18,28 @@
  */
 parser grammar EnvAntlrParser;
 
-@header{package org.netbeans.modules.languages.env.grammar.antlr4.parser;}
+@header{
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.languages.env.grammar.antlr4.parser;
+}
 
 options { 
     superClass = ParserAdaptor;


### PR DESCRIPTION
Follow-up of env file support.
It seems to be a relevant thing during development.
All generated antlr parser files should have the license header to not block development while doing license checks run.
