### PR TITLE
Setting NETBEANS_USERDIR=IGNORE shall use netbeans_default_userdir

### DIFF
--- a/nb/ide.launcher/unix/netbeans
+++ b/nb/ide.launcher/unix/netbeans
@@ -81,17 +81,19 @@ fi
 
 export DEFAULT_USERDIR_ROOT
 
-if ! [ "$NETBEANS_USERDIR" = "IGNORE" ]; then
-    # make sure own launcher directory is on PATH as a fallback
-    PATH=$PATH:`echo $progdir | absolutize_paths`
-fi
-
 # #68373: look for userdir, but do not modify "$@"
-if [ -z "$NETBEANS_USERDIR" ]; then
+if [ "$NETBEANS_USERDIR" = "IGNORE" ]; then
     userdir="${netbeans_default_userdir}"
 else
-    userdir="$NETBEANS_USERDIR"
+    # make sure own launcher directory is on PATH as a fallback
+    PATH=$PATH:`echo $progdir | absolutize_paths`
+    if [ -z "$NETBEANS_USERDIR" ]; then
+        userdir="${netbeans_default_userdir}"
+    else
+        userdir="$NETBEANS_USERDIR"
+    fi
 fi
+
 cachedir="${netbeans_default_cachedir}"
 
 founduserdir=""


### PR DESCRIPTION
- Fixes problem reported by @mbien in [this coment](https://github.com/apache/netbeans/pull/8756#issuecomment-3942538362)
- settting environment variable `NETBEANS_USERDIR=IGNORE` should disable all #8756 manipulations
- but it didn't - resulting in `--userdir` being set to `$PWD/IGNORE`
- this PR addresses that roblem