### PR TITLE
Fix for reformatting issue with unnamed vars GH9255

### DIFF
--- a/java/java.lexer/src/org/netbeans/lib/java/lexer/JavaLexer.java
+++ b/java/java.lexer/src/org/netbeans/lib/java/lexer/JavaLexer.java
@@ -1196,7 +1196,9 @@ public class JavaLexer implements Lexer<JavaTokenId> {
                                             next = nextToken();
                                         } while (next != null && AFTER_VAR_TOKENS.contains(next.id()));
 
-                                        varKeyword = next != null && next.id() == JavaTokenId.IDENTIFIER;
+                                        varKeyword = next != null
+                                                && (next.id() == JavaTokenId.IDENTIFIER
+                                                || next.id() == JavaTokenId.UNDERSCORE);
                                     }
 
                                     input.backup(input.readLengthEOF()- len);

--- a/java/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaLexerBatchTest.java
+++ b/java/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaLexerBatchTest.java
@@ -560,6 +560,23 @@ public class JavaLexerBatchTest extends TestCase {
         LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.SEMICOLON, ";");
     }
 
+    public void testVarUnnamed() {
+        String text = "var _ = 0;";
+        InputAttributes attr = new InputAttributes();
+        attr.setValue(JavaTokenId.language(), "version", Integer.valueOf(22), true);
+        TokenHierarchy<?> hi = TokenHierarchy.create(text, false, JavaTokenId.language(), EnumSet.noneOf(JavaTokenId.class), attr);
+        TokenSequence<?> ts = hi.tokenSequence();
+
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.VAR, "var");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.WHITESPACE, " ");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.UNDERSCORE, "_");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.WHITESPACE, " ");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.EQ, "=");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.WHITESPACE, " ");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.INT_LITERAL, "0");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.SEMICOLON, ";");
+    }
+
     public void testVarWeird() {
         String text = "var = 0; varu = 0; val = 0; if (a.var);";
         InputAttributes attr = new InputAttributes();

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
@@ -6274,13 +6274,12 @@ public class FormatingTest extends NbTestCase {
     }
 
     public void testForVar1() throws Exception {
+        sourceLevel = "10";
         testFile = new File(getWorkDir(), "Test.java");
         TestUtilities.copyStringToFile(testFile, "");
         FileObject testSourceFO = FileUtil.toFileObject(testFile);
         DataObject testSourceDO = DataObject.find(testSourceFO);
         EditorCookie ec = (EditorCookie) testSourceDO.getCookie(EditorCookie.class);
-        String oldLevel = JavaSourceTest.SourceLevelQueryImpl.sourceLevel;
-        JavaSourceTest.SourceLevelQueryImpl.sourceLevel = "1.10";
         final Document doc = ec.openDocument();
         doc.putProperty(Language.class, JavaTokenId.language());
         String content
@@ -6299,17 +6298,15 @@ public class FormatingTest extends NbTestCase {
                 + "    }\n"
                 + "}\n";
         reformat(doc, content, golden);
-        JavaSourceTest.SourceLevelQueryImpl.sourceLevel = oldLevel;
     }
 
     public void testForVar2() throws Exception {
+        sourceLevel = "10";
         testFile = new File(getWorkDir(), "Test.java");
         TestUtilities.copyStringToFile(testFile, "");
         FileObject testSourceFO = FileUtil.toFileObject(testFile);
         DataObject testSourceDO = DataObject.find(testSourceFO);
         EditorCookie ec = (EditorCookie) testSourceDO.getCookie(EditorCookie.class);
-        String oldLevel = JavaSourceTest.SourceLevelQueryImpl.sourceLevel;
-        JavaSourceTest.SourceLevelQueryImpl.sourceLevel = "1.10";
         final Document doc = ec.openDocument();
         doc.putProperty(Language.class, JavaTokenId.language());
         String content
@@ -6328,7 +6325,52 @@ public class FormatingTest extends NbTestCase {
                 + "    }\n"
                 + "}\n";
         reformat(doc, content, golden);
-        JavaSourceTest.SourceLevelQueryImpl.sourceLevel = oldLevel;
+    }
+
+    public void testForVarUnnamed() throws Exception {
+        sourceLevel = "22";
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile, "");
+        FileObject testSourceFO = FileUtil.toFileObject(testFile);
+        DataObject testSourceDO = DataObject.find(testSourceFO);
+        EditorCookie ec = (EditorCookie) testSourceDO.getCookie(EditorCookie.class);
+        final Document doc = ec.openDocument();
+        doc.putProperty(Language.class, JavaTokenId.language());
+        String content
+                = """
+                  package hierbas.del.litoral;
+                  
+                  public class Test {
+                  
+                      public static void main(String[] args) {
+                          int[] orderIDs = {34, 45, 23, 27, 15};
+                          int total = 0;
+                          for (   var   _:orderIDs) {
+                            total++;
+                          }
+                      }
+                  }
+                  """;
+
+        String golden
+                = """
+                  package hierbas.del.litoral;
+                  
+                  public class Test {
+                  
+                      public static void main(String[] args) {
+                          int[] orderIDs = {34, 45, 23, 27, 15};
+                          int total = 0;
+                          for (var _ : orderIDs) {
+                              total++;
+                          }
+                      }
+                  }
+                  """;
+
+        //check no change then formatted
+        reformat(doc, golden, golden);
+        reformat(doc, content, golden);
     }
 
     public void testTryBlockAfterIf() throws Exception {


### PR DESCRIPTION
Update JavaLexer to return token type of `VAR` when followed by underscore as in `var _`.  Fixes formatter issues seen in #9255 Also ensures correct token colouring for this usage.