### PR TITLE
CI: Declare workflow permissions

### DIFF
--- a/.github/workflows/dependency-checks.yml
+++ b/.github/workflows/dependency-checks.yml
@@ -22,6 +22,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab in GitHub UI
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # cancel other workflow run in the same head-base group if it exists
 concurrency: 
   group: dep-checker-${{ github.head_ref || github.run_id }}-${{ github.base_ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,11 @@ on:
   # keep in mind this will have ALL tests enabled
   workflow_dispatch:
 
+# read access for repo checkout and cache restore action; jobs may request more where needed
+permissions:
+  contents: read
+  actions: read
+
 # cancel other PR workflow run in the same head-base group if it exists (e.g. during PR syncs)
 # if this is not a PR run (no github.head_ref and github.base_ref defined), use an UID as group
 concurrency: 
@@ -134,6 +139,9 @@ jobs:
     name: Build Clusters on JDK ${{ matrix.java }}
     if: contains(github.event.pull_request.labels.*.name, 'ci:no-build') == false
     runs-on: ubuntu-latest
+    # write access for cache
+    permissions:
+      actions: write
     timeout-minutes: 40
     strategy:
       matrix:

--- a/.github/workflows/native-binary-build-dlight.nativeexecution.yml
+++ b/.github/workflows/native-binary-build-dlight.nativeexecution.yml
@@ -61,6 +61,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab in GitHub UI
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # cancel other PR workflow run in the same head-base group if it exists (e.g. during PR syncs)
 # if this is not a PR run (no github.head_ref and github.base_ref defined), use an UID as group
 concurrency:

--- a/.github/workflows/native-binary-build-launcher.yml
+++ b/.github/workflows/native-binary-build-launcher.yml
@@ -50,6 +50,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab in GitHub UI
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # cancel other PR workflow run in the same head-base group if it exists (e.g. during PR syncs)
 # if this is not a PR run (no github.head_ref and github.base_ref defined), use an UID as group
 concurrency:

--- a/.github/workflows/native-binary-build-lib.profiler.yml
+++ b/.github/workflows/native-binary-build-lib.profiler.yml
@@ -70,6 +70,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab in GitHub UI
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # cancel other PR workflow run in the same head-base group if it exists (e.g. during PR syncs)
 # if this is not a PR run (no github.head_ref and github.base_ref defined), use an UID as group
 concurrency: 


### PR DESCRIPTION
the workflows were intentionally made to require no noteworthy permissions, this locks it in place.

note: unfortunately this can't be tested before its in master, since the workflow run in this PR would still use the org permissions (even though the log will state otherwise).
