### PR TITLE
PHP: javacup 11a library can be downloaded from maven central

### DIFF
--- a/php/libs.javacup/external/binaries-list
+++ b/php/libs.javacup/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-1DE46CC85D147D9F91AF59D4A0107091C8B112D6 java-cup-11a.jar
+1DE46CC85D147D9F91AF59D4A0107091C8B112D6 net.sf.squirrel-sql.thirdparty-non-maven:java-cup:0.11a

--- a/php/libs.javacup/external/java-cup-0.11a-license.txt
+++ b/php/libs.javacup/external/java-cup-0.11a-license.txt
@@ -3,7 +3,7 @@ Version: 11
 Description: LALR Parser Generator in Java
 License: JavaCUP
 Origin: http://www2.cs.tum.edu/projects/cup/
-Files: java-cup-11a.jar
+Files: java-cup-0.11a.jar
 Source: http://www2.cs.tum.edu/projects/cup/
 OSR: 11673
 

--- a/php/libs.javacup/nbproject/project.properties
+++ b/php/libs.javacup/nbproject/project.properties
@@ -16,5 +16,5 @@
 # under the License.
 
 is.autoload=true
-release.external/java-cup-11a.jar=modules/ext/java-cup-11a.jar
+release.external/java-cup-0.11a.jar=modules/ext/java-cup-11a.jar
 spec.version.base=1.56.0

--- a/php/libs.javacup/nbproject/project.xml
+++ b/php/libs.javacup/nbproject/project.xml
@@ -32,7 +32,7 @@
             </friend-packages>
             <class-path-extension>
                 <runtime-relative-path>ext/java-cup-11a.jar</runtime-relative-path>
-                <binary-origin>external/java-cup-11a.jar</binary-origin>
+                <binary-origin>external/java-cup-0.11a.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/php/php.editor/build.xml
+++ b/php/php.editor/build.xml
@@ -149,7 +149,7 @@
         </delete>
         <taskdef name="javacup"
                  classname="java_cup.anttask.CUPTask"
-                 classpath="${nb_all}/php/libs.javacup/external/java-cup-11a.jar" />
+                 classpath="${nb_all}/php/libs.javacup/external/java-cup-0.11a.jar" />
         <javacup srcfile="${basedir}/tools/ASTPHP5Parser.cup"
                  destdir="${basedir}/src"
                  parser="ASTPHP5Parser"


### PR DESCRIPTION
net.sf.squirrel-sql.thirdparty-non-maven:java-cup:0.11a is bit identical with the current custom hosted version.