### PR TITLE
NPE in profiler trying to display thread dump

### DIFF
--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/OverviewController.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/OverviewController.java
@@ -464,7 +464,7 @@ public class OverviewController extends AbstractController {
                         // sw.append("&nbsp;&nbsp;<span style=\"color: #0033CC\">"); // NOI18N
                         sb.append("&nbsp;&nbsp;<a name=").append(threadInstance.getInstanceId()).append("></a><b ").append(style).append(">");   // NOI18N
                         // -------------------------------------------------------------------
-                        sb.append("\"").append(htmlize(threadName)).append("\"").append(daemon.booleanValue() ? " daemon" : "").append(" prio=").append(priority);   // NOI18N
+                        sb.append("\"").append(htmlize(threadName)).append("\"").append(Boolean.TRUE.equals(daemon) ? " daemon" : "").append(" prio=").append(priority);   // NOI18N
                         if (threadId != null) {
                             sb.append(" tid=").append(threadId);    // NOI18N
                         }


### PR DESCRIPTION
Without this patch, opening a particular 16Gb heap dump I have (taken from Java 21) and clicking on the hyperlink to show threads fails with

```
java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because "daemon" is null
	at org.netbeans.modules.profiler.heapwalk.OverviewController.getStackTrace(OverviewController.java:467)
	at org.netbeans.modules.profiler.heapwalk.OverviewController.computeThreads(OverviewController.java:277)
	at org.netbeans.modules.profiler.heapwalk.ui.OverviewControllerUI$1.run(OverviewControllerUI.java:125)
	at …
```

Why the `daemon` field would not be present, I do not know.

With the patch, the threads (about 400) are displayed, although the GUI freezes for a couple minutes

```
"AWT-EventQueue-0" #39 [54712] prio=6 os_prio=0 cpu=93980.19ms elapsed=119.05s tid=0x00007921680cb860 nid=54712 runnable  [0x0000792189dfc000]
   java.lang.Thread.State: RUNNABLE
	at sun.text.RuleBasedBreakIterator.handleNext(java.base@21.0.10/RuleBasedBreakIterator.java:940)
	at sun.text.RuleBasedBreakIterator.previous(java.base@21.0.10/RuleBasedBreakIterator.java:639)
	at sun.text.RuleBasedBreakIterator.preceding(java.base@21.0.10/RuleBasedBreakIterator.java:792)
	at javax.swing.text.GlyphView.getBreakSpot(java.desktop@21.0.10/GlyphView.java:792)
	at javax.swing.text.GlyphView.getBreakWeight(java.desktop@21.0.10/GlyphView.java:717)
	at javax.swing.text.html.InlineView.getBreakWeight(java.desktop@21.0.10/InlineView.java:150)
	at javax.swing.text.FlowView$LogicalView.getPreferredSpan(java.desktop@21.0.10/FlowView.java:754)
	at javax.swing.text.FlowView.calculateMinorAxisRequirements(java.desktop@21.0.10/FlowView.java:241)
	at javax.swing.text.ParagraphView.calculateMinorAxisRequirements(java.desktop@21.0.10/ParagraphView.java:709)
	at javax.swing.text.html.ParagraphView.calculateMinorAxisRequirements(java.desktop@21.0.10/ParagraphView.java:162)
	at javax.swing.text.BoxView.checkRequests(java.desktop@21.0.10/BoxView.java:936)
	at javax.swing.text.BoxView.getPreferredSpan(java.desktop@21.0.10/BoxView.java:546)
	at javax.swing.text.html.ParagraphView.getPreferredSpan(java.desktop@21.0.10/ParagraphView.java:258)
	at javax.swing.text.html.LineView.getMinimumSpan(java.desktop@21.0.10/LineView.java:74)
	at javax.swing.text.BoxView.calculateMinorAxisRequirements(java.desktop@21.0.10/BoxView.java:904)
	at javax.swing.text.html.BlockView.calculateMinorAxisRequirements(java.desktop@21.0.10/BlockView.java:146)
	at javax.swing.text.BoxView.checkRequests(java.desktop@21.0.10/BoxView.java:936)
	at javax.swing.text.BoxView.getMinimumSpan(java.desktop@21.0.10/BoxView.java:569)
	at javax.swing.text.html.BlockView.getMinimumSpan(java.desktop@21.0.10/BlockView.java:378)
	at javax.swing.text.BoxView.calculateMinorAxisRequirements(java.desktop@21.0.10/BoxView.java:904)
	at javax.swing.text.html.BlockView.calculateMinorAxisRequirements(java.desktop@21.0.10/BlockView.java:146)
	at javax.swing.text.BoxView.checkRequests(java.desktop@21.0.10/BoxView.java:936)
	at javax.swing.text.BoxView.getMinimumSpan(java.desktop@21.0.10/BoxView.java:569)
	at javax.swing.text.html.BlockView.getMinimumSpan(java.desktop@21.0.10/BlockView.java:378)
	at javax.swing.text.BoxView.calculateMinorAxisRequirements(java.desktop@21.0.10/BoxView.java:904)
	at javax.swing.text.html.BlockView.calculateMinorAxisRequirements(java.desktop@21.0.10/BlockView.java:146)
	at javax.swing.text.BoxView.checkRequests(java.desktop@21.0.10/BoxView.java:936)
	at javax.swing.text.BoxView.setSpanOnAxis(java.desktop@21.0.10/BoxView.java:344)
	at javax.swing.text.BoxView.layout(java.desktop@21.0.10/BoxView.java:709)
	at javax.swing.text.BoxView.setSize(java.desktop@21.0.10/BoxView.java:398)
	at javax.swing.plaf.basic.BasicTextUI$RootView.setSize(java.desktop@21.0.10/BasicTextUI.java:1839)
	at javax.swing.plaf.basic.BasicTextUI.getPreferredSize(java.desktop@21.0.10/BasicTextUI.java:959)
	at com.formdev.flatlaf.ui.FlatEditorPaneUI.getPreferredSize(FlatEditorPaneUI.java:223)
	at javax.swing.JComponent.getPreferredSize(java.desktop@21.0.10/JComponent.java:1734)
	at javax.swing.JEditorPane.getPreferredSize(java.desktop@21.0.10/JEditorPane.java:1392)
	at org.netbeans.lib.profiler.ui.components.HTMLTextArea.getPreferredSize(HTMLTextArea.java:654)
	at javax.swing.ScrollPaneLayout.layoutContainer(java.desktop@21.0.10/ScrollPaneLayout.java:799)
	at com.formdev.flatlaf.ui.FlatScrollPaneUI$FlatScrollPaneLayout.layoutContainer(FlatScrollPaneUI.java:563)
	at java.awt.Container.layout(java.desktop@21.0.10/Container.java:1541)
	at java.awt.Container.doLayout(java.desktop@21.0.10/Container.java:1530)
	at java.awt.Container.validateTree(java.desktop@21.0.10/Container.java:1725)
	at java.awt.Container.validate(java.desktop@21.0.10/Container.java:1660)
	- locked <0x000000041a4b0208> (a java.awt.Component$AWTTreeLock)
	at javax.swing.RepaintManager$3.run(java.desktop@21.0.10/RepaintManager.java:757)
	at …
```

---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>