### PR TITLE
Bump webcommon cluster to release=17

### DIFF
--- a/webcommon/api.knockout/nbproject/project.properties
+++ b/webcommon/api.knockout/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/webcommon/cordova.platforms/nbproject/project.properties
+++ b/webcommon/cordova.platforms/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/extbrowser.chrome/build.xml
+++ b/webcommon/extbrowser.chrome/build.xml
@@ -37,7 +37,7 @@
 
     <target name="build-crx-task" depends="keys.check" if="keys.present">
         <mkdir dir="build/antclasses"/>
-        <javac srcdir="antsrc" destdir="build/antclasses" debug="${build.compiler.debug}" deprecation="${build.compiler.deprecation}" includeantruntime="false">
+        <javac srcdir="antsrc" destdir="build/antclasses" release="${javac.release}" debug="${build.compiler.debug}" deprecation="${build.compiler.deprecation}" includeantruntime="false">
             <classpath>
                 <pathelement path="${antsrc.cp}"/>
             </classpath>

--- a/webcommon/extbrowser.chrome/nbproject/project.properties
+++ b/webcommon/extbrowser.chrome/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 extra.module.files=modules/lib/netbeans-chrome-connector.crx

--- a/webcommon/html.angular/nbproject/project.properties
+++ b/webcommon/html.angular/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/html.knockout/nbproject/project.properties
+++ b/webcommon/html.knockout/nbproject/project.properties
@@ -16,5 +16,5 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/javascript.bower/nbproject/project.properties
+++ b/webcommon/javascript.bower/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 

--- a/webcommon/javascript.grunt/nbproject/project.properties
+++ b/webcommon/javascript.grunt/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 

--- a/webcommon/javascript.gulp/nbproject/project.properties
+++ b/webcommon/javascript.gulp/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 

--- a/webcommon/javascript.jstestdriver/nbproject/project.properties
+++ b/webcommon/javascript.jstestdriver/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/javascript.karma/nbproject/project.properties
+++ b/webcommon/javascript.karma/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/javascript.nodejs/nbproject/project.properties
+++ b/webcommon/javascript.nodejs/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 

--- a/webcommon/javascript.v8debug.ui/nbproject/project.properties
+++ b/webcommon/javascript.v8debug.ui/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 
 is.eager=true

--- a/webcommon/javascript.v8debug/nbproject/project.properties
+++ b/webcommon/javascript.v8debug/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javadoc.arch=${basedir}/arch.xml
 
 is.autoload=true

--- a/webcommon/javascript2.doc/nbproject/project.properties
+++ b/webcommon/javascript2.doc/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/javascript2.extdoc/nbproject/project.properties
+++ b/webcommon/javascript2.extdoc/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/javascript2.extjs/nbproject/project.properties
+++ b/webcommon/javascript2.extjs/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 jnlp.verify.excludes=docs/extjs-properties.xml

--- a/webcommon/javascript2.html/nbproject/project.properties
+++ b/webcommon/javascript2.html/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 is.eager=true

--- a/webcommon/javascript2.jade/nbproject/project.properties
+++ b/webcommon/javascript2.jade/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 #jnlp.verify.excludes=docs/jquery-api.xml,docs/jquery-propertyNames.xml

--- a/webcommon/javascript2.jquery/nbproject/project.properties
+++ b/webcommon/javascript2.jquery/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 jnlp.verify.excludes=docs/jquery-api.xml,docs/jquery-propertyNames.xml

--- a/webcommon/javascript2.jsdoc/nbproject/project.properties
+++ b/webcommon/javascript2.jsdoc/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/javascript2.json/nbproject/project.properties
+++ b/webcommon/javascript2.json/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/javascript2.knockout/nbproject/project.properties
+++ b/webcommon/javascript2.knockout/nbproject/project.properties
@@ -16,5 +16,5 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/javascript2.lexer/nbproject/project.properties
+++ b/webcommon/javascript2.lexer/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/javascript2.model/nbproject/project.properties
+++ b/webcommon/javascript2.model/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/javascript2.nodejs/nbproject/project.properties
+++ b/webcommon/javascript2.nodejs/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 

--- a/webcommon/javascript2.prototypejs/nbproject/project.properties
+++ b/webcommon/javascript2.prototypejs/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 

--- a/webcommon/javascript2.react/nbproject/project.properties
+++ b/webcommon/javascript2.react/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 

--- a/webcommon/javascript2.requirejs/nbproject/project.properties
+++ b/webcommon/javascript2.requirejs/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 

--- a/webcommon/javascript2.sdoc/nbproject/project.properties
+++ b/webcommon/javascript2.sdoc/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/javascript2.source.query/nbproject/project.properties
+++ b/webcommon/javascript2.source.query/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial
 
 is.autoload=true

--- a/webcommon/javascript2.types/nbproject/project.properties
+++ b/webcommon/javascript2.types/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/languages.apacheconf/nbproject/project.properties
+++ b/webcommon/languages.apacheconf/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/languages.ini/nbproject/project.properties
+++ b/webcommon/languages.ini/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/lib.chrome_devtools_protocol/nbproject/project.properties
+++ b/webcommon/lib.chrome_devtools_protocol/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint
 javac.release=11
 
 #javadoc.apichanges=${basedir}/apichanges.xml

--- a/webcommon/lib.v8debug/nbproject/project.properties
+++ b/webcommon/lib.v8debug/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 
 is.autoload=true
-javac.compilerargs=-Xlint:unchecked
-javac.source=1.8
+javac.compilerargs=-Xlint
+javac.release=17
 javadoc.apichanges=${basedir}/apichanges.xml
 
 javadoc.arch=${basedir}/arch.xml

--- a/webcommon/libs.plist/nbproject/project.properties
+++ b/webcommon/libs.plist/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 release.external/dd-plist-1.23.jar=modules/ext/dd-plist.jar

--- a/webcommon/netserver/nbproject/project.properties
+++ b/webcommon/netserver/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/selenium2.webclient.mocha/nbproject/project.properties
+++ b/webcommon/selenium2.webclient.mocha/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/selenium2.webclient.protractor/nbproject/project.properties
+++ b/webcommon/selenium2.webclient.protractor/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/selenium2.webclient/nbproject/project.properties
+++ b/webcommon/selenium2.webclient/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/typescript.editor/nbproject/project.properties
+++ b/webcommon/typescript.editor/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/web.client.kit/nbproject/project.properties
+++ b/webcommon/web.client.kit/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/web.client.samples/nbproject/project.properties
+++ b/webcommon/web.client.samples/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/web.clientproject.api/nbproject/project.properties
+++ b/webcommon/web.clientproject.api/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/web.clientproject/nbproject/project.properties
+++ b/webcommon/web.clientproject/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
-javac.compilerargs=-Xlint -Xlint:-serial -Xlint:unchecked
+javac.release=17
+javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/web.inspect/nbproject/project.properties
+++ b/webcommon/web.inspect/nbproject/project.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17

--- a/webcommon/web.javascript.debugger/nbproject/project.properties
+++ b/webcommon/web.javascript.debugger/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/web.webkit.tooling/nbproject/project.properties
+++ b/webcommon/web.webkit.tooling/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial


### PR DESCRIPTION
skipped cordova modules and libs.jstestdriver

should be the last large cluster outside of enterprise

@matthiasblaesing let me know if there is anything what should stay on 8. I looked through all build scripts so this should be hopefully ok but there is always the chance that I missed something.

meta issue https://github.com/apache/netbeans/issues/8813