### PR TITLE
Ensure NodeJSCodeCompletionTest is run with a fixed node js version

### DIFF
--- a/webcommon/javascript2.nodejs/test/unit/src/org/netbeans/modules/javascript2/nodejs/editor/FixedProjectFileOwnerQueryImplementation.java
+++ b/webcommon/javascript2.nodejs/test/unit/src/org/netbeans/modules/javascript2/nodejs/editor/FixedProjectFileOwnerQueryImplementation.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javascript2.nodejs.editor;
+
+import java.net.URI;
+import org.netbeans.api.project.Project;
+import org.netbeans.spi.project.FileOwnerQueryImplementation;
+import org.openide.filesystems.FileObject;
+
+/**
+ * FileOwnerQueryImplementation that return a fixed project for all paths
+ */
+public class FixedProjectFileOwnerQueryImplementation implements FileOwnerQueryImplementation {
+
+    private final Project project;
+
+    public FixedProjectFileOwnerQueryImplementation(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public Project getOwner(URI file) {
+        return project;
+    }
+
+    @Override
+    public Project getOwner(FileObject file) {
+        return project;
+    }
+}

--- a/webcommon/javascript2.nodejs/test/unit/src/org/netbeans/modules/javascript2/nodejs/editor/FixedVersionMockJsSupport.java
+++ b/webcommon/javascript2.nodejs/test/unit/src/org/netbeans/modules/javascript2/nodejs/editor/FixedVersionMockJsSupport.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javascript2.nodejs.editor;
+
+import javax.swing.event.ChangeListener;
+import org.netbeans.modules.javascript2.nodejs.spi.NodeJsSupport;
+import org.netbeans.modules.web.common.api.Version;
+import org.openide.filesystems.FileObject;
+
+/**
+ * Mock NodeJsSupport to enable providing a fixed node js version and not use
+ * fallback.
+ */
+public class FixedVersionMockJsSupport implements NodeJsSupport {
+
+    private final String version;
+
+    public FixedVersionMockJsSupport(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public boolean isSupportEnabled() {
+        return true;
+    }
+
+    @Override
+    public Version getVersion() {
+        return Version.fromDottedNotationWithFallback(version);
+    }
+
+    @Override
+    public String getDocumentationUrl() {
+        return "https://nodejs.org/docs/v" + version + "/api/";
+    }
+
+    @Override
+    public FileObject getDocumentationFolder() {
+        return null;
+    }
+
+    @Override
+    public void addChangeListener(ChangeListener listener) {
+        // Ignore
+    }
+
+    @Override
+    public void removeChangeListener(ChangeListener listener) {
+        // Ignore
+    }
+}

--- a/webcommon/javascript2.nodejs/test/unit/src/org/netbeans/modules/javascript2/nodejs/editor/NodeJSCodeCompletionTest.java
+++ b/webcommon/javascript2.nodejs/test/unit/src/org/netbeans/modules/javascript2/nodejs/editor/NodeJSCodeCompletionTest.java
@@ -25,15 +25,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.netbeans.api.java.classpath.ClassPath;
-import org.netbeans.api.project.Project;
 import org.netbeans.modules.javascript2.editor.JsCodeCompletionBase;
-import static org.netbeans.modules.javascript2.editor.JsTestBase.JS_SOURCE_ID;
 import org.netbeans.modules.javascript2.nodejs.TestProjectSupport;
+import org.netbeans.modules.javascript2.nodejs.TestProjectSupport.TestProject;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
 import org.openide.util.test.MockLookup;
 
+import static org.netbeans.modules.javascript2.editor.JsTestBase.JS_SOURCE_ID;
 /**
  *
  * @author Petr Pisl
@@ -48,20 +50,27 @@ public class NodeJSCodeCompletionTest extends JsCodeCompletionBase {
 
     @Override
     protected void setUp() throws Exception {
-//        super.setUp(); //To change body of generated methods, choose Tools | Templates.
         if (!isSetup) {
             // only for the first run index all sources
             super.setUp();
             isSetup = true;
         }
-        
+
         FileObject folder = getTestFile("TestNavigation");
-        Project testProject = new TestProjectSupport.TestProject(folder, null);
-        List lookupAll = new ArrayList();
+        TestProject testProject = new TestProjectSupport.TestProject(folder, null);
+
+        // NodeJsDataProvider downloads the node js api documentation. The
+        // golden files assume a fixed version, so simulate that for the test
+        // project.
+        Lookup projectLookup = Lookups.fixed(new FixedVersionMockJsSupport("24.14.0"));
+
+        testProject.setLookup(projectLookup);
+
+        List<Object> lookupAll = new ArrayList<>();
         lookupAll.addAll(MockLookup.getDefault().lookupAll(Object.class));
         lookupAll.add(new TestProjectSupport.FileOwnerQueryImpl(testProject));
+        lookupAll.add(new FixedProjectFileOwnerQueryImplementation(testProject));
         MockLookup.setInstances(lookupAll.toArray());
-
     }
 
     public void testBasicExport01() throws Exception {


### PR DESCRIPTION
The test depends on the downloadable API documentation from node js and the golden files are only correct for a limited version range.