### PR TITLE
lsp.client: Fix breadcrumb rendering

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/BreadcrumbsImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/BreadcrumbsImpl.java
@@ -90,7 +90,7 @@ public class BreadcrumbsImpl implements BackgroundTask {
                              capa -> Utils.isEnabled(capa.getDocumentSymbolProvider()),
                              () -> new DocumentSymbolParams(new TextDocumentIdentifier(Utils.toURI(file))),
                              (server, params) -> server.getTextDocumentService().documentSymbol(params),
-                             (server, result) -> result.stream().map(this::toDocumentSymbol).forEach(symbols -> Pair.of(server, symbols)));
+                             (server, result) -> allSymbols.add(Pair.of(server, result.stream().map(this::toDocumentSymbol).toList())));
 
         this.rootElement = new RootBreadcrumbsElementImpl(file, doc, allSymbols);
 


### PR DESCRIPTION
After the document symbols are collected, they also need to be added to the result list. Before this change the result was ignored. This results in an empty breadcrumb list or a breadcrumb list only containing the file entry.

This is an artifact of the support for multiple LSP servers for a single document (2bd5ac3)