### PR TITLE
Fix editing java/maven/mavensrc (unify classpaths used in IDE and ant build)

### DIFF
--- a/java/maven/build.xml
+++ b/java/maven/build.xml
@@ -33,15 +33,8 @@
             release="8"
             includeantruntime="false">
             <classpath>
-                <fileset dir="${maven.embedder.dir}/maven/lib">
-                    <include name="*.jar"/>
-                </fileset>
-                <fileset dir="${maven.embedder.dir}/maven/boot">
-                    <include name="*.jar"/>
-                </fileset>
-                <pathelement location="./external/aether-api-1.13.1.jar"/>
+                <pathelement path="${mavensrc.cp}"/>
             </classpath>
-            <classpath refid="cp"/>
         </javac>
         <copy overwrite="true" tofile="build/mavenclasses/META-INF/sisu/javax.inject.Named" file="mavensrc/org/netbeans/modules/maven/workspace/reader/javax.inject.Named"/>
         <mkdir dir="${cluster}/maven-nblib"/>

--- a/java/maven/nbproject/project.properties
+++ b/java/maven/nbproject/project.properties
@@ -38,3 +38,17 @@ jnlp.indirect.files=maven-nblib/netbeans-eventspy.jar,maven-nblib/netbeans-cos.j
 requires.nb.javac=true
 
 test-unit-sys-prop.test.netbeans.dest.dir=${netbeans.dest.dir}
+
+# Classpath for agent injected into maven run (sourcecode in mavensrc)
+mavensrc.cp=:\
+    ./external/aether-api-1.13.1.jar:\
+    ${libs.json_simple.dir}/modules/ext/json-simple-1.1.1.jar:\
+    ${maven.embedder.dir}/maven/boot/plexus-classworlds-2.9.0.jar:\
+    ${maven.embedder.dir}/maven/lib/javax.annotation-api-1.3.2.jar:\
+    ${maven.embedder.dir}/maven/lib/javax.inject-1.jar:\
+    ${maven.embedder.dir}/maven/lib/maven-core-3.9.12.jar:\
+    ${maven.embedder.dir}/maven/lib/maven-model-3.9.12.jar:\
+    ${maven.embedder.dir}/maven/lib/maven-plugin-api-3.9.12.jar:\
+    ${maven.embedder.dir}/maven/lib/maven-resolver-api-1.9.25.jar:\
+    ${maven.embedder.dir}/maven/lib/org.eclipse.sisu.plexus-0.9.0.M4.jar:\
+    ${maven.embedder.dir}/maven/lib/plexus-utils-3.6.0.jar

--- a/java/maven/nbproject/project.xml
+++ b/java/maven/nbproject/project.xml
@@ -687,7 +687,7 @@
             </friend-packages>
             <extra-compilation-unit>
                 <package-root>mavensrc</package-root>
-                <classpath>${antsrc.cp}</classpath>
+                <classpath>${mavensrc.cp}</classpath>
                 <built-to>build/mavenclasses</built-to>
                 <built-to>${cluster}/maven-nblib/netbeans-cos.jar</built-to>
                 <built-to>${cluster}/maven-nblib/netbeans-eventspy.jar</built-to>


### PR DESCRIPTION
The additional source root `mavensrc` of the `maven` module requires a correct setup of its classpath, so that the IDE does not flag the source as errored.

<img width="378" height="304" alt="grafik" src="https://github.com/user-attachments/assets/395cc4d3-5f23-4802-add4-2b365e46e844" />