### PR TITLE
Provide access to LazyConstant via internal fallback module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -281,6 +281,9 @@ jobs:
         if: ${{ matrix.java == '21' }}
         run: .github/retry.sh ant $OPTS -f platform/masterfs test
 
+      - name: platform/o.n.jdk.fallback
+        run: ant $OPTS -f platform/o.n.jdk.fallback test
+
       - name: Commit Validation tests
         run: .github/retry.sh ant $OPTS -Dcluster.config=$CLUSTER_CONFIG commit-validation
 

--- a/java/maven.indexer/nbproject/project.xml
+++ b/java/maven.indexer/nbproject/project.xml
@@ -26,6 +26,15 @@
             <code-name-base>org.netbeans.modules.maven.indexer</code-name-base>
             <module-dependencies>
                 <dependency>
+                    <code-name-base>o.n.jdk.fallback</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>0-1</release-version>
+                        <specification-version>0.1</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>com.google.gson</code-name-base>
                     <run-dependency/>
                 </dependency>

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryQueries.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryQueries.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -61,6 +62,7 @@ import org.apache.maven.search.backend.smo.SmoSearchBackend;
 import org.apache.maven.search.backend.smo.SmoSearchBackendFactory;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NullAllowed;
+import org.netbeans.jdk.fallback.lang.NBLazyConstant;
 import org.netbeans.modules.maven.indexer.api.NBArtifactInfo;
 import org.netbeans.modules.maven.indexer.api.NBGroupInfo;
 import org.netbeans.modules.maven.indexer.api.NBVersionInfo;
@@ -88,7 +90,12 @@ final class NexusRepositoryQueries implements
 
     private static final Logger LOGGER = Logger.getLogger(NexusRepositoryQueries.class.getName());
 
-    private SmoSearchBackend smo;
+    private final Supplier<SmoSearchBackend> smo = NBLazyConstant.of(() -> SmoSearchBackendFactory.create(
+            SmoSearchBackendFactory.DEFAULT_BACKEND_ID,
+            SmoSearchBackendFactory.DEFAULT_REPOSITORY_ID,
+            SmoSearchBackendFactory.DEFAULT_SMO_URI,
+            new Java11HttpClientTransport(SMORequestResult.REQUEST_TIMEOUT))
+    );
     private final NexusRepositoryIndexManager indexer;
 
     NexusRepositoryQueries(NexusRepositoryIndexManager indexer) {
@@ -887,16 +894,8 @@ final class NexusRepositoryQueries implements
         return toRet;
     }
 
-    synchronized SmoSearchBackend getSMO() {
-        if (smo == null) {
-            smo = SmoSearchBackendFactory.create(
-                    SmoSearchBackendFactory.DEFAULT_BACKEND_ID,
-                    SmoSearchBackendFactory.DEFAULT_REPOSITORY_ID,
-                    SmoSearchBackendFactory.DEFAULT_SMO_URI,
-                    new Java11HttpClientTransport(SMORequestResult.REQUEST_TIMEOUT)
-            );
-        }
-        return smo;
+    SmoSearchBackend getSMO() {
+        return smo.get();
     }
 
     private interface RepoAction {

--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -215,6 +215,7 @@ nb.cluster.platform=\
         o.n.html.ko4j,\
         o.n.html.presenters.spi,\
         o.n.html.xhr4j,\
+        o.n.jdk.fallback,\
         o.n.swing.laf.dark,\
         o.n.swing.laf.flatlaf,\
         o.n.swing.outline,\

--- a/platform/o.n.jdk.fallback/build.xml
+++ b/platform/o.n.jdk.fallback/build.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project basedir="." default="build" name="platform/o.n.jdk.fallback">
+    <description>Builds, tests, and runs the project org.netbeans.jdk.fallback</description>
+    <import file="../../nbbuild/templates/projectized.xml"/>
+</project>

--- a/platform/o.n.jdk.fallback/manifest.mf
+++ b/platform/o.n.jdk.fallback/manifest.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+AutoUpdate-Show-In-Client: false
+AutoUpdate-Essential-Module: true
+OpenIDE-Module: o.n.jdk.fallback/0
+OpenIDE-Module-Localizing-Bundle: org/netbeans/jdk/fallback/Bundle.properties
+OpenIDE-Module-Specification-Version: 0.1

--- a/platform/o.n.jdk.fallback/nbproject/project.properties
+++ b/platform/o.n.jdk.fallback/nbproject/project.properties
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+javac.compilerargs=-Xlint
+javac.release=17
+
+# javadoc.arch=${basedir}/arch.xml
+# javadoc.apichanges=${basedir}/apichanges.xml
+# javadoc.arch=${basedir}/arch.xml

--- a/platform/o.n.jdk.fallback/nbproject/project.xml
+++ b/platform/o.n.jdk.fallback/nbproject/project.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.apisupport.project</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/nb-module-project/3">
+            <code-name-base>o.n.jdk.fallback</code-name-base>
+            <module-dependencies/>
+            <test-dependencies>
+                <test-type>
+                    <name>unit</name>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.junit4</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                </test-type>
+            </test-dependencies>
+            <!-- internal API-->
+            <friend-packages>
+                <friend>org.netbeans.modules.maven.indexer</friend>
+                <package>org.netbeans.jdk.fallback.lang</package>
+            </friend-packages>
+        </data>
+    </configuration>
+</project>

--- a/platform/o.n.jdk.fallback/nbproject/project.xml
+++ b/platform/o.n.jdk.fallback/nbproject/project.xml
@@ -41,6 +41,7 @@
             <!-- internal API-->
             <friend-packages>
                 <friend>org.netbeans.modules.maven.indexer</friend>
+                <friend>org.openide.util</friend>
                 <package>org.netbeans.jdk.fallback.lang</package>
             </friend-packages>
         </data>

--- a/platform/o.n.jdk.fallback/src/org/netbeans/jdk/fallback/Bundle.properties
+++ b/platform/o.n.jdk.fallback/src/org/netbeans/jdk/fallback/Bundle.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-OpenIDE-Module-Name=Simple JDK Fallbacks
+OpenIDE-Module-Name=Internal JDK Fallbacks
 OpenIDE-Module-Display-Category=Libraries
 OpenIDE-Module-Short-Description=Provides internal, non-permanent and possibly incomplete fallbacks for JDK APIs\
  which are useful for NetBeans but not covered by the minimal run requirements yet.

--- a/platform/o.n.jdk.fallback/src/org/netbeans/jdk/fallback/Bundle.properties
+++ b/platform/o.n.jdk.fallback/src/org/netbeans/jdk/fallback/Bundle.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+OpenIDE-Module-Name=Simple JDK Fallbacks
+OpenIDE-Module-Display-Category=Libraries
+OpenIDE-Module-Short-Description=Provides internal, non-permanent and possibly incomplete fallbacks for JDK APIs\
+ which are useful for NetBeans but not covered by the minimal run requirements yet.

--- a/platform/o.n.jdk.fallback/src/org/netbeans/jdk/fallback/lang/NBLazyConstant.java
+++ b/platform/o.n.jdk.fallback/src/org/netbeans/jdk/fallback/lang/NBLazyConstant.java
@@ -21,6 +21,7 @@ package org.netbeans.jdk.fallback.lang;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -28,6 +29,8 @@ import java.util.logging.Logger;
 
 /**
  * Delegates to JDK's LazyConstant and provides a fallback implementation if not available.
+ * 
+ * The fallback implementation simulates behavior of the JDk 27 LazyConstant spec.
  * 
  * Internal API, may be removed when no longer needed.
  * 
@@ -75,9 +78,6 @@ public final class NBLazyConstant {
     @SuppressWarnings("unchecked")
     public static <T> Supplier<T> of(Supplier<? extends T> computingFunction) {
         Objects.requireNonNull(computingFunction);
-        if (computingFunction instanceof DoubleCheckedFallback<? extends T> lc) {
-            return (Supplier<T>) lc;
-        }
         if (lazyConstantFactory != null) {
             try {
                 return (Supplier<T>) lazyConstantFactory.invokeExact(computingFunction);
@@ -91,6 +91,8 @@ public final class NBLazyConstant {
         }
     }
 
+    /// simmulates JDK 27 spec, 25 and 26 are more permissive
+    /// and may allow null or error recovery
     private static class DoubleCheckedFallback<T> implements Supplier<T> {
 
         private volatile T constant;
@@ -105,12 +107,19 @@ public final class NBLazyConstant {
             T c = constant;
             if (c == null) {
                 synchronized (this) {
+                    if (factory == null) { // error state due to past supplier failure
+                        throw new NoSuchElementException("Unable to access the constant because an Exception was thrown at initial computation");
+                    }
                     c = constant;
                     if (c == null) {
-                        c = factory.get();
-                        Objects.requireNonNull(c);
+                        try {
+                            c = factory.get();
+                            Objects.requireNonNull(c);
+                        } catch (Throwable t) {
+                            factory = null;
+                            throw new NoSuchElementException(t);
+                        }
                         constant = c;
-                        factory = null;
                     }
                 }
             }

--- a/platform/o.n.jdk.fallback/src/org/netbeans/jdk/fallback/lang/NBLazyConstant.java
+++ b/platform/o.n.jdk.fallback/src/org/netbeans/jdk/fallback/lang/NBLazyConstant.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.jdk.fallback.lang;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Delegates to JDK's LazyConstant and provides a fallback implementation if not available.
+ * 
+ * Internal API, may be removed when no longer needed.
+ * 
+ * @author mbien
+ */
+public final class NBLazyConstant {
+
+    private static final MethodHandle lazyConstantFactory;
+
+    static {
+        Logger log = Logger.getLogger(NBLazyConstant.class.getName());
+        MethodHandle mh = null;
+        try {
+            if (Boolean.getBoolean("nb.jdk.LazyConstant.usefallback")) {
+                mh = null;
+                log.log(Level.INFO, "using fallback");
+            } else if (Runtime.version().feature() >= 26) {
+                Class<?> entryPoint = Class.forName("java.lang.LazyConstant");
+                mh = MethodHandles.lookup().findStatic(entryPoint, "of", MethodType.methodType(entryPoint, Supplier.class))
+                                           .asType(MethodType.methodType(Supplier.class, Supplier.class));
+            } else if (Runtime.version().feature() == 25) {
+                Class<?> entryPoint = Class.forName("java.lang.StableValue");
+                mh = MethodHandles.lookup().findStatic(entryPoint, "supplier", MethodType.methodType(Supplier.class, Supplier.class));
+            }
+            // dryrun - just to be sure
+            if (mh != null) {
+                Supplier<?> probe = () -> true;
+                ((Supplier<?>)mh.invokeExact(probe)).get();
+            }
+        } catch (Throwable ex) {
+            mh = null;
+            log.log(Level.FINE, "using fallback", ex);
+        }
+        lazyConstantFactory = mh;
+        log.log(Level.FINE, () -> "impl=" + String.valueOf(lazyConstantFactory));
+    }
+
+    private NBLazyConstant() {}
+
+    /**
+     * Create a {@link Supplier} for a lazily initializing constant.
+     * @param computingFunction Factory to create the constant, only called once.
+     * @return Returns the constant, never null.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Supplier<T> of(Supplier<? extends T> computingFunction) {
+        Objects.requireNonNull(computingFunction);
+        if (computingFunction instanceof DoubleCheckedFallback<? extends T> lc) {
+            return (Supplier<T>) lc;
+        }
+        if (lazyConstantFactory != null) {
+            try {
+                return (Supplier<T>) lazyConstantFactory.invokeExact(computingFunction);
+            } catch (RuntimeException | Error e) {
+                throw e;
+            } catch (Throwable ex) {
+                throw new RuntimeException(ex); // shouldn't be reachable under regular circumstances
+            }
+        } else {
+            return new DoubleCheckedFallback<>(computingFunction);
+        }
+    }
+
+    private static class DoubleCheckedFallback<T> implements Supplier<T> {
+
+        private volatile T constant;
+        private Supplier<? extends T> factory;
+
+        private DoubleCheckedFallback(Supplier<? extends T> factory) {
+            this.factory = factory;
+        }
+
+        @Override
+        public T get() {
+            T c = constant;
+            if (c == null) {
+                synchronized (this) {
+                    c = constant;
+                    if (c == null) {
+                        c = factory.get();
+                        Objects.requireNonNull(c);
+                        constant = c;
+                        factory = null;
+                    }
+                }
+            }
+            return c;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "{factory=" + factory + ", constant=" + constant + '}';
+        }
+    }
+}

--- a/platform/o.n.jdk.fallback/src/org/netbeans/jdk/fallback/lang/NBLazyConstant.java
+++ b/platform/o.n.jdk.fallback/src/org/netbeans/jdk/fallback/lang/NBLazyConstant.java
@@ -49,11 +49,11 @@ public final class NBLazyConstant {
                 log.log(Level.INFO, "using fallback");
             } else if (Runtime.version().feature() >= 26) {
                 Class<?> entryPoint = Class.forName("java.lang.LazyConstant");
-                mh = MethodHandles.lookup().findStatic(entryPoint, "of", MethodType.methodType(entryPoint, Supplier.class))
-                                           .asType(MethodType.methodType(Supplier.class, Supplier.class));
+                mh = MethodHandles.publicLookup().findStatic(entryPoint, "of", MethodType.methodType(entryPoint, Supplier.class))
+                                                 .asType(MethodType.methodType(Supplier.class, Supplier.class));
             } else if (Runtime.version().feature() == 25) {
                 Class<?> entryPoint = Class.forName("java.lang.StableValue");
-                mh = MethodHandles.lookup().findStatic(entryPoint, "supplier", MethodType.methodType(Supplier.class, Supplier.class));
+                mh = MethodHandles.publicLookup().findStatic(entryPoint, "supplier", MethodType.methodType(Supplier.class, Supplier.class));
             }
             // dryrun - just to be sure
             if (mh != null) {

--- a/platform/o.n.jdk.fallback/test/unit/src/org/netbeans/jdk/fallback/lang/NBLazyConstantTest.java
+++ b/platform/o.n.jdk.fallback/test/unit/src/org/netbeans/jdk/fallback/lang/NBLazyConstantTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.jdk.fallback.lang;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
+
+public class NBLazyConstantTest {
+
+    @Test
+    public void testFactory() {
+
+        Supplier<Boolean> lazy = NBLazyConstant.of(() -> true);
+        assertNotNull(lazy);
+        assertTrue(lazy.get());
+
+        String impl;
+        if (Runtime.version().feature() >= 26) {
+            impl = "LazyConstant";
+        } else if (Runtime.version().feature() == 25) {
+            impl = "StableSupplier";
+        } else {
+            impl = "DoubleCheckedFallback";
+        }
+        assertTrue(impl + " expected but got " + lazy.getClass(), lazy.getClass().getSimpleName().contains(impl));
+    }
+
+    @Test
+    public void testConstant() {
+        Supplier<Double> lazy = NBLazyConstant.of(() -> Math.random());
+        assertNotNull(lazy);
+        assertEquals(lazy.get(), lazy.get());
+        assertEquals(lazy.get(), lazy.get());
+        assertEquals(lazy.get(), lazy.get());
+    }
+
+    @Test
+    public void testRequireNPEOnNullResult() {
+
+        // StableValue allows null, we use the LazyConstant spec
+        assumeTrue(Runtime.version().feature() != 25);
+
+        AtomicReference<Object> value = new AtomicReference<>();
+        
+        Supplier<Object> lazy = NBLazyConstant.of(() -> value.get());
+        assertNotNull(lazy);
+
+        try {
+            lazy.get();
+            fail();
+        } catch (NullPointerException good) {}
+
+        try {
+            lazy.get();
+            fail();
+        } catch (NullPointerException stillGood) {}
+
+        value.set("good");
+
+        // constant can be computed from now on
+        assertEquals("good", lazy.get());
+        assertEquals("good", lazy.get());
+    }
+
+    @Test
+    public void testExceptionDuringCompute() {
+
+        AtomicBoolean fail = new AtomicBoolean(true);
+        
+        Supplier<Object> lazy = NBLazyConstant.of(() -> {
+            if (fail.get()) {
+                throw new RuntimeException("can't compute");
+            } else {
+                return "good";
+            }
+        });
+        assertNotNull(lazy);
+
+        try {
+            lazy.get();
+            fail();
+        } catch (RuntimeException good) {}
+
+        try {
+            lazy.get();
+            fail();
+        } catch (RuntimeException stillGood) {}
+
+        fail.set(false);
+
+        // constant can be computed from now on
+        assertEquals("good", lazy.get());
+        assertEquals("good", lazy.get());
+    }
+    
+}

--- a/platform/o.n.jdk.fallback/test/unit/src/org/netbeans/jdk/fallback/lang/NBLazyConstantTest.java
+++ b/platform/o.n.jdk.fallback/test/unit/src/org/netbeans/jdk/fallback/lang/NBLazyConstantTest.java
@@ -18,7 +18,9 @@
  */
 package org.netbeans.jdk.fallback.lang;
 
+import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.junit.Test;
@@ -27,6 +29,9 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
 public class NBLazyConstantTest {
+
+    // true if fallback or JDK 27 impl active
+    private static final boolean JDK27_SPEC = Runtime.version().feature() >= 27 || Runtime.version().feature() < 25;
 
     @Test
     public void testFactory() {
@@ -58,29 +63,60 @@ public class NBLazyConstantTest {
     @Test
     public void testRequireNPEOnNullResult() {
 
-        // StableValue allows null, we use the LazyConstant spec
-        assumeTrue(Runtime.version().feature() != 25);
+        // StableValue allows null, we use the LazyConstant JDK 27 spec
+        // since its the least permissive
+        assumeTrue("jdk 25 impl supports null", Runtime.version().feature() != 25);
 
         AtomicReference<Object> value = new AtomicReference<>();
+        AtomicInteger calls = new AtomicInteger();
         
-        Supplier<Object> lazy = NBLazyConstant.of(() -> value.get());
+        Supplier<Object> lazy = NBLazyConstant.of(() -> {
+            calls.incrementAndGet();
+            return value.get();
+        });
         assertNotNull(lazy);
 
         try {
             lazy.get();
             fail();
-        } catch (NullPointerException good) {}
+        } catch (NoSuchElementException good) {
+            assertTrue(JDK27_SPEC);
+            assertEquals(NullPointerException.class, good.getCause().getClass());
+        } catch (NullPointerException good) {
+            assertFalse(JDK27_SPEC);
+        }
+        assertEquals(1, calls.get());
 
         try {
             lazy.get();
             fail();
-        } catch (NullPointerException stillGood) {}
+        } catch (NoSuchElementException stillGood) {
+            assertTrue(JDK27_SPEC);
+            // no cause anymore
+        } catch (NullPointerException stillGood) {
+            assertFalse(JDK27_SPEC);
+        }
+
+        // JDK 25-26 spec has retries, we don't test those since fallback mimics JDK 27
+        if (Runtime.version().feature() == 26) {
+            return;
+        }
+
+        assertEquals(1, calls.get());
 
         value.set("good");
 
-        // constant can be computed from now on
-        assertEquals("good", lazy.get());
-        assertEquals("good", lazy.get());
+        // JDK 27+ spec -> no recovery from error state
+        try {
+            lazy.get();
+            fail();
+        } catch (NoSuchElementException stillGood) {
+            assertTrue(JDK27_SPEC);
+        } catch (NullPointerException stillGood) {
+            assertFalse(JDK27_SPEC);
+        }
+        assertEquals(1, calls.get());
+
     }
 
     @Test
@@ -100,18 +136,41 @@ public class NBLazyConstantTest {
         try {
             lazy.get();
             fail();
-        } catch (RuntimeException good) {}
+        } catch (NoSuchElementException good) {
+            assertTrue(JDK27_SPEC);
+            assertEquals(RuntimeException.class, good.getCause().getClass());
+        } catch (RuntimeException good) {
+            assertFalse(JDK27_SPEC);
+            assertEquals(RuntimeException.class, good.getClass());
+        }
 
         try {
             lazy.get();
             fail();
-        } catch (RuntimeException stillGood) {}
+        } catch (NoSuchElementException good) {
+            assertTrue(JDK27_SPEC);
+            // no cause anymore
+        } catch (RuntimeException good) {
+            assertFalse(JDK27_SPEC);
+            assertEquals(RuntimeException.class, good.getClass());
+        }
 
         fail.set(false);
 
-        // constant can be computed from now on
-        assertEquals("good", lazy.get());
-        assertEquals("good", lazy.get());
+        // we don't test error recovery of 25 and 26
+        if (!JDK27_SPEC) {
+//            assertEquals("good", lazy.get());
+//            assertEquals("good", lazy.get());
+            return;
+        }
+
+        try {
+            lazy.get();
+            fail();
+        } catch (RuntimeException stillInFailureState) {
+            assertEquals(NoSuchElementException.class, stillInFailureState.getClass());
+        }
+        
     }
     
 }

--- a/platform/openide.util/nbproject/project.xml
+++ b/platform/openide.util/nbproject/project.xml
@@ -26,6 +26,15 @@
             <code-name-base>org.openide.util</code-name-base>
             <module-dependencies>
                 <dependency>
+                    <code-name-base>o.n.jdk.fallback</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>0-1</release-version>
+                        <specification-version>0.1</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.openide.util.lookup</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/platform/openide.util/src/org/openide/util/RequestProcessor.java
+++ b/platform/openide.util/src/org/openide/util/RequestProcessor.java
@@ -51,8 +51,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.netbeans.jdk.fallback.lang.NBLazyConstant;
 import org.openide.util.lookup.Lookups;
 
 /** Request processor is {@link Executor} (since version 7.16) capable to
@@ -2078,8 +2080,9 @@ outer:  do {
             logger().log(Level.SEVERE, "Error in RequestProcessor " + todo.debug(), ex);
         }
 
-        // TODO LazyConstant candidate
-        private static final Set<Class<? extends Runnable>> warnedClasses = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
+        private static final Supplier<Set<Class<? extends Runnable>>> warnedClasses = NBLazyConstant.of(
+                () -> Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()))
+        );
         private void registerParallel(Task todo, RequestProcessor rp) {
             if (rp.warnParallel == 0 || todo.run == null) {
                 return;
@@ -2097,7 +2100,7 @@ outer:  do {
                     number.incrementAndGet();
                 }
             }
-            if (number.get() >= rp.warnParallel && warnedClasses.add(c)) {
+            if (number.get() >= rp.warnParallel && warnedClasses.get().add(c)) {
                 final String msg = "Too many " + c.getName() + " (" + number + ") in shared RequestProcessor; create your own"; // NOI18N
                 Exception ex = null;
                 Item itm = todo.item;


### PR DESCRIPTION
 - introduces "JDK Fallbacks" friend module for internal use only
 - module delegates to JDK implementations if available and uses fallbacks if not
 - the accessors are meant to be temporary friend API with expiration date, only to bridge the gap between lower and upper runtime requirements

It being internal API also allows it to serve as adapter to JDK preview features, e.g `LazyConstant` has 3 slightly different JDK implementations (JEP 502, 526 and 531 in JDK 25, 26 and 27) which would be used if available and allows more flexibility in case of future changes.

namespace and module location can probably be improved. It would be also good to find some usage candidates and add a reference commit before merge.

draft for feedback