### PR TITLE
Add the maven action toolbar config to OptionsExport

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/layer.xml
+++ b/java/maven/src/org/netbeans/modules/maven/layer.xml
@@ -205,7 +205,7 @@
     <folder name="OptionsExport">
         <folder name="Java">
             <file name="Maven">
-                <attr name="include" stringvalue="config/(Preferences/org/netbeans/modules/maven([.]properties|/(?!externalOwners[.]properties).*)|Projects/org-netbeans-modules-maven/nbactions[.]xml)"/>
+                <attr name="include" stringvalue="config/(Preferences/org/netbeans/modules/maven([.]properties|/(?!externalOwners[.]properties).*)|Projects/org-netbeans-modules-maven/nbactions[.]xml|Actions/Maven/.*)"/>
                 <attr name="displayName" bundlevalue="org.netbeans.modules.maven.Bundle#options-export-displayName"/>
             </file>
         </folder>


### PR DESCRIPTION
`config/Actions/Maven/*` contains the toolbar config files

<img width="350" height="30" alt="mavenbar" src="https://github.com/user-attachments/assets/740ad3e4-8e60-4462-92a8-d86bbcbc32a7" />

(buttons on the right)

The import itself seems to work but the buttons will only show up after the second launch atm.

see second screenshot in https://github.com/apache/netbeans/pull/7537 for the options