### PR TITLE
[GITHUB-9198] Do not remove for each variables, even if unused.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/Feature.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/Feature.java
@@ -45,7 +45,12 @@ public enum Feature {
     VIRTUAL_THREADS(19, 21),
 
     /// https://openjdk.org/jeps/440
-    RECORD_PATTERN(19, 21);
+    RECORD_PATTERN(19, 21),
+    
+    /// https://openjdk.org/jeps/456
+    UNNAMED_VARIABLES(21, 22),
+
+    ;
 
     /// preview begin
     public final int PREVIEW;

--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unused.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Unused.java
@@ -19,16 +19,25 @@
 package org.netbeans.modules.java.hints.bugs;
 
 import com.sun.source.tree.Tree.Kind;
+import com.sun.source.util.TreePath;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.ElementKind;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.TreeMaker;
+import org.netbeans.api.java.source.WorkingCopy;
 import org.netbeans.modules.java.editor.base.semantic.UnusedDetector;
 import org.netbeans.modules.java.editor.base.semantic.UnusedDetector.UnusedDescription;
+import org.netbeans.modules.java.hints.Feature;
 import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.editor.hints.Fix;
 import org.netbeans.spi.java.hints.BooleanOption;
 import org.netbeans.spi.java.hints.ErrorDescriptionFactory;
 import org.netbeans.spi.java.hints.Hint;
 import org.netbeans.spi.java.hints.HintContext;
+import org.netbeans.spi.java.hints.JavaFix;
 import org.netbeans.spi.java.hints.JavaFixUtilities;
 import org.netbeans.spi.java.hints.TriggerTreeKind;
 import org.openide.util.NbBundle.Messages;
@@ -45,6 +54,8 @@ import org.openide.util.NbBundle.Messages;
     "TP_UnusedPackagePrivate=Will also detect package private elements that are unused"
 })
 public class Unused {
+
+    private static final Set<ElementKind> SUPPORT_UNNAMED = Set.of(ElementKind.BINDING_VARIABLE, ElementKind.EXCEPTION_PARAMETER, ElementKind.LOCAL_VARIABLE, ElementKind.RESOURCE_VARIABLE);
 
     private static final boolean DETECT_UNUSED_PACKAGE_PRIVATE_DEFAULT = true;
 
@@ -108,10 +119,7 @@ public class Unused {
             case NOT_WRITTEN: message = Bundle.ERR_NotWritten(name);
                 break;
             case NOT_READ: message = Bundle.ERR_NotRead(name);
-                //unclear what can be done with unused binding variables currently (before "_"):
-                if (ud.unusedElementPath().getParentPath().getLeaf().getKind() != Kind.BINDING_PATTERN) {
-                    fix = JavaFixUtilities.safelyRemoveFromParent(ctx, Bundle.FIX_RemoveUsedElement(name), ud.unusedElementPath());
-                }
+                fix = JavaFixUtilities.safelyRemoveFromParent(ctx, Bundle.FIX_RemoveUsedElement(name), ud.unusedElementPath());
                 break;
             case NOT_USED:
                 if (ud.unusedElement().getKind() == ElementKind.CONSTRUCTOR) {
@@ -125,7 +133,39 @@ public class Unused {
             default:
                 throw new IllegalStateException("Unknown unused type: " + ud.reason());
         }
-        return fix != null ? ErrorDescriptionFactory.forName(ctx, ud.unusedElementPath(), message, fix)
-                           : ErrorDescriptionFactory.forName(ctx, ud.unusedElementPath(), message);
+
+        List<Fix> fixes = new ArrayList<>();
+
+        if (fix != null) {
+            fixes.add(fix);
+        }
+
+        if (Feature.UNNAMED_VARIABLES.isEnabled(ctx.getInfo()) &&
+            SUPPORT_UNNAMED.contains(ud.unusedElement().getKind())) {
+            fixes.add(new RenameToUnderscore(ctx.getInfo(), ctx.getPath()).toEditorFix());
+        }
+
+        return ErrorDescriptionFactory.forName(ctx, ud.unusedElementPath(), message, fixes.toArray(Fix[]::new));
+    }
+
+    private static final class RenameToUnderscore extends JavaFix {
+
+        public RenameToUnderscore(CompilationInfo info, TreePath tp) {
+            super(info, tp);
+        }
+
+        @Override
+        @Messages("FIX_RenameToUnderscore=Rename the variable to '_'")
+        protected String getText() {
+            return Bundle.FIX_RenameToUnderscore();
+        }
+
+        @Override
+        protected void performRewrite(TransformationContext ctx) throws Exception {
+            WorkingCopy wc = ctx.getWorkingCopy();
+            TreeMaker make = wc.getTreeMaker();
+            wc.rewrite(ctx.getPath().getLeaf(), make.setLabel(ctx.getPath().getLeaf(), "_"));
+        }
+
     }
 }

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnusedTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/UnusedTest.java
@@ -135,4 +135,74 @@ public class UnusedTest extends NbTestCase {
                 .assertWarnings();
     }
 
+    public void testUnusedForEach() throws Exception {
+        HintTest.create()
+                .input("""
+                       package test;
+                       public class Test {
+                           public void test(String[] args) {
+                               for (String a : args) {}
+                           }
+                       }
+                       """)
+                .run(Unused.class)
+                .assertWarnings("3:20-3:21:verifier:" + Bundle.ERR_NotRead("a"))
+                .findWarning("3:20-3:21:verifier:" + Bundle.ERR_NotRead("a"))
+                .assertFixes();
+    }
+
+    public void testToUndescore1() throws Exception {
+        HintTest.create()
+                .sourceLevel("22")
+                .input("""
+                       package test;
+                       public class Test {
+                           public void test(String[] args) {
+                               String u = "";
+                           }
+                       }
+                       """)
+                .run(Unused.class)
+                .findWarning("3:15-3:16:verifier:" + Bundle.ERR_NotRead("u"))
+                .applyFix(Bundle.FIX_RenameToUnderscore())
+                .assertCompilable()
+                .assertOutput("""
+                              package test;
+                              public class Test {
+                                  public void test(String[] args) {
+                                      String _ = "";
+                                  }
+                              }
+                              """);
+    }
+
+    public void testToUndescore2() throws Exception {
+        HintTest.create()
+                .sourceLevel("22")
+                .input("""
+                       package test;
+                       public class Test {
+                           String u = "";
+                       }
+                       """)
+                .run(Unused.class)
+                .findWarning("2:11-2:12:verifier:" + Bundle.ERR_NotRead("u"))
+                .assertFixes(Bundle.FIX_RemoveUsedElement("u"));
+    }
+
+    public void testToUndescore3() throws Exception {
+        HintTest.create()
+                .sourceLevel("21")
+                .input("""
+                       package test;
+                       public class Test {
+                           public void test(String[] args) {
+                               String u = "";
+                           }
+                       }
+                       """)
+                .run(Unused.class)
+                .findWarning("3:15-3:16:verifier:" + Bundle.ERR_NotRead("u"))
+                .assertFixes(Bundle.FIX_RemoveUsedElement("u"));
+    }
 }

--- a/java/spi.java.hints/src/org/netbeans/spi/java/hints/JavaFixUtilities.java
+++ b/java/spi.java.hints/src/org/netbeans/spi/java/hints/JavaFixUtilities.java
@@ -31,6 +31,7 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.CompoundAssignmentTree;
 import com.sun.source.tree.DoWhileLoopTree;
+import com.sun.source.tree.EnhancedForLoopTree;
 import com.sun.source.tree.ExpressionStatementTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
@@ -1835,6 +1836,21 @@ public class JavaFixUtilities {
         }
 
         private static boolean canSafelyRemove(CompilationInfo info, TreePath tp) {
+            if (tp.getParentPath() != null) {
+                //cannot remove from some parent trees:
+                switch (tp.getParentPath().getLeaf().getKind()) {
+                    case BINDING_PATTERN -> {
+                        return false;
+                    }
+                    case ENHANCED_FOR_LOOP -> {
+                        EnhancedForLoopTree loop = (EnhancedForLoopTree) tp.getParentPath().getLeaf();
+
+                        if (loop.getVariable() == tp.getLeaf()) {
+                            return false;
+                        }
+                    }
+                }
+            }
             AtomicBoolean ret = new AtomicBoolean(true);
             Element el = info.getTrees().getElement(tp);
             if (el != null) {

--- a/java/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/JavaFixUtilitiesTest.java
+++ b/java/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/JavaFixUtilitiesTest.java
@@ -39,6 +39,7 @@ import javax.lang.model.util.ElementFilter;
 import org.netbeans.modules.java.hints.spiimpl.TestBase;
 import org.netbeans.modules.java.hints.spiimpl.hints.HintsInvoker;
 import org.netbeans.modules.java.hints.providers.spi.Trigger.PatternDescription;
+import org.netbeans.modules.java.hints.spiimpl.SyntheticFix;
 import org.netbeans.modules.java.hints.spiimpl.options.HintsSettings;
 import org.netbeans.modules.java.hints.spiimpl.pm.PatternCompilerUtilities;
 import org.netbeans.modules.java.source.parsing.JavacParser;
@@ -507,6 +508,102 @@ public class JavaFixUtilitiesTest extends TestBase {
                            "        System.err.println(\"a\");\n" +
                            "    }\n" +
 		           "}\n");
+    }
+
+    public void testRemovedFromForEach1() throws Exception {
+        performRemoveFromParentTest("""
+                                    package test;
+                                    import java.io.InputStream;
+                                    public class Test {
+                                        private void t(String[] args) throws Exception {
+                                            for (String a : args)
+                                                System.err.println();
+                                        }
+                                    }
+                                    """,
+                                    "System.err.println();",
+                                    """
+                                    package test;
+                                    import java.io.InputStream;
+                                    public class Test {
+                                        private void t(String[] args) throws Exception {
+                                            for (String a : args) {
+                                            }
+                                        }
+                                    }
+                                    """,
+                                    true);
+    }
+
+    public void testRemovedFromForEach2() throws Exception {
+        performRemoveFromParentTest("""
+                                    package test;
+                                    import java.io.InputStream;
+                                    public class Test {
+                                        private void t(String[] args) throws Exception {
+                                            for (String a : args)
+                                                System.err.println();
+                                        }
+                                    }
+                                    """,
+                                    "System.err.println();",
+                                    """
+                                    package test;
+                                    import java.io.InputStream;
+                                    public class Test {
+                                        private void t(String[] args) throws Exception {
+                                            for (String a : args) {
+                                            }
+                                        }
+                                    }
+                                    """,
+                                    true);
+    }
+
+    public void testRemovedFromForEach3() throws Exception {
+        performRemoveFromParentTest("""
+                                    package test;
+                                    import java.io.InputStream;
+                                    public class Test {
+                                        private void t(String[] args) throws Exception {
+                                            for (String a : args)
+                                                System.err.println();
+                                        }
+                                    }
+                                    """,
+                                    "String a",
+                                    null,
+                                    true);
+    }
+
+    public void testRemovedFromForEach4() throws Exception {
+        performRemoveFromParentTest("""
+                                    package test;
+                                    import java.util.List;
+                                    public class Test {
+                                        private void t() throws Exception {
+                                            for (String a : List.of("")
+                                                System.err.println();
+                                        }
+                                    }
+                                    """,
+                                    "java.util.List.of($args)",
+                                    null,
+                                    true);
+    }
+
+    public void testRemoveBindingPattern1() throws Exception {
+        performRemoveFromParentTest("""
+                                    package test;
+                                    public class Test {
+                                        private void t(Object o) throws Exception {
+                                            if (o instanceof String str) {}
+                                        }
+                                    }
+                                    """,
+                                    "String str",
+                                    null,
+                                    true);
     }
 
     public void testUnresolvableTarget() throws Exception {
@@ -1396,13 +1493,19 @@ public class JavaFixUtilitiesTest extends TestBase {
     }
 
     public void performRemoveFromParentTest(String code, String rule, String golden) throws Exception {
+        performRemoveFromParentTest(code, rule, golden, false);
+    }
+
+    public void performRemoveFromParentTest(String code, String rule, String golden, boolean safelyRemove) throws Exception {
 	prepareTest("test/Test.java", code);
 
         HintDescription hd = HintDescriptionFactory.create()
                                                    .setTrigger(PatternDescription.create(rule, Collections.<String, String>emptyMap()))
                                                    .setWorker(new HintDescription.Worker() {
             @Override public Collection<? extends ErrorDescription> createErrors(HintContext ctx) {
-                return Collections.singletonList(ErrorDescriptionFactory.forName(ctx, ctx.getPath(), "", JavaFixUtilities.removeFromParent(ctx, "", ctx.getPath())));
+                Fix fix = safelyRemove ? JavaFixUtilities.safelyRemoveFromParent(ctx, "", ctx.getPath())
+                                       : JavaFixUtilities.removeFromParent(ctx, "", ctx.getPath());
+                return Collections.singletonList(ErrorDescriptionFactory.forName(ctx, ctx.getPath(), "", fix));
             }
         }).produce();
 
@@ -1410,11 +1513,22 @@ public class JavaFixUtilitiesTest extends TestBase {
 
         assertEquals(computeHints.toString(), 1, computeHints.size());
 
-        Fix fix = computeHints.get(0).getFixes().getFixes().get(0);
+        List<Fix> fixes = computeHints.get(0).getFixes().getFixes();
 
-	fix.implement();
+        assertEquals(String.valueOf(fixes), 1, fixes.size());
 
-        assertEquals(golden, doc.getText(0, doc.getLength()));
+        if (golden != null) {
+            Fix fix = fixes.get(0);
+
+            fix.implement();
+
+            assertEquals(golden, doc.getText(0, doc.getLength()));
+        } else {
+            Fix fix = fixes.get(0);
+
+            assertTrue(String.valueOf(fixes),
+                       fix instanceof SyntheticFix);
+        }
     }
  
     static {


### PR DESCRIPTION
For code like:
```
for (String s : java.util.List.of("")) {}
```

the `s` is unused, and there's a fix proposed to remove the variable. That obviously cannot work.

There's already a check in `Unused` that disables that fix for binding patterns/variables. It could be enhanced for the for each, but it does not feel right - the `JavaFixUtilities.safelyRemoveFromParent` should do that.

So, this PR tweak `JavaFixUtilities.safelyRemoveFromParent` so that it won't try to remove the binding variables, and for-each variables.

It also adds a new fix to change the name of the variable to `_`, for source level >= 22.

closes #9198 

---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>