### PR TITLE
Git: Improve handling of ambigous ID input in checkout dialog

### DIFF
--- a/ide/git/src/org/netbeans/modules/git/ui/repository/RevisionInfoPanelController.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/repository/RevisionInfoPanelController.java
@@ -25,6 +25,7 @@ import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.text.DateFormat;
 import java.util.Date;
+import org.eclipse.jgit.errors.AmbiguousObjectException;
 import org.netbeans.modules.git.client.GitClient;
 import org.netbeans.libs.git.GitException;
 import org.netbeans.libs.git.GitRevisionInfo;
@@ -182,7 +183,7 @@ public class RevisionInfoPanelController {
                     mergedStatus = commonAncestor != null && commonAncestor.getRevision().equals(revisionInfo.getRevision());
                 }
             } catch (GitException ex) {
-                if (!(ex instanceof GitException.MissingObjectException)) {
+                if (!(ex instanceof GitException.MissingObjectException || ex.getCause() instanceof AmbiguousObjectException)) {
                     GitClientExceptionHandler.notifyException(ex, true);
                 }
                 revisionInfo = null;

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/Bundle.properties
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/Bundle.properties
@@ -16,4 +16,4 @@
 # under the License.
 
 MSG_Exception_IdNotACommit = The given id [{0}] is not a commit or an annotated tag.
-MSG_Exception_IdNotUnique = Given objectId [{0}] is not unique.
+MSG_Exception_IdAmbiguous = The given objectId [{0}] is ambiguous.

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/Utils.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/Utils.java
@@ -287,7 +287,7 @@ public final class Utils {
         } catch (RevisionSyntaxException ex) {
             throw new GitException.MissingObjectException(objectId, GitObjectType.COMMIT, ex);
         } catch (AmbiguousObjectException ex) {
-            throw new GitException(MessageFormat.format(Utils.getBundle(Utils.class).getString("MSG_Exception_IdNotACommit"), objectId), ex); //NOI18N
+            throw new GitException(MessageFormat.format(Utils.getBundle(Utils.class).getString("MSG_Exception_IdAmbiguous"), objectId), ex); //NOI18N
         } catch (IOException ex) {
             throw new GitException(ex);
         }


### PR DESCRIPTION
In the checkout dialog users can enter object ids manually. As git allows using truncated IDs as identifiers, subsets of the complete id are valid inputs. When these are resolved an the id-part can't be resolved to a single object a dialog pops out telling users, that the commit does not exist.

 1. The message is wrong. An object with that abreviated id exists, it is just not one, but multiple.
 2. For the commit dialog the dialog stops the user while typing. This makes entering object id arkward.

Both points are addressed here.

Screenshot of the problem:

<img width="1126" height="428" alt="grafik" src="https://github.com/user-attachments/assets/e084ca41-a427-402e-b82f-7ad30ef4cb5c" />

Observed exception (causing the dialog):

```
INFO [org.netbeans.modules.git]: The given id [7b] is not a commit or an annotated tag. org.eclipse.jgit.errors.AmbiguousObjectException: Object abbreviation 7b is ambiguous
	at org.eclipse.jgit.lib.Repository.resolveAbbreviation(Repository.java:925)
	at org.eclipse.jgit.lib.Repository.resolveSimple(Repository.java:853)
	at org.eclipse.jgit.lib.Repository.resolve(Repository.java:818)
	at org.eclipse.jgit.lib.Repository.resolve(Repository.java:474)
	at org.netbeans.libs.git.jgit.Utils.parseObjectId(Utils.java:286)
Caused: org.netbeans.libs.git.GitException: The given id [7b] is not a commit or an annotated tag.
	at org.netbeans.libs.git.jgit.Utils.parseObjectId(Utils.java:290)
	at org.netbeans.libs.git.jgit.Utils.findCommit(Utils.java:265)
	at org.netbeans.libs.git.jgit.Utils.findCommit(Utils.java:261)
	at org.netbeans.libs.git.jgit.commands.LogCommand.run(LogCommand.java:109)
	at org.netbeans.libs.git.jgit.commands.GitCommand$1.run(GitCommand.java:56)
	at org.netbeans.libs.git.jgit.commands.GitCommand$1.run(GitCommand.java:53)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:251)
	at org.netbeans.libs.git.jgit.commands.GitCommand.execute(GitCommand.java:53)
	at org.netbeans.libs.git.GitClient.log(GitClient.java:941)
	at org.netbeans.modules.git.client.GitClient$38.call(GitClient.java:603)
	at org.netbeans.modules.git.client.GitClient$38.call(GitClient.java:599)
	at org.netbeans.modules.git.client.GitClient$CommandInvoker$1$1.call(GitClient.java:945)
	at org.netbeans.modules.git.client.GitClient$CommandInvoker$1.call(GitClient.java:968)
	at org.netbeans.modules.git.client.GitClient$CommandInvoker.runMethodIntern(GitClient.java:980)
	at org.netbeans.modules.git.client.GitClient$CommandInvoker.runMethod(GitClient.java:909)
	at org.netbeans.modules.git.client.GitClient$CommandInvoker.runMethod(GitClient.java:887)
	at org.netbeans.modules.git.client.GitClient.log(GitClient.java:599)
[catch] at org.netbeans.modules.git.ui.repository.RevisionInfoPanelController$LoadInfoWorker.run(RevisionInfoPanelController.java:179)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1403)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:287)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2018)
```