### PR TITLE
Bump php cluster to release=21

### DIFF
--- a/php/hudson.php/nbproject/project.properties
+++ b/php/hudson.php/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/php/languages.neon/nbproject/project.properties
+++ b/php/languages.neon/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/php/php.api.annotation/nbproject/project.properties
+++ b/php/php.api.annotation/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/php/php.api.documentation/nbproject/project.properties
+++ b/php/php.api.documentation/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/php/php.api.editor/nbproject/project.properties
+++ b/php/php.api.editor/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/php/php.api.executable/nbproject/project.properties
+++ b/php/php.api.executable/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/php/php.api.framework/nbproject/project.properties
+++ b/php/php.api.framework/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/php/php.api.phpmodule/nbproject/project.properties
+++ b/php/php.api.phpmodule/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/php/php.api.templates/nbproject/project.properties
+++ b/php/php.api.templates/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/php/php.api.testing/nbproject/project.properties
+++ b/php/php.api.testing/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/php/php.apigen/nbproject/project.properties
+++ b/php/php.apigen/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/php/php.atoum/nbproject/project.properties
+++ b/php/php.atoum/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/php/php.code.analysis/nbproject/project.properties
+++ b/php/php.code.analysis/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/php/php.codeception/nbproject/project.properties
+++ b/php/php.codeception/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/php/php.composer/nbproject/project.properties
+++ b/php/php.composer/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/php/php.dbgp/nbproject/project.properties
+++ b/php/php.dbgp/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/php/php.doctrine2/nbproject/project.properties
+++ b/php/php.doctrine2/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/php/php.editor/nbproject/project.properties
+++ b/php/php.editor/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 nbjavac.ignore.missing.enclosing=**/CUP$ASTPHP5Parser$actions.class
 nbm.needs.restart=true

--- a/php/php.kit/nbproject/project.properties
+++ b/php/php.kit/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.release=17
+javac.release=21
 nbm.needs.restart=true

--- a/php/php.latte/nbproject/project.properties
+++ b/php/php.latte/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/php/php.nette.tester/nbproject/project.properties
+++ b/php/php.nette.tester/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/php/php.nette2/nbproject/project.properties
+++ b/php/php.nette2/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base.fatal.warning=false

--- a/php/php.phing/nbproject/project.properties
+++ b/php/php.phing/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 

--- a/php/php.phpdoc/nbproject/project.properties
+++ b/php/php.phpdoc/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 nbm.module.author=Tomas Mysik

--- a/php/php.phpunit/nbproject/project.properties
+++ b/php/php.phpunit/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/php/php.project/nbproject/project.properties
+++ b/php/php.project/nbproject/project.properties
@@ -17,7 +17,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.release=17
+javac.release=21
 javadoc.arch=${basedir}/arch.xml
 
 release.external/phpsigfiles-1.8.zip=docs/phpsigfiles.zip

--- a/php/php.refactoring/nbproject/project.properties
+++ b/php/php.refactoring/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test-unit-sys-prop.xtest.php.home=${netbeans.dest.dir}/php

--- a/php/php.samples/nbproject/project.properties
+++ b/php/php.samples/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 license.file=licence.txt

--- a/php/php.smarty/nbproject/project.properties
+++ b/php/php.smarty/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 nbm.homepage=http://wiki.netbeans.org/PhpSmartyFrameworkPlugin
 

--- a/php/php.symfony/nbproject/project.properties
+++ b/php/php.symfony/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base.fatal.warning=false
 

--- a/php/php.symfony2/nbproject/project.properties
+++ b/php/php.symfony2/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base.fatal.warning=false

--- a/php/php.twig/nbproject/project.properties
+++ b/php/php.twig/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/php/php.zend/nbproject/project.properties
+++ b/php/php.zend/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base.fatal.warning=false
 

--- a/php/php.zend2/nbproject/project.properties
+++ b/php/php.zend2/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base.fatal.warning=false
 

--- a/php/selenium2.php/nbproject/project.properties
+++ b/php/selenium2.php/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/php/spellchecker.bindings.php/nbproject/project.properties
+++ b/php/spellchecker.bindings.php/nbproject/project.properties
@@ -16,5 +16,5 @@
 # under the License.
 
 is.eager=true
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/php/websvc.saas.codegen.php/nbproject/project.properties
+++ b/php/websvc.saas.codegen.php/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.release=17
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial


### PR DESCRIPTION
the php cluster doesn't affect the graalvm job so we should be able to bump it for NB 30 (which uses JDK 21+ as build and run requirement)

last bump happened for NB 28 https://github.com/apache/netbeans/pull/8802 via the `--release` migration