### PR TITLE
StaticImport hint should support records and other class kinds

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/Bundle.properties
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/Bundle.properties
@@ -283,7 +283,9 @@ HINT_SerialVersionUID_Generated=Add generated serialVersionUID
 FieldForUnusedParamCustomizer.finalFields.text=<html>Fields are <code>final</code></html>
 ACSD_Final_Fields=Make fields created by this hint final.
 
-DSC_StaticImport=Convert a static method/field/enum-field reference to use a static import. Feedback to <a href="http://www.netbeans.org/issues/show_bug.cgi?id=89258">http://www.netbeans.org/issues/show_bug.cgi?id=89258</a>
+DSC_StaticImport=<html>Convert a static method/field/enum-field reference to use a static import.\
+ <p><code>Math.abs(-1)</code> -> <code>abs(-1)</code></p><html>
+
 DN_StaticImport=Static imports
 ERR_StaticImport=Convert to static import
 HINT_StaticImport=Convert {0} to static import

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/StaticImportTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/StaticImportTest.java
@@ -99,6 +99,12 @@ public class StaticImportTest extends NbTestCase {
         String golden = "package test; import static java.lang.Math.abs; public class Test { public Test() { abs(1); } }";
         performFixTest(test, golden);
     }
+    
+    public void testStaticImportHint1_InRecord() throws Exception {
+        String test = "package test; public record Test(int n) { public Test { Math.|abs(n); } }";
+        String golden = "package test; import static java.lang.Math.abs; public record Test(int n) { public Test { abs(n); } }";
+        performFixTest(test, golden, 17);
+    }
 
     public void testStaticImportHint2() throws Exception {
         String test = "package test; public class Test { public Test() { Test.get|Logger(); } public static void getLogger() { } }";
@@ -161,10 +167,14 @@ public class StaticImportTest extends NbTestCase {
         performAnalysisTest(test);
     }
 
+    private void performFixTest(String test, String golden) throws Exception {
+        performFixTest(test, golden, 8);
+    }
+
     // test is single line source code for test.Test, | in the member select, space before
     // golden is the output to test against
     // sn is the simple name of the static method
-    private void performFixTest(String test, String golden) throws Exception {
+    private void performFixTest(String test, String golden, int level) throws Exception {
         int offset = test.indexOf("|");
         assertTrue(offset != -1);
         int end = test.indexOf("(", offset) - 1;
@@ -172,6 +182,7 @@ public class StaticImportTest extends NbTestCase {
         int start = test.lastIndexOf(" ", offset) + 1;
         assertTrue(start > 0);
         HintTest.create()
+                .sourceLevel(level)
                 .input(test.replace("|", ""))
                 .run(StaticImport.class)
                 .findWarning("0:" + start + "-0:" + end + ":hint:" + NbBundle.getMessage(StaticImport.class, "ERR_StaticImport"))


### PR DESCRIPTION
uses javac's `Element.getKind().isClass()` as filter which matches all class kinds.

minor code improvements and indentation fixes

note: the hint is disabled by default

fixes https://github.com/apache/netbeans/issues/9166