### PR TITLE
Add support to show images in markdown preview.

### DIFF
--- a/ide/markdown/src/org/netbeans/modules/markdown/MarkdownViewerElement.java
+++ b/ide/markdown/src/org/netbeans/modules/markdown/MarkdownViewerElement.java
@@ -243,6 +243,7 @@ public class MarkdownViewerElement implements MultiViewElement {
                 HTMLEditorKit kit = (HTMLEditorKit) viewer.getEditorKit();
 
                 HTMLDocument doc = (HTMLDocument) viewer.getDocument();
+                doc.setBase(dataObject.getPrimaryFile().getParent().toURL());
 
                 // Would be better to create some diff and update the changed elemets
                 doc.remove(0, doc.getLength());


### PR DESCRIPTION
Set missing base to use relative paths for loading images.

With this PR you can see the images that I load from a folder called screenshots on the project root folder.
Before it couldn't find them.

Before:
<img width="1403" height="578" alt="image" src="https://github.com/user-attachments/assets/9ac55afe-33ad-4596-a316-dd4c31e00e37" />

After:
<img width="1174" height="743" alt="image" src="https://github.com/user-attachments/assets/d0d6ec79-6a67-4365-aed7-43b733338fed" />


### PR approval and merge checklist:

1. [ ] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [ ] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [ ] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [ ] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))