### PR TITLE
Bump ide cluster to release=17

### DIFF
--- a/ide/api.debugger/nbproject/project.properties
+++ b/ide/api.debugger/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint
 javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/api.java.classpath/nbproject/project.properties
+++ b/ide/api.java.classpath/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/api.xml.ui/nbproject/project.properties
+++ b/ide/api.xml.ui/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint:all

--- a/ide/api.xml/nbproject/project.properties
+++ b/ide/api.xml/nbproject/project.properties
@@ -18,7 +18,7 @@
 is.autoload=true
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 javadoc.overview=${basedir}/doc/overview.html
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/bugtracking.bridge/nbproject/project.properties
+++ b/ide/bugtracking.bridge/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/bugtracking.commons/nbproject/project.properties
+++ b/ide/bugtracking.commons/nbproject/project.properties
@@ -16,6 +16,6 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 

--- a/ide/bugtracking/nbproject/project.properties
+++ b/ide/bugtracking/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 javadoc.arch=${basedir}/arch.xml

--- a/ide/c.google.gson/nbproject/project.properties
+++ b/ide/c.google.gson/nbproject/project.properties
@@ -17,5 +17,5 @@
 release.external/gson-2.13.2.jar=modules/com-google-gson.jar
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=8
 nbm.module.author=Jan Lahoda

--- a/ide/c.google.guava.failureaccess/nbproject/project.properties
+++ b/ide/c.google.guava.failureaccess/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=8
 spec.version.base=1.10.0
 release.external/failureaccess-1.0.3.jar=modules/com-google-guava-failureaccess.jar
 is.autoload=true

--- a/ide/c.google.guava/nbproject/project.properties
+++ b/ide/c.google.guava/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=8
 spec.version.base=27.25.0
 release.external/guava-33.4.6-jre.jar=modules/com-google-guava.jar
 is.autoload=true

--- a/ide/code.analysis/nbproject/project.properties
+++ b/ide/code.analysis/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml

--- a/ide/core.browser.webview/nbproject/project.properties
+++ b/ide/core.browser.webview/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.47.0
 is.eager=true

--- a/ide/core.browser/nbproject/project.properties
+++ b/ide/core.browser/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 spec.version.base=1.60.0

--- a/ide/core.ide/nbproject/project.properties
+++ b/ide/core.ide/nbproject/project.properties
@@ -22,7 +22,7 @@ extra.module.files=\
     netbeans.css,\
     shortcuts.pdf
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/core.multitabs.project/nbproject/project.properties
+++ b/ide/core.multitabs.project/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 nbm.needs.restart=true
 spec.version.base=1.42.0

--- a/ide/csl.types/nbproject/project.properties
+++ b/ide/csl.types/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 javadoc.arch=${basedir}/arch.xml

--- a/ide/css.editor/nbproject/project.properties
+++ b/ide/css.editor/nbproject/project.properties
@@ -25,7 +25,7 @@ jnlp.indirect.files=\
     docs/css3-spec.zip
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/ide/css.model/nbproject/project.properties
+++ b/ide/css.model/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/css.prep/nbproject/project.properties
+++ b/ide/css.prep/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 auxiliary.org-netbeans-modules-css-prep.less_2e_configured=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test-unit-sys-prop.netbeans.dirs=${netbeans.dest.dir}/${nb.cluster.ide.dir}

--- a/ide/css.visual/nbproject/project.properties
+++ b/ide/css.visual/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 
 cp.extra=
-javac.compilerargs=\ -Xlint:unchecked  -Xlint -Xlint:-serial
-javac.source=1.8
+javac.compilerargs=-Xlint -Xlint:-serial
+javac.release=17
 
 test.config.stable.includes=\
 **/CSSTest.class

--- a/ide/db.core/nbproject/project.properties
+++ b/ide/db.core/nbproject/project.properties
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/ide/db.dataview/nbproject/project.properties
+++ b/ide/db.dataview/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 release.external/commons-csv-1.8.jar=modules/ext/commons-csv-1.8.jar
 release.external/fastexcel-0.10.15.jar=modules/ext/fastexcel-0.10.15.jar

--- a/ide/db.drivers/nbproject/project.properties
+++ b/ide/db.drivers/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=8
 release.external/postgresql-42.5.4.jar=modules/ext/postgresql-42.5.4.jar
 jnlp.indirect.jars=\
     modules/ext/postgresql-42.5.4.jar

--- a/ide/db.metadata.model/nbproject/project.properties
+++ b/ide/db.metadata.model/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.unit.cp.extra=external/derby-10.14.2.0.jar\:external/mysql-connector-j-8.0.31.jar

--- a/ide/db.mysql/nbproject/org-netbeans-modules-db-mysql.sig
+++ b/ide/db.mysql/nbproject/org-netbeans-modules-db-mysql.sig
@@ -516,8 +516,6 @@ meth public final void setName(java.lang.String)
 meth public final void setPriority(int)
 meth public final void stop()
  anno 0 java.lang.Deprecated()
-meth public final void stop(java.lang.Throwable)
- anno 0 java.lang.Deprecated()
 meth public final void suspend()
  anno 0 java.lang.Deprecated()
 meth public int countStackFrames()
@@ -540,8 +538,6 @@ meth public static void setDefaultUncaughtExceptionHandler(java.lang.Thread$Unca
 meth public static void sleep(long) throws java.lang.InterruptedException
 meth public static void sleep(long,int) throws java.lang.InterruptedException
 meth public static void yield()
-meth public void destroy()
- anno 0 java.lang.Deprecated()
 meth public void interrupt()
 meth public void run()
 meth public void setContextClassLoader(java.lang.ClassLoader)

--- a/ide/db.mysql/nbproject/project.properties
+++ b/ide/db.mysql/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=0.60.0
 

--- a/ide/db.sql.editor/nbproject/project.properties
+++ b/ide/db.sql.editor/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 spec.version.base=1.69.0
 
 # org-netbeans-core: for /xml/lookups in the default fs

--- a/ide/db.sql.visualeditor/nbproject/project.properties
+++ b/ide/db.sql.visualeditor/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 #is.autoload=true
 #cp.extra=${ravelibs/jsf.dir}/${nb.modules.dir}/ext/jsf-api.jar
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 module.javadoc.packages= org.netbeans.modules.db.sql.visualeditor.api

--- a/ide/db/nbproject/project.properties
+++ b/ide/db/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.release=11
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/dbapi/nbproject/project.properties
+++ b/ide/dbapi/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 
 spec.version.base=1.66.0

--- a/ide/derby/nbproject/project.properties
+++ b/ide/derby/nbproject/project.properties
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
-javac.compilerargs=-Xlint:unchecked
+javac.release=17
+javac.compilerargs=-Xlint
 
 release.build/derbysampledb.zip=modules/ext/derbysampledb.zip
 extra.module.files=modules/ext/derbysampledb.zip

--- a/ide/diff/nbproject/project.properties
+++ b/ide/diff/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint
 javac.release=17
 
 spec.version.base=1.83.0

--- a/ide/dlight.nativeexecution.nb/nbproject/project.properties
+++ b/ide/dlight.nativeexecution.nb/nbproject/project.properties
@@ -16,5 +16,5 @@
 # under the License.
 
 is.autoload=true
-javac.release=11
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/dlight.terminal/nbproject/project.properties
+++ b/ide/dlight.terminal/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.56.0

--- a/ide/docker.api/nbproject/project.properties
+++ b/ide/docker.api/nbproject/project.properties
@@ -18,5 +18,5 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 

--- a/ide/docker.editor/nbproject/project.properties
+++ b/ide/docker.editor/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/docker.ui/nbproject/project.properties
+++ b/ide/docker.ui/nbproject/project.properties
@@ -17,4 +17,4 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17

--- a/ide/editor.actions/nbproject/project.properties
+++ b/ide/editor.actions/nbproject/project.properties
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.title=Editor Actions
 spec.version.base=1.63.0
 

--- a/ide/editor.autosave/nbproject/project.properties
+++ b/ide/editor.autosave/nbproject/project.properties
@@ -16,6 +16,6 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 javadoc.title=Editor Autosave
 is.eager=true

--- a/ide/editor.bookmarks/nbproject/project.properties
+++ b/ide/editor.bookmarks/nbproject/project.properties
@@ -18,6 +18,6 @@
 #javadoc.arch=${basedir}/arch/arch-editor-bookmarks.xml
 #test.qa-functional.cp.extra=${editor/bookmarks.dir}/modules/org-netbeans-modules-editor-bookmarks.jar:${editor.dir}/modules/org-netbeans-modules-editor.jar:${editor.dir}/modules/org-netbeans-modules-editor-lib.jar:${nb_all}/editor/build/test/qa-functional/classes
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 # #178009
 disable.qa-functional.tests=true

--- a/ide/editor.bracesmatching/nbproject/project.properties
+++ b/ide/editor.bracesmatching/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/editor.breadcrumbs/nbproject/project.properties
+++ b/ide/editor.breadcrumbs/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/editor.codetemplates/nbproject/project.properties
+++ b/ide/editor.codetemplates/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 #javadoc.name=EditorCodeTemplates
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml

--- a/ide/editor.completion/nbproject/project.properties
+++ b/ide/editor.completion/nbproject/project.properties
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 spec.version.base=1.77.0

--- a/ide/editor.deprecated.pre65formatting/nbproject/project.properties
+++ b/ide/editor.deprecated.pre65formatting/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.63.0

--- a/ide/editor.document/nbproject/project.properties
+++ b/ide/editor.document/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.41.0
 javadoc.arch=${basedir}/arch.xml

--- a/ide/editor.errorstripe.api/nbproject/project.properties
+++ b/ide/editor.errorstripe.api/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 spec.version.base=2.64.0
 is.autoload=true
 

--- a/ide/editor.errorstripe/nbproject/project.properties
+++ b/ide/editor.errorstripe/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 spec.version.base=2.66.0
 nbm.needs.restart=true
 

--- a/ide/editor.fold.nbui/nbproject/project.properties
+++ b/ide/editor.fold.nbui/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=1.44.0

--- a/ide/editor.fold/nbproject/project.properties
+++ b/ide/editor.fold/nbproject/project.properties
@@ -20,6 +20,6 @@ javadoc.apichanges=${basedir}/apichanges.xml
 #javadoc.base=../../../editor/fold
 #cp.extra=
 
-javac.source=1.8
+javac.release=17
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/editor.global.format/nbproject/project.properties
+++ b/ide/editor.global.format/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.47.0

--- a/ide/editor.guards/nbproject/project.properties
+++ b/ide/editor.guards/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 
 is.autoload=true
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml
 

--- a/ide/editor.indent.project/nbproject/project.properties
+++ b/ide/editor.indent.project/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 javadoc.arch=${basedir}/arch.xml

--- a/ide/editor.indent.support/nbproject/project.properties
+++ b/ide/editor.indent.support/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/editor.indent/nbproject/project.properties
+++ b/ide/editor.indent/nbproject/project.properties
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
-javac.compilerargs=-Xlint:unchecked
+javac.release=17
+javac.compilerargs=-Xlint
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/editor.kit/nbproject/project.properties
+++ b/ide/editor.kit/nbproject/project.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17

--- a/ide/editor.lib/nbproject/project.properties
+++ b/ide/editor.lib/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint
 javac.release=17
 spec.version.base=4.39.0
 is.autoload=true

--- a/ide/editor.lib2/nbproject/project.properties
+++ b/ide/editor.lib2/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
-javac.compilerargs=-Xlint:unchecked
+javac.release=17
+javac.compilerargs=-Xlint
 spec.version.base=2.52.0
 
 javadoc.arch=${basedir}/arch.xml

--- a/ide/editor.macros/nbproject/project.properties
+++ b/ide/editor.macros/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 spec.version.base=1.63.0
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/editor.plain.lib/nbproject/project.properties
+++ b/ide/editor.plain.lib/nbproject/project.properties
@@ -17,4 +17,4 @@
 
 #javadoc.arch=${basedir}/arch/arch-editor-plain-lib.xml
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17

--- a/ide/editor.search/nbproject/project.properties
+++ b/ide/editor.search/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.57.0

--- a/ide/editor.settings.lib/nbproject/project.properties
+++ b/ide/editor.settings.lib/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.83.0

--- a/ide/editor.settings.storage/nbproject/project.properties
+++ b/ide/editor.settings.storage/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 
 is.eager=true
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=1.84.0

--- a/ide/editor.settings/nbproject/project.properties
+++ b/ide/editor.settings/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:all
-javac.source=1.8
+javac.release=17
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml
 

--- a/ide/editor.structure/nbproject/project.properties
+++ b/ide/editor.structure/nbproject/project.properties
@@ -17,9 +17,9 @@
 
 
 
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint
 
-javac.source=1.8
+javac.release=17
 
 spec.version.base=1.79.0
 

--- a/ide/editor.tools.storage/nbproject/project.properties
+++ b/ide/editor.tools.storage/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml

--- a/ide/editor.util/nbproject/project.properties
+++ b/ide/editor.util/nbproject/project.properties
@@ -17,8 +17,8 @@
 
 is.autoload=true
 javadoc.arch=${basedir}/arch.xml
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.title=Editor Utilities
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/editor/nbproject/project.properties
+++ b/ide/editor/nbproject/project.properties
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 spec.version.base=1.119.0
 is.autoload=true
 

--- a/ide/extbrowser/nbproject/project.properties
+++ b/ide/extbrowser/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 javadoc.arch=${basedir}/arch.xml
 # test.unit.cp.extra and/or test.unit.run.cp.extra
-javac.source=1.8
+javac.release=17
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\
     **/ExtWebBrowserTest.class,\

--- a/ide/extexecution.base/nbproject/project.properties
+++ b/ide/extexecution.base/nbproject/project.properties
@@ -17,7 +17,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/extexecution.impl/nbproject/project.properties
+++ b/ide/extexecution.impl/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/extexecution.process/nbproject/project.properties
+++ b/ide/extexecution.process/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.release=11
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/extexecution/nbproject/project.properties
+++ b/ide/extexecution/nbproject/project.properties
@@ -17,7 +17,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/git/nbproject/project.properties
+++ b/ide/git/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint
 javac.release=17
 nbm.homepage=http://netbeans.org/projects/versioncontrol/pages/Git_main
 nbm.module.author=Ondrej Vrabec

--- a/ide/go.lang/nbproject/project.properties
+++ b/ide/go.lang/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 
 # As of 2nd Jan 2023, we use the Grammar from:
 # https://github.com/antlr/grammars-v4/tree/4794c0c5371ce6b0711a306256f8f7706394ec6d/golang

--- a/ide/gototest/nbproject/project.properties
+++ b/ide/gototest/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 is.autoload=true

--- a/ide/gsf.codecoverage/nbproject/project.properties
+++ b/ide/gsf.codecoverage/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 ant.jar=${ant.core.lib}

--- a/ide/gsf.testrunner.ui/nbproject/project.properties
+++ b/ide/gsf.testrunner.ui/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.apichanges=${basedir}/apichanges.xml
 spec.version.base=1.47.0

--- a/ide/gsf.testrunner/nbproject/project.properties
+++ b/ide/gsf.testrunner/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/html.custom/nbproject/project.properties
+++ b/ide/html.custom/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/html.editor.lib/nbproject/project.properties
+++ b/ide/html.editor.lib/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 #javadoc.arch=${basedir}/arch/arch-html-editor-lib.xml
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/html.editor/nbproject/project.properties
+++ b/ide/html.editor/nbproject/project.properties
@@ -17,8 +17,8 @@
 
 release.external/html-4.01.zip=docs/html-4.01.zip
 
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 jnlp.verify.excludes=docs/html-4.01.zip
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/html.indexing/nbproject/project.properties
+++ b/ide/html.indexing/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true

--- a/ide/html.lexer/nbproject/project.properties
+++ b/ide/html.lexer/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 
 is.autoload=true
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 #javadoc.arch=${basedir}/arch.xml
 #javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.title=HTML Lexer API

--- a/ide/html.parser/nbproject/project.properties
+++ b/ide/html.parser/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 
 release.external/htmlparser-1.4.20190624.jar=modules/ext/html5-parser.jar
 release.external/html5doc.zip=docs/html5doc.zip

--- a/ide/html.validation/nbproject/project.properties
+++ b/ide/html.validation/nbproject/project.properties
@@ -32,7 +32,7 @@ release.external/salvation-2.7.2.jar=modules/ext/salvation.jar
 release.external/galimatias-0.1.3.jar=modules/ext/galimatias.jar
 release.external/langdetect-1.2.jar=modules/ext/langdetect.jar
 
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/html/nbproject/project.properties
+++ b/ide/html/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.arch=${basedir}/arch.xml

--- a/ide/httpserver/nbproject/project.properties
+++ b/ide/httpserver/nbproject/project.properties
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 spec.version.base=2.68.0
 release.external/tomcat-embed-core-9.0.113.jar=modules/ext/webserver.jar
 release.external/tomcat-annotations-api-9.0.113.jar=modules/ext/webserver-annotations.jar

--- a/ide/hudson.git/nbproject/project.properties
+++ b/ide/hudson.git/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/hudson.mercurial/nbproject/project.properties
+++ b/ide/hudson.mercurial/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/hudson.subversion/nbproject/project.properties
+++ b/ide/hudson.subversion/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/hudson.tasklist/nbproject/project.properties
+++ b/ide/hudson.tasklist/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/hudson.ui/nbproject/project.properties
+++ b/ide/hudson.ui/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/hudson/nbproject/project.properties
+++ b/ide/hudson/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/ide.kit/nbproject/project.properties
+++ b/ide/ide.kit/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 
 test.config.commit.includes=\
     org/netbeans/modules/ide/kit/Verify*.class

--- a/ide/image/nbproject/project.properties
+++ b/ide/image/nbproject/project.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17

--- a/ide/javascript2.debug.ui/nbproject/project.properties
+++ b/ide/javascript2.debug.ui/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 
 is.autoload=true

--- a/ide/javascript2.debug/nbproject/project.properties
+++ b/ide/javascript2.debug/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 
 is.autoload=true

--- a/ide/jellytools.ide/nbproject/project.properties
+++ b/ide/jellytools.ide/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=3.65.0
 

--- a/ide/jumpto/nbproject/project.properties
+++ b/ide/jumpto/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint
 javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/languages.diff/nbproject/project.properties
+++ b/ide/languages.diff/nbproject/project.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17

--- a/ide/languages.go/nbproject/project.properties
+++ b/ide/languages.go/nbproject/project.properties
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17

--- a/ide/languages.manifest/nbproject/project.properties
+++ b/ide/languages.manifest/nbproject/project.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17

--- a/ide/languages/nbproject/project.properties
+++ b/ide/languages/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 build.compiler.deprecation=false
 is.autoload=true
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=1.153.0
 

--- a/ide/lexer.antlr4/nbproject/project.properties
+++ b/ide/lexer.antlr4/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 
 is.autoload=true
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.apichanges=${basedir}/apichanges.xml
 
 spec.version.base=1.14.0

--- a/ide/lexer.nbbridge/nbproject/project.properties
+++ b/ide/lexer.nbbridge/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=1.64.0

--- a/ide/lexer/nbproject/project.properties
+++ b/ide/lexer/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 
 is.autoload=true
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 spec.version.base=1.95.0

--- a/ide/lib.terminalemulator/nbproject/project.properties
+++ b/ide/lib.terminalemulator/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 nbm.homepage=http://wiki.netbeans.org/TerminalEmulator

--- a/ide/libs.antlr3.runtime/nbproject/project.properties
+++ b/ide/libs.antlr3.runtime/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 
 is.autoload=true
-javac.source=1.8
+javac.release=8
 release.external/antlr-runtime-3.5.3.jar=modules/ext/antlr-runtime-3.5.3.jar
 
 license.file=../external/antlr-3.5.3-license.txt

--- a/ide/libs.antlr4.runtime/nbproject/project.properties
+++ b/ide/libs.antlr4.runtime/nbproject/project.properties
@@ -18,7 +18,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=8
 release.external/antlr4-runtime-4.13.1.jar=modules/ext/antlr4-runtime-4.13.1.jar
 
 license.file=../external/antlr4-runtime-4.13.1-license.txt

--- a/ide/libs.commons_compress/nbproject/project.properties
+++ b/ide/libs.commons_compress/nbproject/project.properties
@@ -17,6 +17,6 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=8
 release.external/commons-compress-1.27.1.jar=modules/ext/commons-compress-1.27.1.jar
 spec.version.base=0.38.0

--- a/ide/libs.freemarker/nbproject/project.properties
+++ b/ide/libs.freemarker/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint
 javac.release=17
 release.external/freemarker-2.3.34.jar=modules/ext/freemarker-2.3.34.jar
 module.jar.verifylinkageignores=freemarker.((ext.ant.FreemarkerXmlTask)|(template.DefaultObjectWrapper))

--- a/ide/libs.jaxb/nbproject/project.properties
+++ b/ide/libs.jaxb/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
+javac.release=8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 jnlp.indirect.jars=\

--- a/ide/libs.jsch.agentproxy/nbproject/project.properties
+++ b/ide/libs.jsch.agentproxy/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 
 sigtest.gen.fail.on.error=false
 

--- a/ide/libs.svnClientAdapter.javahl/nbproject/project.properties
+++ b/ide/libs.svnClientAdapter.javahl/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 
 is.eager=true
-javac.source=1.8
+javac.release=17
 release.external/adapter-javahl-1.14.0.jar=modules/ext/adapter-javahl.jar
 release.external/javahl-1.14.0.jar=modules/ext/javahl.jar
 

--- a/ide/libs.svnClientAdapter/nbproject/project.properties
+++ b/ide/libs.svnClientAdapter/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 
-javac.source=1.8
+javac.release=17
 release.external/adapter-base-1.14.0.jar=modules/ext/adapter-base.jar
 
 # Hidden class found: org.tigris.subversion.svnclientadapter.commandline.CommandLine$CmdArguments in method protected byte[] org.tigris.subversion.svnclientadapter.commandline.SvnCommandLine.execBytes(org.tigris.subversion.svnclientadapter.commandline.CommandLine$CmdArguments,boolean) throws java.lang.Exception in class org.tigris.subversion.svnclientadapter.commandline.SvnCommandLine

--- a/ide/libs.tomljava/nbproject/project.properties
+++ b/ide/libs.tomljava/nbproject/project.properties
@@ -16,6 +16,6 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
+javac.release=8
 javac.compilerargs=-Xlint -Xlint:-serial
 release.external/toml-java-13.5.1.jar=modules/ext/toml-java-13.5.1.jar

--- a/ide/localhistory/nbproject/project.properties
+++ b/ide/localhistory/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 nbm.needs.restart=true
 
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 #qa-functional
 test.qa-functional.cp.extra=${openide.nodes.dir}/modules/org-openide-nodes.jar:\
 ${openide.util.dir}/lib/org-openide-util.jar:${openide.util.ui.dir}/lib/org-openide-util-ui.jar

--- a/ide/markdown/nbproject/project.properties
+++ b/ide/markdown/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/mercurial/nbproject/project.properties
+++ b/ide/mercurial/nbproject/project.properties
@@ -14,8 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 nbm.homepage=http://wiki.netbeans.org/wiki/view/MercurialVersionControl
 nbm.module.author=John Rice and Padraig O'Briain
 nbm.needs.restart=true

--- a/ide/nativeimage.api/nbproject/project.properties
+++ b/ide/nativeimage.api/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/notifications/nbproject/project.properties
+++ b/ide/notifications/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/o.n.swing.dirchooser/nbproject/project.properties
+++ b/ide/o.n.swing.dirchooser/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=11
+javac.release=17
 javadoc.arch=${basedir}/arch.xml

--- a/ide/o.openidex.util/nbproject/project.properties
+++ b/ide/o.openidex.util/nbproject/project.properties
@@ -18,7 +18,7 @@
 is.autoload=true
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/options.editor/nbproject/project.properties
+++ b/ide/options.editor/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint
 javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/parsing.api/nbproject/project.properties
+++ b/ide/parsing.api/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=9.39.0

--- a/ide/parsing.nb/nbproject/project.properties
+++ b/ide/parsing.nb/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.36.0
 #javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/parsing.ui/nbproject/project.properties
+++ b/ide/parsing.ui/nbproject/project.properties
@@ -16,5 +16,5 @@
 # under the License.
 is.eager=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 spec.version.base=1.46.0

--- a/ide/print.editor/nbproject/project.properties
+++ b/ide/print.editor/nbproject/project.properties
@@ -16,5 +16,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
-javac.compilerargs=-Xlint:unchecked
+javac.release=17
+javac.compilerargs=-Xlint

--- a/ide/project.ant.compat8/nbproject/project.properties
+++ b/ide/project.ant.compat8/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/project.ant.ui/nbproject/project.properties
+++ b/ide/project.ant.ui/nbproject/project.properties
@@ -18,7 +18,7 @@
 is.autoload=true
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/project.indexingbridge/nbproject/project.properties
+++ b/ide/project.indexingbridge/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/project.libraries.ui/nbproject/project.properties
+++ b/ide/project.libraries.ui/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml

--- a/ide/project.libraries/nbproject/project.properties
+++ b/ide/project.libraries/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/project.spi.intern.impl/nbproject/project.properties
+++ b/ide/project.spi.intern.impl/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/project.spi.intern/nbproject/project.properties
+++ b/ide/project.spi.intern/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/projectapi.nb/nbproject/project.properties
+++ b/ide/projectapi.nb/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/projectui.buildmenu/nbproject/project.properties
+++ b/ide/projectui.buildmenu/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 
 spec.version.base=1.58.0

--- a/ide/projectui/nbproject/project.properties
+++ b/ide/projectui/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint
 javac.release=17
 spec.version.base=1.91.0
 

--- a/ide/projectuiapi.base/nbproject/project.properties
+++ b/ide/projectuiapi.base/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 spec.version.base=1.118.0
 is.autoload=true
 javadoc.arch=${basedir}/arch.xml

--- a/ide/properties.syntax/nbproject/project.properties
+++ b/ide/properties.syntax/nbproject/project.properties
@@ -17,4 +17,4 @@
 
 is.eager=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17

--- a/ide/properties/nbproject/project.properties
+++ b/ide/properties/nbproject/project.properties
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 
 test.config.create.includes=org/netbeans/properties/jelly2tests/suites/creating_properties_file/*Test.class

--- a/ide/schema2beans/nbproject/project.properties
+++ b/ide/schema2beans/nbproject/project.properties
@@ -19,4 +19,4 @@ is.autoload=true
 cp.extra=\
     ${ant.core.lib}
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17

--- a/ide/selenium2.server/nbproject/project.properties
+++ b/ide/selenium2.server/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/selenium2/nbproject/project.properties
+++ b/ide/selenium2/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/server/nbproject/project.properties
+++ b/ide/server/nbproject/project.properties
@@ -18,7 +18,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/slf4j.api/nbproject/project.properties
+++ b/ide/slf4j.api/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=8
 release.external/slf4j-api-1.7.36.jar=modules/slf4j-api.jar
 is.autoload=true

--- a/ide/spellchecker.apimodule/nbproject/project.properties
+++ b/ide/spellchecker.apimodule/nbproject/project.properties
@@ -17,8 +17,8 @@
 # under the License.
 #
 is.autoload=true
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 nbm.homepage=http://spellchecker.netbeans.org
 nbm.module.author=Jan Lahoda

--- a/ide/spellchecker.bindings.htmlxml/nbproject/project.properties
+++ b/ide/spellchecker.bindings.htmlxml/nbproject/project.properties
@@ -16,8 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 is.eager=true
 
 javadoc.arch=${basedir}/arch.xml

--- a/ide/spellchecker.bindings.properties/nbproject/project.properties
+++ b/ide/spellchecker.bindings.properties/nbproject/project.properties
@@ -16,8 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 is.eager=true
 
 javadoc.arch=${basedir}/arch.xml

--- a/ide/spellchecker.dictionary_en/nbproject/project.properties
+++ b/ide/spellchecker.dictionary_en/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 release.external/wordlist-en_GB-large-2017.08.24.zip=modules/dict/wordlist-en_GB-large-2017.08.24.zip
 release.external/wordlist-en_US-large-2017.08.24.zip=modules/dict/wordlist-en_US-large-2017.08.24.zip
 jnlp.indirect.files=modules/dict/dictionary_en_US.description,modules/dict/dictionary_en_GB.description,modules/dict/dictionary_en.description,modules/dict/wordlist-en_GB-large-2017.08.24.zip,modules/dict/wordlist-en_US-large-2017.08.24.zip

--- a/ide/spellchecker/nbproject/project.properties
+++ b/ide/spellchecker/nbproject/project.properties
@@ -16,8 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 nbm.homepage=http://spellchecker.netbeans.org
 nbm.module.author=Jan Lahoda
 spec.version.base=1.67.0

--- a/ide/spi.debugger.ui/nbproject/project.properties
+++ b/ide/spi.debugger.ui/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/spi.editor.hints.projects/nbproject/project.properties
+++ b/ide/spi.editor.hints.projects/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/spi.editor.hints/nbproject/project.properties
+++ b/ide/spi.editor.hints/nbproject/project.properties
@@ -14,8 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 spec.version.base=1.74.0

--- a/ide/spi.navigator/nbproject/project.properties
+++ b/ide/spi.navigator/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint
 javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/spi.palette/nbproject/project.properties
+++ b/ide/spi.palette/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 
 is.autoload=true
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/spi.tasklist/nbproject/project.properties
+++ b/ide/spi.tasklist/nbproject/project.properties
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 spec.version.base=1.67.0

--- a/ide/spi.viewmodel/nbproject/project.properties
+++ b/ide/spi.viewmodel/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 
 is.autoload=true
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 # Need extra runtime dependency on modules which are loaded transitively:

--- a/ide/subversion/nbproject/project.properties
+++ b/ide/subversion/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 spec.version.base=1.74.0
 
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 
 #qa-functional
 test.qa-functional.cp.extra=${openide.nodes.dir}/modules/org-openide-nodes.jar:\${openide.util.dir}/lib/org-openide-util.jar:${openide.util.ui.dir}/lib/org-openide-util-ui.jar

--- a/ide/swing.validation/nbproject/project.properties
+++ b/ide/swing.validation/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 nbm.homepage=https://github.com/timboudreau/simplevalidation/

--- a/ide/target.iterator/nbproject/project.properties
+++ b/ide/target.iterator/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/tasklist.projectint/nbproject/project.properties
+++ b/ide/tasklist.projectint/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17

--- a/ide/tasklist.todo/nbproject/project.properties
+++ b/ide/tasklist.todo/nbproject/project.properties
@@ -14,8 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 spec.version.base=1.63.0
 #hook for apisupport TestBase
 test-unit-sys-prop.test.nbcvsroot=${nb_all}

--- a/ide/tasklist.ui/nbproject/project.properties
+++ b/ide/tasklist.ui/nbproject/project.properties
@@ -14,8 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 spec.version.base=1.63.0
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/team.commons/nbproject/project.properties
+++ b/ide/team.commons/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml

--- a/ide/team.ide/nbproject/project.properties
+++ b/ide/team.ide/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/terminal.nb/nbproject/project.properties
+++ b/ide/terminal.nb/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/terminal/nbproject/project.properties
+++ b/ide/terminal/nbproject/project.properties
@@ -25,7 +25,7 @@ auxiliary.org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.inden
 auxiliary.org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.spaces-per-tab=8
 auxiliary.org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.tab-size=8
 auxiliary.org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-limit-width=80
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 nbm.homepage=http://wiki.netbeans.org/TerminalEmulator 

--- a/ide/utilities.project/nbproject/project.properties
+++ b/ide/utilities.project/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 
 is.eager=true
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/ide/utilities/nbproject/project.properties
+++ b/ide/utilities/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-#javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint
 
 javac.release=17
 javadoc.arch=${basedir}/arch.xml

--- a/ide/versioning.core/nbproject/project.properties
+++ b/ide/versioning.core/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint
 javac.release=17
 
 javadoc.name=Versioning

--- a/ide/versioning.indexingbridge/nbproject/project.properties
+++ b/ide/versioning.indexingbridge/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/versioning.masterfs/nbproject/project.properties
+++ b/ide/versioning.masterfs/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test-unit-sys-prop.work.dir=${basedir}/build/test/unit/work

--- a/ide/versioning.system.cvss.installer/nbproject/project.properties
+++ b/ide/versioning.system.cvss.installer/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/versioning.ui/nbproject/project.properties
+++ b/ide/versioning.ui/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.eager=true
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint
 javac.release=17
 
 spec.version.base=1.55.0

--- a/ide/versioning.util/nbproject/project.properties
+++ b/ide/versioning.util/nbproject/project.properties
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
-javac.release=11
+javac.compilerargs=-Xlint
+javac.release=17
 
 javadoc.name=Versioning Support Utilities
 spec.version.base=2.8.0

--- a/ide/versioning/nbproject/project.properties
+++ b/ide/versioning/nbproject/project.properties
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 
 javadoc.name=Versioning
 spec.version.base=1.79.0

--- a/ide/web.browser.api/nbproject/project.properties
+++ b/ide/web.browser.api/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 ant.jar=${ant.core.lib}

--- a/ide/web.common.ui/nbproject/project.properties
+++ b/ide/web.common.ui/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/web.common/nbproject/project.properties
+++ b/ide/web.common/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/web.indent/nbproject/project.properties
+++ b/ide/web.indent/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true

--- a/ide/web.webkit.debugging/nbproject/project.properties
+++ b/ide/web.webkit.debugging/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/xml.axi/nbproject/project.properties
+++ b/ide/xml.axi/nbproject/project.properties
@@ -18,7 +18,7 @@
 #
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/xml.catalog.ui/nbproject/project.properties
+++ b/ide/xml.catalog.ui/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=2.35.0

--- a/ide/xml.catalog/nbproject/project.properties
+++ b/ide/xml.catalog/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 spec.version.base=3.36.0
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/xml.core/nbproject/project.properties
+++ b/ide/xml.core/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 spec.version.base=1.75.0
 is.autoload=true
 

--- a/ide/xml.jaxb.api/nbproject/project.properties
+++ b/ide/xml.jaxb.api/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
+javac.release=8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 jnlp.indirect.jars=\

--- a/ide/xml.lexer/nbproject/project.properties
+++ b/ide/xml.lexer/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 
 is.autoload=true
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.apichanges=${basedir}/apichanges.xml
 
 javadoc.arch=${basedir}/arch.xml

--- a/ide/xml.multiview/nbproject/project.properties
+++ b/ide/xml.multiview/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=1.70.0
 is.autoload=true

--- a/ide/xml.retriever/nbproject/project.properties
+++ b/ide/xml.retriever/nbproject/project.properties
@@ -17,7 +17,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/ide/xml.schema.completion/nbproject/project.properties
+++ b/ide/xml.schema.completion/nbproject/project.properties
@@ -16,5 +16,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml

--- a/ide/xml.schema.model/nbproject/project.properties
+++ b/ide/xml.schema.model/nbproject/project.properties
@@ -18,7 +18,7 @@
 #
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 spec.version.base=1.64.0

--- a/ide/xml.text/nbproject/project.properties
+++ b/ide/xml.text/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 
 test.unit.cp.extra=${openide.dir}/core/openide.jar:${openide.loaders.dir}/core/openide-loaders.jar
 test.unit.run.cp.extra=${test.unit.cp.extra}

--- a/ide/xml.wsdl.model/nbproject/project.properties
+++ b/ide/xml.wsdl.model/nbproject/project.properties
@@ -18,7 +18,7 @@
 #
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=1.65.0
 release.external/generated-wsdl-xsd-2004.08.24.jar=modules/ext/generated-wsdl-xsd-2004.08.24.jar

--- a/ide/xml.xam/nbproject/project.properties
+++ b/ide/xml.xam/nbproject/project.properties
@@ -18,7 +18,7 @@
 #
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 spec.version.base=1.64.0

--- a/ide/xml.xdm/nbproject/project.properties
+++ b/ide/xml.xdm/nbproject/project.properties
@@ -18,7 +18,7 @@
 #
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=1.66.0
 

--- a/ide/xml/nbproject/project.properties
+++ b/ide/xml/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 is.autoload=true
 
 javadoc.packages=\

--- a/ide/xsl/nbproject/project.properties
+++ b/ide/xsl/nbproject/project.properties
@@ -16,6 +16,6 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 
 test.config.stableBTD.includes=**/*Test.class


### PR DESCRIPTION
skipped
 - xml.tax
 - xml.text.obsolete90
 - o.n.agent
 - dlight.nativeexecution (solaris support removal pending)

consolidated compiler args property

edited db.mysql sig file (Thread.destroy() and stop() removal)

dropped libwrappers (without sources) to their bytecode level if they had a javac property defined.

meta issue https://github.com/apache/netbeans/issues/8813