### PR TITLE
javadoc renderer: fix snippet rendering of deprecated sections 

### DIFF
--- a/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementJavadoc.java
+++ b/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementJavadoc.java
@@ -856,7 +856,7 @@ public class ElementJavadoc {
                         });
                         sb.append("<p>"); //NOI18N
                         if (doc.containsKey(DocTree.Kind.DEPRECATED)) {
-                            sb.append("<b>").append(NbBundle.getMessage(ElementJavadoc.class, "JCD-deprecated")).append("</b> <i>").append(doc.get(DocTree.Kind.DEPRECATED)).append("</i><p>"); //NOI18N
+                            sb.append("<b>").append(NbBundle.getMessage(ElementJavadoc.class, "JCD-deprecated")).append("</b> <div style=\"font-style: italic\">").append(doc.get(DocTree.Kind.DEPRECATED)).append("</div><p>"); //NOI18N
                         }
                         if (doc.containsKey(null)) {
                             sb.append(doc.get(null));


### PR DESCRIPTION
~the browser renders inline snippets as code blocks, lets do the same.~ turned out to be a problem in the html generator

before:
<img width="580" height="351" alt="image" src="https://github.com/user-attachments/assets/f7109746-c38f-44cc-81c5-eff38226217b" />

after:
<img width="577" height="345" alt="image" src="https://github.com/user-attachments/assets/c13e1e78-f57f-4983-ad8d-b0c0263b0b36" />



fixes #8963