### PR TITLE
CI: Update upload/download actions and switch to direct upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,25 +180,25 @@ jobs:
 
       - name: Upload Workspace
         if: ${{ (matrix.java == '21') && success() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
-          name: build
           path: /tmp/build.tar.zst
-          compression-level: 0
+          archive: false
           retention-days: 2
           if-no-files-found: error
           
       - name: Create Dev Build
         if: ${{ matrix.java == '21' && contains(github.event.pull_request.labels.*.name, 'ci:dev-build') && success() }}
-        run: ant $OPTS -quiet -Dcluster.config=$CLUSTER_CONFIG zip-cluster-config
+        run: |
+          ant $OPTS -quiet -Dcluster.config=$CLUSTER_CONFIG zip-cluster-config
+          mv nbbuild/NetBeans-*.zip nbbuild/dev-build_${{github.event.pull_request.number || github.run_id}}.zip
 
       - name: Upload Dev Build
         if: ${{ matrix.java == '21' && contains(github.event.pull_request.labels.*.name, 'ci:dev-build') && success() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
-          name: dev-build_${{github.event.pull_request.number || github.run_id}}
-          path: nbbuild/NetBeans-*.zip
-          compression-level: 0
+          path: nbbuild/dev-build_*.zip
+          archive: false
           retention-days: 7
           if-no-files-found: error
 
@@ -267,9 +267,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       # tar on MacOS is not aware of zstd "tar --zstd -xf build.tar.zst" doesn't work
       - name: Extract on MacOS
@@ -359,9 +359,9 @@ jobs:
 
       - name: Download Build
         if: ${{ needs.base-build.result == 'success' && !cancelled() }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         if: ${{ needs.base-build.result == 'success' && !cancelled() }}
@@ -403,9 +403,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -494,9 +494,9 @@ jobs:
           distribution: ${{ env.DEFAULT_JAVA_DISTRIBUTION }}
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -544,9 +544,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -876,9 +876,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -1007,9 +1007,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -1170,9 +1170,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -1305,9 +1305,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -1494,9 +1494,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -1550,9 +1550,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -1610,9 +1610,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -1655,9 +1655,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -1833,9 +1833,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -1883,9 +1883,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -1934,9 +1934,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -1982,9 +1982,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -2227,9 +2227,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -2320,9 +2320,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -2399,9 +2399,9 @@ jobs:
       # - - -
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -2528,9 +2528,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -2569,9 +2569,9 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
       - name: Download Build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: build
+          name: build.tar.zst 
 
       - name: Extract
         run: tar --zstd -xf build.tar.zst
@@ -2653,12 +2653,12 @@ jobs:
       - name: Delete Workspace Artifact
         uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
         with:
-          name: build
+          name: build.tar.zst 
           useGlob: false
 
       - name: Delete Dev Build Artifact
         uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
         if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:dev-build') && cancelled() }}
         with:
-          name: dev-build_${{github.event.pull_request.number || github.run_id}}
+          name: dev-build_${{github.event.pull_request.number || github.run_id}}.zip
           useGlob: false

--- a/.github/workflows/native-binary-build-dlight.nativeexecution.yml
+++ b/.github/workflows/native-binary-build-dlight.nativeexecution.yml
@@ -97,7 +97,7 @@ jobs:
           ls -l -R ${SOURCES}
 
       - name: Upload native sources
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: nativeexecution-external-sources
           path: ide/dlight.nativeexecution/build/sources/
@@ -113,7 +113,7 @@ jobs:
     steps:
 
       - name: Download sources
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: nativeexecution-external-sources
 
@@ -129,7 +129,7 @@ jobs:
         working-directory: ide/dlight.nativeexecution/tools
 
       - name: Upload artifact Linux 64 bit
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: Linux-x86_64
           path: ide/dlight.nativeexecution/tools/buildall/
@@ -147,7 +147,7 @@ jobs:
 #    steps:
 #
 #      - name: Download sources
-#        uses: actions/download-artifact@v7
+#        uses: actions/download-artifact@v8
 #        with:
 #          name: nativeexecution-external-sources
 #
@@ -161,7 +161,7 @@ jobs:
 #        shell: bash
 #        working-directory: ide/dlight.nativeexecution/tools
 #      - name: Upload artifact Windows 64 bit
-#        uses: actions/upload-artifact@v6
+#        uses: actions/upload-artifact@v7
 #        with:
 #          name: Windows-x86_64
 #          path: ide/dlight.nativeexecution/tools/buildall/
@@ -177,7 +177,7 @@ jobs:
     steps:
 
       - name: Download sources
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: nativeexecution-external-sources
 
@@ -191,7 +191,7 @@ jobs:
         working-directory: ide/dlight.nativeexecution/tools
 
       - name: Upload artifact macOS x86_64
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: MacOSX-x86_64
           path: ide/dlight.nativeexecution/tools/buildall/
@@ -206,7 +206,7 @@ jobs:
     steps:
 
       - name: Download sources
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: nativeexecution-external-sources
 
@@ -220,7 +220,7 @@ jobs:
         working-directory: ide/dlight.nativeexecution/tools
 
       - name: Upload artifact macOS arm64
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: MacOSX-arm_64
           path: ide/dlight.nativeexecution/tools/buildall/
@@ -241,7 +241,7 @@ jobs:
       run: mkdir -p myfiles/
 
     - name: Download artifacts from predecessor jobs
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v8
       with:
         path: myfiles/
 
@@ -270,7 +270,7 @@ jobs:
          echo ""                                                               >> "$BUILDINFO"
 
     - name: Upload bundle
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: nativeexecution-external-binaries
         path: myfiles/

--- a/.github/workflows/native-binary-build-launcher.yml
+++ b/.github/workflows/native-binary-build-launcher.yml
@@ -89,7 +89,7 @@ jobs:
           ls -l -R ${SOURCES}
 
       - name: Upload native sources
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: launcher-external-sources
           path: nbbuild/build/native/launcher/sources/
@@ -108,7 +108,7 @@ jobs:
         run: sudo apt install mingw-w64 mingw-w64-tools
 
       - name: Download sources
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: launcher-external-sources
 
@@ -122,7 +122,7 @@ jobs:
         working-directory: platform/o.n.bootstrap/launcher/windows/
 
       - name: Upload bootstrap artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: launcher-bootstrap-bin
           path: platform/o.n.bootstrap/launcher/windows/build/
@@ -138,7 +138,7 @@ jobs:
         working-directory: harness/apisupport.harness/windows-launcher-src
 
       - name: Upload harness artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: launcher-harness-bin
           path: harness/apisupport.harness/windows-launcher-src/build/
@@ -154,7 +154,7 @@ jobs:
         working-directory: nb/ide.launcher/windows
 
       - name: Upload IDE artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: launcher-ide-bin
           path: nb/ide.launcher/windows/build/
@@ -174,7 +174,7 @@ jobs:
       run: mkdir -p myfiles/
 
     - name: Download artifacts from predecessor jobs
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v8
       with:
         path: myfiles/
 
@@ -206,7 +206,7 @@ jobs:
          echo ""                                                               >> "$BUILDINFO"
 
     - name: Upload bundle
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: launcher-external-binaries
         path: myfiles/

--- a/.github/workflows/native-binary-build-lib.profiler.yml
+++ b/.github/workflows/native-binary-build-lib.profiler.yml
@@ -121,7 +121,7 @@ jobs:
           cp NOTICE ${SOURCES}/NOTICE
           ls -l -R ${SOURCES}
       - name: Upload native sources 
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: profiler-external-sources-ASF
           path: profiler/lib.profiler/build/sources/
@@ -137,7 +137,7 @@ jobs:
     steps:
 
       - name: Download sources
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: profiler-external-sources-ASF
         
@@ -174,13 +174,13 @@ jobs:
       #   Upload interim build artifacts to GitHub
       #
       - name: Upload artifact Linux 64 bit
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: linux-amd64
           path: profiler/lib.profiler/release/lib/deployed/jdk16/linux-amd64/
           if-no-files-found: error
       - name: Upload artifact Linux 32 bit
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: linux
           path: profiler/lib.profiler/release/lib/deployed/jdk16/linux/
@@ -198,7 +198,7 @@ jobs:
     steps:
 
       - name: Download sources
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: profiler-external-sources-ASF
 
@@ -245,13 +245,13 @@ jobs:
       #   Upload interim build artifacts to GitHub
       #
       - name: Upload artifact Windows 64 bit
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: windows-amd64
           path: profiler/lib.profiler/release/lib/deployed/jdk16/windows-amd64/
           if-no-files-found: error
       - name: Upload artifact Windows 32 bit
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: windows
           path: profiler/lib.profiler/release/lib/deployed/jdk16/windows/
@@ -267,7 +267,7 @@ jobs:
     steps:
 
       - name: Download sources
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: profiler-external-sources-ASF
 
@@ -291,7 +291,7 @@ jobs:
       #   Upload interim build artifacts to GitHub
       #
       - name: Upload artifact MacOS 64 bit
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: mac
           path: profiler/lib.profiler/release/lib/deployed/jdk16/mac/
@@ -312,7 +312,7 @@ jobs:
       run: mkdir -p myfiles/lib/deployed/jdk16
 
     - name: Download artifacts from predecessor jobs
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v8
       with:
         path: myfiles/lib/deployed/jdk16
         
@@ -342,7 +342,7 @@ jobs:
 
 
     - name: Upload bundle
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: profiler-external-binaries-ASF
         path: myfiles/


### PR DESCRIPTION
dev-builds (and the pipeline workspace artifact) were zipped twice due to a limitation of the action, this fixes it with the update. (new `archive: false` param)

in other words: the dev-build artifact is uploaded 1:1 without extra wrapping by github, making it easier to use when downloaded manually