### PR TITLE
Form Editor: When designing form larger than design area scrolling the form needs to available

### DIFF
--- a/java/form/src/org/netbeans/modules/form/HandleLayer.java
+++ b/java/form/src/org/netbeans/modules/form/HandleLayer.java
@@ -1231,15 +1231,26 @@ public class HandleLayer extends JPanel implements MouseListener, MouseMotionLis
             }
         }
         Component[] clicked = getDeepestComponentsAt(formDesigner.getComponentLayer(), p);
-        if (clicked != null && clicked.length > 0 && clicked[0] instanceof JTabbedPane) {
-            JTabbedPane tabbedPane = (JTabbedPane)clicked[0];
-            p = convertPointToComponent(p, tabbedPane);
-            for (int i=0,n=tabbedPane.getTabCount(); i < n; i++) {
-                Rectangle rect = tabbedPane.getBoundsAt(i);
-                if (rect != null && rect.contains(p)) {
-                    tabbedPane.setSelectedIndex(i);
-                    break;
+        if (clicked != null && clicked.length > 0) {
+            Point pointInComponent = convertPointToComponent(p, clicked[0]);
+            if (clicked[0] instanceof JTabbedPane tabbedPane) {
+                for (int i = 0, n = tabbedPane.getTabCount(); i < n; i++) {
+                    Rectangle rect = tabbedPane.getBoundsAt(i);
+                    if (rect != null && rect.contains(pointInComponent)) {
+                        tabbedPane.setSelectedIndex(i);
+                        break;
+                    }
                 }
+            } else if (clicked[0] instanceof JScrollBar scrollbar) {
+                double position;
+                if (scrollbar.getOrientation() == JScrollBar.VERTICAL) {
+                    double offset = scrollbar.getVisibleAmount() * (((double) scrollbar.getHeight()) / scrollbar.getMaximum());
+                    position = ((double) pointInComponent.y - (offset / 2)) / (scrollbar.getHeight() - offset);
+                } else {
+                    double offset = scrollbar.getVisibleAmount() * (((double) scrollbar.getWidth()) / scrollbar.getMaximum());
+                    position = ((double) pointInComponent.x - (offset / 2)) / (scrollbar.getWidth() - offset);
+                }
+                scrollbar.setValue((int) (scrollbar.getMaximum() * position));
             }
         }
     }


### PR DESCRIPTION
When a larger form is designed it can exceed the available screen space and is placed in a JScrollPane. In that case the designer needs to be able to adjust the design time scroll position so that positions become accessible that are currently not in the default view port:

<img width="922" height="806" alt="grafik" src="https://github.com/user-attachments/assets/d017b570-d97b-4814-8b28-4487910fb42d" />

This does not implement full scrollbar behavior, but just allows to change the scrollbar position by clicking the position the scrollbar shall update to.