### PR TITLE
Fixes some "invalid project.xml" warnings

### DIFF
--- a/ide/languages.toml/nbproject/project.xml
+++ b/ide/languages.toml/nbproject/project.xml
@@ -230,11 +230,6 @@
                         <recursive/>
                         <compile-dependency/>
                     </test-dependency>
-                    <test-dependency>
-                        <code-name-base>org.openide.util.lookup</code-name-base>
-                        <compile-dependency/>
-                        <test/>
-                    </test-dependency>
                 </test-type>
             </test-dependencies>
             <public-packages/>

--- a/ide/xml.lexer/nbproject/project.xml
+++ b/ide/xml.lexer/nbproject/project.xml
@@ -71,10 +71,6 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.netbeans.modules.editor.mimelookup.impl</code-name-base>
-                        <recursive/>
-                    </test-dependency>
-                    <test-dependency>
                         <code-name-base>org.netbeans.modules.masterfs</code-name-base>
                     </test-dependency>
                 </test-type>

--- a/java/api.maven/nbproject/project.xml
+++ b/java/api.maven/nbproject/project.xml
@@ -111,11 +111,6 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.netbeans.modules.maven</code-name-base>
-                        <recursive/>
-                        <compile-dependency/>
-                    </test-dependency>
-                    <test-dependency>
                         <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
                         <recursive/>
                         <compile-dependency/>

--- a/java/gradle.java/nbproject/project.xml
+++ b/java/gradle.java/nbproject/project.xml
@@ -374,11 +374,6 @@
                         <recursive/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.netbeans.modules.gradle</code-name-base>
-                        <recursive/>
-                        <test/>
-                    </test-dependency>
-                    <test-dependency>
                         <code-name-base>org.netbeans.modules.project.dependency</code-name-base>
                         <compile-dependency/>
                     </test-dependency>

--- a/webcommon/javascript2.vue/nbproject/project.xml
+++ b/webcommon/javascript2.vue/nbproject/project.xml
@@ -188,10 +188,6 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.netbeans.modules.javascript2.jade</code-name-base>
-                        <compile-dependency/>
-                    </test-dependency>
-                    <test-dependency>
                         <code-name-base>org.netbeans.modules.editor.mimelookup</code-name-base>
                         <recursive/>
                         <compile-dependency/>


### PR DESCRIPTION
Removes duplicated dependency declarations in

 - ide/languages.toml
 - ide/xml.lexer
 - java/api.maven
 - java/gradle.java
 - webcommon/javascript2.vue


log msg looks like:
```
WARNING [org.netbeans.modules.apisupport.project]: Invalid project.xml (java/gradle.java); testdependency org.netbeans.modules.gradle is duplicated!
```
occurs during indexing or project loading.