### PR TITLE
Don't call deprecated FileUtil::preventFileChooserSymlinkTraversal

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/NbPlatformCustomizerHarness.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/platform/NbPlatformCustomizerHarness.java
@@ -194,6 +194,7 @@ public class NbPlatformCustomizerHarness extends JPanel {
     private void browseButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_browseButtonActionPerformed
         JFileChooser jfc = new JFileChooser() {
             // Trick stolen from ProjectChooserAccessory.ProjectFileChooser:
+            @Override
             public void approveSelection() {
                 File dir = FileUtil.normalizeFile(getSelectedFile());
                 if (NbPlatform.isHarness(dir)) {
@@ -203,7 +204,6 @@ public class NbPlatformCustomizerHarness extends JPanel {
                 }
             }
         };
-        FileUtil.preventFileChooserSymlinkTraversal(jfc, null);
         jfc.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         jfc.setSelectedFile(plaf.getHarnessLocation());
         if (jfc.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/project/templatePanelVisual.javx
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/project/templatePanelVisual.javx
@@ -132,7 +132,6 @@ public class ${TEMPLATENAME}PanelVisual extends JPanel implements DocumentListen
         String command = evt.getActionCommand();
         if ("BROWSE".equals(command)) {
             JFileChooser chooser = new JFileChooser();
-            FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
             chooser.setDialogTitle("Select Project Location");
             chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
             String path = this.projectLocationTextField.getText();

--- a/contrib/groovy.grailsproject/src/org/netbeans/modules/groovy/grailsproject/ui/wizards/impl/PanelProjectLocationVisual.java
+++ b/contrib/groovy.grailsproject/src/org/netbeans/modules/groovy/grailsproject/ui/wizards/impl/PanelProjectLocationVisual.java
@@ -216,7 +216,6 @@ public class PanelProjectLocationVisual extends SettingsPanel implements Documen
 
     private void browseLocationJButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_browseLocationJButtonActionPerformed
             JFileChooser chooser = new JFileChooser ();
-            FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
             chooser.setDialogTitle(NbBundle.getMessage(PanelProjectLocationVisual.class,"GetProjectLocationPanel.FileChooserTitle"));
             chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
             String path = projectLocationTextField.getText().trim();

--- a/contrib/j2ee.jboss4/src/org/netbeans/modules/j2ee/jboss4/customizer/CustomizerSupport.java
+++ b/contrib/j2ee.jboss4/src/org/netbeans/modules/j2ee/jboss4/customizer/CustomizerSupport.java
@@ -604,7 +604,6 @@ public final class CustomizerSupport {
 
         private void addPathElement () {
             JFileChooser chooser = new JFileChooser();
-            FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
             chooser.setMultiSelectionEnabled (true);
             String title = null;
             String message = null;
@@ -630,9 +629,7 @@ public final class CustomizerSupport {
             //#61789 on old macosx (jdk 1.4.1) these two method need to be called in this order.
             chooser.setAcceptAllFileFilterUsed( false );
             chooser.setFileFilter (new SimpleFileFilter(message,new String[] {"ZIP","JAR"}));   //NOI18N
-            if (this.currentDir != null && currentDir.exists()) {
-                chooser.setCurrentDirectory(this.currentDir);
-            }
+            chooser.setCurrentDirectory(this.currentDir != null && currentDir.exists() ? this.currentDir : null);
             if (chooser.showOpenDialog(this)==JFileChooser.APPROVE_OPTION) {
                 File[] fs = chooser.getSelectedFiles();
                 PathModel model = (PathModel) this.resources.getModel();

--- a/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/ui/service/subpanels/KeystorePanel.form
+++ b/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/ui/service/subpanels/KeystorePanel.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
 

--- a/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/ui/service/subpanels/KeystorePanel.java
+++ b/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/ui/service/subpanels/KeystorePanel.java
@@ -375,18 +375,15 @@ public class KeystorePanel extends JPanel {
     
     private void keystoreLocationButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_keystoreLocationButtonActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setDialogTitle(NbBundle.getMessage(KeystorePanel.class, "LBL_KeystoreBrowse_Title")); //NOI18N
         chooser.setFileSelectionMode (JFileChooser.FILES_ONLY);
         chooser.setMultiSelectionEnabled(false);
         chooser.setFileFilter(new StoreFileFilter());
         File f = new File(keystoreLocationTextField.getText());
-        if ((f != null) && (f.exists())) {
-            if (f.isDirectory()) {
-                chooser.setCurrentDirectory(f);
-            } else {
-                chooser.setCurrentDirectory(f.getParentFile());
-            }
+        if (f.exists()) {
+            chooser.setCurrentDirectory(f);
+        } else {
+            chooser.setCurrentDirectory(null);
         }
         if (chooser.showOpenDialog(this)== JFileChooser.APPROVE_OPTION) {
             File file = chooser.getSelectedFile();

--- a/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/ui/service/subpanels/TruststorePanel.form
+++ b/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/ui/service/subpanels/TruststorePanel.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
 

--- a/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/ui/service/subpanels/TruststorePanel.java
+++ b/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/ui/service/subpanels/TruststorePanel.java
@@ -335,18 +335,15 @@ public class TruststorePanel extends JPanel {
     
     private void storeLocationButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_storeLocationButtonActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setDialogTitle(NbBundle.getMessage(TruststorePanel.class, "LBL_TruststoreBrowse_Title")); //NOI18N
         chooser.setFileSelectionMode (JFileChooser.FILES_ONLY);
         chooser.setMultiSelectionEnabled(false);
         chooser.setFileFilter(new StoreFileFilter());
         File f = new File(storeLocationTextField.getText());
-        if ((f != null) && (f.exists())) {
-            if (f.isDirectory()) {
-                chooser.setCurrentDirectory(f);
-            } else {
-                chooser.setCurrentDirectory(f.getParentFile());
-            }
+        if (f.exists()) {
+            chooser.setCurrentDirectory(f);
+        } else {
+            chooser.setCurrentDirectory(null);
         }
         if (chooser.showOpenDialog(this)== JFileChooser.APPROVE_OPTION) {
             File file = chooser.getSelectedFile();

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/CustomizerRun.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/CustomizerRun.java
@@ -269,7 +269,6 @@ public class CustomizerRun extends JPanel implements HelpCtx.Provider {
             
     private void jButtonWorkingDirectoryBrowseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButtonWorkingDirectoryBrowseActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         chooser.setMultiSelectionEnabled(false);
         

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/CustomizerSources.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/CustomizerSources.java
@@ -546,7 +546,6 @@ public class CustomizerSources extends javax.swing.JPanel implements HelpCtx.Pro
 
     private void configFilesFolderBrowseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_configFilesFolderBrowseActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         File fileName = new File(jTextFieldConfigFilesFolder.getText());
         File configFiles = fileName.isAbsolute() ? fileName : new File(projectFld, fileName.getPath());

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/wizards/PanelSourceFolders.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/wizards/PanelSourceFolders.java
@@ -384,7 +384,6 @@ public class PanelSourceFolders extends SettingsPanel implements PropertyChangeL
 
     private void jButtonLibrariesActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButtonLibrariesActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         if (jTextFieldLibraries.getText().length() > 0 && getLibraries().exists()) {
             chooser.setSelectedFile(getLibraries());
@@ -399,7 +398,6 @@ public class PanelSourceFolders extends SettingsPanel implements PropertyChangeL
 
     private void jButtonConfigFilesLocationActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButtonConfigFilesLocationActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         if (jTextFieldConfigFiles.getText().length() > 0 && getConfigFiles().exists()) {
             chooser.setSelectedFile(getConfigFiles());

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/customizer/CustomizerSources.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/customizer/CustomizerSources.java
@@ -433,7 +433,6 @@ public class CustomizerSources extends javax.swing.JPanel implements HelpCtx.Pro
     
     private void jButtonBrowseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButtonBrowseActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         File fileName = new File(jTextFieldConfigFilesFolder.getText());
         File configFiles = fileName.isAbsolute() ? fileName : new File(projectFld, fileName.getPath());

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/wizards/PanelSourceFolders.form
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/wizards/PanelSourceFolders.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
 

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/wizards/PanelSourceFolders.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/wizards/PanelSourceFolders.java
@@ -385,7 +385,6 @@ public class PanelSourceFolders extends SettingsPanel implements PropertyChangeL
 
     private void jButtonLibrariesActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButtonLibrariesActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
         if (jTextFieldLibraries.getText().length() > 0 && getLibraries().exists()) {
             chooser.setSelectedFile(getLibraries());
@@ -400,7 +399,6 @@ public class PanelSourceFolders extends SettingsPanel implements PropertyChangeL
 
     private void jButtonConfigFilesLocationActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButtonConfigFilesLocationActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
         if (jTextFieldConfigFiles.getText().length() > 0 && getConfigFiles().exists()) {
             chooser.setSelectedFile(getConfigFiles());

--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/sharability/ServerVolumeCustomizer.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/sharability/ServerVolumeCustomizer.java
@@ -286,7 +286,6 @@ public class ServerVolumeCustomizer extends javax.swing.JPanel implements Custom
             baseFolder = new File(URI.create(area.getLocation().toExternalForm())).getParentFile();
         }
         FileChooser chooser = new FileChooser(baseFolder, baseFolder);
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setAcceptAllFileFilterUsed(false);
         if (!this.volumeType.equals(ServerLibraryTypeProvider.VOLUME_JAVADOC)
                 && !this.volumeType.equals(ServerLibraryTypeProvider.VOLUME_SOURCE)) {

--- a/enterprise/jakarta.transformer/src/org/netbeans/modules/fish/payara/jakarta/transformer/TransformerPanelVisual.java
+++ b/enterprise/jakarta.transformer/src/org/netbeans/modules/fish/payara/jakarta/transformer/TransformerPanelVisual.java
@@ -140,9 +140,7 @@ public class TransformerPanelVisual extends JPanel {
     private void selectSourceButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_selectSourceButtonActionPerformed
         String command = evt.getActionCommand();
         if ("BROWSE".equals(command)) {
-            JFileChooser chooser = new JFileChooser();
-            //FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
-            chooser.setCurrentDirectory(chooser.getCurrentDirectory());            
+            JFileChooser chooser = new JFileChooser();      
             chooser.setDialogTitle("Select source to transform");
             chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
             String path = this.source.getText();
@@ -163,9 +161,7 @@ public class TransformerPanelVisual extends JPanel {
     private void selectTargetButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_selectTargetButtonActionPerformed
         String command = evt.getActionCommand();
         if ("BROWSE".equals(command)) {
-            JFileChooser chooser = new JFileChooser();
-            //FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
-            chooser.setCurrentDirectory(chooser.getCurrentDirectory());            
+            JFileChooser chooser = new JFileChooser();       
             chooser.setDialogTitle("Select Folder to Transform");
             chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
             String path = this.target.getText();

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectLocationPanel.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectLocationPanel.java
@@ -235,7 +235,6 @@ final class ProjectLocationPanel extends JPanel implements DocumentListener {
         String command = evt.getActionCommand();        
         if ( "BROWSE".equals( command ) ) { // NOI18N                
             JFileChooser chooser = new JFileChooser ();
-            FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
             chooser.setDialogTitle(NbBundle.getMessage(ProjectLocationPanel.class,"LBL_NWP1_SelectProjectLocation"));
             chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
             String path = this.projectLocationTextField.getText();

--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/customizer/CustomizerSupport.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/customizer/CustomizerSupport.java
@@ -606,7 +606,6 @@ public final class CustomizerSupport {
 
         private void addPathElement () {
             JFileChooser chooser = new JFileChooser();
-            chooser.setCurrentDirectory(null);
             chooser.setMultiSelectionEnabled (true);
             String title = null;
             String message = null;

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/customizer/CustomizerSupport.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/customizer/CustomizerSupport.java
@@ -587,7 +587,6 @@ public final class CustomizerSupport {
 
         private void addPathElement () {
             JFileChooser chooser = new JFileChooser();
-            FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
             chooser.setMultiSelectionEnabled (true);
             String title = null;
             String message = null;

--- a/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/ui/WebClasspathPanel.java
+++ b/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/ui/WebClasspathPanel.java
@@ -305,20 +305,17 @@ public class WebClasspathPanel extends javax.swing.JPanel implements HelpCtx.Pro
 
     private void addClasspathActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_addClasspathActionPerformed
         FileChooser chooser = new FileChooser(this.projectFolder, null);
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
+        chooser.setCurrentDirectory(null);
         chooser.setFileSelectionMode (JFileChooser.FILES_AND_DIRECTORIES);
         chooser.setMultiSelectionEnabled(true);
         if (lastChosenFile != null) {
             chooser.setSelectedFile(lastChosenFile);
-        }
-        else {
-            if (projectFolder!= null) {
-                File files[] = projectFolder.listFiles();
-                if (files != null && files.length > 0) {
-                    chooser.setSelectedFile(files[0]);
-                } else {
-                    chooser.setSelectedFile(projectFolder);
-                }
+        } else if (projectFolder!= null) {
+            File[] files = projectFolder.listFiles();
+            if (files != null && files.length > 0) {
+                chooser.setSelectedFile(files[0]);
+            } else {
+                chooser.setSelectedFile(projectFolder);
             }
         }
         chooser.setDialogTitle(NbBundle.getMessage(WebClasspathPanel.class, "LBL_Browse_Classpath"));

--- a/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/ui/WebLocationsPanel.java
+++ b/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/ui/WebLocationsPanel.java
@@ -320,7 +320,7 @@ private void jButtonWebInfActionPerformed(java.awt.event.ActionEvent evt) {//GEN
     private static JFileChooser createChooser(File webPagesLoc, WizardDescriptor wizardDescriptor) {
 	String path = webPagesLoc.getAbsolutePath();
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, new File(path));
+        chooser.setCurrentDirectory(new File(path));
         chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         chooser.setAcceptAllFileFilterUsed(false);
         

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/ui/customizer/CustomizerSources.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/ui/customizer/CustomizerSources.java
@@ -528,7 +528,6 @@ private void includeExcludeButtonActionPerformed(java.awt.event.ActionEvent evt)
     
     private void updateFolder(JTextField textField) {
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         File fileName = new File(textField.getText());
         File folder = fileName.isAbsolute() ? fileName : new File(projectFld, fileName.getPath());

--- a/extide/gradle/src/org/netbeans/modules/gradle/newproject/GradleInitPanelVisual.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/newproject/GradleInitPanelVisual.java
@@ -185,7 +185,6 @@ public class GradleInitPanelVisual extends javax.swing.JPanel {
     private void btBrowseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btBrowseActionPerformed
         if ("BROWSE".equals(evt.getActionCommand())) { //NOI18N
             JFileChooser chooser = new JFileChooser();
-            chooser.setCurrentDirectory(null);
             chooser.setDialogTitle(Bundle.TIT_Select_Project_Location());
             chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
             String path = tfLocation.getText();

--- a/extide/gradle/src/org/netbeans/modules/gradle/newproject/ProjectAttributesPanelVisual.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/newproject/ProjectAttributesPanelVisual.java
@@ -252,7 +252,6 @@ public final class ProjectAttributesPanelVisual extends JPanel implements Docume
     private void btBrowseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btBrowseActionPerformed
         if ("BROWSE".equals(evt.getActionCommand())) { //NOI18N
             JFileChooser chooser = new JFileChooser();
-            chooser.setCurrentDirectory(null);
             chooser.setDialogTitle(Bundle.TIT_Select_Project_Location());
             chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
             String path = tfProjectLocation.getText();

--- a/groovy/groovy.samples/src/org/netbeans/modules/groovy/samples/gjdemo/GroovyJavaDemoPanelVisual.java
+++ b/groovy/groovy.samples/src/org/netbeans/modules/groovy/samples/gjdemo/GroovyJavaDemoPanelVisual.java
@@ -126,7 +126,6 @@ public class GroovyJavaDemoPanelVisual extends JPanel implements DocumentListene
         String command = evt.getActionCommand();
         if ("BROWSE".equals(command)) {
             JFileChooser chooser = new JFileChooser();
-            FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
             chooser.setDialogTitle("Select Project Location");
             chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
             String path = this.projectLocationTextField.getText();

--- a/groovy/groovy.samples/src/org/netbeans/modules/groovy/samples/nbprojectgen/NBProjectGeneratorsPanelVisual.java
+++ b/groovy/groovy.samples/src/org/netbeans/modules/groovy/samples/nbprojectgen/NBProjectGeneratorsPanelVisual.java
@@ -126,7 +126,6 @@ public class NBProjectGeneratorsPanelVisual extends JPanel implements DocumentLi
         String command = evt.getActionCommand();
         if ("BROWSE".equals(command)) {
             JFileChooser chooser = new JFileChooser();
-            FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
             chooser.setDialogTitle("Select Project Location");
             chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
             String path = this.projectLocationTextField.getText();

--- a/ide/db.mysql/src/org/netbeans/modules/db/mysql/ui/AdminPropertiesPanel.java
+++ b/ide/db.mysql/src/org/netbeans/modules/db/mysql/ui/AdminPropertiesPanel.java
@@ -164,7 +164,6 @@ public class AdminPropertiesPanel extends javax.swing.JPanel {
     private void chooseFile(JTextField txtField) {
         JFileChooser chooser = new JFileChooser();
         
-        chooser.setCurrentDirectory(null);
         chooser.setFileSelectionMode (JFileChooser.FILES_ONLY);
         
         String path = txtField.getText().trim();

--- a/ide/derby/src/org/netbeans/modules/derby/ui/DerbyPropertiesPanel.java
+++ b/ide/derby/src/org/netbeans/modules/derby/ui/DerbyPropertiesPanel.java
@@ -305,7 +305,6 @@ public class DerbyPropertiesPanel extends javax.swing.JPanel {
 
 private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
         JFileChooser chooser = new JFileChooser();
-        chooser.setCurrentDirectory(null);
         chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
         String location = getInstallLocation();
         if (location.length() > 0) {
@@ -326,7 +325,6 @@ private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRS
 
     private void browseButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_browseButtonActionPerformed
         JFileChooser chooser = new JFileChooser();
-        chooser.setCurrentDirectory(null);
         chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
         String derbySystemHome = getDerbySystemHome();
         if (derbySystemHome.length() > 0) {

--- a/ide/diff/src/org/netbeans/modules/diff/PatchAction.java
+++ b/ide/diff/src/org/netbeans/modules/diff/PatchAction.java
@@ -242,7 +242,7 @@ public class PatchAction extends NodeAction {
                 break;
             }
         }
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, patchDir);
+        chooser.setCurrentDirectory(patchDir);
         chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
         String title = NbBundle.getMessage(PatchAction.class,
             (fo.isData()) ? "TITLE_SelectPatchForFile"

--- a/ide/project.ant.ui/src/org/netbeans/modules/project/ant/ui/VariablePanel.java
+++ b/ide/project.ant.ui/src/org/netbeans/modules/project/ant/ui/VariablePanel.java
@@ -134,7 +134,6 @@ public class VariablePanel extends javax.swing.JPanel implements DocumentListene
 private void browseButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_browseButtonActionPerformed
     JFileChooser chooser = new JFileChooser();
     chooser.setFileHidingEnabled(false);
-    FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
     chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
     chooser.setMultiSelectionEnabled(false);
     chooser.setDialogTitle(NbBundle.getBundle(VariablePanel.class).getString("MSG_Choose_Folder"));

--- a/ide/project.ant/src/org/netbeans/modules/project/ant/ProjectLibraryProvider.java
+++ b/ide/project.ant/src/org/netbeans/modules/project/ant/ProjectLibraryProvider.java
@@ -180,7 +180,7 @@ public class ProjectLibraryProvider implements ArealLibraryProvider<ProjectLibra
     }
 
     public ProjectLibraryArea createArea() {
-        JFileChooser jfc = new JFileChooser();
+        JFileChooser jfc = new JFileChooser(); // XXX remember last-selected dir
         jfc.setApproveButtonText(NbBundle.getMessage(ProjectLibraryProvider.class, "ProjectLibraryProvider.open_or_create"));
         FileFilter filter = new FileFilter() {
             public boolean accept(File f) {
@@ -191,7 +191,6 @@ public class ProjectLibraryProvider implements ArealLibraryProvider<ProjectLibra
             }
         };
         jfc.setFileFilter(filter);
-        FileUtil.preventFileChooserSymlinkTraversal(jfc, null); // XXX remember last-selected dir
         while (jfc.showOpenDialog(Utilities.findDialogParent()) == JFileChooser.APPROVE_OPTION) {
             File f = jfc.getSelectedFile();
             if (filter.accept(f)) {

--- a/ide/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.java
@@ -475,7 +475,7 @@ public class ProjectChooserAccessory extends javax.swing.JPanel
             }
         }
 
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, currDir);
+        chooser.setCurrentDirectory(currDir);
         new ProjectFileView(chooser);
 
         return chooser;

--- a/java/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/BasicProjectInfoPanel.java
+++ b/java/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/BasicProjectInfoPanel.java
@@ -456,7 +456,6 @@ public class BasicProjectInfoPanel extends javax.swing.JPanel implements HelpCtx
 
     private void browseProjectLocationActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_browseProjectLocationActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
         if (projectLocation.getText().length() > 0 && getProjectLocation().exists()) {
             chooser.setSelectedFile(getProjectLocation());
@@ -472,7 +471,6 @@ public class BasicProjectInfoPanel extends javax.swing.JPanel implements HelpCtx
 
     private void browseProjectFolderActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_browseProjectFolderActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
         if (projectFolder.getText().length() > 0 && getProjectFolder().exists()) {
             chooser.setSelectedFile(getProjectFolder());
@@ -490,7 +488,6 @@ public class BasicProjectInfoPanel extends javax.swing.JPanel implements HelpCtx
 
     private void browseAntScriptActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_browseAntScriptActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode (JFileChooser.FILES_ONLY);
         if (antScript.getText().length() > 0 && getAntScript().exists()) {
             chooser.setSelectedFile(getAntScript());

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/library/J2SEVolumeCustomizer.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/library/J2SEVolumeCustomizer.java
@@ -295,7 +295,6 @@ public class J2SEVolumeCustomizer extends javax.swing.JPanel implements Customiz
     private void addResource(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_addResource
         // TODO add your handling code here:
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setAcceptAllFileFilterUsed(false);
         if (this.volumeType.equals(PersistenceLibrarySupport.VOLUME_TYPE_CLASSPATH)) {
             chooser.setMultiSelectionEnabled (true);

--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/LibrariesNode.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/LibrariesNode.java
@@ -1763,7 +1763,7 @@ public final class LibrariesNode extends AbstractNode {
             }
             chooser.enableVariableBasedSelection(true);
             chooser.setFileHidingEnabled(false);
-            FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
+            chooser.setCurrentDirectory(null);
             chooser.setFileSelectionMode( JFileChooser.FILES_AND_DIRECTORIES );
             chooser.setMultiSelectionEnabled( true );
             chooser.setDialogTitle( NbBundle.getMessage( LibrariesNode.class, "LBL_AddJar_DialogTitle" ) ); // NOI18N

--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/EditMediator.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/customizer/EditMediator.java
@@ -284,7 +284,6 @@ public final class EditMediator implements ActionListener, ListSelectionListener
                             }
                             chooser.enableVariableBasedSelection(true);
                             chooser.setFileHidingEnabled(false);
-                            FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
                             chooser.setFileSelectionMode(fileSelectionMode);
                             chooser.setMultiSelectionEnabled( true );
                             chooser.setDialogTitle( NbBundle.getMessage( EditMediator.class, "LBL_AddJar_DialogTitle" ) ); // NOI18N

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/ClasspathPanel.form
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/ClasspathPanel.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
 

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/ClasspathPanel.java
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/ClasspathPanel.java
@@ -710,10 +710,7 @@ public class ClasspathPanel extends javax.swing.JPanel implements HelpCtx.Provid
     }//GEN-LAST:event_removeClasspathActionPerformed
 
     private void addClasspathActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_addClasspathActionPerformed
-        FileChooser chooser;
-        chooser = new FileChooser(model.getBaseFolder(), null);
-
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
+        FileChooser chooser = new FileChooser(model.getBaseFolder(), null);
         chooser.setFileSelectionMode (JFileChooser.FILES_AND_DIRECTORIES);
         chooser.setMultiSelectionEnabled(true);
         chooser.setDialogTitle(NbBundle.getMessage(ClasspathPanel.class, "LBL_Browse_Classpath"));

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/OutputPanel.java
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/OutputPanel.java
@@ -350,7 +350,6 @@ public class OutputPanel extends javax.swing.JPanel implements HelpCtx.Provider 
 
     private void javadocBrowseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_javadocBrowseActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode (JFileChooser.FILES_AND_DIRECTORIES);
         chooser.setMultiSelectionEnabled(false);
         if (lastChosenFile != null) {
@@ -529,7 +528,6 @@ public class OutputPanel extends javax.swing.JPanel implements HelpCtx.Provider 
 
     private void addOutputActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_addOutputActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode (JFileChooser.FILES_AND_DIRECTORIES);
         chooser.setMultiSelectionEnabled(true);
         if (lastChosenFile != null) {

--- a/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerRun.java
+++ b/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerRun.java
@@ -575,7 +575,6 @@ public class CustomizerRun extends JPanel implements HelpCtx.Provider {
 
     private void jButtonWorkingDirectoryBrowseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButtonWorkingDirectoryBrowseActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
         chooser.setMultiSelectionEnabled(false);
         

--- a/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/PanelProjectLocationVisual.java
+++ b/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/wizards/PanelProjectLocationVisual.java
@@ -165,7 +165,6 @@ public class PanelProjectLocationVisual extends SettingsPanel implements Documen
         String command = evt.getActionCommand();        
         if ( "BROWSE".equals( command ) ) { // NOI18N                
             JFileChooser chooser = new JFileChooser ();
-            FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
             chooser.setDialogTitle(NbBundle.getMessage(PanelProjectLocationVisual.class,"LBL_NWP1_SelectProjectLocation"));
             chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
             String path = this.projectLocationTextField.getText();
@@ -311,7 +310,6 @@ public class PanelProjectLocationVisual extends SettingsPanel implements Documen
     
     private static JFileChooser createChooser() {
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode( JFileChooser.DIRECTORIES_ONLY );
         chooser.setAcceptAllFileFilterUsed( false );
         chooser.setName( "Select Project Directory" ); // XXX // NOI18N

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/wizard/DetectPanel.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/wizard/DetectPanel.java
@@ -355,7 +355,6 @@ public class DetectPanel extends javax.swing.JPanel {
     
     private String browse (String oldValue, String title) {
         JFileChooser chooser = new JFileChooser ();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
         if (Utilities.isMac()) {
             //New JDKs and JREs are bundled into package, allow JFileChooser to navigate in

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerRun.java
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerRun.java
@@ -582,7 +582,6 @@ public class CustomizerRun extends JPanel implements HelpCtx.Provider {
 
     private void jButtonWorkingDirectoryBrowseActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButtonWorkingDirectoryBrowseActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
         chooser.setMultiSelectionEnabled(false);
         

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelProjectLocationExtSrc.java
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelProjectLocationExtSrc.java
@@ -451,7 +451,6 @@ class PanelProjectLocationExtSrc extends SettingsPanel {
     private void browseProjectLocation(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_browseProjectLocation
         // TODO add your handling code here:
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setDialogTitle(NbBundle.getMessage(PanelSourceFolders.class,"LBL_NWP1_SelectProjectLocation"));
         chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
         String path = this.projectLocation.getText();

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelProjectLocationVisual.java
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/wizards/PanelProjectLocationVisual.java
@@ -167,7 +167,6 @@ public class PanelProjectLocationVisual extends SettingsPanel implements Documen
         String command = evt.getActionCommand();        
         if ( "BROWSE".equals( command ) ) { // NOI18N                
             JFileChooser chooser = new JFileChooser ();
-            FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
             chooser.setDialogTitle(NbBundle.getMessage(PanelSourceFolders.class,"LBL_NWP1_SelectProjectLocation"));
             chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
             String path = this.projectLocationTextField.getText();
@@ -324,7 +323,6 @@ public class PanelProjectLocationVisual extends SettingsPanel implements Documen
     
     private static JFileChooser createChooser() {
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode( JFileChooser.DIRECTORIES_ONLY );
         chooser.setAcceptAllFileFilterUsed( false );
         chooser.setName( "Select Project Directory" ); // XXX // NOI18N

--- a/java/java.project.ui/src/org/netbeans/spi/java/project/support/ui/EditJarPanel.java
+++ b/java/java.project.ui/src/org/netbeans/spi/java/project/support/ui/EditJarPanel.java
@@ -279,7 +279,6 @@ class EditJarPanel extends javax.swing.JPanel {
         }
         chooser.enableVariableBasedSelection(true);
         chooser.setFileHidingEnabled(false);
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
         chooser.setMultiSelectionEnabled(false);
         chooser.setDialogTitle(LBL_Edit_Jar_Panel_browse());
@@ -315,7 +314,7 @@ class EditJarPanel extends javax.swing.JPanel {
         }
         chooser.enableVariableBasedSelection(true);
         chooser.setFileHidingEnabled(false);
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
+        chooser.setCurrentDirectory(null);
         chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
         chooser.setMultiSelectionEnabled(false);
         chooser.setDialogTitle(LBL_Edit_Jar_Panel_browse());

--- a/java/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/JWSCustomizerPanel.java
+++ b/java/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/JWSCustomizerPanel.java
@@ -476,7 +476,6 @@ public class JWSCustomizerPanel extends JPanel implements HelpCtx.Provider {
 
     private void browseButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_browseButtonActionPerformed
         JFileChooser chooser = new JFileChooser();
-        FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
         chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
         chooser.setMultiSelectionEnabled(false);
         chooser.setFileFilter(new IconFileFilter());

--- a/java/maven/src/org/netbeans/modules/maven/customizer/RunJarPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/RunJarPanel.java
@@ -439,7 +439,6 @@ public class RunJarPanel extends javax.swing.JPanel implements HelpCtx.Provider 
 
     private void btnWorkDirActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnWorkDirActionPerformed
         JFileChooser chooser = new JFileChooser();
-        chooser.setCurrentDirectory(null);
         chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
         chooser.setMultiSelectionEnabled(false);
         

--- a/java/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.java
@@ -426,7 +426,6 @@ public class BasicPanelVisual extends JPanel implements DocumentListener, Window
         String command = evt.getActionCommand();
         if ("BROWSE".equals(command)) { //NOI18N
             JFileChooser chooser = new JFileChooser();
-            chooser.setCurrentDirectory(null);
             chooser.setDialogTitle(TIT_Select_Project_Location());
             chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
             String path = this.projectLocationTextField.getText();

--- a/java/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/UpdateEclipseReferencePanel.java
+++ b/java/projectimport.eclipse.core/src/org/netbeans/modules/projectimport/eclipse/core/UpdateEclipseReferencePanel.java
@@ -233,7 +233,6 @@ class UpdateEclipseReferencePanel extends javax.swing.JPanel implements Document
 
 private void browseProjectButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_browseProjectButtonActionPerformed
     JFileChooser chooser = new JFileChooser();
-    FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
     chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
     chooser.setMultiSelectionEnabled(false);
     chooser.setDialogTitle(org.openide.util.NbBundle.getMessage(UpdateEclipseReferencePanel.class, "TITLE_Select_Eclipse_Project"));
@@ -245,7 +244,6 @@ private void browseProjectButtonActionPerformed(java.awt.event.ActionEvent evt) 
 
 private void browseWorkspaceButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_browseWorkspaceButtonActionPerformed
     JFileChooser chooser = new JFileChooser();
-    FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
     chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
     chooser.setMultiSelectionEnabled(false);
     chooser.setDialogTitle(org.openide.util.NbBundle.getMessage(UpdateEclipseReferencePanel.class, "TITLE_Select_Eclipse_Workspace"));

--- a/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXIconsPanel.java
+++ b/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXIconsPanel.java
@@ -275,7 +275,6 @@ public class JFXIconsPanel extends javax.swing.JPanel {
 
     private void wsIconButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_wsIconButtonActionPerformed
         JFileChooser chooser = new JFileChooser();
-        chooser.setCurrentDirectory(null);
         chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
         chooser.setMultiSelectionEnabled(false);
         chooser.setFileFilter(new IconFileFilter(true));
@@ -300,7 +299,6 @@ public class JFXIconsPanel extends javax.swing.JPanel {
 
     private void splashButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_splashButtonActionPerformed
         JFileChooser chooser = new JFileChooser();
-        chooser.setCurrentDirectory(null);
         chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
         chooser.setMultiSelectionEnabled(false);
         chooser.setFileFilter(new IconFileFilter(false));
@@ -325,7 +323,6 @@ public class JFXIconsPanel extends javax.swing.JPanel {
 
     private void nativeIconButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_nativeIconButtonActionPerformed
         JFileChooser chooser = new JFileChooser();
-        chooser.setCurrentDirectory(null);
         chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
         chooser.setMultiSelectionEnabled(false);
         chooser.setFileFilter(new IconFileFilter(false));

--- a/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXRunPanel.java
+++ b/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/ui/JFXRunPanel.java
@@ -1011,7 +1011,6 @@ private void buttonNewActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIR
 
 private void buttonWorkDirActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_buttonWorkDirActionPerformed
         JFileChooser chooser = new JFileChooser();
-        chooser.setCurrentDirectory(null);
         chooser.setFileSelectionMode (JFileChooser.DIRECTORIES_ONLY);
         chooser.setMultiSelectionEnabled(false);
         
@@ -1154,7 +1153,6 @@ private void buttonWorkDirActionPerformed(java.awt.event.ActionEvent evt) {//GEN
 
 private void buttonWebPageActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_buttonWebPageActionPerformed
     JFileChooser chooser = new JFileChooser();
-    chooser.setCurrentDirectory(null);
     chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
     chooser.setMultiSelectionEnabled(false);
     chooser.setFileFilter(new HtmlFileFilter());

--- a/platform/openide.filesystems.nb/src/org/openide/filesystems/FileChooserBuilder.java
+++ b/platform/openide.filesystems.nb/src/org/openide/filesystems/FileChooserBuilder.java
@@ -85,9 +85,6 @@ public class FileChooserBuilder {
     private BadgeProvider badger;
     private String title;
     private String approveText;
-    //Just in case...
-    private static boolean PREVENT_SYMLINK_TRAVERSAL =
-            !Boolean.getBoolean("allow.filechooser.symlink.traversal"); //NOI18N
     private final String dirKey;
     private File failoverDir;
     private FileFilter filter;
@@ -391,10 +388,6 @@ public class FileChooserBuilder {
         if (badger != null) {
             chooser.setFileView(new CustomFileView(new BadgeIconProvider(badger),
                     chooser.getFileSystemView()));
-        }
-        if (PREVENT_SYMLINK_TRAVERSAL) {
-            FileUtil.preventFileChooserSymlinkTraversal(chooser,
-                    chooser.getCurrentDirectory());
         }
         if (filter != null) {
             chooser.setFileFilter(filter);

--- a/platform/openide.filesystems/src/org/openide/filesystems/FileUtil.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/FileUtil.java
@@ -2138,7 +2138,7 @@ public final class FileUtil extends Object {
      * @since org.openide/1 4.42
      * @deprecated Just use {@link javax.swing.JFileChooser#setCurrentDirectory}. JDK 6 does not have this bug.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public static void preventFileChooserSymlinkTraversal(javax.swing.JFileChooser chooser, File currentDirectory) {
         chooser.setCurrentDirectory(currentDirectory);
     }

--- a/platform/openide.loaders/src/org/openide/actions/SaveAsAction.java
+++ b/platform/openide.loaders/src/org/openide/actions/SaveAsAction.java
@@ -154,7 +154,7 @@ final class SaveAsAction extends AbstractAction implements ContextAwareAction {
         chooser.setMultiSelectionEnabled( false );
         if( null != newFile ) {
             chooser.setSelectedFile( newFile );
-            FileUtil.preventFileChooserSymlinkTraversal( chooser, newFile.getParentFile() );
+            chooser.setCurrentDirectory(newFile.getParentFile());
         }
         File initialFolder = getInitialFolderFrom( newFile );
         if( null != initialFolder )

--- a/rust/rust.project/src/org/netbeans/modules/rust/project/templates/RustProjectTemplatePanelVisual.java
+++ b/rust/rust.project/src/org/netbeans/modules/rust/project/templates/RustProjectTemplatePanelVisual.java
@@ -149,7 +149,6 @@ public class RustProjectTemplatePanelVisual extends JPanel implements DocumentLi
         String command = evt.getActionCommand();
         if ("BROWSE".equals(command)) {
             JFileChooser chooser = new JFileChooser();
-            FileUtil.preventFileChooserSymlinkTraversal(chooser, null);
             chooser.setDialogTitle("Select Project Location");
             chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
             String path = this.projectLocationTextField.getText();


### PR DESCRIPTION
Method is non-functional since java 6 and can be inlined as simple `JFileChooser::setCurrentDirectory` call. A code template used it too.

Reduces warning noise.
