### PR TITLE
Fix ZIP export to open the parent folder of the exported project

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/zip/ExportZIP.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/zip/ExportZIP.java
@@ -115,7 +115,7 @@ public class ExportZIP extends JPanel {
                         }
                         StatusDisplayer.getDefault().setStatusText(MSG_created(zip));
                         try {
-                            Desktop.getDesktop().open(zip);
+                            Desktop.getDesktop().open(zip.getParentFile());
                         } catch (Exception x) {
                             LOG.log(Level.FINE, null, x);
                         }


### PR DESCRIPTION
The previous implementation opened the generated ZIP file directly after export, leading to inconsistent and undesirable behavior across platforms:

- Windows: Behavior depends on the configured default handler. The default is Explorer, which shows the archive view, but third-party tools open their own archive UI, making it harder to locate the parent directory.  
- macOS: Opening a ZIP file triggers automatic extraction by default, so the exported archive would be immediately unpacked.  
- Linux (most distributions): The ZIP file opens in the configured archive manager, showing its contents instead of the containing folder.  

This change opens the parent directory of the exported ZIP, providing more consistent behavior across platforms. It also aligns with how `Desktop.getDesktop().open(...)` is used elsewhere in the repository, for example in [DiscoPlatformIt.java](https://github.com/apache/netbeans/blob/7c3467371f935edb2accf8acf8b6bdd0605d8117/java/java.disco/src/org/netbeans/modules/java/disco/DiscoPlatformIt.java#L147).