### PR TITLE
Fix and disable masterfs lockfile test which is failing since 17u18

### DIFF
--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/StatFilesTest.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/StatFilesTest.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.masterfs.filebasedfs.fileobjects;
 
+import java.awt.GraphicsEnvironment;
 import java.io.File;
 
 import java.io.IOException;
@@ -26,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
 import org.netbeans.junit.NbTestCase;
+import org.netbeans.junit.RandomlyFails;
 import org.netbeans.modules.masterfs.filebasedfs.FileBasedFileSystem;
 import org.netbeans.modules.masterfs.filebasedfs.naming.FileNaming;
 import org.netbeans.modules.masterfs.filebasedfs.naming.NamingFactory;
@@ -49,6 +51,7 @@ public class StatFilesTest extends NbTestCase {
 
     @Override
     protected void setUp() throws java.lang.Exception {
+        GraphicsEnvironment.isHeadless(); // may cause file reads in a static initializer on linux
         FileObjectFactory.WARNINGS = false;
         clearWorkDir();
         testFile = new File(getWorkDir(), "testLockFile.txt");
@@ -151,6 +154,7 @@ public class StatFilesTest extends NbTestCase {
         monitor.getResults().assertResult(1, StatFiles.READ);
     }
 
+    @RandomlyFails // JDK update releases caused failures
     public void testLockFile() throws IOException {
         FileObject fobj = getFileObject(testFile);
         monitor.reset();


### PR DESCRIPTION
this test was patched in past for similar reasons and can start failing again when the JDK updates.

`testLockFile()` is now disabled in CI

