### PR TITLE
EL: improve resourcebundles handling

### DIFF
--- a/enterprise/web.el/nbproject/project.properties
+++ b/enterprise/web.el/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test-unit-sys-prop.web.project.jars=\

--- a/enterprise/web.el/src/org/netbeans/modules/web/el/completion/ELCodeCompletionHandler.java
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/completion/ELCodeCompletionHandler.java
@@ -76,6 +76,7 @@ import org.netbeans.modules.web.el.refactoring.RefactoringUtil;
 import org.netbeans.modules.web.el.spi.ELPlugin;
 import org.netbeans.modules.web.el.spi.ELVariableResolver.VariableInfo;
 import org.netbeans.modules.web.el.spi.Function;
+import org.netbeans.modules.web.el.spi.ResolverContext;
 import org.netbeans.modules.web.el.spi.ResourceBundle;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
@@ -176,7 +177,7 @@ public final class ELCodeCompletionHandler implements CodeCompletionHandler2 {
                         // seems to be something like "sessionScope.^", so complete beans from the scope
                         proposeBeansFromScope(ccontext, context, prefixMatcher, element, node, proposals);
                     } else if (ELTypeUtilities.isResourceBundleVar(ccontext, node)) {
-                        proposeBundleKeysInDotNotation(context, prefixMatcher, element, node, proposals);
+                        proposeBundleKeysInDotNotation(ccontext, context, prefixMatcher, element, node, proposals);
                     } else if (resolved == null) {
                         if (target instanceof AstDotSuffix == false && node instanceof AstFunction == false) {
                             proposeFunctions(ccontext, context, prefixMatcher, element, proposals);
@@ -603,12 +604,13 @@ public final class ELCodeCompletionHandler implements CodeCompletionHandler2 {
         if (!resourceBundles.canHaveBundles()) {
             return;
         }
+        ResolverContext resolverContext = new ResolverContext();
         FileObject bundleFile = null;
-        List<Location> bundleLocations = resourceBundles.getLocationsForBundleIdent(bundleKey);
+        List<Location> bundleLocations = resourceBundles.getLocationsForBundleIdent(resolverContext, bundleKey);
         if (!bundleLocations.isEmpty()) {
             bundleFile = bundleLocations.get(0).getFile();
         }
-        for (Map.Entry<String, String> entry : resourceBundles.getEntries(bundleKey).entrySet()) {
+        for (Map.Entry<String, String> entry : resourceBundles.getEntries(resolverContext, bundleKey).entrySet()) {
             if (!prefix.matches(entry.getKey())) {
                 continue;
             }
@@ -620,7 +622,8 @@ public final class ELCodeCompletionHandler implements CodeCompletionHandler2 {
     }
     
     // "msg.key" notation
-    private void proposeBundleKeysInDotNotation(CodeCompletionContext context,
+    private void proposeBundleKeysInDotNotation(CompilationContext ccontext,
+            CodeCompletionContext context,
             PrefixMatcher prefix, 
             ELElement elElement, 
             Node baseObjectNode,
@@ -632,11 +635,11 @@ public final class ELCodeCompletionHandler implements CodeCompletionHandler2 {
             return;
         }
         FileObject bundleFile = null;
-        List<Location> bundleLocations = resourceBundles.getLocationsForBundleIdent(bundleKey);
+        List<Location> bundleLocations = resourceBundles.getLocationsForBundleIdent(ccontext.context(), bundleKey);
         if (!bundleLocations.isEmpty()) {
             bundleFile = bundleLocations.get(0).getFile();
         }
-        for (Map.Entry<String, String> entry : resourceBundles.getEntries(bundleKey).entrySet()) {
+        for (Map.Entry<String, String> entry : resourceBundles.getEntries(ccontext.context(), bundleKey).entrySet()) {
             if (!prefix.matches(entry.getKey())) {
                 continue;
             }

--- a/enterprise/web.el/src/org/netbeans/modules/web/el/completion/ELResourceBundleKeyCompletionItem.java
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/completion/ELResourceBundleKeyCompletionItem.java
@@ -38,7 +38,7 @@ import org.openide.util.ImageUtilities;
  *
  * @author Erno Mononen
  */
-final class ELResourceBundleKeyCompletionItem extends DefaultCompletionProposal {
+public final class ELResourceBundleKeyCompletionItem extends DefaultCompletionProposal {
 
     private static final String ICON_PATH = "org/netbeans/modules/web/el/completion/resources/propertiesKey.gif";//NOI18N
 

--- a/enterprise/web.el/src/org/netbeans/modules/web/el/completion/resources/propertiesKey.svg
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/completion/resources/propertiesKey.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<svg id="propertiesKey" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+    <g transform="scale(1, 1.2)">
+        <text
+            id="B2"
+            x="8"
+            y="12"
+            fill="#ffb0a9"
+            stroke="#814641"
+            stroke-width="5%"
+            font-size="13"
+            font-family="sans-serif"
+            font-weight="bold"
+        >
+            α
+        </text>
+        <text
+            id="B"
+            x="0"
+            y="12"
+            fill="#a7cdea"
+            stroke="#476174"
+            stroke-width="5%"
+            font-size="17"
+            font-family="sans-serif"
+            font-weight="bold"
+        >
+            a
+        </text>
+    </g>
+</svg>

--- a/enterprise/web.el/src/org/netbeans/modules/web/el/completion/resources/propertiesLocale.svg
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/completion/resources/propertiesLocale.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<svg id="propertiesLocale" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+    <g>
+        <text
+            id="B2"
+            x="8"
+            y="15"
+            fill="#ffb0a9"
+            stroke="#814641"
+            stroke-width="5%"
+            font-size="12"
+            font-family="sans-serif"
+            font-weight="bold">
+            α
+        </text>
+        <text
+            id="B"
+            x="1"
+            y="15"
+            fill="#a7cdea"
+            stroke="#476174"
+            stroke-width="5%"
+            font-size="15"
+            font-family="sans-serif"
+            font-weight="bold">
+            a
+        </text>
+        <polygon points="4,1 12,1 8,6"
+                 fill="#D3D3D3" 
+                 stroke="#595959" 
+                 stroke-width="1" 
+                 stroke-linejoin="round"/>
+    </g>
+</svg>

--- a/enterprise/web.el/src/org/netbeans/modules/web/el/hints/ResourceBundleKeys.java
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/hints/ResourceBundleKeys.java
@@ -73,7 +73,7 @@ public final class ResourceBundleKeys extends ELRule {
             }
             for (Pair<AstIdentifier, Node> pair : resourceBundles.collectKeys(each.getNode(), info.context())) {
                 String clearedKey = pair.second().getImage().replace("'", "").replace("\"", "");
-                if (!resourceBundles.isValidKey(pair.first().getImage(), clearedKey)) {
+                if (!resourceBundles.isValidKey(info.context(), pair.first().getImage(), clearedKey)) {
                     Hint hint = new Hint(this,
                             NbBundle.getMessage(ResourceBundleKeys.class, "ResourceBundleKeys_Unknown", clearedKey),
                             elResult.getFileObject(),

--- a/enterprise/web.el/src/org/netbeans/modules/web/el/navigation/ELDeclarationFinder.java
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/navigation/ELDeclarationFinder.java
@@ -41,7 +41,6 @@ import org.netbeans.api.java.source.SourceUtils;
 import org.netbeans.api.java.source.Task;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
-import org.netbeans.modules.csl.api.DataLoadersBridge;
 import org.netbeans.modules.csl.api.DeclarationFinder;
 import org.netbeans.modules.csl.api.ElementKind;
 import org.netbeans.modules.csl.api.HtmlFormatter;
@@ -54,6 +53,7 @@ import org.netbeans.modules.web.el.CompilationContext;
 import org.netbeans.modules.web.el.ELElement;
 import org.netbeans.modules.web.el.ELTypeUtilities;
 import org.netbeans.modules.web.el.ResourceBundles;
+import org.netbeans.modules.web.el.completion.ELResourceBundleKeyCompletionItem;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
@@ -95,12 +95,13 @@ public class ELDeclarationFinder implements DeclarationFinder {
                     // resolve resource bundles
                     ResourceBundles resourceBundles = ResourceBundles.get(file);
                     if (resourceBundles.canHaveBundles()) {
-                        List<ResourceBundles.Location> bundleLocations = getBundleLocations(resourceBundles, nodeElem);
+                        List<RefsHolder> bundleLocations = getBundleLocations(context, resourceBundles, nodeElem);
                         if (!bundleLocations.isEmpty()) {
-                            refs.fo = bundleLocations.get(0).getFile();
-                            refs.offset = bundleLocations.get(0).getOffset();
-                            for (ResourceBundles.Location location : bundleLocations) {
-                                alternatives.add(new ResourceBundleAlternative(location));
+                            refs.fo = bundleLocations.get(0).fo;
+                            refs.offset = bundleLocations.get(0).offset;
+                            refs.elementHandle = bundleLocations.get(0).elementHandle;
+                            for (RefsHolder location : bundleLocations) {
+                                alternatives.add(new ResourceBundleAlternative(location.fo, location.offset, location.lineNumber));
                             }
                         }
                     }
@@ -128,7 +129,7 @@ public class ELDeclarationFinder implements DeclarationFinder {
         }
 
         if (refs.fo != null && refs.offset != -1) {
-            DeclarationLocation declarationLocation = new DeclarationLocation(refs.fo, refs.offset);
+            DeclarationLocation declarationLocation = new DeclarationLocation(refs.fo, refs.offset, refs.elementHandle);
             for (AlternativeLocation alternativeLocation : alternatives) {
                 declarationLocation.addAlternative(alternativeLocation);
             }
@@ -152,9 +153,10 @@ public class ELDeclarationFinder implements DeclarationFinder {
         return ret.get();
     }
 
-    private static List<ResourceBundles.Location> getBundleLocations(ResourceBundles resourceBundles, Pair<Node, ELElement> nodeElem) {
+    private static List<RefsHolder> getBundleLocations(CompilationContext ccontext, ResourceBundles resourceBundles, Pair<Node, ELElement> nodeElem) {
         if (nodeElem.first() instanceof AstIdentifier) {
-            return resourceBundles.getLocationsForBundleIdent(nodeElem.first().getImage());
+            List<ResourceBundles.Location> locations = resourceBundles.getLocationsForBundleIdent(ccontext.context(), nodeElem.first().getImage());
+            return locations.stream().map(location -> new RefsHolder(location.getFile(), location.getOffset())).toList();
         } else {
             AstPath astPath = new AstPath(nodeElem.second().getNode());
             for (Node node : astPath.rootToLeaf()) {
@@ -165,21 +167,32 @@ public class ELDeclarationFinder implements DeclarationFinder {
                         // bundle['key']
                         image = image.substring(1, image.length() - 1);
                     }
-                    return resourceBundles.getLocationsForBundleKey(node.getImage(), image);
+                    final String key = image;
+                    List<ResourceBundles.Location> locations = resourceBundles.getLocationsForBundleKey(ccontext.context(), node.getImage(), key);
+                    final String value;
+                    if (!locations.isEmpty()) {
+                        value = resourceBundles.getValueWithVarName(ccontext.context(), node.getImage(), key);
+                    } else {
+                        value = null;
+                    }
+                    return locations.stream().map(location -> new RefsHolder(location.getFile(), location.getOffset(),
+                            new ELResourceBundleKeyCompletionItem(key, value, nodeElem.second(), location.getFile()).getElement(), location.getLineNumber())).toList();
                 }
             }
         }
-        return Collections.<ResourceBundles.Location>emptyList();
+        return Collections.emptyList();
     }
 
     private static class ResourceBundleAlternative implements AlternativeLocation {
 
         private final FileObject file;
         private final int offset;
+        private final int lineNumber;
 
-        public ResourceBundleAlternative(ResourceBundles.Location location) {
-            this.offset = location.getOffset();
-            this.file = location.getFile();
+        public ResourceBundleAlternative(FileObject file, int offset, int lineNumber) {
+            this.offset = offset;
+            this.file = file;
+            this.lineNumber = lineNumber;
         }
 
         @Override
@@ -189,13 +202,10 @@ public class ELDeclarationFinder implements DeclarationFinder {
 
         @Override
         public String getDisplayHtml(HtmlFormatter formatter) {
-            StringBuilder b = new StringBuilder();
-
-            b.append("<font color=007c00>");//NOI18N
-            b.append("<b>"); //NOI18N
-            b.append(file.getName());
-            b.append("</b>"); //NOI18N
-            b.append("</font> in "); //NOI18N
+            formatter.emphasis(true);
+            formatter.appendText(file.getName());
+            formatter.emphasis(false);
+            formatter.appendText(" in ");
 
             //add a link to the file relative to the web root
             FileObject pathRoot = ProjectWebRootQuery.getWebRoot(file);
@@ -215,14 +225,14 @@ public class ELDeclarationFinder implements DeclarationFinder {
                 path = file.getPath();
             }
 
-            b.append("<i>"); //NOI18N
-            b.append(path);
-            b.append("</i>"); //NOI18N
-            if (offset > 0) {
-                b.append(":"); //NOI18N
-                b.append(offset + 1); //line offsets are counted from zero, but in editor lines starts with one.
+            formatter.appendHtml("<i>");
+            formatter.appendText(path);
+            formatter.appendHtml("</i>");
+            if (lineNumber > -1) {
+                formatter.appendText(":"); //NOI18N
+                formatter.appendText(String.valueOf(lineNumber + 1)); //line numbers are counted from zero, but in editor lines starts with one.
             }
-            return b.toString();
+            return formatter.getText();
         }
 
         @Override
@@ -274,9 +284,27 @@ public class ELDeclarationFinder implements DeclarationFinder {
 
     private static class RefsHolder {
 
-        private ElementHandle<Element> handle;
-        private FileObject fo;
-        private int offset = -1;
+        ElementHandle<Element> handle;
+        FileObject fo;
+        int offset = -1;
+        int lineNumber = -1;
+        org.netbeans.modules.csl.api.ElementHandle elementHandle;
+
+        RefsHolder() {
+        }
+
+        RefsHolder(FileObject fo, int offset) {
+            this.fo = fo;
+            this.offset = offset;
+        }
+
+        public RefsHolder(FileObject fo, int offset, org.netbeans.modules.csl.api.ElementHandle elementHandle, int lineNumber) {
+            this.fo = fo;
+            this.offset = offset;
+            this.elementHandle = elementHandle;
+            this.lineNumber = lineNumber;
+        }
+
     }
 
     private static class ResourceBundleElementHandle implements org.netbeans.modules.csl.api.ElementHandle {

--- a/enterprise/web.el/src/org/netbeans/modules/web/el/navigation/ELHyperlinkProvider.java
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/navigation/ELHyperlinkProvider.java
@@ -84,7 +84,7 @@ import org.openide.util.Pair;
 public final class ELHyperlinkProvider implements HyperlinkProviderExt {
 
     @Override
-    public boolean isHyperlinkPoint(final Document doc, final int offset, HyperlinkType type) {
+    public boolean isHyperlinkPoint(final Document doc, final int offset, HyperlinkType type) {        
         final AtomicBoolean ret = new AtomicBoolean(false);
         doc.render(new Runnable() {
 
@@ -130,12 +130,14 @@ public final class ELHyperlinkProvider implements HyperlinkProviderExt {
     public String getTooltipText(Document doc, int offset, HyperlinkType type) {
         Pair<Node, ELElement> nodeAndElement = resolveNodeAndElement(doc, offset, new AtomicBoolean());
         if (nodeAndElement != null) {
-            if (nodeAndElement.first() instanceof AstString) {
+            if (nodeAndElement.first() instanceof AstString || nodeAndElement.first() instanceof AstDotSuffix) {
                 // could be a resource bundle key
-                return getTooltipTextForBundleKey(nodeAndElement);
-            } else {
-                return getTooltipTextForElement(nodeAndElement);
+                String tooltip = getTooltipTextForBundleKey(nodeAndElement);
+                if (tooltip != null) {
+                    return tooltip;
+                }
             }
+            return getTooltipTextForElement(nodeAndElement);
         }
         return null;
     }

--- a/enterprise/web.el/src/org/netbeans/modules/web/el/spi/ResourceBundle.java
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/spi/ResourceBundle.java
@@ -25,23 +25,23 @@ import org.openide.filesystems.FileObject;
  * @author marekfukala
  */
 public final class ResourceBundle {
-    
+
     private final String baseName, var;
     private final List<FileObject> files;
-    
+
     public ResourceBundle(String baseName, String var, List<FileObject> files) {
         this.baseName = baseName;
         this.var = var;
         this.files = files;
     }
-    
+
     /**
      * @return fully qualified name of the properties file representing the resource bundle.
      */
     public String getBaseName() {
         return baseName;
     }
-    
+
     /**
      * @return variable representing the resource bundle
      */
@@ -54,6 +54,11 @@ public final class ResourceBundle {
      */
     public List<FileObject> getFiles() {
         return files;
+    }
+
+    @Override
+    public String toString() {
+        return "ResourceBundle{" + "baseName=" + baseName + ", var=" + var + '}';
     }
 
 }

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/resources/propertiesKey.svg
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/resources/propertiesKey.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<svg id="propertiesKey" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+    <g transform="scale(1, 1.2)">
+        <text
+            id="B2"
+            x="8"
+            y="12"
+            fill="#ffb0a9"
+            stroke="#814641"
+            stroke-width="5%"
+            font-size="13"
+            font-family="sans-serif"
+            font-weight="bold"
+        >
+            α
+        </text>
+        <text
+            id="B"
+            x="0"
+            y="12"
+            fill="#a7cdea"
+            stroke="#476174"
+            stroke-width="5%"
+            font-size="17"
+            font-family="sans-serif"
+            font-weight="bold"
+        >
+            a
+        </text>
+    </g>
+</svg>

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/resources/propertiesLocale.svg
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/resources/propertiesLocale.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<svg id="propertiesLocale" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+    <g>
+        <text
+            id="B2"
+            x="8"
+            y="15"
+            fill="#ffb0a9"
+            stroke="#814641"
+            stroke-width="5%"
+            font-size="12"
+            font-family="sans-serif"
+            font-weight="bold">
+            α
+        </text>
+        <text
+            id="B"
+            x="1"
+            y="15"
+            fill="#a7cdea"
+            stroke="#476174"
+            stroke-width="5%"
+            font-size="15"
+            font-family="sans-serif"
+            font-weight="bold">
+            a
+        </text>
+        <polygon points="4,1 12,1 8,6"
+                 fill="#D3D3D3" 
+                 stroke="#595959" 
+                 stroke-width="1" 
+                 stroke-linejoin="round"/>
+    </g>
+</svg>

--- a/ide/properties/src/org/netbeans/modules/properties/propertiesKey.svg
+++ b/ide/properties/src/org/netbeans/modules/properties/propertiesKey.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<svg id="propertiesKey" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+    <g transform="scale(1, 1.2)">
+        <text
+            id="B2"
+            x="8"
+            y="12"
+            fill="#ffb0a9"
+            stroke="#814641"
+            stroke-width="5%"
+            font-size="13"
+            font-family="sans-serif"
+            font-weight="bold"
+        >
+            α
+        </text>
+        <text
+            id="B"
+            x="0"
+            y="12"
+            fill="#a7cdea"
+            stroke="#476174"
+            stroke-width="5%"
+            font-size="17"
+            font-family="sans-serif"
+            font-weight="bold"
+        >
+            a
+        </text>
+    </g>
+</svg>

--- a/ide/properties/src/org/netbeans/modules/properties/propertiesLocale.svg
+++ b/ide/properties/src/org/netbeans/modules/properties/propertiesLocale.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<svg id="propertiesLocale" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+    <g>
+        <text
+            id="B2"
+            x="8"
+            y="15"
+            fill="#ffb0a9"
+            stroke="#814641"
+            stroke-width="5%"
+            font-size="12"
+            font-family="sans-serif"
+            font-weight="bold">
+            α
+        </text>
+        <text
+            id="B"
+            x="1"
+            y="15"
+            fill="#a7cdea"
+            stroke="#476174"
+            stroke-width="5%"
+            font-size="15"
+            font-family="sans-serif"
+            font-weight="bold">
+            a
+        </text>
+        <polygon points="4,1 12,1 8,6"
+                 fill="#D3D3D3" 
+                 stroke="#595959" 
+                 stroke-width="1" 
+                 stroke-linejoin="round"/>
+    </g>
+</svg>


### PR DESCRIPTION
This is a follow-up to #8603 
The main aim is enabling CTRL + Hover and CTRL + click on ResourceBundle items in JSF pages:
<img width="291" height="47" alt="image" src="https://github.com/user-attachments/assets/1fd678be-21df-49ea-847b-3d1f48a94ecc" />
<img width="431" height="107" alt="image" src="https://github.com/user-attachments/assets/cad22916-fb18-4a4f-a70b-882f7445c519" />
The features were already integrated in ELHyperlinkProvider but it seems GsfHyperlinkProvider has the precedence so I had to implement them in ELDeclarationFinder (which is called by GsfHyperlinkProvider).
Aside from that, I tried to improve the resource bundled loading here and there, using the built-in cache whenever possible.
This also includes:
- new svg icons
- declaration popup look improved