### PR TITLE
Enhance behaviour of showing Favorites on first editor usage

### DIFF
--- a/platform/favorites/src/org/netbeans/modules/favorites/Bundle.properties
+++ b/platform/favorites/src/org/netbeans/modules/favorites/Bundle.properties
@@ -50,3 +50,6 @@ OpenIDE-Module-Long-Description=Favorites module enables you to create a view of
 
 # Options Export
 Favorites.Options.Export.displayName=Favorites
+
+# Automatically open when first file opened for editing
+Favorites.openOnFirstFile=true

--- a/platform/favorites/src/org/netbeans/modules/favorites/Module.java
+++ b/platform/favorites/src/org/netbeans/modules/favorites/Module.java
@@ -33,6 +33,7 @@ import org.netbeans.swing.plaf.LFCustoms;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
+import org.openide.util.NbBundle;
 import org.openide.util.NbPreferences;
 import org.openide.windows.OnShowing;
 import org.openide.windows.TopComponent;
@@ -40,16 +41,25 @@ import org.openide.windows.WindowManager;
 
 /**
  * For lifecycle tasks.
+ *
  * @author mbien
  */
 public final class Module {
 
     private static final String INITIAL_OPEN_DONE_KEY = "initial-open-done"; //NOI18N
+    private static final String INITIAL_OPEN_BRANDING_KEY = "Favorites.openOnFirstFile"; //NOI18N
 
     private Module() {}
 
     @OnShowing
     public final static class EDTInit implements Runnable {
+
+        private final boolean openOnFirstFile;
+
+        public EDTInit() {
+            openOnFirstFile = Boolean.parseBoolean(
+                    NbBundle.getMessage(Module.class, INITIAL_OPEN_BRANDING_KEY));
+        }
 
         @Override
         public void run() {
@@ -76,6 +86,9 @@ public final class Module {
 
         // very first file editor opened will also open the Favorites tab
         private void attachFirstEditorOpenListener() {
+            if (!openOnFirstFile) {
+                return;
+            }
             Preferences prefs = NbPreferences.forModule(Module.class);
             if (prefs.getBoolean(INITIAL_OPEN_DONE_KEY, false)) {
                 return;


### PR DESCRIPTION
Follow up on #8908 

- Only open Favorites when first file editor is opened.  Don't open if Dashboard or other non-file TopComponent is opened in editor mode.  Requires moving to listen on TopComponent registry.
- Simplify branding this feature disabled in platform applications.  Ideally the default would be off and enabled in the IDE branding, however as we've already shipped the platform with it enabled by default I've left as is.

A further enhancement might be to do the equivalent of calling `Tab::doSelectNode` but without taking focus away from the opening editor?

~~Could possible target delivery, but it's a minor usage fix so left for NB30 for now.~~