### PR TITLE
[GITHUB-9193] Resolve erroneous types in diamond-base new class expressions.

### DIFF
--- a/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
+++ b/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
@@ -2218,6 +2218,9 @@ public final class JavaCompletionTask<T> extends BaseTask {
                 case GTGTGT:
                     controller = env.getController();
                     TypeMirror tm = controller.getTrees().getTypeMirror(new TreePath(path, nc.getIdentifier()));
+                    if (tm.getKind() == TypeKind.ERROR) {
+                        tm = env.getController().getTrees().getOriginalType((ErrorType) tm);
+                    }
                     addMembers(env, tm, ((DeclaredType) tm).asElement(), EnumSet.of(CONSTRUCTOR), null, false, false, false, true, addSwitchItemDefault);
                     break;
             }

--- a/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/1.8/diamond1.pass
+++ b/java/java.completion/test/unit/data/goldenfiles/org/netbeans/modules/java/completion/JavaCompletionTaskTest/1.8/diamond1.pass
@@ -1,0 +1,2 @@
+public Test(T value)
+public Test(String name, T value)

--- a/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask18FeaturesTest.java
+++ b/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask18FeaturesTest.java
@@ -346,6 +346,21 @@ public class JavaCompletionTask18FeaturesTest extends CompletionTestBase {
         performTest("Final", 1125, "var", "effectivellyFinal.pass", "1.8");
     }
 
+    public void testDiamond1() throws Exception {
+        performTest("Empty", 808,
+                """
+                package test;
+                public class Test {
+                    public static class Test<T> {
+                        public Test(T value) { }
+                        public Test(String name, T value) { }
+                    }
+                    private static void test() {
+                        new Test<>
+                """,
+                "diamond1.pass", "1.8");
+    }
+
     static {
         JavacParser.DISABLE_SOURCE_LEVEL_DOWNGRADE = true;
     }


### PR DESCRIPTION
Consider code like:
```
package test;
public class Test {
    public static class Test<T> {
        public Test(T value) { }
        public Test(String name, T value) { }
    }
    private static void test() {
        new Test<>/*CC here*/
    }
}
```

Invoking code completion at the marked place leads to an empty result. The issue is that when the `new Test<>` is attributed, it gets an erroneous type. I don't think there's currently a good argument to change the attribution, but the original type of the erroneous type is a usable type, so we can use that original type, and things should work.

The bug report says there's a difference between custom and JDK classes, but looking into that deeper, that's not the case. But there's a difference between classes that have a no-arg constructor, and those that only have constructors with arguments. The latter ones don't currently work, and would hopefully be fixed by this PR.

Closes #9193 

---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>