### PR TITLE
Follow FlatLaf colours for component drag target indicator.

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/view/dnd/DropTargetGlassPane.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/dnd/DropTargetGlassPane.java
@@ -292,7 +292,9 @@ public final class DropTargetGlassPane extends JPanel implements DropTargetListe
     private Stroke stroke;
     private Stroke getIndicationStroke() {
         if (stroke == null) {
-            stroke = new BasicStroke(3, BasicStroke.CAP_SQUARE, BasicStroke.JOIN_MITER, 10.0f, new float[] {10.0f}, 0.0f);
+            int strokeWidth = UIManager.getInt("Panel.dropTargetGlassPane.strokeWidth");
+            strokeWidth = strokeWidth < 1 ? 3 : strokeWidth;
+            stroke = new BasicStroke(strokeWidth, BasicStroke.CAP_SQUARE, BasicStroke.JOIN_MITER, 10.0f, new float[] {10.0f}, 0.0f);
         }
         return stroke;
     }        

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -72,6 +72,10 @@ ViewTab.underlineColor=$EditorTab.underlineColor
 ViewTab.inactiveUnderlineColor=$EditorTab.inactiveUnderlineColor
 ViewTab.tabSeparatorColor=$EditorTab.tabSeparatorColor
 
+#---- Tab Dragging ----
+
+Panel.dropTargetGlassPane=tint($EditorTab.underlineColor, 25%)
+
 #---- SlidingButton ----
 
 SlidingButton.hoverBackground=$ViewTab.hoverBackground

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -94,6 +94,11 @@ ViewTab.tabSeparatorColor=$Component.borderColor
 ViewTab.showTabSeparators=true
 ViewTab.showSelectedTabBorder=true
 
+#---- Tab Dragging ----
+
+Panel.dropTargetGlassPane=$EditorTab.underlineColor
+Panel.dropTargetGlassPane.strokeWidth=3
+
 #---- Multi-tabs ----
 
 nb.multitabs.tabInsets=5,2,7,2

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
@@ -39,7 +39,6 @@ EditorTab.attentionForeground=#000
 EditorTab.underlineColor=$TabbedPane.underlineColor
 EditorTab.inactiveUnderlineColor=#00000000
 
-
 #---- ViewTab ----
 
 ViewTab.background=$EditorTab.background
@@ -56,6 +55,9 @@ ViewTab.attentionForeground=$EditorTab.attentionForeground
 ViewTab.underlineColor=$EditorTab.underlineColor
 ViewTab.inactiveUnderlineColor=$EditorTab.inactiveUnderlineColor
 
+#---- Tab Dragging ----
+
+Panel.dropTargetGlassPane=shade($EditorTab.underlineColor, 20%)
 
 #---- SlidingButton ----
 


### PR DESCRIPTION
Update FlatLaf properties to set the colour of the drag target indicator to match the active tab underline colour (usually accent colour).  Also make the stroke weight configurable and reduce slightly in FlatLaf.

This follows a conversation with @Chris2011 on Slack, and also relates to an old discussion in #7420 and follow up on #8845  I always use the orange accent colour, so until Chris mentioned this I hadn't even realised it wasn't picking up the accent colour already! :smile: 

<img width="884" height="858" alt="Screenshot from 2026-02-16 14-44-16" src="https://github.com/user-attachments/assets/3152995c-be6c-4966-9499-036a6ad15988" />
