### PR TITLE
Fix possible NPE in maven ModuleInfoSelector

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/classpath/ClassPathProviderImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/classpath/ClassPathProviderImpl.java
@@ -514,8 +514,7 @@ public final class ClassPathProviderImpl implements ClassPathProvider, ActiveJ2S
                     if(moduleInfoFile.exists()) {
                         FileObject moduleInfo = FileUtil.toFileObject(moduleInfoFile);
                         String sourceLevel = SourceLevelQuery.getSourceLevel2(moduleInfo).getSourceLevel();
-                        String ide_jdkvers = System.getProperty("java.version"); //NOI18N
-                        if(!sourceLevel.startsWith("1.") && !ide_jdkvers.startsWith("1.")) { //NOI18N
+                        if (sourceLevel != null && !sourceLevel.startsWith("1.")) { //NOI18N
                             // both sourceLevel and ideJDK are 9+
                             ret = hasModuleInfoCP.get();  
                         }


### PR DESCRIPTION
`SourceLevelQuery` may return null. (e.g if the version string isn't valid)

code section was introduced a while ago https://github.com/apache/netbeans/pull/2037

fixes https://github.com/apache/netbeans/issues/9180