### PR TITLE
FISH-12969 Payara Server Startup Fails in Apache NetBeans IDE Due to the CRaCCheckpointTo Option

### DIFF
--- a/enterprise/payara.tooling/nbproject/org-netbeans-modules-payara-tooling.sig
+++ b/enterprise/payara.tooling/nbproject/org-netbeans-modules-payara-tooling.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.26
+#Version 2.27
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable
@@ -1238,6 +1238,7 @@ CLSS public final org.netbeans.modules.payara.tooling.data.JDKVersion
 meth public boolean equals(java.lang.Object)
 meth public boolean ge(org.netbeans.modules.payara.tooling.data.JDKVersion)
 meth public boolean gt(org.netbeans.modules.payara.tooling.data.JDKVersion)
+meth public boolean isOptionSupported(org.netbeans.modules.payara.tooling.server.parser.JvmConfigReader$JvmOption,java.lang.String)
 meth public boolean le(org.netbeans.modules.payara.tooling.data.JDKVersion)
 meth public boolean lt(org.netbeans.modules.payara.tooling.data.JDKVersion)
 meth public int hashCode()
@@ -1248,8 +1249,6 @@ meth public java.util.Optional<java.lang.Short> getUpdate()
 meth public java.util.Optional<java.lang.String> getVM()
 meth public java.util.Optional<java.lang.String> getVendor()
 meth public short getMajor()
-meth public static boolean isCorrectJDK(java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion>,java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion>)
-meth public static boolean isCorrectJDK(org.netbeans.modules.payara.tooling.data.JDKVersion,java.util.Optional<java.lang.String>,java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion>,java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion>)
 meth public static org.netbeans.modules.payara.tooling.data.JDKVersion getDefaultPlatformVersion()
 meth public static org.netbeans.modules.payara.tooling.data.JDKVersion toValue(java.lang.String)
 meth public static org.netbeans.modules.payara.tooling.data.JDKVersion toValue(java.lang.String,java.lang.String)

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/JDKVersion.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/JDKVersion.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.payara.tooling.data;
 
 import java.util.Optional;
+import org.netbeans.modules.payara.tooling.server.parser.JvmConfigReader;
 
 public final class JDKVersion {
 
@@ -283,24 +284,51 @@ public final class JDKVersion {
         return IDE_JDK_VERSION;
     }
 
-    public static boolean isCorrectJDK(JDKVersion jdkVersion, Optional<String> vendorOrVM, Optional<JDKVersion> minVersion, Optional<JDKVersion> maxVersion) {
+    public boolean isOptionSupported(
+            JvmConfigReader.JvmOption jvmOption,
+            String javaHome) {
+
         boolean correctJDK = true;
 
-        if (vendorOrVM.isPresent()) {
-            correctJDK = jdkVersion.getVendor().map(vendor -> vendor.contains(vendorOrVM.get())).orElse(false)
-                    || jdkVersion.getVM().map(vm -> vm.contains(vendorOrVM.get())).orElse(false);
+        if (jvmOption.vendorOrVM.isPresent()) {
+            correctJDK
+                    = this.getVendor()
+                            .map(v -> v.contains(jvmOption.vendorOrVM.get()))
+                            .orElse(false)
+                    || this.getVM()
+                            .map(vm -> vm.contains(jvmOption.vendorOrVM.get()))
+                            .orElse(false);
         }
-        if (correctJDK && minVersion.isPresent()) {
-            correctJDK = jdkVersion.ge(minVersion.get());
+
+        if (correctJDK && jvmOption.minVersion.isPresent()) {
+            correctJDK = this.ge(jvmOption.minVersion.get());
         }
-        if (correctJDK && maxVersion.isPresent()) {
-            correctJDK = jdkVersion.le(maxVersion.get());
+
+        if (correctJDK && jvmOption.maxVersion.isPresent()) {
+            correctJDK = this.le(jvmOption.maxVersion.get());
+        }
+
+        if (correctJDK
+                && jvmOption.option != null
+                && jvmOption.option.matches("^-XX:[+-]?CRaC.*")) {
+
+            correctJDK = this.isCRaCSupported(javaHome);
         }
         return correctJDK;
     }
 
-    public static boolean isCorrectJDK(Optional<JDKVersion> minVersion, Optional<JDKVersion> maxVersion) {
-        return isCorrectJDK(IDE_JDK_VERSION, Optional.empty(), minVersion, maxVersion);
+    /**
+     * Checks whether the given JDK installation supports CRaC by verifying the
+     * presence of the lib/criu directory.
+     *
+     * @param javaHome Java home directory to check
+     * @return true if CRaC-enabled JDK
+     */
+    private boolean isCRaCSupported(String javaHome) {
+        return Optional.ofNullable(javaHome)
+                .map(home -> new java.io.File(home, "lib/criu"))
+                .map(java.io.File::exists)
+                .orElse(false);
     }
 
     static {

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/ServerTasks.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/ServerTasks.java
@@ -157,11 +157,18 @@ public class ServerTasks {
             }
         }
 
-        JDKVersion javaVersion = args.getJavaVersion() == null ? JDKVersion.getDefaultPlatformVersion() : args.getJavaVersion() ;
+        JDKVersion javaVersion = args.getJavaVersion() == null ? JDKVersion.getDefaultPlatformVersion() : args.getJavaVersion();
+        String selectedJavaHome
+                = args.getJavaHome() != null
+                ? args.getJavaHome()
+                : System.getProperty("java.home");
         List<String> optList
                 = jvmConfigReader.getJvmOptions()
                         .stream()
-                        .filter(fullOption -> JDKVersion.isCorrectJDK(javaVersion, fullOption.vendorOrVM, fullOption.minVersion, fullOption.maxVersion))
+                        .filter(fullOption
+                                -> javaVersion.isOptionSupported(
+                                fullOption,
+                                selectedJavaHome))
                         .map(fullOption -> fullOption.option)
                         .collect(toList());
 


### PR DESCRIPTION
Payara Server startup may fail in Apache NetBeans when domain.xml contains
the JVM option:

`-XX:CRaCCheckpointTo=...`

This option is only supported by CRaC-enabled JDKs. The IDE 
previously filtered JVM options only by version and vendor, without checking
whether the selected JDK supports CRaC. As a result, non-CRaC JDKs failed to
start with “Unrecognized VM option” errors.

This PR enhances `JDKVersion.isCorrectJDK(...)` to additionally validate
CRaC-related options. CRaC options are now applied only if the selected
server JDK (javaHome) contains lib/criu, indicating CRaC support.

No changes to existing vendor/version logic. Standard JDK behavior remains
unchanged.