### PR TITLE
Revert gradle downloader TLS handshake workaround again.

### DIFF
--- a/enterprise/micronaut/test/unit/src/org/netbeans/modules/micronaut/gradle/MicronautGradleArtifactsImplTest.java
+++ b/enterprise/micronaut/test/unit/src/org/netbeans/modules/micronaut/gradle/MicronautGradleArtifactsImplTest.java
@@ -45,14 +45,6 @@ import org.openide.windows.IOProvider;
  */
 public class MicronautGradleArtifactsImplTest extends NbTestCase {
 
-    static {
-        // TODO remove ASAP from MicronautGradleArtifactsImplTest and ProjectViewTest
-        // investigate "javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure"
-        // during gradle download "at org.netbeans.modules.gradle.spi.newproject.TemplateOperation$InitStep.execute(TemplateOperation.java:317)"
-        // this looks like a misconfigured webserver to me
-        System.setProperty("https.protocols", "TLSv1.2");
-    }
-
     public MicronautGradleArtifactsImplTest(String name) {
         super(name);
     }

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/ProjectViewTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/ProjectViewTest.java
@@ -102,14 +102,6 @@ public class ProjectViewTest extends NbTestCase {
     private final Gson gson = new Gson();
     private Socket clientSocket;
     private Thread serverThread;
-    
-    static {
-        // TODO remove ASAP from MicronautGradleArtifactsImplTest and ProjectViewTest
-        // investigate "javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure"
-        // during gradle download "at org.netbeans.modules.gradle.spi.newproject.TemplateOperation$InitStep.execute(TemplateOperation.java:317)"
-        // this looks like a misconfigured webserver to me
-        System.setProperty("https.protocols", "TLSv1.2");
-    }
 
     public ProjectViewTest(String name) {
         super(name);


### PR DESCRIPTION
workaround is no longer needed. (unclear what fixed it, likely some of the routine dependency updates)

partially reverts c0f09c927b7a63ebc228156afc8e2ff35ec34b84

fixes #6680