### PR TITLE
Enable Plain Text Spellchecker for Markdown

### DIFF
--- a/ide/markdown/src/org/netbeans/modules/markdown/MarkdownDataObject.java
+++ b/ide/markdown/src/org/netbeans/modules/markdown/MarkdownDataObject.java
@@ -120,7 +120,7 @@ public class MarkdownDataObject extends MultiDataObject {
     @MultiViewElement.Registration(
             displayName = "#LBL_Markdown_EDITOR",
             iconBase = "org/netbeans/modules/markdown/markdown.png",
-            mimeType = "text/markdown",
+            mimeType = MarkdownDataObject.MIME_TYPE,
             persistenceType = TopComponent.PERSISTENCE_ONLY_OPENED,
             preferredID = "Markdown",
             position = 1000

--- a/ide/markdown/src/org/netbeans/modules/markdown/resources/layer.xml
+++ b/ide/markdown/src/org/netbeans/modules/markdown/resources/layer.xml
@@ -23,6 +23,16 @@
 <filesystem>
     <folder name="Editors">
         <folder name="text">
+            <folder name="markdown">
+                <folder name="TokenListProvider">
+                    <file name="org-netbeans-modules-spellchecker-plain-PlainTokenListProvider.instance" />
+                </folder>
+                <folder name="CompletionProviders">
+                    <file name="org-netbeans-modules-spellchecker-completion-WordCompletion.instance">
+                        <attr name="position" intvalue="600"/>
+                    </file>
+                </folder>
+            </folder>
             <folder name="x-markdown-nb-preview">
                 <attr name="displayName" bundlevalue="org.netbeans.modules.markdown.resources.Bundle#Editors/text/x-markdown-nb-preview"/>
                 <folder name="FontsColors">


### PR DESCRIPTION
This adds the Plain Text Spellchecker which is not the best, though better than none.

Also made `text/x-markdown` the only MIME-TYPE used here for consistency.

It might be tempting to use `text/markdown` since that's the official one from 2016 [RFC 7763](https://www.rfc-editor.org/rfc/rfc7763)

I've checked, that the previous MIME `text/x-markdown-nb` was not used anywhere else in the IDE.