### PR TITLE
Fix ZIP export to automatically append .zip extension

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/zip/ExportZIP.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/zip/ExportZIP.java
@@ -477,7 +477,11 @@ public class ExportZIP extends JPanel {
     private void zipButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_zipButtonActionPerformed
         JFileChooser fc = new JFileChooser();
         if (fc.showSaveDialog(this) == JFileChooser.APPROVE_OPTION) {
-            zipField.setText(fc.getSelectedFile().getAbsolutePath());
+            String sf = fc.getSelectedFile().getAbsolutePath();
+            if (!"zip".equalsIgnoreCase(FileUtil.getExtension(sf))) {
+                sf += ".zip";
+            }
+            zipField.setText(sf);
         }
     }//GEN-LAST:event_zipButtonActionPerformed
 


### PR DESCRIPTION
When using File -> Export Project -> To ZIP, selecting a file with the browse dialog did not automatically append the .zip extension. Users had to type it manually. This change ensures that if the selected file name does not end with .zip (case-insensitive), the extension is automatically added, improving usability and preventing missing extensions.