### PR TITLE
Update osuosl repo url

### DIFF
--- a/nbbuild/binaries-default-properties.xml
+++ b/nbbuild/binaries-default-properties.xml
@@ -21,7 +21,7 @@
 -->
 <project name="binaries-default-properties" default="netbeans" basedir=".">
   <property name="binaries.cache" location="${user.home}/.hgexternalcache"/>
-  <property name="binaries.server" value="https://netbeans.osuosl.org/binaries/"/>
+  <property name="binaries.server" value="https://netbeans.osuosl.org/pub/netbeans/binaries/"/>
   <!-- space separated list; add temp staging repos here when testing -->
   <property name="binaries.repos" value="https://repo.maven.apache.org/maven2/"/>
 </project>


### PR DESCRIPTION
url no longer valid

https://netbeans.osuosl.org/binaries/ ->
https://netbeans.osuosl.org/pub/netbeans/binaries/


noticed that the paperwork job started failing in https://github.com/apache/netbeans/pull/9151, since it downloads a jar which is not in the gh cache.

targets delivery