### PR TITLE
Use InputStream.transferTo() instead of FileUtil.copy() and simplify usages

### DIFF
--- a/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/spi/BrandingSupportTest.java
+++ b/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/spi/BrandingSupportTest.java
@@ -133,22 +133,10 @@ public class BrandingSupportTest extends TestBase {
     }
     
     private File createNewSource(final BrandingSupport.BrandedFile bFile) throws MalformedURLException, FileNotFoundException, IOException {
-        OutputStream os = null;
-        InputStream is = null;
-        File newSource = new File(getWorkDir(),"newSource.gif");
-        
-        try {
-            
-            os = new FileOutputStream(newSource);
-            is = bFile.getBrandingSource().openStream();
-            FileUtil.copy(is,os);
-        } finally  {
-            if (is != null) {
-                is.close();
-            }
-            if (os != null) {
-                os.close();
-            }
+        File newSource = new File(getWorkDir(), "newSource.gif");
+        try (InputStream is = bFile.getBrandingSource().openStream();
+             OutputStream os = new FileOutputStream(newSource);) {
+            is.transferTo(os);
         }
         return newSource;
     }

--- a/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/BuildZipDistributionTest.java
+++ b/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/suite/BuildZipDistributionTest.java
@@ -183,9 +183,9 @@ public class BuildZipDistributionTest extends TestBase {
             }
             File entry = new File(expand, path);
             entry.getParentFile().mkdirs();
-            FileOutputStream os = new FileOutputStream(entry);
-            FileUtil.copy(f.getInputStream(jarEntry), os);
-            os.close();
+            try (FileOutputStream os = new FileOutputStream(entry)) {
+                f.getInputStream(jarEntry).transferTo(os);
+            }
         }
 
         File root = new File(expand, "fakeapp");

--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/api/LayerHandle.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/api/LayerHandle.java
@@ -213,16 +213,9 @@ public final class LayerHandle {
 
     public static FileObject createLayer(FileObject projectDir, String layerPath) throws IOException {
         FileObject layerFO = createFileObject(projectDir, layerPath);
-        InputStream is = LayerHandle.class.getResourceAsStream("/org/netbeans/modules/apisupport/project/ui/resources/layer_template.xml"); // NOI18N
-        try {
-            OutputStream os = layerFO.getOutputStream();
-            try {
-                FileUtil.copy(is, os);
-            } finally {
-                os.close();
-            }
-        } finally {
-            is.close();
+        try (InputStream is = LayerHandle.class.getResourceAsStream("/org/netbeans/modules/apisupport/project/ui/resources/layer_template.xml"); // NOI18N
+             OutputStream os = layerFO.getOutputStream()) {
+            is.transferTo(os);
         }
         return layerFO;
     }

--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/BrandingSupport.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/BrandingSupport.java
@@ -277,21 +277,10 @@ public abstract class BrandingSupport {
         
         assert target.exists();
         FileObject fo = FileUtil.toFileObject(target);
-        InputStream is = null;
-        OutputStream os = null;
-        try {
-            is = bFile.getBrandingSource().openStream();
-            os = fo.getOutputStream();
-            FileUtil.copy(is, os);
+        try (InputStream is = bFile.getBrandingSource().openStream();
+             OutputStream os = fo.getOutputStream()) {
+            is.transferTo(os);
         } finally {
-            if (is != null) {
-                is.close();
-            }
-            
-            if (os != null) {
-                os.close();
-            }
-            
             brandedFiles.add(bFile);
             bFile.modified = false;
         }

--- a/apisupport/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/TestUtil.java
+++ b/apisupport/apisupport.project/test/unit/src/org/netbeans/modules/apisupport/project/TestUtil.java
@@ -34,7 +34,6 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.zip.CRC32;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.test.TestFileUtils;
 import org.openide.util.test.JarBuilder;
 
@@ -65,16 +64,8 @@ public class TestUtil {
             }
         } else {
             assert from.isFile() : from;
-            InputStream is = new FileInputStream(from);
-            try {
-                OutputStream os = new FileOutputStream(to);
-                try {
-                    FileUtil.copy(is, os);
-                } finally {
-                    os.close();
-                }
-            } finally {
-                is.close();
+            try (InputStream is = new FileInputStream(from); OutputStream os = new FileOutputStream(to)) {
+                is.transferTo(os);
             }
         }
     }

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/CreatedModifiedFiles.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/CreatedModifiedFiles.java
@@ -1472,16 +1472,8 @@ public final class CreatedModifiedFiles {
     }
 
     private static void copyByteAfterByte(FileObject content, FileObject target) throws IOException {
-        OutputStream os = target.getOutputStream();
-        try {
-            InputStream is = content.getInputStream();
-            try {
-                FileUtil.copy(is, os);
-            } finally {
-                is.close();
-            }
-        } finally {
-            os.close();
+        try (OutputStream os = target.getOutputStream(); InputStream is = content.getInputStream()) {
+            is.transferTo(os);
         }
     }
 

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/librarydescriptor/CreatedModifiedFilesProvider.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/librarydescriptor/CreatedModifiedFilesProvider.java
@@ -215,9 +215,7 @@ final class CreatedModifiedFilesProvider {
         }
 
         private static void createZipFile(OutputStream target, FileObject root, Collection<? extends FileObject> files) throws IOException {
-            ZipOutputStream str = null;
-            try {
-                str = new ZipOutputStream(target);
+            try (ZipOutputStream str = new ZipOutputStream(target)) {
                 for (FileObject fo : files) {
                     String relativePath = FileUtil.getRelativePath(root, fo);
                     if (fo.isFolder()) {
@@ -230,21 +228,11 @@ final class CreatedModifiedFilesProvider {
                     ZipEntry entry = new ZipEntry(relativePath);
                     str.putNextEntry(entry);
                     if (fo.isData()) {
-                        InputStream in = null;
-                        try {
-                            in = fo.getInputStream();
-                            FileUtil.copy(in, str);
-                        } finally {
-                            if (in != null) {
-                                in.close();
-                            }
+                        try (InputStream in = fo.getInputStream()) {
+                            in.transferTo(str);
                         }
                     }
                     str.closeEntry();
-                }
-            } finally {
-                if (str != null) {
-                    str.close();
                 }
             }
         }

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/project/NewProjectIterator.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/project/NewProjectIterator.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
@@ -324,13 +323,9 @@ public final class NewProjectIterator extends BasicWizardIterator {
         }
     }
     
-    private static void createZipFile(OutputStream target, FileObject root, Collection /* FileObject*/ files) throws IOException {
-        ZipOutputStream str = null;
-        try {
-            str = new ZipOutputStream(target);
-            Iterator it = files.iterator();
-            while (it.hasNext()) {
-                FileObject fo = (FileObject)it.next();
+    private static void createZipFile(OutputStream target, FileObject root, Collection<FileObject> files) throws IOException {
+        try (ZipOutputStream str = new ZipOutputStream(target)) {
+            for (FileObject fo : files) {
                 String path = FileUtil.getRelativePath(root, fo);
                 if (fo.isFolder() && !path.endsWith("/")) {
                     path = path + "/";
@@ -338,21 +333,11 @@ public final class NewProjectIterator extends BasicWizardIterator {
                 ZipEntry entry = new ZipEntry(path);
                 str.putNextEntry(entry);
                 if (fo.isData()) {
-                    InputStream in = null;
-                    try {
-                        in = fo.getInputStream();
-                        FileUtil.copy(in, str);
-                    } finally {
-                        if (in != null) {
-                            in.close();
-                        }
+                    try (InputStream in = fo.getInputStream()) {
+                        in.transferTo(str);
                     }
                 }
                 str.closeEntry();
-            }
-        } finally {
-            if (str != null) {
-                str.close();
             }
         }
     }

--- a/apisupport/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/DesignSupportTest.java
+++ b/apisupport/apisupport.wizards/test/unit/src/org/netbeans/modules/apisupport/project/ui/wizard/winsys/DesignSupportTest.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.apisupport.project.ui.wizard.winsys;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import org.netbeans.junit.NbTestCase;
 import org.openide.filesystems.FileObject;
@@ -37,9 +38,10 @@ public class DesignSupportTest extends NbTestCase {
     protected void setUp() throws IOException {
         FileSystem ms = FileUtil.createMemoryFileSystem();
         fo = ms.getRoot().createData("my.wsmode");
-        OutputStream os = fo.getOutputStream();
-        FileUtil.copy(DesignSupportTest.class.getResourceAsStream("testWsmode.xml"), os);
-        os.close();
+        try (InputStream is = DesignSupportTest.class.getResourceAsStream("testWsmode.xml");
+             OutputStream os = fo.getOutputStream()) {
+            is.transferTo(os);
+        }
     }
     public void testReadingOfAMode() throws Exception {
         String read = DesignSupport.readMode(fo);

--- a/contrib/j2ee.jboss4/src/org/netbeans/modules/j2ee/jboss4/ide/JBDriverDeployer.java
+++ b/contrib/j2ee.jboss4/src/org/netbeans/modules/j2ee/jboss4/ide/JBDriverDeployer.java
@@ -116,18 +116,12 @@ public class JBDriverDeployer implements JDBCDriverDeployer {
                     File libsDir = properties.getLibsDir();
                     File toJar = new File(libsDir, file.getNameExt());
                     try {
-                        BufferedInputStream is = new BufferedInputStream(file.getInputStream());
-                        try {
+                        try (BufferedInputStream is = new BufferedInputStream(file.getInputStream())) {
                             String msg = NbBundle.getMessage(JBDriverDeployer.class, "MSG_DeployingJDBCDrivers", toJar.getPath());
                             eventSupport.fireProgressEvent(null, new JBDeploymentStatus(ActionType.EXECUTE, CommandType.DISTRIBUTE, StateType.RUNNING, msg));
-                            BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(toJar));
-                            try {
-                                FileUtil.copy(is, os);
-                            } finally {
-                                os.close();
+                            try (BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(toJar))) {
+                                is.transferTo(os);
                             }
-                        } finally {
-                            is.close();
                         }
                     } catch (IOException e) {
                         LOGGER.log(Level.INFO, null, e);

--- a/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/deploy/WLDriverDeployer.java
+++ b/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/deploy/WLDriverDeployer.java
@@ -109,19 +109,13 @@ public class WLDriverDeployer implements JDBCDriverDeployer {
                         for (FileObject file : jdbcDriverURLs) {
                             File toJar = new File(libsDir, file.getNameExt());
                             try {
-                                BufferedInputStream is = new BufferedInputStream(file.getInputStream());
-                                try {
+                                try (BufferedInputStream is = new BufferedInputStream(file.getInputStream())) {
                                     progress.fireProgressEvent(null, new WLDeploymentStatus(
                                             ActionType.EXECUTE, CommandType.DISTRIBUTE, StateType.RUNNING,
                                             NbBundle.getMessage(WLDriverDeployer.class, "MSG_DeployingJDBCDrivers", toJar.getPath())));
-                                    BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(toJar));
-                                    try {
-                                        FileUtil.copy(is, os);
-                                    } finally {
-                                        os.close();
+                                    try (BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(toJar))) {
+                                        is.transferTo(os);
                                     }
-                                } finally {
-                                    is.close();
                                 }
                             } catch (IOException e) {
                                 LOGGER.log(Level.INFO, null, e);

--- a/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/deploy/WLJpa2SwitchSupport.java
+++ b/contrib/j2ee.weblogic9/src/org/netbeans/modules/j2ee/weblogic9/deploy/WLJpa2SwitchSupport.java
@@ -168,8 +168,7 @@ public final class WLJpa2SwitchSupport {
                 createContributionsJar(oepeFile, contribPath);
                 // exists so update cp
             } else {
-                JarFile oepeJarFile = new JarFile(oepeFile);
-                try {
+                try (JarFile oepeJarFile = new JarFile(oepeFile)) {
                     Manifest mf = oepeJarFile.getManifest();
                     String cp = mf.getMainAttributes().getValue(Name.CLASS_PATH);
                     if (cp == null) {
@@ -194,15 +193,12 @@ public final class WLJpa2SwitchSupport {
                         mf.getMainAttributes().put(Name.CLASS_PATH, updated.toString());
                         replaceManifest(oepeFile, mf);
                     }
-                } finally {
-                    oepeJarFile.close();
                 }
             }
 
             // update weblogic.jar
             File weblogicFile = WebLogicLayout.getWeblogicJar(serverRoot);
-            JarFile weblogicJarFile = new JarFile(weblogicFile);
-            try {
+            try (JarFile weblogicJarFile = new JarFile(weblogicFile)) {
                 Manifest wlManifest = weblogicJarFile.getManifest();
                 String cp = wlManifest.getMainAttributes().getValue(Name.CLASS_PATH);
                 if (cp == null) {
@@ -217,8 +213,6 @@ public final class WLJpa2SwitchSupport {
                     wlManifest.getMainAttributes().put(Name.CLASS_PATH, cp);
                     replaceManifest(weblogicFile, wlManifest);
                 }
-            } finally {
-                weblogicJarFile.close();
             }
         } catch (IOException ex) {
             Exceptions.printStackTrace(ex);
@@ -241,8 +235,7 @@ public final class WLJpa2SwitchSupport {
             if (!oepeJarFile.exists() || !oepeJarFile.isFile()) {
                 return;
             }
-            JarFile file = new JarFile(oepeJarFile);
-            try {
+            try (JarFile file = new JarFile(oepeJarFile)) {
                 Manifest mf = file.getManifest();
                 String cp = mf.getMainAttributes().getValue(Name.CLASS_PATH);
                 if (cp == null) {
@@ -262,8 +255,6 @@ public final class WLJpa2SwitchSupport {
                     mf.getMainAttributes().remove(Name.CLASS_PATH);
                 }
                 replaceManifest(oepeJarFile, mf);
-            } finally {
-                file.close();
             }
         } catch (IOException ex) {
             // TODO some exception/message to the user
@@ -354,20 +345,10 @@ public final class WLJpa2SwitchSupport {
                 jarFile.getName(), "tmp"); // NOI18N
         File tmpJar = new File(jarFile.getParentFile(), tmpName + ".tmp"); // NOI18N
         try {
-            InputStream is = new BufferedInputStream(
-                    new FileInputStream(jarFile));
-            try {
-                OutputStream os = new BufferedOutputStream(
-                        new FileOutputStream(tmpJar));
-                try {
-                    replaceManifest(is, os, manifest);
-                } finally {
-                    os.close();
-                }
-            } finally {
-                is.close();
+            try (InputStream is = new BufferedInputStream(new FileInputStream(jarFile));
+                 OutputStream os = new BufferedOutputStream(new FileOutputStream(tmpJar))) {
+                replaceManifest(is, os, manifest);
             }
-
             if (tmpJar.renameTo(jarFile)) {
                 LOGGER.log(Level.FINE, "Successfully moved {0}", tmpJar);
                 return;
@@ -380,64 +361,43 @@ public final class WLJpa2SwitchSupport {
     }
 
     private void replaceManifest(InputStream is, OutputStream os, Manifest manifest) throws IOException {
-        JarInputStream in = new JarInputStream(is);
-        try {
-            JarOutputStream out = new JarOutputStream(os, manifest);
-            try {
-                JarEntry entry = null;
-                byte[] temp = new byte[32768];
-                while ((entry = in.getNextJarEntry()) != null) {
-                    String name = entry.getName();
-                    if (name.equalsIgnoreCase("META-INF/MANIFEST.MF")) { // NOI18N
-                        continue;
-                    }
-                    out.putNextEntry(entry);
-                    while (in.available() != 0) {
-                        int read = in.read(temp);
-                        if (read != -1) {
-                            out.write(temp, 0, read);
-                        }
-                    }
-                    out.closeEntry();
+        try (JarInputStream in = new JarInputStream(is); JarOutputStream out = new JarOutputStream(os, manifest)) {
+            JarEntry entry = null;
+            byte[] temp = new byte[32768];
+            while ((entry = in.getNextJarEntry()) != null) {
+                String name = entry.getName();
+                if (name.equalsIgnoreCase("META-INF/MANIFEST.MF")) { // NOI18N
+                    continue;
                 }
-            } finally {
-                out.close();
+                out.putNextEntry(entry);
+                while (in.available() != 0) {
+                    int read = in.read(temp);
+                    if (read != -1) {
+                        out.write(temp, 0, read);
+                    }
+                }
+                out.closeEntry();
             }
-        } finally {
-            in.close();
         }
     }
 
     private void createContributionsJar(File jarFile, String classpath) throws IOException {
         //need to create zip file
-        OutputStream os = new BufferedOutputStream(new FileOutputStream(jarFile));
-        try {
+        try (OutputStream os = new BufferedOutputStream(new FileOutputStream(jarFile))) {
             Manifest manifest = new Manifest();
             manifest.getMainAttributes().put(Name.MANIFEST_VERSION, "1.0"); // NOI18N
             manifest.getMainAttributes().put(Name.CLASS_PATH, classpath);
-            JarOutputStream dest = new JarOutputStream(new BufferedOutputStream(os), manifest);
-            try {
+            try (JarOutputStream dest = new JarOutputStream(new BufferedOutputStream(os), manifest)) {
                 dest.closeEntry();
                 dest.finish();
-            } finally {
-                dest.close();
             }
-        } finally {
-            os.close();
         }
     }
 
     private void copy(File source, File dest) throws IOException {
-        InputStream is = new BufferedInputStream(new FileInputStream(source));
-        try {
-            OutputStream os = new BufferedOutputStream(new FileOutputStream(dest));
-            try {
-                FileUtil.copy(is, os);
-            } finally {
-                os.close();
-            }
-        } finally {
-            is.close();
+        try (InputStream is = new BufferedInputStream(new FileInputStream(source));
+             OutputStream os = new BufferedOutputStream(new FileOutputStream(dest))) {
+            is.transferTo(os);
         }
     }
 

--- a/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/wizard/STSWizard.java
+++ b/contrib/websvc.wsitconf/src/org/netbeans/modules/websvc/wsitconf/wizard/STSWizard.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.websvc.wsitconf.wizard;
 import java.awt.Component;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -116,40 +115,23 @@ public class STSWizard implements TemplateWizard.Iterator {
 
         FileUtil.runAtomicAction(new Runnable() {
             public void run() {
-                OutputStream schemaos = null;
-                InputStream schemaIS = null;
                 try {
-                    FileObject wsdlFolder = FileUtil.toFileObject(userDirF);
-                    schemaIS = this.getClass().getClassLoader().getResourceAsStream("org/netbeans/modules/websvc/wsitconf/resources/templates/sts_schema.template"); //NOI18N
-                    FileObject schema = null;
-                    try {
-                        schema = wsdlFolder.createData("sts_schema.xsd");
-                    } catch (IOException ex) { // do not care - this is thrown if the file already exists
-                        logger.log(Level.FINE, null, ex);
-                        logger.log(Level.FINE, "schema: " + schema);
-                        schema = wsdlFolder.getFileObject("sts_schema.xsd");
+                    try (InputStream schemaIS = this.getClass().getClassLoader().getResourceAsStream("org/netbeans/modules/websvc/wsitconf/resources/templates/sts_schema.template")) { //NOI18N
+                        FileObject wsdlFolder = FileUtil.toFileObject(userDirF);
+                        FileObject schema = null;
+                        try {
+                            schema = wsdlFolder.createData("sts_schema.xsd");
+                        } catch (IOException ex) { // do not care - this is thrown if the file already exists
+                            logger.log(Level.FINE, null, ex);
+                            logger.log(Level.FINE, "schema: " + schema);
+                            schema = wsdlFolder.getFileObject("sts_schema.xsd");
+                        }
+                        try (OutputStream schemaos = schema.getOutputStream()) {
+                            schemaIS.transferTo(schemaos);
+                        }
                     }
-                    schemaos = schema.getOutputStream();
-                    FileUtil.copy(schemaIS, schemaos);
-                } catch (FileNotFoundException ex) {
-                    logger.log(Level.INFO, null, ex);
                 } catch (IOException ex) {
                     logger.log(Level.INFO, null, ex);
-                } finally {
-                    if (schemaos != null) {
-                        try {
-                            schemaos.close();
-                        } catch (IOException ex) {
-                            logger.log(Level.INFO, null, ex);
-                        }
-                    }
-                    if (schemaIS != null) {
-                        try {
-                            schemaIS.close();
-                        } catch (IOException ex) {
-                            logger.log(Level.INFO, null, ex);
-                        }
-                    }
                 }
             }
         });
@@ -161,70 +143,35 @@ public class STSWizard implements TemplateWizard.Iterator {
                 FileObject wsdlFolder = FileUtil.toFileObject(userDirF);
                 FileObject wsdlFO = null;
                 try {
-                    OutputStream wsdlos = null;
-                    InputStream wsdlIS = null;
                     try {
-                        wsdlIS = this.getClass().getClassLoader().getResourceAsStream("org/netbeans/modules/websvc/wsitconf/resources/templates/" + fileName + ".template"); //NOI18N
-
-                        try {
-                            wsdlFO = wsdlFolder.createData(fileName, "wsdl");
-                        } catch (IOException ex) { // do not care - this is thrown if the file already exists
-                            logger.log(Level.FINE, null, ex);
-                            logger.log(Level.FINE, "wsdl: " + wsdlFO);
-                            wsdlFO = wsdlFolder.getFileObject(fileName, "wsdl");
-                        }
-                        wsdlos = wsdlFO.getOutputStream();
-                        FileUtil.copy(wsdlIS, wsdlos);
-                    } catch (FileNotFoundException ex) {
-                        logger.log(Level.INFO, null, ex);
+                        try (InputStream wsdlIS = this.getClass().getClassLoader().getResourceAsStream("org/netbeans/modules/websvc/wsitconf/resources/templates/" + fileName + ".template")) { //NOI18N
+                            try {
+                                wsdlFO = wsdlFolder.createData(fileName, "wsdl");
+                            } catch (IOException ex) { // do not care - this is thrown if the file already exists
+                                logger.log(Level.FINE, null, ex);
+                                logger.log(Level.FINE, "wsdl: " + wsdlFO);
+                                wsdlFO = wsdlFolder.getFileObject(fileName, "wsdl");
+                            }
+                            try (OutputStream wsdlos = wsdlFO.getOutputStream()) {
+                                wsdlIS.transferTo(wsdlos);
+                            }
+                        }                    
                     } catch (IOException ex) {
                         logger.log(Level.INFO, null, ex);
-                    } finally {
-                        if (wsdlos != null) {
-                            try {
-                                wsdlos.close();
-                            } catch (IOException ex) {
-                                logger.log(Level.INFO, null, ex);
-                            }
-                        }
-                        if (wsdlIS != null) {
-                            try {
-                                wsdlIS.close();
-                            } catch (IOException ex) {
-                                logger.log(Level.INFO, null, ex);
-                            }
-                        }
                     }
 
                     String newName = serviceName;
                     FileObject newFO = null;
 
-                    InputStream fi = null;
-                    OutputStream fo = null;
-
                     try {
-                        File f = new File(FileUtil.toFile(wsdlFolder).getAbsolutePath(), newName + ".wsdl");
+                        File f = new File(FileUtil.toFile(wsdlFolder).getAbsolutePath(), newName + ".wsdl"); //NOI18N
                         f.createNewFile();
-                        fo = new FileOutputStream(f);
-                        fi = wsdlFO.getInputStream();
-                        FileUtil.copy(fi, fo);
-                        newFO = FileUtil.toFileObject(f);
-                    //newFO = FileUtil.copyFile(wsdlFO, wsdlFolder, newName);
-                    } catch (FileNotFoundException ex) {
-                        logger.log(Level.INFO, null, ex);
+                        try (InputStream fi = wsdlFO.getInputStream(); OutputStream fo = new FileOutputStream(f)) {
+                            fi.transferTo(fo);
+                            newFO = FileUtil.toFileObject(f);
+                        }
                     } catch (IOException ex) {
                         logger.log(Level.INFO, null, ex);
-                    } finally {
-                        try {
-                            if (fi != null) {
-                                fi.close();
-                            }
-                            if (fo != null) {
-                                fo.close();
-                            }
-                        } catch (IOException ex) {
-                            logger.log(Level.INFO, null, ex);
-                        }
                     }
 
                     File newFile = FileUtil.toFile(newFO);
@@ -232,31 +179,20 @@ public class STSWizard implements TemplateWizard.Iterator {
 
                     wiz.putProperty(WizardProperties.WSDL_FILE_PATH, newFile.getPath());
 
-                    BufferedWriter writer = null;
                     try {
                         List<String> lines = wsdlFO.asLines();
-                        writer = new BufferedWriter(new FileWriter(newFile));
-
-                        for (String line : lines) {
-                            if ((index = line.indexOf(SERVICENAME_TAG)) != -1) {
-                                line = line.replaceAll(SERVICENAME_TAG, serviceName);
+                        try (BufferedWriter writer = new BufferedWriter(new FileWriter(newFile))) {
+                            for (String line : lines) {
+                                if ((index = line.indexOf(SERVICENAME_TAG)) != -1) {
+                                    line = line.replaceAll(SERVICENAME_TAG, serviceName);
+                                }
+                                writer.write(line);
+                                writer.newLine();
                             }
-                            writer.write(line);
-                            writer.newLine();
+                            writer.flush();
                         }
-                    } catch (FileNotFoundException ex) {
-                        logger.log(Level.INFO, null, ex);
                     } catch (IOException ex) {
                         logger.log(Level.INFO, null, ex);
-                    } finally {
-                        try {
-                            if (writer != null) {
-                                writer.flush();
-                                writer.close();
-                            }
-                        } catch (IOException ex) {
-                            logger.log(Level.INFO, null, ex);
-                        }
                     }
 
                     wsdlModeler = WsdlModelerFactory.getDefault().getWsdlModeler(wsdlURL);
@@ -267,11 +203,7 @@ public class STSWizard implements TemplateWizard.Iterator {
                             if (wsdlModel == null) {
                                 try {
                                     WsdlServiceHandler.parse(wsdlURL.toExternalForm());
-                                } catch (ParserConfigurationException ex) {
-                                    logger.log(Level.FINE, null, ex);
-                                } catch (SAXException ex) {
-                                    logger.log(Level.FINE, null, ex);
-                                } catch (IOException ex) {
+                                } catch (ParserConfigurationException | SAXException | IOException ex) {
                                     logger.log(Level.FINE, null, ex);
                                 }
                             } else {

--- a/contrib/websvc.wsitconf/test/unit/src/org/netbeans/modules/websvc/wsitconf/util/TestUtil.java
+++ b/contrib/websvc.wsitconf/test/unit/src/org/netbeans/modules/websvc/wsitconf/util/TestUtil.java
@@ -33,7 +33,6 @@ import java.nio.file.Files;
 import javax.swing.text.Document;
 import org.netbeans.modules.xml.wsdl.model.WSDLModel;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.FileLock;
 
 /**
@@ -139,13 +138,11 @@ public class TestUtil {
             dest = destFolder.createData(filename);
         }
         FileLock lock = dest.lock();
-        OutputStream out = dest.getOutputStream(lock);
-        InputStream in = TestUtil.class.getResourceAsStream(path);
         try {
-            FileUtil.copy(in, out);
+            try (InputStream in = TestUtil.class.getResourceAsStream(path); OutputStream out = dest.getOutputStream(lock)) {
+                in.transferTo(out);
+            }
         } finally {
-            out.close();
-            in.close();
             if (lock != null) lock.releaseLock();
         }
         return dest;

--- a/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/LanguageServerImpl.java
+++ b/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/LanguageServerImpl.java
@@ -216,7 +216,7 @@ public class LanguageServerImpl implements LanguageServerProvider {
             } else if (commandsPath != null && commandsPath.canRead()) {
                 try (InputStream in = new FileInputStream(commandsPath);
                      OutputStream out = new FileOutputStream(tempFile)) {
-                    FileUtil.copy(in, out);
+                    in.transferTo(out);
                 } catch (IOException ex) {
                     LOG.log(Level.WARNING, null, ex);
                     return null;

--- a/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/JDBCDriverDeployHelper.java
+++ b/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/JDBCDriverDeployHelper.java
@@ -22,7 +22,6 @@ package org.netbeans.modules.glassfish.eecommon.api;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -32,8 +31,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.jar.JarEntry;
-import java.util.jar.JarInputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.enterprise.deploy.shared.ActionType;
@@ -53,10 +50,8 @@ import org.netbeans.modules.j2ee.common.DatasourceHelper;
 import org.netbeans.modules.j2ee.deployment.common.api.Datasource;
 import org.openide.ErrorManager;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
 import org.openide.util.NbBundle;
-import org.openide.util.Parameters;
 
 public class JDBCDriverDeployHelper {
 
@@ -173,28 +168,12 @@ public class JDBCDriverDeployHelper {
                     try {
                         File toJar = new File(libsDir, new File(jarUrl.toURI()).getName());
                         try {
-                            BufferedInputStream is = new BufferedInputStream(jarUrl.openStream());
-                            try {
+                            try (BufferedInputStream is = new BufferedInputStream(jarUrl.openStream())) {
                                 msg = NbBundle.getMessage(JDBCDriverDeployHelper.class, "MSG_DeployDriver", toJar.getPath());
                                 eventSupport.fireHandleProgressEvent(null, ProgressEventSupport.createStatus(ActionType.EXECUTE, CommandType.DISTRIBUTE, msg, StateType.RUNNING));
-                                BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(toJar));
-                                try {
-                                    FileUtil.copy(is, os);
-                                } finally {
-                                    if (null != os)
-                                        try {
-                                            os.close();
-                                        } catch (IOException ioe) {
-
-                                        }
+                                try (BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(toJar))) {
+                                    is.transferTo(os);
                                 }
-                            } finally {
-                                if (null != is)
-                                    try {
-                                        is.close();
-                                    } catch (IOException ioe) {
-                                        
-                                    }
                             }
                         } catch (IOException e) {
                             Logger.getLogger(this.getClass().getName()).log(Level.FINER,"",e);

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/AntDeploymentProviderImpl.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/AntDeploymentProviderImpl.java
@@ -71,11 +71,8 @@ class AntDeploymentProviderImpl implements AntDeploymentProvider {
 
     @Override
     public void writeDeploymentScript(OutputStream os, Object moduleType) throws IOException {
-        InputStream is = AntDeploymentProviderImpl.class.getResourceAsStream("ant-deploy.xml"); // NOI18N            
-        try {
-            FileUtil.copy(is, os);
-        } finally {
-            is.close();
+        try (InputStream is = AntDeploymentProviderImpl.class.getResourceAsStream("ant-deploy.xml")) { // NOI18N
+            is.transferTo(os);
         }
     }
 

--- a/enterprise/j2ee.ejbcore/test/unit/src/org/netbeans/modules/j2ee/ejbcore/test/TestBase.java
+++ b/enterprise/j2ee.ejbcore/test/unit/src/org/netbeans/modules/j2ee/ejbcore/test/TestBase.java
@@ -197,16 +197,8 @@ public class TestBase extends NbTestCase {
             }
         } else {
             assert from.isFile();
-            InputStream is = new FileInputStream(from);
-            try {
-                OutputStream os = new FileOutputStream(to);
-                try {
-                    FileUtil.copy(is, os);
-                } finally {
-                    os.close();
-                }
-            } finally {
-                is.close();
+            try (InputStream is = new FileInputStream(from); OutputStream os = new FileOutputStream(to)) {
+                is.transferTo(os);
             }
         }
     }

--- a/enterprise/j2ee.ejbcore/test/unit/src/org/netbeans/modules/j2ee/ejbcore/test/TestUtilities.java
+++ b/enterprise/j2ee.ejbcore/test/unit/src/org/netbeans/modules/j2ee/ejbcore/test/TestUtilities.java
@@ -19,13 +19,10 @@
 
 package org.netbeans.modules.j2ee.ejbcore.test;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileUtil;
 
 /**
  * 
@@ -37,13 +34,9 @@ public class TestUtilities {
     }
     
     public static final FileObject copyStringToFileObject(FileObject fo, String content) throws IOException {
-        OutputStream os = fo.getOutputStream();
-        try {
-            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-            FileUtil.copy(is, os);
+        try (OutputStream os = fo.getOutputStream()) {
+            os.write(content.getBytes(StandardCharsets.UTF_8));
             return fo;
-        } finally {
-            os.close();
         }
     }
 }

--- a/enterprise/j2ee.ejbverification/test/unit/src/org/netbeans/modules/j2ee/ejbverification/TestBase.java
+++ b/enterprise/j2ee.ejbverification/test/unit/src/org/netbeans/modules/j2ee/ejbverification/TestBase.java
@@ -247,16 +247,8 @@ public class TestBase extends NbTestCase {
             }
         } else {
             assert from.isFile();
-            InputStream is = new FileInputStream(from);
-            try {
-                OutputStream os = new FileOutputStream(to);
-                try {
-                    FileUtil.copy(is, os);
-                } finally {
-                    os.close();
-                }
-            } finally {
-                is.close();
+            try (InputStream is = new FileInputStream(from); OutputStream os = new FileOutputStream(to)) {
+                is.transferTo(os);
             }
         }
     }
@@ -334,17 +326,9 @@ public class TestBase extends NbTestCase {
     }
 
     public static final FileObject copyStringToFileObject(FileObject fo, String content) throws IOException {
-        OutputStream os = fo.getOutputStream();
-        try {
-            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-            try {
-                FileUtil.copy(is, os);
-                return fo;
-            } finally {
-                is.close();
-            }
-        } finally {
-            os.close();
+        try (OutputStream os = fo.getOutputStream()) {
+            os.write(content.getBytes(StandardCharsets.UTF_8));
+            return fo;
         }
     }
 

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/newproject/MicronautProjectWizardIterator.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/newproject/MicronautProjectWizardIterator.java
@@ -225,7 +225,7 @@ public class MicronautProjectWizardIterator implements WizardDescriptor.Progress
                 } else {
                     FileObject fo = FileUtil.createData(folder, entryName);
                     try (OutputStream out = fo.getOutputStream()) {
-                        FileUtil.copy(zis, out);
+                        zis.transferTo(out);
                         File backingFile = FileUtil.toFile(fo);
                         if (backingFile != null) {
                             // Workaround for limit of JDK API:

--- a/enterprise/web.jsf.editor/test/unit/src/org/netbeans/modules/web/jsf/editor/JsfHtmlExtensionTest.java
+++ b/enterprise/web.jsf.editor/test/unit/src/org/netbeans/modules/web/jsf/editor/JsfHtmlExtensionTest.java
@@ -146,7 +146,7 @@ public class JsfHtmlExtensionTest extends TestBaseForTestProject {
 
     private static void copyStreamToFile(InputStream inputStream, File path) throws IOException {
         try (FileOutputStream outputStream = new FileOutputStream(path, false)) {
-            FileUtil.copy(inputStream, outputStream);
+            inputStream.transferTo(outputStream);
         }
     }
     

--- a/enterprise/web.jsf.navigation/nbproject/project.properties
+++ b/enterprise/web.jsf.navigation/nbproject/project.properties
@@ -24,7 +24,7 @@
 #${ravelibs/jsf.dir}/${nb.modules.dir}/ext/jsf-api.jar
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 test.qa-functional.cp.extra=\
     ${web.jsf.dir}/modules/org-netbeans-modules-web-jsf-navigation.jar:\
     ${projectapi.dir}/modules/org-netbeans-modules-projectapi.jar:\

--- a/enterprise/web.jsf.navigation/test/unit/src/org/netbeans/modules/web/jsf/navigation/PageFlowTestUtility.java
+++ b/enterprise/web.jsf.navigation/test/unit/src/org/netbeans/modules/web/jsf/navigation/PageFlowTestUtility.java
@@ -250,9 +250,7 @@ public class PageFlowTestUtility {
     }
 
     private static void unZipFile(File archiveFile, FileObject destDir) throws IOException {
-        FileInputStream fis = new FileInputStream(archiveFile);
-        try {
-            ZipInputStream str = new ZipInputStream(fis);
+        try (ZipInputStream str = new ZipInputStream(new FileInputStream(archiveFile))) {
             ZipEntry entry;
             while ((entry = str.getNextEntry()) != null) {
                 if (entry.isDirectory()) {
@@ -261,19 +259,14 @@ public class PageFlowTestUtility {
                     FileObject fo = FileUtil.createData(destDir, entry.getName());
                     FileLock lock = fo.lock();
                     try {
-                        OutputStream out = fo.getOutputStream(lock);
-                        try {
-                            FileUtil.copy(str, out);
-                        } finally {
-                            out.close();
+                        try (OutputStream out = fo.getOutputStream(lock)) {
+                            str.transferTo(out);
                         }
                     } finally {
                         lock.releaseLock();
                     }
                 }
             }
-        } finally {
-            fis.close();
         }
     }
 

--- a/enterprise/web.jsf/nbproject/project.properties
+++ b/enterprise/web.jsf/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=17
 spec.version.base=2.12.0
 
 test.config.default.excludes=\

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/refactoring/Modifications.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/refactoring/Modifications.java
@@ -27,7 +27,6 @@ import org.netbeans.api.queries.FileEncodingQuery;
 import org.netbeans.editor.BaseDocument;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
 import org.openide.text.PositionRef;
 
@@ -111,21 +110,14 @@ public final class Modifications {
                 return;
             }
         }
-        InputStream ins = null;
-        ByteArrayOutputStream baos = null;
         Reader inputReader = null;
         try {
             Charset encoding = FileEncodingQuery.getEncoding(fileObject);
-            ins = fileObject.getInputStream();
-            baos = new ByteArrayOutputStream();
-            FileUtil.copy(ins, baos);
-
-            ins.close();
-            ins = null;
-            byte[] arr = baos.toByteArray();
+            byte[] arr;
+            try (InputStream ins = fileObject.getInputStream()) {
+                arr = ins.readAllBytes();
+            }
             int arrLength = convertToLF(arr);
-            baos.close();
-            baos = null;
             inputReader = new InputStreamReader(new ByteArrayInputStream(arr, 0, arrLength), encoding);
             // initialize standard commit output stream, if user
             // does not provide his own writer
@@ -189,12 +181,6 @@ public final class Modifications {
                 outWriter.write(buff, 0, count);
             }
         } finally {
-            if (ins != null) {
-                ins.close();
-            }
-            if (baos != null) {
-                baos.close();
-            }
             if (inputReader != null) {
                 inputReader.close();
             }

--- a/enterprise/web.jspparser/test/unit/src/org/netbeans/modules/web/jspparser/CacheTest.java
+++ b/enterprise/web.jspparser/test/unit/src/org/netbeans/modules/web/jspparser/CacheTest.java
@@ -311,16 +311,8 @@ public class CacheTest extends NbTestCase {
     }
 
     private void copy(FileObject source, FileObject target) throws Exception {
-        InputStream is = source.getInputStream();
-        OutputStream os = target.getOutputStream();
-        try {
-            try {
-                FileUtil.copy(is, os);
-            } finally {
-                is.close();
-            }
-        } finally {
-            os.close();
+        try (InputStream is = source.getInputStream(); OutputStream os = target.getOutputStream()) {
+            is.transferTo(os);
         }
     }
 }

--- a/enterprise/websvc.utilities/nbproject/project.properties
+++ b/enterprise/websvc.utilities/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint:unchecked
 
 is.autoload=true

--- a/enterprise/websvc.utilities/test/unit/src/org/netbeans/modules/websvc/api/support/java/TestUtilities.java
+++ b/enterprise/websvc.utilities/test/unit/src/org/netbeans/modules/websvc/api/support/java/TestUtilities.java
@@ -42,28 +42,21 @@ public class TestUtilities {
     }
 
     public static final FileObject copyStringToFileObject(FileObject fo, String content) throws IOException {
-        OutputStream os = fo.getOutputStream();
-        try {
-            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-            FileUtil.copy(is, os);
+        try (OutputStream os = fo.getOutputStream()) {
+            os.write(content.getBytes(StandardCharsets.UTF_8));
             return fo;
-        } finally {
-            os.close();
         }
     }
 
     public static final String copyFileObjectToString (FileObject fo) throws java.io.IOException {
         int s = (int)FileUtil.toFile(fo).length();
         byte[] data = new byte[s];
-        InputStream stream = fo.getInputStream();
-        try {
+        try (InputStream stream = fo.getInputStream()) {
             int len = stream.read(data);
             if (len != s) {
                 throw new EOFException("truncated file");
             }
             return new String (data);
-        } finally {
-            stream.close();
         }
     }
     

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoaderTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoaderTest.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.gradle.loaders;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.util.Set;
@@ -93,8 +94,9 @@ public class DiskCacheProjectLoaderTest extends AbstractGradleProjectTestCase{
         projectDir = ret.createFolder(name);
         projectDir.getFileSystem().runAtomicAction(() -> {;
             FileObject bs = projectDir.createData("build.gradle");
-            try (OutputStream os = bs.getOutputStream()) {
-                FileUtil.copy(getClass().getResourceAsStream(resource), os);
+            try (InputStream is = getClass().getResourceAsStream(resource);
+                 OutputStream os = bs.getOutputStream()) {
+                is.transferTo(os);
             }
         });
         return projectDir;

--- a/groovy/groovy.samples/nbproject/project.properties
+++ b/groovy/groovy.samples/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.8
+javac.release=17
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/groovy/groovy.samples/src/org/netbeans/modules/groovy/samples/gjdemo/GroovyJavaDemoWizardIterator.java
+++ b/groovy/groovy.samples/src/org/netbeans/modules/groovy/samples/gjdemo/GroovyJavaDemoWizardIterator.java
@@ -20,7 +20,6 @@ package org.netbeans.modules.groovy.samples.gjdemo;
 
 import java.awt.Component;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -171,8 +170,7 @@ public class GroovyJavaDemoWizardIterator implements WizardDescriptor./*Progress
     }
 
     private static void unZipFile(InputStream source, FileObject projectRoot) throws IOException {
-        try {
-            ZipInputStream str = new ZipInputStream(source);
+        try (ZipInputStream str = new ZipInputStream(source);) {
             ZipEntry entry;
             while ((entry = str.getNextEntry()) != null) {
                 if (entry.isDirectory()) {
@@ -187,25 +185,18 @@ public class GroovyJavaDemoWizardIterator implements WizardDescriptor./*Progress
                     }
                 }
             }
-        } finally {
-            source.close();
         }
     }
 
     private static void writeFile(ZipInputStream str, FileObject fo) throws IOException {
-        OutputStream out = fo.getOutputStream();
-        try {
-            FileUtil.copy(str, out);
-        } finally {
-            out.close();
+        try (OutputStream out = fo.getOutputStream()) {
+            str.transferTo(out);
         }
     }
 
     private static void filterProjectXML(FileObject fo, ZipInputStream str, String name) throws IOException {
         try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            FileUtil.copy(str, baos);
-            Document doc = XMLUtil.parse(new InputSource(new ByteArrayInputStream(baos.toByteArray())), false, false, null, null);
+            Document doc = XMLUtil.parse(new InputSource(new ByteArrayInputStream(str.readAllBytes())), false, false, null, null);
             NodeList nl = doc.getDocumentElement().getElementsByTagName("name");
             if (nl != null) {
                 for (int i = 0; i < nl.getLength(); i++) {
@@ -219,11 +210,8 @@ public class GroovyJavaDemoWizardIterator implements WizardDescriptor./*Progress
                     }
                 }
             }
-            OutputStream out = fo.getOutputStream();
-            try {
+            try (OutputStream out = fo.getOutputStream()) {
                 XMLUtil.write(doc, out, "UTF-8");
-            } finally {
-                out.close();
             }
         } catch (Exception ex) {
             Exceptions.printStackTrace(ex);

--- a/groovy/groovy.samples/src/org/netbeans/modules/groovy/samples/nbprojectgen/NBProjectGeneratorsWizardIterator.java
+++ b/groovy/groovy.samples/src/org/netbeans/modules/groovy/samples/nbprojectgen/NBProjectGeneratorsWizardIterator.java
@@ -20,7 +20,6 @@ package org.netbeans.modules.groovy.samples.nbprojectgen;
 
 import java.awt.Component;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -171,8 +170,7 @@ public class NBProjectGeneratorsWizardIterator implements WizardDescriptor./*Pro
     }
 
     private static void unZipFile(InputStream source, FileObject projectRoot) throws IOException {
-        try {
-            ZipInputStream str = new ZipInputStream(source);
+        try (ZipInputStream str = new ZipInputStream(source)) {
             ZipEntry entry;
             while ((entry = str.getNextEntry()) != null) {
                 if (entry.isDirectory()) {
@@ -187,25 +185,18 @@ public class NBProjectGeneratorsWizardIterator implements WizardDescriptor./*Pro
                     }
                 }
             }
-        } finally {
-            source.close();
         }
     }
 
     private static void writeFile(ZipInputStream str, FileObject fo) throws IOException {
-        OutputStream out = fo.getOutputStream();
-        try {
-            FileUtil.copy(str, out);
-        } finally {
-            out.close();
+        try (OutputStream out = fo.getOutputStream()) {
+            str.transferTo(out);
         }
     }
 
     private static void filterProjectXML(FileObject fo, ZipInputStream str, String name) throws IOException {
         try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            FileUtil.copy(str, baos);
-            Document doc = XMLUtil.parse(new InputSource(new ByteArrayInputStream(baos.toByteArray())), false, false, null, null);
+            Document doc = XMLUtil.parse(new InputSource(new ByteArrayInputStream(str.readAllBytes())), false, false, null, null);
             NodeList nl = doc.getDocumentElement().getElementsByTagName("name");
             if (nl != null) {
                 for (int i = 0; i < nl.getLength(); i++) {
@@ -219,11 +210,8 @@ public class NBProjectGeneratorsWizardIterator implements WizardDescriptor./*Pro
                     }
                 }
             }
-            OutputStream out = fo.getOutputStream();
-            try {
+            try (OutputStream out = fo.getOutputStream()) {
                 XMLUtil.write(doc, out, "UTF-8");
-            } finally {
-                out.close();
             }
         } catch (Exception ex) {
             Exceptions.printStackTrace(ex);

--- a/ide/csl.api/src/org/netbeans/modules/csl/spi/GsfUtilities.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/spi/GsfUtilities.java
@@ -448,12 +448,8 @@ public final class GsfUtilities {
             FileLock lock = fd.lock();
 
             try {
-                OutputStream os = fd.getOutputStream(lock);
-
-                try {
-                    FileUtil.copy(jis, os);
-                } finally {
-                    os.close();
+                try (OutputStream os = fd.getOutputStream(lock)) {
+                    jis.transferTo(os);
                 }
             } finally {
                 lock.releaseLock();

--- a/ide/csl.api/src/org/netbeans/modules/csl/spi/support/ModificationResult.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/spi/support/ModificationResult.java
@@ -133,22 +133,15 @@ public final class ModificationResult implements org.netbeans.modules.refactorin
                 return;
             }
         }
-        InputStream ins = null;
-        ByteArrayOutputStream baos = null;           
         Reader in = null;
         Writer out2 = out;
         try {
             Charset encoding = FileEncodingQuery.getEncoding(fo);
-            ins = fo.getInputStream();
-            baos = new ByteArrayOutputStream();
-            FileUtil.copy(ins, baos);
-
-            ins.close();
-            ins = null;
-            byte[] arr = baos.toByteArray();
+            byte[] arr;
+            try (InputStream ins = fo.getInputStream()) {
+                arr = ins.readAllBytes();
+            }
             int arrLength = convertToLF(arr);
-            baos.close();
-            baos = null;
             in = new InputStreamReader(new ByteArrayInputStream(arr, 0, arrLength), encoding);
             // initialize standard commit output stream, if user
             // does not provide his own writer
@@ -198,10 +191,6 @@ public final class ModificationResult implements org.netbeans.modules.refactorin
             while ((n = in.read(buff)) > 0)
                 out2.write(buff, 0, n);
         } finally {
-            if (ins != null)
-                ins.close();
-            if (baos != null)
-                baos.close();
             if (in != null)
                 in.close();
             if (out2 != null)

--- a/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
+++ b/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
@@ -22,7 +22,6 @@ package org.netbeans.modules.csl.api.test;
 import java.awt.event.ActionEvent;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -346,17 +345,9 @@ public abstract class CslTestBase extends NbTestCase {
     }
 
     public static final FileObject copyStringToFileObject(FileObject fo, String content) throws IOException {
-        OutputStream os = fo.getOutputStream();
-        try {
-            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-            try {
-                FileUtil.copy(is, os);
-                return fo;
-            } finally {
-                is.close();
-            }
-        } finally {
-            os.close();
+        try (OutputStream os = fo.getOutputStream()) {
+            os.write(content.getBytes(StandardCharsets.UTF_8));
+            return fo;
         }
     }
 
@@ -390,13 +381,10 @@ public abstract class CslTestBase extends NbTestCase {
 
     /** Copy-pasted from APISupport. */
     protected static String slurp(File file) throws IOException {
-        InputStream is = new FileInputStream(file);
-        try {
+        try (InputStream is = new FileInputStream(file)) {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            FileUtil.copy(is, baos);
-            return baos.toString("UTF-8");
-        } finally {
-            is.close();
+            is.transferTo(baos);
+            return baos.toString(StandardCharsets.UTF_8);
         }
     }
 

--- a/ide/derby/src/org/netbeans/modules/derby/Util.java
+++ b/ide/derby/src/org/netbeans/modules/derby/Util.java
@@ -113,9 +113,7 @@ public class Util {
     }
 
     public static void extractZip(File source, FileObject target) throws IOException {
-        FileInputStream is = new FileInputStream(source);
-        try {
-            ZipInputStream zis = new ZipInputStream(is);
+        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(source))) {
             ZipEntry ze;
 
             while ((ze = zis.getNextEntry()) != null) {
@@ -131,18 +129,13 @@ public class Util {
                 FileObject fd = FileUtil.createData(target, name);
                 FileLock lock = fd.lock();
                 try {
-                    OutputStream os = fd.getOutputStream(lock);
-                    try {
-                        FileUtil.copy(zis, os);
-                    } finally {
-                        os.close();
+                    try (OutputStream os = fd.getOutputStream(lock)) {
+                        zis.transferTo(os);
                     }
                 } finally {
                     lock.releaseLock();
                 }
             }
-        } finally {
-            is.close();
         }
     }
 

--- a/ide/diff/src/org/netbeans/api/diff/StreamSource.java
+++ b/ide/diff/src/org/netbeans/api/diff/StreamSource.java
@@ -178,7 +178,7 @@ public abstract class StreamSource extends Object {
                     copyStreamsCloseAll(new OutputStreamWriter(baos, encoding), r);
                     in = new ByteArrayInputStream(baos.toByteArray());
                 }
-                org.openide.filesystems.FileUtil.copy(in, out = new FileOutputStream(tmp));
+                in.transferTo(out = new FileOutputStream(tmp));
             } finally {
                 if (in != null) in.close();
                 if (out != null) out.close();

--- a/ide/diff/test/unit/src/org/netbeans/api/diff/PatchUtilsTest.java
+++ b/ide/diff/test/unit/src/org/netbeans/api/diff/PatchUtilsTest.java
@@ -24,7 +24,6 @@ import java.lang.reflect.Field;
 
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.diff.PatchAction;
-import org.openide.filesystems.FileUtil;
 
 /**
  * 
@@ -203,13 +202,9 @@ public class PatchUtilsTest extends NbTestCase {
     }
 
     private File createFile(File file) throws IOException {
-        final FileInputStream fileInputStream = new FileInputStream(new File(dataDir, "goldenFileBefore"));
-        final FileOutputStream fileOutputStream = new FileOutputStream(file);
-        try {
-            FileUtil.copy(fileInputStream, fileOutputStream);
-        } finally {
-            fileInputStream.close();
-            fileOutputStream.close();
+        try (FileInputStream fis = new FileInputStream(new File(dataDir, "goldenFileBefore"));
+             FileOutputStream fos = new FileOutputStream(file)) {
+            fis.transferTo(fos);
         }
         return file;
     }

--- a/ide/docker.api/src/org/netbeans/modules/docker/FolderUploader.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/FolderUploader.java
@@ -84,7 +84,7 @@ public class FolderUploader {
                                             path);
                                     aos.putArchiveEntry(entry);
                                     try (InputStream is = new BufferedInputStream(child.getInputStream())) {
-                                        FileUtil.copy(is, aos);
+                                        is.transferTo(aos);
                                     }
                                     aos.closeArchiveEntry();
                                 }

--- a/ide/docker.editor/src/org/netbeans/modules/docker/editor/util/DocDownloader.java
+++ b/ide/docker.editor/src/org/netbeans/modules/docker/editor/util/DocDownloader.java
@@ -65,7 +65,7 @@ public class DocDownloader {
             try {
                 final ByteArrayOutputStream out = new ByteArrayOutputStream();
                 try(BufferedInputStream in = new BufferedInputStream(url.openStream())) {
-                    FileUtil.copy(in, out);
+                    in.transferTo(out);
                 }
                 return cancel.call() ?
                         ""  //NOI18N

--- a/ide/html/test/unit/src/org/netbeans/modules/html/EncodingTest.java
+++ b/ide/html/test/unit/src/org/netbeans/modules/html/EncodingTest.java
@@ -145,22 +145,16 @@ public class EncodingTest extends NbTestCase {
     }
 
     private void copy(final String res, final FileObject data) throws Exception {
-        final InputStream is = getClass ().getResourceAsStream ("data/"+res);   //NOI18N
-        try {
+        try (InputStream is = getClass ().getResourceAsStream ("data/"+res)) { //NOI18N
             assertNotNull (res+" should exist", is);    //NOI18N
             FileLock lock = data.lock();
             try {
-                OutputStream os = data.getOutputStream (lock);
-                try {
-                    FileUtil.copy (is, os);
-                } finally {
-                    os.close ();
+                try (OutputStream os = data.getOutputStream(lock)) {
+                    is.transferTo(os);
                 }
             } finally {
                 lock.releaseLock ();
             }
-        } finally {
-            is.close ();
         }
     }
 
@@ -189,7 +183,7 @@ public class EncodingTest extends NbTestCase {
         FileObject data = FileUtil.createData (FileUtil.toFileObject(getWorkDir()), res);
         FileLock lock = data.lock();
         OutputStream os = data.getOutputStream (lock);
-        FileUtil.copy (is, os);
+        is.transferTo (os);
         is.close ();
         os.close ();
         lock.releaseLock ();

--- a/ide/hudson.mercurial/src/org/netbeans/modules/hudson/mercurial/MercurialHyperlink.java
+++ b/ide/hudson.mercurial/src/org/netbeans/modules/hudson/mercurial/MercurialHyperlink.java
@@ -39,7 +39,6 @@ import org.netbeans.api.diff.StreamSource;
 import org.netbeans.modules.hudson.ui.api.HudsonSCMHelper;
 import org.netbeans.modules.hudson.spi.HudsonJobChangeItem.HudsonJobChangeFile;
 import org.netbeans.modules.hudson.spi.HudsonJobChangeItem.HudsonJobChangeFile.EditType;
-import org.openide.filesystems.FileUtil;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.RequestProcessor;
 import org.openide.windows.OutputEvent;
@@ -97,13 +96,10 @@ class MercurialHyperlink implements OutputListener {
             rev = null;
         } else {
             rev = after ? node : findParent(repo, node);
-            InputStream is = repo.resolve("raw-file/" + rev + "/" + file.getName()).toURL().openStream(); // NOI18N
-            try {
+            try (InputStream is = repo.resolve("raw-file/" + rev + "/" + file.getName()).toURL().openStream()) { // NOI18N
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                FileUtil.copy(is, baos);
+                is.transferTo(baos);
                 r = new StringReader(baos.toString());
-            } finally {
-                is.close();
             }
         }
         String mimeType = "text/plain"; // NOI18N // XXX use FileUtil.getMIMETypeExtensions

--- a/ide/hudson.subversion/src/org/netbeans/modules/hudson/subversion/SubversionHyperlink.java
+++ b/ide/hudson.subversion/src/org/netbeans/modules/hudson/subversion/SubversionHyperlink.java
@@ -143,7 +143,7 @@ class SubversionHyperlink implements OutputListener {
             InputStream is = new URL(repo + "/!svn/ver/" + rev + path).openStream(); // NOI18N
             try {
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                FileUtil.copy(is, baos);
+                is.transferTo(baos);
                 r = new StringReader(baos.toString());
             } finally {
                 is.close();

--- a/ide/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ViewConfigAction.java
+++ b/ide/hudson.ui/src/org/netbeans/modules/hudson/ui/actions/ViewConfigAction.java
@@ -23,7 +23,6 @@ import java.awt.event.ActionEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.VetoableChangeListener;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -34,7 +33,6 @@ import javax.swing.AbstractAction;
 import org.netbeans.modules.hudson.api.ConnectionBuilder;
 import org.netbeans.modules.hudson.api.HudsonJob;
 import static org.netbeans.modules.hudson.ui.actions.Bundle.*;
-import org.openide.filesystems.FileUtil;
 import org.openide.text.CloneableEditorSupport;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle.Messages;
@@ -71,14 +69,11 @@ public class ViewConfigAction extends AbstractAction {
         
         @Messages({"# {0} - URL", "ViewConfigAction_could_not_connect=Could not retrieve: {0}"})
         @Override public InputStream inputStream() throws IOException {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] byteArray;
             try {
                 URLConnection conn = new ConnectionBuilder().homeURL(new URL(home)).url(url).connection();
-                InputStream is = conn.getInputStream();
-                try {
-                    FileUtil.copy(is, baos);
-                } finally {
-                    is.close();
+                try (InputStream is = conn.getInputStream()) {
+                    byteArray = is.readAllBytes();
                 }
             } catch (IOException x) {
                 if (Exceptions.findLocalizedMessage(x) == null) {
@@ -86,7 +81,7 @@ public class ViewConfigAction extends AbstractAction {
                 }
                 throw x;
             }
-            return new ByteArrayInputStream(baos.toByteArray());
+            return new ByteArrayInputStream(byteArray);
         }
 
         @Override public OutputStream outputStream() throws IOException {

--- a/ide/hudson/src/org/netbeans/modules/hudson/api/ConnectionBuilder.java
+++ b/ide/hudson/src/org/netbeans/modules/hudson/api/ConnectionBuilder.java
@@ -31,6 +31,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -56,7 +57,6 @@ import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle.Messages;
 import static org.netbeans.modules.hudson.api.Bundle.*;
-import org.openide.filesystems.FileUtil;
 import org.openide.util.NetworkSettings;
 import org.openide.util.RequestProcessor;
 import org.openide.xml.XMLUtil;
@@ -357,11 +357,10 @@ public final class ConnectionBuilder {
                                     LOG.log(Level.FINER, "Retrying after auth from {0}", authenticator);
                                     conn = retry;
                                     try { // check for CSRF before continuing
-                                        InputStream is = new ConnectionBuilder().url(new URL(home, "crumbIssuer/api/xml?xpath=concat(//crumbRequestField,'=',//crumb)")).homeURL(home).connection().getInputStream();
-                                        try {
+                                        try (InputStream is = new ConnectionBuilder().url(new URL(home, "crumbIssuer/api/xml?xpath=concat(//crumbRequestField,'=',//crumb)")).homeURL(home).connection().getInputStream()) {
                                             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                                            FileUtil.copy(is, baos);
-                                            String crumb = baos.toString("UTF-8");
+                                            is.transferTo(baos);
+                                            String crumb = baos.toString(StandardCharsets.UTF_8);
                                             String[] crumbA = crumb.split("=", 2);
                                             if (crumbA.length == 2 && crumbA[0].indexOf('\n') == -1) {
                                                 LOG.log(Level.FINER, "Received crumb: {0}", crumb);
@@ -369,8 +368,6 @@ public final class ConnectionBuilder {
                                             } else {
                                                 LOG.log(Level.WARNING, "Bad crumb response: {0}", crumb);
                                             }
-                                        } finally {
-                                            is.close();
                                         }
                                     } catch (FileNotFoundException x) {
                                         LOG.finer("not using crumbs");

--- a/ide/languages/src/org/netbeans/modules/languages/LanguagesManager.java
+++ b/ide/languages/src/org/netbeans/modules/languages/LanguagesManager.java
@@ -230,17 +230,11 @@ public class LanguagesManager extends org.netbeans.api.languages.LanguagesManage
                             FileUtil.createData(toolbarDefault, "uncomment").setAttribute("position", 32000);
 
                             if (root.getFileObject("Keybindings/NetBeans/Defaults/keybindings.xml") == null) {
-                                InputStream is = getClass().getClassLoader().getResourceAsStream("org/netbeans/modules/languages/resources/DefaultKeyBindings.xml");
-                                try {
+                                try (InputStream is = getClass().getClassLoader().getResourceAsStream("org/netbeans/modules/languages/resources/DefaultKeyBindings.xml")) {
                                     FileObject bindings = FileUtil.createData(root, "Keybindings/NetBeans/Defaults/keybindings.xml");
-                                    OutputStream os = bindings.getOutputStream();
-                                    try {
-                                        FileUtil.copy(is, os);
-                                    } finally {
-                                        os.close();
+                                    try (OutputStream os = bindings.getOutputStream()) {
+                                        is.transferTo(os);
                                     }
-                                } finally {
-                                    is.close();
                                 }
                             }
                         }

--- a/ide/libs.freemarker/test/unit/src/org/netbeans/freemarker/templates/SCFTHandlerTest.java
+++ b/ide/libs.freemarker/test/unit/src/org/netbeans/freemarker/templates/SCFTHandlerTest.java
@@ -279,7 +279,7 @@ public class SCFTHandlerTest extends NbTestCase {
          FileObject xmldir = FileUtil.createFolder(root, "xml");
          FileObject xml = FileUtil.createData(xmldir, "class.txt");
          OutputStream os = xml.getOutputStream();
-         FileUtil.copy(getClass().getResourceAsStream("utf8.xml"), os);
+         getClass().getResourceAsStream("utf8.xml").transferTo(os);
          xml.setAttribute("javax.script.ScriptEngine", "freemarker");
          os.close();
          

--- a/ide/localhistory/src/org/netbeans/modules/localhistory/ui/actions/RevertDeletedAction.java
+++ b/ide/localhistory/src/org/netbeans/modules/localhistory/ui/actions/RevertDeletedAction.java
@@ -30,7 +30,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URISyntaxException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -193,8 +192,6 @@ public class RevertDeletedAction extends NodeAction {
         }
         File storeFile = se.getStoreFile();
                 
-        InputStream is = null;
-        OutputStream os = null;
         try {               
             FileObject parentFO = file.getParentFile().toFileObject();             
             if(parentFO != null) {
@@ -203,9 +200,10 @@ public class RevertDeletedAction extends NodeAction {
                 } else {            
                     FileObject fo = FileUtil.createData(parentFO, file.getName());                
 
-                    os = getOutputStream(fo);     
-                    is = se.getStoreFileInputStream();                    
-                    FileUtil.copy(is, os);            
+                    try (InputStream is = se.getStoreFileInputStream();
+                         OutputStream os = getOutputStream(fo)) {     
+                        is.transferTo(os);
+                    }
                 }
             } else {
                 VCSFileProxy parentFile = file.getParentFile();
@@ -216,22 +214,16 @@ public class RevertDeletedAction extends NodeAction {
                     if(!storeFile.isFile()) {
                         file.toFile().mkdirs();
                     } else {            
-                        is = se.getStoreFileInputStream();                    
-                        FileUtils.copy(is, file.toFile());
+                        try (InputStream is = se.getStoreFileInputStream()) {
+                            FileUtils.copy(is, file.toFile());
+                        }
                     }
-                    
                 } else {
                     LocalHistory.LOG.log(Level.WARNING, "FileObject for remote file {0} is null. Can''t revert.", file.getParentFile().getPath());
                 }
             }
         } catch (Exception e) {            
             LocalHistory.LOG.log(Level.SEVERE, null, e);
-            return;
-        } finally {
-            try {
-                if(os != null) { os.close(); }
-                if(is != null) { is.close(); }
-            } catch (IOException e) {}
         } 
     }
     

--- a/ide/localhistory/src/org/netbeans/modules/localhistory/utils/FileUtils.java
+++ b/ide/localhistory/src/org/netbeans/modules/localhistory/utils/FileUtils.java
@@ -34,8 +34,6 @@ import org.netbeans.modules.localhistory.LocalHistory;
 import org.netbeans.modules.versioning.core.api.VCSFileProxy;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
-import org.openide.util.Exceptions;
-import org.openide.util.lookup.Lookups;
 
 /**
  * @author Tomas Stupka
@@ -114,13 +112,8 @@ public class FileUtils {
         if (os == null ) {
             throw new NullPointerException("output stream must not be null"); // NOI18N
         }        
-        InputStream is = null;
-        try {
-            is = createInputStream(file);            
-            FileUtil.copy(is, os);
-        } finally {
-            if (is != null) { try { is.close(); } catch (IOException ex) { } }
-            if (os != null) { try { os.close(); } catch (IOException ex) { } }
+        try (InputStream is = createInputStream(file); os) {
+            is.transferTo(os);
         }
     }
     
@@ -139,13 +132,8 @@ public class FileUtils {
         if (os == null ) {
             throw new NullPointerException("output stream must not be null"); // NOI18N
         }        
-        InputStream is = null;
-        try {
-            is = createInputStream(file);            
-            FileUtil.copy(is, os);
-        } finally {
-            if (is != null) { try { is.close(); } catch (IOException ex) { } }
-            if (os != null) { try { os.close(); } catch (IOException ex) { } }
+        try (InputStream is = createInputStream(file); os) {            
+            is.transferTo(os);
         }
     }
     

--- a/ide/localhistory/src/org/netbeans/modules/localhistory/utils/Utils.java
+++ b/ide/localhistory/src/org/netbeans/modules/localhistory/utils/Utils.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.localhistory.utils;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -48,8 +47,6 @@ public class Utils {
     }
     
     public static void revert(StoreEntry se) {
-        InputStream is = null;
-        OutputStream os = null;
         try {
             VCSFileProxy file = se.getFile();
             FileObject fo = file.toFileObject();
@@ -57,19 +54,14 @@ public class Utils {
                 if(fo == null) {
                     fo = FileUtil.createData(file.getParentFile().toFileObject(), file.getName());
                 }
-                os = getOutputStream(fo);
-                is = se.getStoreFileInputStream();
-                FileUtil.copy(is, os);
+                try (InputStream is = se.getStoreFileInputStream(); OutputStream os = getOutputStream(fo)) {
+                    is.transferTo(os);
+                }
             } else {
                 fo.delete();
             }
         } catch (Exception e) {
             LocalHistory.LOG.log(Level.SEVERE, null, e);
-        } finally {
-            try {
-                if(os != null) { os.close(); }
-                if(is != null) { is.close(); }
-            } catch (IOException e) {}
         }
     }
     

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/refactoring/ModificationResult.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/refactoring/ModificationResult.java
@@ -133,22 +133,15 @@ public final class ModificationResult implements org.netbeans.modules.refactorin
                 return;
             }
         }
-        InputStream ins = null;
-        ByteArrayOutputStream baos = null;           
         Reader in = null;
         Writer out2 = out;
         try {
             Charset encoding = FileEncodingQuery.getEncoding(fo);
-            ins = fo.getInputStream();
-            baos = new ByteArrayOutputStream();
-            FileUtil.copy(ins, baos);
-
-            ins.close();
-            ins = null;
-            byte[] arr = baos.toByteArray();
+            byte[] arr;
+            try (InputStream ins = fo.getInputStream()) {
+                arr = ins.readAllBytes();
+            }
             int arrLength = convertToLF(arr);
-            baos.close();
-            baos = null;
             in = new InputStreamReader(new ByteArrayInputStream(arr, 0, arrLength), encoding);
             // initialize standard commit output stream, if user
             // does not provide his own writer
@@ -198,10 +191,6 @@ public final class ModificationResult implements org.netbeans.modules.refactorin
             while ((n = in.read(buff)) > 0)
                 out2.write(buff, 0, n);
         } finally {
-            if (ins != null)
-                ins.close();
-            if (baos != null)
-                baos.close();
             if (in != null)
                 in.close();
             if (out2 != null)

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/options/LanguageStorage.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/options/LanguageStorage.java
@@ -136,7 +136,7 @@ public class LanguageStorage {
                     syntax.setAttribute("textmate-grammar", findScope(grammar));
                     try (InputStream in = new FileInputStream(grammar);
                          OutputStream out = syntax.getOutputStream()) {
-                        FileUtil.copy(in, out);
+                        in.transferTo(out);
                     }
                     FileObject loader = FileUtil.getConfigFile("Loaders/" + description.mimeType + "/Factories/data-object.instance");
                     if (loader != null) {
@@ -174,7 +174,7 @@ public class LanguageStorage {
                         icon = FileUtil.createData(FileUtil.getConfigRoot(), "Loaders/" + description.mimeType + "/Factories/icon.png");
                         try (InputStream in = new FileInputStream(iconFile);
                              OutputStream out = icon.getOutputStream()) {
-                            FileUtil.copy(in, out);
+                            in.transferTo(out);
                         }
 
                         loader.setAttribute("iconBase", icon.getNameExt());

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdater.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdater.java
@@ -5539,7 +5539,7 @@ public final class RepositoryUpdater implements PathRegistryListener, PropertyCh
                 final File packedIndex = new File (into,getSimpleName(indexURL));       //NOI18N
                 try (final InputStream in = new BufferedInputStream(indexURL.openStream());
                      final OutputStream out = new BufferedOutputStream(new FileOutputStream(packedIndex))) {
-                     FileUtil.copy(in, out);
+                    in.transferTo(out);
                 }
                 return packedIndex;
             } catch (IOException ioe) {
@@ -5561,7 +5561,7 @@ public final class RepositoryUpdater implements PathRegistryListener, PropertyCh
                         target.getParentFile().mkdirs();
                         try (final InputStream in = zf.getInputStream(entry);
                             final FileOutputStream out = new FileOutputStream(target)) {
-                                FileUtil.copy(in, out);
+                            in.transferTo(out);
                         }
                     }
                 }

--- a/ide/project.ant/src/org/netbeans/modules/project/ant/AntBasedProjectFactorySingleton.java
+++ b/ide/project.ant/src/org/netbeans/modules/project/ant/AntBasedProjectFactorySingleton.java
@@ -302,13 +302,10 @@ public final class AntBasedProjectFactorySingleton implements ProjectFactory2 {
     }
     private Document loadProjectXml(File projectDiskFile) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        InputStream is = new FileInputStream(projectDiskFile);
-        try {
-            FileUtil.copy(is, baos);
-        } finally {
-            is.close();
+        byte[] data;
+        try (InputStream is = new FileInputStream(projectDiskFile)) {
+            data = is.readAllBytes();
         }
-        byte[] data = baos.toByteArray();
         InputSource src = new InputSource(new ByteArrayInputStream(data));
         src.setSystemId(BaseUtilities.toURI(projectDiskFile).toString());
         try {

--- a/ide/projectapi/test/unit/src/org/netbeans/api/project/TestUtil.java
+++ b/ide/projectapi/test/unit/src/org/netbeans/api/project/TestUtil.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -321,18 +320,12 @@ public final class TestUtil {
         }
         assert fo.isData();
         if (content != null || touch) {
-            OutputStream os = fo.getOutputStream();
-            try {
+            try (OutputStream os = fo.getOutputStream()) {
                 if (content != null) {
-                    InputStream is = content.openStream();
-                    try {
-                        FileUtil.copy(is, os);
-                    } finally {
-                        is.close();
+                    try (InputStream is = content.openStream()) {
+                        is.transferTo(os);
                     }
                 }
-            } finally {
-                os.close();
             }
         }
         return fo;

--- a/ide/projectui/src/org/netbeans/modules/project/ui/zip/ImportZIP.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/zip/ImportZIP.java
@@ -32,9 +32,7 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -45,7 +43,6 @@ import javax.swing.JFileChooser;
 import javax.swing.JPanel;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import org.netbeans.api.progress.ProgressHandle;
-import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ui.OpenProjects;
@@ -61,7 +58,6 @@ import org.openide.awt.ActionRegistration;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Cancellable;
-import org.openide.util.NbBundle;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.RequestProcessor;
 import org.openide.util.Utilities;
@@ -226,11 +222,8 @@ public class ImportZIP extends JPanel {
                         if (!p.isDirectory() && !p.mkdirs()) {
                             throw new IOException("could not make " + p);
                         }
-                        OutputStream os = new FileOutputStream(f);
-                        try {
-                            FileUtil.copy(zis, os);
-                        } finally {
-                            os.close();
+                        try (OutputStream os = new FileOutputStream(f)) {
+                            zis.transferTo(os);
                         }
                         if (entry.getTime() > 0) {
                             if (!f.setLastModified(entry.getTime())) {

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/BackupFacility.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/BackupFacility.java
@@ -265,11 +265,8 @@ public abstract class BackupFacility {
         }
 
         private void copy(InputStream is, OutputStream os) throws IOException {
-            try {
-                FileUtil.copy(is, os);
-            } finally {
-                is.close();
-                os.close();
+            try (is; os) {
+                is.transferTo(os);
             }
         }
         

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/BackupFacility2.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/BackupFacility2.java
@@ -561,29 +561,23 @@ abstract class BackupFacility2 {
         }
 
         private void copy(FileObject a, File b) throws IOException {
-            InputStream fs = a.getInputStream();
-            FileOutputStream fo = new FileOutputStream(b);
-            copy(fs, fo);
+            try (InputStream fs = a.getInputStream(); 
+                 FileOutputStream fo = new FileOutputStream(b)) {
+                fs.transferTo(fo);
+            }
         }
 
         private void copy(File a, File b) throws IOException {
-            FileInputStream fs = new FileInputStream(a);
-            FileOutputStream fo = new FileOutputStream(b);
-            copy(fs, fo);
+            try (FileInputStream fs = new FileInputStream(a);
+                 FileOutputStream fo = new FileOutputStream(b)) {
+                fs.transferTo(fo);
+            }
         }
 
         private void copy(File a, FileObject b) throws IOException {
-            FileInputStream fs = new FileInputStream(a);
-            OutputStream fo = b.getOutputStream();
-            copy(fs, fo);
-        }
-
-        private void copy(InputStream is, OutputStream os) throws IOException {
-            try {
-                FileUtil.copy(is, os);
-            } finally {
-                is.close();
-                os.close();
+            try (FileInputStream fs = new FileInputStream(a);
+                 OutputStream fo = b.getOutputStream()) {
+                fs.transferTo(fo);
             }
         }
 

--- a/ide/subversion/src/org/netbeans/modules/subversion/util/SvnUtils.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/util/SvnUtils.java
@@ -1008,7 +1008,7 @@ public class SvnUtils {
             }
             os = fo.getOutputStream();
             is = FileUtil.toFileObject(oldFile).getInputStream();
-            FileUtil.copy(is, os);
+            is.transferTo(os);
         } catch (IOException e) {
             if (refersToDirectory(e)) {
                 Subversion.LOG.log(Level.FINE, null, e);

--- a/ide/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/testvcs/TestVCSInterceptor.java
+++ b/ide/versioning.core/test/unit/src/org/netbeans/modules/versioning/core/spi/testvcs/TestVCSInterceptor.java
@@ -23,7 +23,6 @@ import org.netbeans.modules.versioning.core.spi.VCSInterceptor;
 
 import java.util.*;
 import org.netbeans.modules.versioning.core.api.VCSFileProxy;
-import org.openide.filesystems.FileUtil;
 
 /**
  * @author Maros Sandor
@@ -307,11 +306,9 @@ public class TestVCSInterceptor extends VCSInterceptor {
         
         private void copy(File fromFile, File toFile) throws IOException {
             if(fromFile.isFile()) {
-                InputStream is = new FileInputStream (fromFile);
-                OutputStream os = new FileOutputStream(toFile);
-                FileUtil.copy(is, os);
-                is.close();
-                os.close();
+                try (InputStream is = new FileInputStream (fromFile); OutputStream os = new FileOutputStream(toFile)) {
+                    is.transferTo(os);
+                }
             } else {
                 toFile.mkdirs();
                 File[] files = fromFile.listFiles();

--- a/ide/versioning.masterfs/test/unit/src/org/netbeans/modules/versioning/masterfs/FileVCSTest.java
+++ b/ide/versioning.masterfs/test/unit/src/org/netbeans/modules/versioning/masterfs/FileVCSTest.java
@@ -103,11 +103,9 @@ public class FileVCSTest extends VCSFilesystemTestFactory {
     
     private void copy(File fromFile, File toFile) throws IOException {
         if(fromFile.isFile()) {
-            InputStream is = new FileInputStream (fromFile);
-            OutputStream os = new FileOutputStream(toFile);
-            FileUtil.copy(is, os);
-            is.close();
-            os.close();
+            try (InputStream is = new FileInputStream (fromFile); OutputStream os = new FileOutputStream(toFile)) {
+                is.transferTo(os);
+            }
         } else {
             toFile.mkdirs();
             File[] files = fromFile.listFiles();

--- a/ide/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestVCSInterceptor.java
+++ b/ide/versioning/test/unit/src/org/netbeans/modules/versioning/spi/testvcs/TestVCSInterceptor.java
@@ -133,7 +133,7 @@ public class TestVCSInterceptor extends VCSInterceptor {
         doCopyFiles.add(to);
         FileInputStream is = new FileInputStream(from);
         FileOutputStream os = new FileOutputStream(to);
-        FileUtil.copy(is, os);
+        is.transferTo(os);
         is.close();
         os.close();
     }

--- a/ide/web.browser.api/src/org/netbeans/modules/web/browser/spi/ExternalModificationsSupport.java
+++ b/ide/web.browser.api/src/org/netbeans/modules/web/browser/spi/ExternalModificationsSupport.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.web.browser.spi;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
@@ -27,7 +26,6 @@ import javax.swing.text.StyledDocument;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.modules.web.browser.Helper;
-import org.netbeans.modules.web.common.api.DependentFileQuery;
 import org.netbeans.modules.web.common.api.ServerURLMapping;
 import org.netbeans.modules.web.common.api.WebUtils;
 import org.openide.DialogDescriptor;
@@ -106,28 +104,20 @@ public final class ExternalModificationsSupport {
                 }
             }
         }
-        OutputStream os = null;
         FileLock lock = null;
         try {
             lock = modifiedFile.lock();
-            os = modifiedFile.getOutputStream(lock);
-            // TODO: is encoding going to be OK?? what encoding CDT sends the file in??
-            FileUtil.copy(new ByteArrayInputStream(content.getBytes()), os);
+            try (OutputStream os = modifiedFile.getOutputStream(lock)) {
+                // TODO: is encoding going to be OK?? what encoding CDT sends the file in??
+                os.write(content.getBytes());
+            }
         } catch (FileAlreadyLockedException ex) {
             DialogDisplayer.getDefault().notify(new DialogDescriptor.Message(
                     "Content of "+FileUtil.getFileDisplayName(modifiedFile)+" cannot be updated with "
                     + "changes coming from the Chrome Developer Tools because file is locked!"));
-            return;
         } catch (IOException ex) {
             Exceptions.printStackTrace(ex);
         } finally {
-            if (os != null) {
-                try {
-                    os.close();
-                } catch (IOException ex) {
-                    Exceptions.printStackTrace(ex);
-                }
-            }
             if (lock != null) {
                 lock.releaseLock();
             }

--- a/ide/web.common/src/org/netbeans/modules/web/common/api/WebServer.java
+++ b/ide/web.common/src/org/netbeans/modules/web/common/api/WebServer.java
@@ -339,7 +339,7 @@ public final class WebServer {
                         try {
                             out.writeBytes("HTTP/1.1 200 OK\nContent-Length: "+fo.getSize()+"\n" //NOI18N
                                     + "Content-Type: "+mime+"\n\n"); //NOI18N
-                            FileUtil.copy(fis, out);
+                            fis.transferTo(out);
                         } catch (SocketException se) {
                             // browser refused to accept data or closed the connection;
                             // not much we can do about this

--- a/ide/web.common/src/org/netbeans/modules/web/common/remote/RemoteFilesCache.java
+++ b/ide/web.common/src/org/netbeans/modules/web/common/remote/RemoteFilesCache.java
@@ -111,25 +111,16 @@ public class RemoteFilesCache {
     }
     
     private void fetchRemoteFile(File destination, URL url) throws IOException {
-        InputStream is = null;
+        InputStream tmp;
         try {
-            is = url.openStream();
+            tmp = url.openStream();
         } catch (FileNotFoundException ex) {
-            is = new ByteArrayInputStream(("file not found at "+url.toExternalForm()+" \n"+ex.toString()).getBytes()); //NOI18N
+            tmp = new ByteArrayInputStream(("file not found at "+url.toExternalForm()+" \n"+ex.toString()).getBytes()); //NOI18N
         } catch (Throwable ex) {
-            is = new ByteArrayInputStream(("could not open stream for "+url.toExternalForm()+" \n"+ex.toString()).getBytes()); //NOI18N
+            tmp = new ByteArrayInputStream(("could not open stream for "+url.toExternalForm()+" \n"+ex.toString()).getBytes()); //NOI18N
         }
-        OutputStream os = null;
-        try {
-            os = new FileOutputStream(destination);
-            FileUtil.copy(is, os);
-        } finally {
-            if (os != null) {
-                os.close();
-            }
-            if (is != null) {
-                is.close();
-            }
+        try (InputStream is = tmp; OutputStream os = new FileOutputStream(destination)) {
+            is.transferTo(os);
         }
         FileObject fo = FileUtil.toFileObject(destination);
         fo.refresh();

--- a/ide/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/util/Helper.java
+++ b/ide/xml.multiview/test/unit/src/org/netbeans/modules/xml/multiview/test/util/Helper.java
@@ -48,16 +48,9 @@ public class Helper {
 
             @Override
             public void run() throws IOException {
-                BufferedInputStream is = new BufferedInputStream(new FileInputStream(source));
-                try {
-                    BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(target));
-                    try {
-                        FileUtil.copy(is, os);
-                    } finally {
-                        os.close();
-                    }
-                } finally {
-                    is.close();
+                try (BufferedInputStream is = new BufferedInputStream(new FileInputStream(source));
+                     BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(target))) {
+                    is.transferTo(os);
                 }
             }
         });

--- a/ide/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/Util.java
+++ b/ide/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/Util.java
@@ -54,7 +54,6 @@ import org.netbeans.modules.xml.xam.dom.AbstractDocumentModel;
 import org.netbeans.modules.xml.xam.dom.DocumentModel;
 import org.openide.filesystems.FileLock;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.Lookups;
@@ -315,13 +314,11 @@ public class Util {
             dest = destFolder.createData(filename);
         }
         FileLock lock = dest.lock();
-        OutputStream out = dest.getOutputStream(lock);
-        InputStream in = Util.class.getResourceAsStream(path);
         try {
-            FileUtil.copy(in, out);
+            try (InputStream in = Util.class.getResourceAsStream(path); OutputStream out = dest.getOutputStream(lock)) {
+                in.transferTo(out);
+            }
         } finally {
-            out.close();
-            in.close();
             if (lock != null) lock.releaseLock();
         }
         return dest;

--- a/ide/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/Util.java
+++ b/ide/xml.wsdl.model/test/unit/src/org/netbeans/modules/xml/wsdl/model/Util.java
@@ -230,13 +230,11 @@ public class Util {
             dest = destFolder.createData(filename);
         }
         FileLock lock = dest.lock();
-        OutputStream out = dest.getOutputStream(lock);
-        InputStream in = Util.class.getResourceAsStream(path);
         try {
-            FileUtil.copy(in, out);
+            try (InputStream in = Util.class.getResourceAsStream(path); OutputStream out = dest.getOutputStream(lock)) {
+                in.transferTo(out);
+            }
         } finally {
-            out.close();
-            in.close();
             if (lock != null) lock.releaseLock();
         }
         return dest;

--- a/java/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/TestBase.java
+++ b/java/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/TestBase.java
@@ -146,16 +146,8 @@ public abstract class TestBase extends NbTestCase {
             }
         } else {
             assert from.isFile();
-            InputStream is = new FileInputStream(from);
-            try {
-                OutputStream os = new FileOutputStream(to);
-                try {
-                    FileUtil.copy(is, os);
-                } finally {
-                    os.close();
-                }
-            } finally {
-                is.close();
+            try (InputStream is = new FileInputStream(from); OutputStream os = new FileOutputStream(to)) {
+                is.transferTo(os);
             }
         }
     }

--- a/java/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/spi/support/UtilTest.java
+++ b/java/ant.freeform/test/unit/src/org/netbeans/modules/ant/freeform/spi/support/UtilTest.java
@@ -30,7 +30,6 @@ import org.netbeans.modules.ant.freeform.TestBase;
 import org.netbeans.spi.project.AuxiliaryConfiguration;
 import org.netbeans.spi.project.support.ant.AntProjectHelper;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileUtil;
 import org.openide.util.Utilities;
 import org.openide.xml.XMLUtil;
 import org.w3c.dom.Document;
@@ -137,11 +136,8 @@ public class UtilTest extends TestBase {
     }
     private static String xmlSimplified(FileObject f) throws Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        InputStream is = f.getInputStream();
-        try {
-            FileUtil.copy(is, baos);
-        } finally {
-            is.close();
+        try (InputStream is = f.getInputStream()) {
+            is.transferTo(baos);
         }
         return xmlSimplified(baos.toString("UTF-8"));
     }

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/MIMETypes.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/MIMETypes.java
@@ -26,7 +26,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
@@ -127,7 +129,10 @@ public final class MIMETypes {
         if (TEMP_TRUFFLE_JAR == null) {
             File truffleJarFile = Files.createTempFile("TmpTruffleBcknd", ".jar").toFile();   // NOI18N
             truffleJarFile.deleteOnExit();
-            FileUtil.copy(RemoteServices.openRemoteClasses(), new FileOutputStream(truffleJarFile));
+            try (InputStream is = RemoteServices.openRemoteClasses();
+                 OutputStream os = new FileOutputStream(truffleJarFile)) {
+                is.transferTo(os);
+            }
             TEMP_TRUFFLE_JAR = truffleJarFile.getAbsolutePath();
         }
         return TEMP_TRUFFLE_JAR;

--- a/java/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/TestUtilities.java
+++ b/java/j2ee.core.utilities/test/unit/src/org/netbeans/modules/j2ee/core/api/support/java/TestUtilities.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.j2ee.core.api.support.java;
 
-import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
@@ -42,13 +41,9 @@ public class TestUtilities {
     }
 
     public static final FileObject copyStringToFileObject(FileObject fo, String content) throws IOException {
-        OutputStream os = fo.getOutputStream();
-        try {
-            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-            FileUtil.copy(is, os);
+        try (OutputStream os = fo.getOutputStream()) {
+            os.write(content.getBytes(StandardCharsets.UTF_8));
             return fo;
-        } finally {
-            os.close();
         }
     }
 

--- a/java/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/j2ee/jpa/refactoring/SourceTestSupport.java
+++ b/java/j2ee.jpa.refactoring/test/unit/src/org/netbeans/modules/j2ee/jpa/refactoring/SourceTestSupport.java
@@ -19,11 +19,9 @@
 package org.netbeans.modules.j2ee.jpa.refactoring;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
@@ -119,13 +117,9 @@ public abstract class SourceTestSupport extends NbTestCase{
     }
     
     protected FileObject copyStringToFileObject(FileObject fo, String content) throws Exception {
-        OutputStream os = fo.getOutputStream();
-        try {
-            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-            FileUtil.copy(is, os);
+        try (OutputStream os = fo.getOutputStream()) {
+            os.write(content.getBytes(StandardCharsets.UTF_8));
             return fo;
-        } finally {
-            os.close();
         }
     }
     

--- a/java/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/support/TestUtilities.java
+++ b/java/j2ee.metadata.model.support/test/unit/src/org/netbeans/modules/j2ee/metadata/model/support/TestUtilities.java
@@ -19,8 +19,6 @@
 
 package org.netbeans.modules.j2ee.metadata.model.support;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -28,7 +26,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -55,12 +52,8 @@ public class TestUtilities {
      * @param content the contents to copy.
      */ 
     public static final void copyStringToFileObject(FileObject fo, String contents) throws IOException {
-        OutputStream os = fo.getOutputStream();
-        try {
-            InputStream is = new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8));
-            FileUtil.copy(is, os);
-        } finally {
-            os.close();
+        try (OutputStream os = fo.getOutputStream()) {
+            os.write(contents.getBytes(StandardCharsets.UTF_8));
         }
     }
 
@@ -71,12 +64,8 @@ public class TestUtilities {
      * @param content the contents to copy.
      */ 
     public static final void copyStringToFile(File file, String content) throws IOException {
-        OutputStream os = new FileOutputStream(file);
-        try {
-            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-            FileUtil.copy(is, os);
-        } finally {
-            os.close();
+        try (OutputStream os = new FileOutputStream(file)) {
+            os.write(content.getBytes(StandardCharsets.UTF_8));
         }
     }
 
@@ -87,9 +76,7 @@ public class TestUtilities {
      * @return string representing the contents of the given stream.
      */ 
     public static final String copyStreamToString(InputStream input) throws IOException {
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
-        FileUtil.copy(input, output);
-        return StandardCharsets.UTF_8.newDecoder().decode(ByteBuffer.wrap(output.toByteArray())).toString();
+        return StandardCharsets.UTF_8.newDecoder().decode(ByteBuffer.wrap(input.readAllBytes())).toString();
     }
 
     /**
@@ -99,11 +86,8 @@ public class TestUtilities {
      * @return string representing the contents of the given <code>fo</code>.
      */ 
     public static final String copyFileObjectToString(FileObject fo) throws IOException {
-        InputStream stream = fo.getInputStream();
-        try {
+        try (InputStream stream = fo.getInputStream()) {
             return copyStreamToString(stream);
-        } finally {
-            stream.close();
         }
     }
 
@@ -114,11 +98,8 @@ public class TestUtilities {
      * @return string representing the contents of the given <code>file</code>.
      */ 
     public static final String copyFileToString(File file) throws IOException {
-        InputStream stream = new FileInputStream(file);
-        try{
+        try (InputStream stream = new FileInputStream(file)) {
             return copyStreamToString(stream);
-        } finally {
-            stream.close();
         }
     }
 

--- a/java/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/classpath/ModuleClassPathsTest.java
+++ b/java/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/classpath/ModuleClassPathsTest.java
@@ -724,7 +724,7 @@ public class ModuleClassPathsTest extends NbTestCase {
                 final FileLock lck = res[0].lock();
                 try (OutputStream out = res[0].getOutputStream(lck);
                         InputStream in = new ByteArrayInputStream(module.toString().getBytes(FileEncodingQuery.getEncoding(res[0])))) {
-                    FileUtil.copy(in, out);
+                    in.transferTo(out);
                 } finally {
                     lck.releaseLock();
                 }
@@ -840,7 +840,7 @@ public class ModuleClassPathsTest extends NbTestCase {
                 path = f.getNameExt();
             }
             out.putNextEntry(new ZipEntry(path));
-            FileUtil.copy(f.getInputStream(), out);
+            f.getInputStream().transferTo(out);
             out.closeEntry();
         }
     }

--- a/java/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/ShowGoldenFilesPanel.java
+++ b/java/java.editor.base/test/unit/src/org/netbeans/modules/java/editor/base/semantic/ShowGoldenFilesPanel.java
@@ -36,7 +36,6 @@ import javax.swing.text.AttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyleContext;
 import javax.swing.text.StyledDocument;
-import org.openide.filesystems.FileUtil;
 
 /**
  *
@@ -139,32 +138,12 @@ public class ShowGoldenFilesPanel extends javax.swing.JPanel {
     }// </editor-fold>//GEN-END:initComponents
 
     private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
-// TODO add your handling code here:
-        InputStream source = null;
-        OutputStream target = null;
                 
-        try {
-            source = new FileInputStream(testFile);
-            target = new FileOutputStream(goldenFile);
-            
-            FileUtil.copy(source, target);
+        try (InputStream source = new FileInputStream(testFile);
+             OutputStream target = new FileOutputStream(goldenFile)) {
+            source.transferTo(target);
         } catch (IOException e) {
             e.printStackTrace();
-        } finally {
-            if (source != null) {
-                try {
-                    source.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-            if (target != null) {
-                try {
-                    target.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
         }
         c.setVisible(false);
     }//GEN-LAST:event_jButton1ActionPerformed

--- a/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/TestPerformer.java
+++ b/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/test/TestPerformer.java
@@ -177,7 +177,7 @@ public class TestPerformer {
      */
     private static FileObject copyStringToFile(FileObject f, String content) throws Exception {
         try (InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)); OutputStream os = f.getOutputStream()) {
-            FileUtil.copy(is, os);
+            is.transferTo(os);
         }
         return f;
     }

--- a/java/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/J2SEDeployProperties.java
+++ b/java/java.j2sedeploy/src/org/netbeans/modules/java/j2sedeploy/J2SEDeployProperties.java
@@ -193,7 +193,7 @@ public final class J2SEDeployProperties {
         lock = buildExFo.lock();
         try (final InputStream in = J2SEDeployProperties.class.getClassLoader().getResourceAsStream(BUILD_SCRIPT_PROTOTYPE);
              final OutputStream out = buildExFo.getOutputStream(lock)) {
-            FileUtil.copy(in, out);
+            in.transferTo(out);
         } finally {
             lock.releaseLock();
         }

--- a/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/J2SEModularProjectProperties.java
+++ b/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/J2SEModularProjectProperties.java
@@ -20,7 +20,6 @@
 package org.netbeans.modules.java.j2semodule.ui.customizer;
 
 import java.awt.event.ActionListener;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -469,11 +468,8 @@ public class J2SEModularProjectProperties {
                 } else {
                     fo = FileUtil.toFileObject(file);
                 }
-                OutputStream out = fo.getOutputStream();
-                try {
-                    FileUtil.copy(new ByteArrayInputStream(CHANGED_LICENSE_PATH_CONTENT.getBytes()), out);
-                } finally {
-                    out.close();
+                try (OutputStream out = fo.getOutputStream()) {
+                    out.write(CHANGED_LICENSE_PATH_CONTENT.getBytes());
                 }
             }
             // Store properties

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/J2SEActionProvider.java
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/J2SEActionProvider.java
@@ -760,7 +760,7 @@ public class J2SEActionProvider extends BaseActionProvider {
                 final FileLock lock = cosScript.lock();
                 try (InputStream in = getClass().getResourceAsStream(SCRIPT_TEMPLATE);
                         OutputStream out = cosScript.getOutputStream(lock)) {
-                    FileUtil.copy(in, out);
+                    in.transferTo(out);
                 } finally {
                     lock.releaseLock();
                 }

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/J2SEProjectProperties.java
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/J2SEProjectProperties.java
@@ -20,7 +20,6 @@
 package org.netbeans.modules.java.j2seproject.ui.customizer;
 
 import java.awt.event.ActionListener;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -51,7 +50,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.swing.ButtonModel;
 import javax.swing.ComboBoxModel;
-import javax.swing.DefaultButtonModel;
 import javax.swing.DefaultListModel;
 import javax.swing.JToggleButton;
 import javax.swing.ListCellRenderer;
@@ -469,11 +467,8 @@ public class J2SEProjectProperties {
                 } else {
                     fo = FileUtil.toFileObject(file);
                 }
-                OutputStream out = fo.getOutputStream();
-                try {
-                    FileUtil.copy(new ByteArrayInputStream(CHANGED_LICENSE_PATH_CONTENT.getBytes()), out);
-                } finally {
-                    out.close();
+                try (OutputStream out = fo.getOutputStream()) {
+                    out.write(CHANGED_LICENSE_PATH_CONTENT.getBytes());
                 }
             }
             // Store properties

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
@@ -463,7 +463,7 @@ final class LspTemplateUI {
         String descriptionText = null;
         if (description != null) {
             try (ByteArrayOutputStream os = new ByteArrayOutputStream(); InputStream is = description.openStream()) {
-                FileUtil.copy(is, os);
+                is.transferTo(os);
                 String s = os.toString("UTF-8");
                 descriptionText = stripHtml(s);
             } catch (IOException ex) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/OptionsExportModel.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/OptionsExportModel.java
@@ -697,7 +697,7 @@ final class OptionsExportModel {
      */
     private void copyFile(String relativePath, OutputStream out) throws IOException {
         try (InputStream in = getInputStream(relativePath)) {
-            FileUtil.copy(in, out);
+            in.transferTo(out);
         }
     }
 

--- a/java/java.source.ant/src/org/netbeans/modules/java/source/ant/ProjectRunnerImpl.java
+++ b/java/java.source.ant/src/org/netbeans/modules/java/source/ant/ProjectRunnerImpl.java
@@ -680,30 +680,8 @@ public class ProjectRunnerImpl implements JavaRunnerImplementation {
     }
 
     private static void copyFile(URLConnection source, FileObject target) throws IOException {
-        InputStream ins = null;
-        OutputStream out = null;
-
-        try {
-            ins = source.getInputStream();
-            out = target.getOutputStream();
-
-            FileUtil.copy(ins, out);
-        } finally {
-            if (ins != null) {
-                try {
-                    ins.close();
-                } catch (IOException ex) {
-                    Exceptions.printStackTrace(ex);
-                }
-            }
-
-            if (out != null) {
-                try {
-                    out.close();
-                } catch (IOException ex) {
-                    Exceptions.printStackTrace(ex);
-                }
-            }
+        try (InputStream ins = source.getInputStream(); OutputStream out = target.getOutputStream()) {
+            ins.transferTo(out);
         }
     }
 

--- a/java/java.source.base/src/org/netbeans/modules/java/source/JavadocHelper.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/JavadocHelper.java
@@ -22,7 +22,6 @@ import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import java.awt.EventQueue;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -58,7 +57,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.ModuleElement;
-import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
@@ -87,9 +85,7 @@ import org.netbeans.modules.java.source.parsing.FileObjects;
 import org.netbeans.modules.parsing.lucene.support.Convertor;
 import org.netbeans.modules.parsing.lucene.support.Convertors;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
-import org.openide.util.NbBundle;
 import org.openide.util.Parameters;
 import org.openide.util.RequestProcessor;
 
@@ -378,9 +374,7 @@ public class JavadocHelper {
                                 getFirstLocation(),
                                 Bundle.LBL_HTTPJavadocDownload());
                         }
-                        ByteArrayOutputStream baos = new ByteArrayOutputStream(20 * 1024); // typical size for Javadoc page?
-                        FileUtil.copy(uncached, baos);
-                        data = baos.toByteArray();
+                        data = uncached.readAllBytes();
                         if (fileURI != null) {
                             remoteFileContentCache.put(fileURI, data);
                         }

--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexer.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexer.java
@@ -225,7 +225,7 @@ public class JavaCustomIndexer extends CustomIndexer {
                             toDir.mkdirs();
                             File to = new File(toDir, name);
                             try (OutputStream os = new FileOutputStream(to); InputStream is = ch.getInputStream()) {
-                                FileUtil.copy(is, os);
+                                is.transferTo(os);
                             }
                         }
                     }

--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
@@ -524,7 +524,7 @@ final class VanillaCompileWorker extends CompileWorker {
     private static void copyFile(FileObject updatedFile, JavaFileObject target) throws IOException {
         try (InputStream ins = updatedFile.getInputStream();
              OutputStream out = target.openOutputStream()) {
-            FileUtil.copy(ins, out);
+            ins.transferTo(out);
         }
     }
 

--- a/java/java.source.base/src/org/netbeans/modules/java/source/usages/BuildArtifactMapperImpl.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/usages/BuildArtifactMapperImpl.java
@@ -33,7 +33,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -61,7 +60,6 @@ import org.netbeans.api.queries.FileBuiltQuery.Status;
 import org.netbeans.api.queries.VisibilityQuery;
 import org.netbeans.modules.java.preprocessorbridge.api.CompileOnSaveActionQuery;
 import org.netbeans.modules.java.preprocessorbridge.spi.CompileOnSaveAction;
-import org.netbeans.modules.java.source.NoJavacHelper;
 import org.netbeans.modules.java.source.indexing.COSSynchronizingIndexer;
 import org.netbeans.modules.java.source.indexing.JavaIndex;
 import org.netbeans.modules.java.source.parsing.FileObjects;
@@ -247,34 +245,15 @@ public class BuildArtifactMapperImpl {
             LOG.log(Level.FINER, "#227791: proceeding to overwrite {0} with {1}", new Object[] {target, updatedFile});
         }
 
-        InputStream ins = null;
-        OutputStream out = null;
 
         try {
-            ins = new FileInputStream(updatedFile);
-            out = new FileOutputStream(target);
-
-            FileUtil.copy(ins, out);
+            try (InputStream ins = new FileInputStream(updatedFile); OutputStream out = new FileOutputStream(target)) {
+                ins.transferTo(out);
+            }
             return true;
         } catch (FileNotFoundException fnf) {
             LOG.log(Level.INFO, "Cannot open file.", fnf);   //NOI18N
             return false;
-        } finally {
-            if (ins != null) {
-                try {
-                    ins.close();
-                } catch (IOException ex) {
-                    Exceptions.printStackTrace(ex);
-                }
-            }
-
-            if (out != null) {
-                try {
-                    out.close();
-                } catch (IOException ex) {
-                    Exceptions.printStackTrace(ex);
-                }
-            }
         }
     }
     
@@ -286,31 +265,9 @@ public class BuildArtifactMapperImpl {
             }
         }
 
-        InputStream ins = null;
-        OutputStream out = null;
-
-        try {
-            ins = updatedFile.getInputStream();
-            out = new FileOutputStream(target);
-
-            FileUtil.copy(ins, out);
+        try (InputStream ins = updatedFile.getInputStream(); OutputStream out = new FileOutputStream(target)) {
+            ins.transferTo(out);
             //target.setLastModified(MINIMAL_TIMESTAMP); see 156153
-        } finally {
-            if (ins != null) {
-                try {
-                    ins.close();
-                } catch (IOException ex) {
-                    Exceptions.printStackTrace(ex);
-                }
-            }
-
-            if (out != null) {
-                try {
-                    out.close();
-                } catch (IOException ex) {
-                    Exceptions.printStackTrace(ex);
-                }
-            }
         }
     }
 

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/SourceUtilsTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/SourceUtilsTest.java
@@ -21,7 +21,6 @@ package org.netbeans.api.java.source;
 
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -698,11 +697,8 @@ public class SourceUtilsTest extends ClassIndexTestCase {
         final FileObject fo = FileUtil.createData(folder, name);
         final FileLock lock = fo.lock();
         try {
-            final OutputStream out = fo.getOutputStream(lock);
-            try {
-                FileUtil.copy(new ByteArrayInputStream(content.getBytes()), out);
-            } finally {
-                out.close();
+            try (OutputStream out = fo.getOutputStream(lock)) {
+                out.write(content.getBytes());
             }
         } finally {
             lock.releaseLock();

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TestUtilities.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TestUtilities.java
@@ -19,13 +19,11 @@
 
 package org.netbeans.api.java.source;
 
-import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
@@ -33,9 +31,7 @@ import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.spi.FileSystemProvider;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.ServiceLoader;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -55,7 +51,6 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.modules.SpecificationVersion;
 import org.openide.util.BaseUtilities;
-import org.openide.util.Utilities;
 
 /**
  * Utilities to aid unit testing java.source module.
@@ -173,12 +168,9 @@ public final class TestUtilities {
      * @return the created file
      */
     public static final File copyStringToFile (File f, String content) throws Exception {
-        FileOutputStream os = new FileOutputStream(f);
-        InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-        FileUtil.copy(is, os);
-        os.close ();
-        is.close();
-            
+        try (FileOutputStream os = new FileOutputStream(f)) {
+            os.write(content.getBytes(StandardCharsets.UTF_8));
+        }
         return f;
     }
     
@@ -190,12 +182,9 @@ public final class TestUtilities {
      * @return the created file
      */
     public static final FileObject copyStringToFile (FileObject f, String content) throws Exception {
-        OutputStream os = f.getOutputStream();
-        InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-        FileUtil.copy(is, os);
-        os.close ();
-        is.close();
-            
+        try (OutputStream os = f.getOutputStream()) {
+            os.write(content.getBytes(StandardCharsets.UTF_8));
+        }
         return f;
     }   
 

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/ModuleNamesTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/ModuleNamesTest.java
@@ -627,10 +627,7 @@ public class ModuleNamesTest extends NbTestCase {
                         null;
                 if (fo != null) {
                     try (InputStream in = fo.openInputStream()) {
-                        final ByteArrayOutputStream out = new ByteArrayOutputStream();
-                        FileUtil.copy(in, out);
-                        out.close();
-                        return out.toByteArray();
+                        return in.readAllBytes();
                     }
                 } else {
                     return null;

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/TestUtil.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/TestUtil.java
@@ -155,7 +155,7 @@ public class TestUtil {
                         if (!f.getNameExt().equals("module-info.class")) {
                             out.putNextEntry(new ZipEntry(FileUtil.getRelativePath(root, f)));
                             try (InputStream in = f.getInputStream()) {
-                                FileUtil.copy(in, out);
+                                in.transferTo(out);
                             }
                         }
                     }

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexerTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexerTest.java
@@ -62,7 +62,7 @@ public class JavaCustomIndexerTest extends NbTestCase {
             InputStream is = getClass().getResourceAsStream("/test2/NoCompileTestData.class")
         ) {
             assertNotNull("test2/NoCompileTestData found", is);
-            FileUtil.copy(is, os);
+            is.transferTo(os);
         }
 
         binQuery2.root = classesRoot.toURL();

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/FastJarTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/FastJarTest.java
@@ -19,12 +19,9 @@
 package org.netbeans.modules.java.source.parsing;
 
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,7 +30,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.java.source.TestUtil;
-import org.openide.filesystems.FileUtil;
 
 /**
  *
@@ -70,8 +66,7 @@ public class FastJarTest extends NbTestCase {
             for (FastJar.Entry e : fastEntries) {
                 map.put (e.name,e);
             }
-            ZipFile zf = new ZipFile (f);
-            try {          
+            try (ZipFile zf = new ZipFile (f)) {          
                 Enumeration<? extends ZipEntry> zipEntries = zf.entries();
                 int entryCount = 0;
                 while (zipEntries.hasMoreElements())  {
@@ -82,32 +77,18 @@ public class FastJarTest extends NbTestCase {
                     long zipTime = zipEntry.getTime();
                     long eTime = e.getTime();
                     assertEquals(zipTime, eTime);
-                    InputStream zs = zf.getInputStream(zipEntry);
-                    try {
-                        InputStream fs = FastJar.getInputStream(f, e);                                                    
-                        try {                   
-                            assertEquals(e.name, zs, fs);
-                        } finally {
-                            fs.close();
-                        }
-                    } finally {
-                        zs.close();
+                    try (InputStream zs = zf.getInputStream(zipEntry); InputStream fs = FastJar.getInputStream(f, e)) {                   
+                        assertEquals(e.name, zs, fs);
                     }
                 }                
                 assertEquals (entryCount, map.size());
-            } finally {
-                zf.close();
             }
         }
     }    
     
     private void assertEquals (String file, InputStream a, InputStream b) throws IOException {
-        ByteArrayOutputStream oa = new ByteArrayOutputStream ();
-        ByteArrayOutputStream ob = new ByteArrayOutputStream ();
-        FileUtil.copy(a, oa);
-        FileUtil.copy(b, ob);
-        byte[] aa = oa.toByteArray();
-        byte[] ab = ob.toByteArray();
+        byte[] aa = a.readAllBytes();
+        byte[] ab = b.readAllBytes();
         assertEquals ("file: "+ file ,aa.length,ab.length);
         for (int i=0; i< aa.length; i++) {
             assertEquals("file: "+file+ " offset: "+ i, aa[i], ab[i]);

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/JavacParserTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/JavacParserTest.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.URI;
 import java.net.URL;
@@ -36,12 +35,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
@@ -69,9 +66,7 @@ import org.netbeans.api.lexer.Language;
 import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.api.lexer.TokenSequence;
 import org.netbeans.junit.NbTestCase;
-import org.netbeans.modules.java.source.NoJavacHelper;
 import org.netbeans.modules.java.source.tasklist.CompilerSettings;
-import org.netbeans.modules.openide.util.GlobalLookup;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
@@ -93,8 +88,6 @@ import org.netbeans.modules.parsing.spi.ParserFactory;
 import org.netbeans.modules.parsing.spi.SchedulerTask;
 import org.netbeans.modules.parsing.spi.SourceModificationEvent;
 import org.netbeans.modules.parsing.spi.TaskFactory;
-import org.netbeans.spi.java.queries.CompilerOptionsQueryImplementation;
-import org.openide.util.lookup.ProxyLookup;
 
 /**
  *
@@ -702,11 +695,9 @@ public class JavacParserTest extends NbTestCase {
         assertNotNull("Resource found", resource);
         file.getParentFile().mkdirs();
         assertTrue("New file " + file + " created", file.createNewFile());
-        FileOutputStream os = new FileOutputStream(file);
-        InputStream is = resource.openStream();
-        FileUtil.copy(is, os);
-        is.close();
-        os.close();
+        try (InputStream is = resource.openStream(); FileOutputStream os = new FileOutputStream(file)) {
+            is.transferTo(os);
+        }
     }
     
     private static final CompilerSettingsImpl settings = new CompilerSettingsImpl();

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/BinaryAnalyserTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/BinaryAnalyserTest.java
@@ -447,13 +447,9 @@ public class BinaryAnalyserTest extends NbTestCase {
             File target = new File(where, current.getName());
             target.getParentFile().mkdirs();
             assertTrue(target.getParentFile().isDirectory());
-            InputStream in = jf.getInputStream(current);
-            OutputStream out = new BufferedOutputStream(new FileOutputStream(target));
-
-            FileUtil.copy(in, out);
-
-            in.close();
-            out.close();
+            try (InputStream in = jf.getInputStream(current); OutputStream out = new BufferedOutputStream(new FileOutputStream(target))) {
+                in.transferTo(out);
+            }
         }
     }
 

--- a/java/java.source/src/org/netbeans/modules/java/classfile/CodeGenerator.java
+++ b/java/java.source/src/org/netbeans/modules/java/classfile/CodeGenerator.java
@@ -46,7 +46,6 @@ import com.sun.tools.javap.ConstantWriter;
 import com.sun.tools.javap.Context;
 import com.sun.tools.javap.Messages;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -140,12 +139,8 @@ public class CodeGenerator {
 
         try {
             FileObject file = FileUtil.createMemoryFileSystem().getRoot().createData(toOpenHandle.getKind() == ElementKind.MODULE ? "module-info.java" : "test.java");  //NOI18N
-            OutputStream out = file.getOutputStream();
-
-            try {
-                FileUtil.copy(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)), out); //NOI18N
-            } finally {
-                out.close();
+            try (OutputStream out = file.getOutputStream()) {
+                out.write("".getBytes(StandardCharsets.UTF_8)); 
             }
 
             JavaSource js = JavaSource.create(cpInfo, file);
@@ -270,11 +265,8 @@ public class CodeGenerator {
                 if (resultFile != null && !resultFile.canWrite()) {
                     resultFile.setWritable(true);
                 }
-                out = result[0].getOutputStream();
-                try {
-                    FileUtil.copy(new ByteArrayInputStream(r.getResultingSource(file).getBytes(StandardCharsets.UTF_8)), out);
-                } finally {
-                    out.close();
+                try (OutputStream out = result[0].getOutputStream()) {
+                    out.write(r.getResultingSource(file).getBytes(StandardCharsets.UTF_8));
                 }
                 if (resultFile != null) {
                     resultFile.setReadOnly();

--- a/java/java.sourceui/test/unit/src/org/netbeans/api/java/source/ui/ElementHeadersTest.java
+++ b/java/java.sourceui/test/unit/src/org/netbeans/api/java/source/ui/ElementHeadersTest.java
@@ -465,7 +465,7 @@ public class ElementHeadersTest extends NbTestCase {
             FileObject utilDir = FileUtil.createFolder(openideBin, "org/openide/util");
             FileObject cf = utilDir.createData("Cancellable", "class");
             try (InputStream is = cancURL.openStream(); OutputStream os = cf.getOutputStream()) {
-                FileUtil.copy(is, os);
+                is.transferTo(os);
             }
             classPathElements = new FileObject[] { openideBin };
             return null;

--- a/java/jshell.support/src/org/netbeans/modules/jshell/support/SnippetsFolder.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/support/SnippetsFolder.java
@@ -155,7 +155,7 @@ public class SnippetsFolder implements PersistentSnippets {
         FileObject target = FileUtil.createFolder(pdir, PATH_SNIPPETS);
         
         try(OutputStream ostm = target.createAndOpen(name + ".java")) {
-            FileUtil.copy(contents, ostm);
+            contents.transferTo(ostm);
         } 
         FileObject snipFile = target.getFileObject(name + ".java");
         return snipFile;

--- a/java/maven.checkstyle/src/org/netbeans/modules/maven/format/checkstyle/AuxPropsImpl.java
+++ b/java/maven.checkstyle/src/org/netbeans/modules/maven/format/checkstyle/AuxPropsImpl.java
@@ -93,7 +93,7 @@ public class AuxPropsImpl implements AuxiliaryProperties, PropertyChangeListener
             file = cacheDir.createData("checkstyle-checker", "xml");
         }
         try (in; OutputStream outst = file.getOutputStream()) {
-            FileUtil.copy(in, outst);
+            in.transferTo(outst);
         }
         return file;
     }

--- a/java/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/ClassDependencyIndexCreatorTest.java
+++ b/java/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/ClassDependencyIndexCreatorTest.java
@@ -32,7 +32,6 @@ import org.netbeans.modules.maven.indexer.api.RepositoryInfo;
 import org.netbeans.modules.maven.indexer.api.RepositoryQueries.ClassUsage;
 import org.netbeans.modules.maven.indexer.spi.ClassUsageQuery;
 import org.netbeans.modules.maven.indexer.spi.ClassesQuery;
-import org.openide.filesystems.FileUtil;
 import org.openide.util.test.JarBuilder;
 import org.openide.util.test.TestFileUtils;
 
@@ -154,9 +153,7 @@ public class ClassDependencyIndexCreatorTest extends NexusTestBase {
                 "pkg/Clazz.class:ABC");
         Map<String, byte[]> content = new TreeMap<>();
         new ClassDependencyIndexCreator().read(jar, (String name, InputStream classData, Set<String> siblings) -> {
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            FileUtil.copy(classData, out);
-            content.put(name, out.toByteArray());
+            content.put(name, classData.readAllBytes());
         });
         assertEquals("[pkg/Clazz]", content.keySet().toString());
         assertEquals("[65, 66, 67]", Arrays.toString(content.get("pkg/Clazz")));

--- a/java/maven.model/test/unit/src/org/netbeans/modules/maven/pom/ModelTest.java
+++ b/java/maven.model/test/unit/src/org/netbeans/modules/maven/pom/ModelTest.java
@@ -199,7 +199,7 @@ public class ModelTest extends TestCase {
         FileObject fo = FileUtil.toFileObject(templateFile);
         FileInputStream str = new FileInputStream(templateFile);
         StringOutputStream out = new StringOutputStream();
-        FileUtil.copy(str, out);
+        str.transferTo(out);
         String dir = System.getProperty("java.io.tmpdir");
         File sourceFile = new File(dir, templateName);
         ModelSource source = Utilities.createModelSourceForMissingFile(sourceFile, true, out.toString(), "text/xml");

--- a/java/maven.refactoring/test/unit/src/org/netbeans/modules/maven/refactoring/dependency/MavenDependencyModifierImplTestBase.java
+++ b/java/maven.refactoring/test/unit/src/org/netbeans/modules/maven/refactoring/dependency/MavenDependencyModifierImplTestBase.java
@@ -65,7 +65,7 @@ public class MavenDependencyModifierImplTestBase extends NbTestCase {
                 FileObject fo = src.getFileObject(alternateBuildscript);
                 FileObject target = projectDir.getFileObject("pom.xml");
                 try (InputStream is = fo.getInputStream(); OutputStream os = target.getOutputStream()) {
-                    FileUtil.copy(is, os);
+                    is.transferTo(os);
                 }
                 /*
                 if (target != null) {

--- a/java/maven/src/org/netbeans/modules/maven/cos/CopyResourcesOnSave.java
+++ b/java/maven/src/org/netbeans/modules/maven/cos/CopyResourcesOnSave.java
@@ -131,7 +131,7 @@ public class CopyResourcesOnSave extends FileChangeAdapter {
                 is = srcFile.getInputStream();
                 fl = destFile.lock();
                 os = destFile.getOutputStream(fl);
-                FileUtil.copy(is, os);
+                is.transferTo(os);
             } finally {
                 if (is != null) {
                     is.close();

--- a/java/maven/src/org/netbeans/modules/maven/customizer/LicenseHeaderPanelProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/LicenseHeaderPanelProvider.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.maven.customizer;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -103,11 +102,8 @@ public class LicenseHeaderPanelProvider implements ProjectCustomizer.CompositeCa
                                 fo = FileUtil.toFileObject(file);
                             }
                             if (fo.isData()) {
-                                OutputStream out = fo.getOutputStream();
-                                try {
-                                    FileUtil.copy(new ByteArrayInputStream(licenseContent.getBytes()), out);
-                                } finally {
-                                    out.close();
+                                try (OutputStream out = fo.getOutputStream()) {
+                                    out.write(licenseContent.getBytes());
                                 }
                             }
                         } else {

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/classpath/ClassPathProviderImplTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/classpath/ClassPathProviderImplTest.java
@@ -557,7 +557,7 @@ public class ClassPathProviderImplTest extends NbTestCase {
             // rewrite the file in place
             try (InputStream is = prjCopy.getFileObject("pom-with-processor.xml").getInputStream();
                  OutputStream os = pom.getOutputStream()) {
-                FileUtil.copy(is, os);
+                is.transferTo(os);
             }
         });
         

--- a/java/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/Modifications.java
+++ b/java/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/Modifications.java
@@ -28,7 +28,6 @@ import org.netbeans.api.queries.FileEncodingQuery;
 import org.netbeans.editor.BaseDocument;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
 import org.openide.text.PositionBounds;
 import org.openide.text.PositionRef;
@@ -110,21 +109,14 @@ public final class Modifications implements org.netbeans.modules.refactoring.spi
                 return;
             }
         }
-        InputStream ins = null;
-        ByteArrayOutputStream baos = null;
         Reader inputReader = null;
         try {
             Charset encoding = FileEncodingQuery.getEncoding(fileObject);
-            ins = fileObject.getInputStream();
-            baos = new ByteArrayOutputStream();
-            FileUtil.copy(ins, baos);
-
-            ins.close();
-            ins = null;
-            byte[] arr = baos.toByteArray();
+            byte[] arr;
+            try (InputStream ins = fileObject.getInputStream()) {
+                arr = ins.readAllBytes();
+            }
             int arrLength = convertToLF(arr);
-            baos.close();
-            baos = null;
             inputReader = new InputStreamReader(new ByteArrayInputStream(arr, 0, arrLength), encoding);
             // initialize standard commit output stream, if user
             // does not provide his own writer
@@ -186,10 +178,6 @@ public final class Modifications implements org.netbeans.modules.refactoring.spi
             while ((count = inputReader.read(buff)) > 0)
                 outWriter.write(buff, 0, count);
         } finally {
-            if (ins != null)
-                ins.close();
-            if (baos != null)
-                baos.close();
             if (inputReader != null)
                 inputReader.close();
             if (outWriter != null)

--- a/java/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/TestUtils.java
+++ b/java/spring.beans/test/unit/src/org/netbeans/modules/spring/beans/TestUtils.java
@@ -31,7 +31,6 @@ import org.netbeans.api.lexer.Language;
 import org.netbeans.api.xml.lexer.XMLTokenId;
 import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.spring.api.beans.SpringConstants;
-import org.openide.filesystems.FileUtil;
 import org.openide.text.CloneableEditorSupport;
 
 /**
@@ -76,31 +75,20 @@ public class TestUtils {
     }
 
     public static void copyStringToFile(String string, File path) throws IOException {
-        InputStream inputStream = new ByteArrayInputStream(string.getBytes(StandardCharsets.UTF_8));
-        try {
+        try (InputStream inputStream = new ByteArrayInputStream(string.getBytes(StandardCharsets.UTF_8))) {
             copyStreamToFile(inputStream, path);
-        } finally {
-            inputStream.close();
         }
     }
 
     public static String copyFileToString(File path) throws IOException {
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        FileInputStream inputStream = new FileInputStream(path);
-        try {
-            FileUtil.copy(inputStream, outputStream);
-        } finally {
-            inputStream.close();
+        try (FileInputStream inputStream = new FileInputStream(path)) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
         }
-        return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
     }
 
     private static void copyStreamToFile(InputStream inputStream, File path) throws IOException {
-        FileOutputStream outputStream = new FileOutputStream(path, false);
-        try {
-            FileUtil.copy(inputStream, outputStream);
-        } finally {
-            outputStream.close();
+        try (FileOutputStream outputStream = new FileOutputStream(path, false)) {
+            inputStream.transferTo(outputStream);
         }
     }
 }

--- a/javafx/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/GoldenFileTestBase.java
+++ b/javafx/javafx2.editor/test/unit/src/org/netbeans/modules/javafx2/editor/GoldenFileTestBase.java
@@ -29,9 +29,7 @@ import java.util.Collection;
 import javax.swing.text.Document;
 import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.modules.javafx2.editor.completion.model.FxmlParserResult;
-import org.netbeans.modules.javafx2.editor.parser.FxModelBuilder;
 import org.netbeans.modules.javafx2.editor.parser.PrintVisitor;
-import org.netbeans.modules.javafx2.editor.sax.XmlLexerParser;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -62,11 +60,9 @@ public abstract class GoldenFileTestBase extends FXMLCompletionTestBase {
                 replaceAll("\\.", "/") + "/" + fname + ".fxml");
         
         File w = new File(getWorkDir(), f.getName());
-        InputStream is = new FileInputStream(f);
-        OutputStream os = new FileOutputStream(w);
-        FileUtil.copy(is, os);
-        os.close();
-        is.close();
+        try (InputStream is = new FileInputStream(f); OutputStream os = new FileOutputStream(w)) {
+            is.transferTo(os);
+        }
         FileObject fo = FileUtil.toFileObject(w);
         sourceDO = DataObject.find(fo);
         document = ((EditorCookie)sourceDO.getCookie(EditorCookie.class)).openDocument();

--- a/php/php.api.phpmodule/src/org/netbeans/modules/php/api/util/FileUtils.java
+++ b/php/php.api.phpmodule/src/org/netbeans/modules/php/api/util/FileUtils.java
@@ -624,7 +624,7 @@ public final class FileUtils {
             return;
         }
         try (InputStream inputStream = zipFile.getInputStream(zipEntry); FileOutputStream outputStream = new FileOutputStream(destinationFile)) {
-            FileUtil.copy(inputStream, outputStream);
+            inputStream.transferTo(outputStream);
         }
     }
 

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/TestUtilities.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/TestUtilities.java
@@ -30,7 +30,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
 
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.FileUtil;
 
 /**
  * Utilities to aid unit testing java.source module.
@@ -85,12 +84,9 @@ public final class TestUtilities {
      * @return the created file
      */
     public static final File copyStringToFile (File f, String content) throws Exception {
-        FileOutputStream os = new FileOutputStream(f);
-        InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-        FileUtil.copy(is, os);
-        os.close ();
-        is.close();
-            
+        try (FileOutputStream os = new FileOutputStream(f)) {
+            os.write(content.getBytes(StandardCharsets.UTF_8));
+        }
         return f;
     }
     
@@ -102,12 +98,9 @@ public final class TestUtilities {
      * @return the created file
      */
     public static final FileObject copyStringToFile (FileObject f, String content) throws Exception {
-        OutputStream os = f.getOutputStream();
-        InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-        FileUtil.copy(is, os);
-        os.close ();
-        is.close();
-            
+        try (OutputStream os = f.getOutputStream()) {
+            os.write(content.getBytes(StandardCharsets.UTF_8));
+        }
         return f;
     }   
 

--- a/php/php.project/src/org/netbeans/modules/php/project/connections/RemoteClient.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/connections/RemoteClient.java
@@ -879,7 +879,7 @@ public final class RemoteClient implements Cancellable {
                     // TODO the doewnload action shoudln't save all file before
                     // executing, then the ide will ask, whether user wants
                     // to replace currently editted file.
-                    FileUtil.copy(in, out);
+                    in.transferTo(out);
                     moved = true;
                 }
             } finally {

--- a/php/php.project/src/org/netbeans/modules/php/project/connections/sync/SyncController.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/connections/sync/SyncController.java
@@ -492,7 +492,7 @@ public final class SyncController implements Cancellable {
                 return false;
             }
             try (InputStream inputStream = source.getInputStream(); OutputStream outputStream = fileObject.getOutputStream()) {
-                FileUtil.copy(inputStream, outputStream);
+                inputStream.transferTo(outputStream);
             }
             return true;
         }

--- a/php/php.project/src/org/netbeans/modules/php/project/connections/sync/diff/DiffPanel.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/connections/sync/diff/DiffPanel.java
@@ -297,7 +297,7 @@ public final class DiffPanel extends JPanel {
             return;
         }
         try (InputStream inputStream = fileObject.getInputStream(); OutputStream outputStream = localTmpFile.getOutputStream()) {
-            FileUtil.copy(inputStream, outputStream);
+            inputStream.transferTo(outputStream);
         }
     }
 

--- a/php/php.project/src/org/netbeans/modules/php/project/ui/customizer/PhpProjectProperties.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/ui/customizer/PhpProjectProperties.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.php.project.ui.customizer;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -813,7 +812,7 @@ public final class PhpProjectProperties implements ConfigManager.ConfigProvider 
                 } else {
                     charsetName = ProjectPropertiesSupport.getEncoding(project);
                 }
-                FileUtil.copy(new ByteArrayInputStream(changedLicensePathContent.getBytes(charsetName)), out);
+                out.write(changedLicensePathContent.getBytes(charsetName));
             }
         }
 

--- a/php/php.samples/src/org/netbeans/modules/php/samples/PHPSamplesWizardIterator.java
+++ b/php/php.samples/src/org/netbeans/modules/php/samples/PHPSamplesWizardIterator.java
@@ -20,7 +20,6 @@ package org.netbeans.modules.php.samples;
 
 import java.awt.Component;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -226,19 +225,14 @@ public class PHPSamplesWizardIterator implements WizardDescriptor./*Progress*/In
     }
 
     private static void writeFile(ZipInputStream str, FileObject fo) throws IOException {
-        OutputStream out = fo.getOutputStream();
-        try {
-            FileUtil.copy(str, out);
-        } finally {
-            out.close();
+        try (OutputStream out = fo.getOutputStream()) {
+            str.transferTo(out);
         }
     }
 
     private static void filterProjectXML(FileObject fo, ZipInputStream str, String name) throws IOException {
         try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            FileUtil.copy(str, baos);
-            Document doc = XMLUtil.parse(new InputSource(new ByteArrayInputStream(baos.toByteArray())), false, false, null, null);
+            Document doc = XMLUtil.parse(new InputSource(new ByteArrayInputStream(str.readAllBytes())), false, false, null, null);
             NodeList nl = doc.getDocumentElement().getElementsByTagName("name");
             if (nl != null) {
                 for (int i = 0; i < nl.getLength(); i++) {
@@ -252,11 +246,8 @@ public class PHPSamplesWizardIterator implements WizardDescriptor./*Progress*/In
                     }
                 }
             }
-            OutputStream out = fo.getOutputStream();
-            try {
+            try (OutputStream out = fo.getOutputStream()) {
                 XMLUtil.write(doc, out, "UTF-8");
-            } finally {
-                out.close();
             }
         } catch (Exception ex) {
             Exceptions.printStackTrace(ex);

--- a/platform/api.templates/test/unit/src/org/netbeans/modules/templates/Bug138973Test.java
+++ b/platform/api.templates/test/unit/src/org/netbeans/modules/templates/Bug138973Test.java
@@ -23,7 +23,6 @@ import java.util.Enumeration;
 import org.openide.loaders.*;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -81,11 +80,9 @@ public class Bug138973Test extends NbTestCase {
         templateFile.setAttribute ("template", Boolean.TRUE);
         templateFile.setAttribute(ScriptingCreateFromTemplateHandler.SCRIPT_ENGINE_ATTR, "js");
         byte[] templateBytes = TESTING_TEXT.getBytes(StandardCharsets.ISO_8859_1);
-        InputStream source = new ByteArrayInputStream(templateBytes);
-        OutputStream target = templateFile.getOutputStream();
-        FileUtil.copy(source, target);
-        target.close();
-        source.close();
+        try (OutputStream target = templateFile.getOutputStream()) {
+            target.write(templateBytes);
+        }
         assert templateFile.getSize() != 0L;
         templateFile.setAttribute("template", Boolean.TRUE);
 

--- a/platform/api.templates/test/unit/src/org/netbeans/modules/templates/SCFTHandlerTest.java
+++ b/platform/api.templates/test/unit/src/org/netbeans/modules/templates/SCFTHandlerTest.java
@@ -243,7 +243,7 @@ public class SCFTHandlerTest extends NbTestCase {
          FileObject xmldir = FileUtil.createFolder(root, "xml");
          FileObject xml = FileUtil.createData(xmldir, "class.txt");
          OutputStream os = xml.getOutputStream();
-         FileUtil.copy(getClass().getResourceAsStream("utf8.xml"), os);
+         getClass().getResourceAsStream("utf8.xml").transferTo(os);
          xml.setAttribute(ScriptingCreateFromTemplateHandler.SCRIPT_ENGINE_ATTR, "js");
          os.close();
          

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
@@ -63,7 +63,6 @@ import org.netbeans.updater.ModuleDeactivator;
 import org.netbeans.updater.ModuleUpdater;
 import org.netbeans.updater.UpdateTracking;
 import org.netbeans.updater.UpdaterDispatcher;
-import org.openide.filesystems.FileUtil;
 import org.openide.modules.*;
 import org.openide.util.*;
 import org.openide.xml.XMLUtil;
@@ -468,35 +467,15 @@ public class Utilities {
         doc.getDocumentElement ().normalize ();
 
         dest.getParentFile ().mkdirs ();
-        InputStream is = null;
-        ByteArrayOutputStream bos = new ByteArrayOutputStream ();
-        OutputStream fos = null;
         try {
-            try {
-                XMLUtil.write (doc, bos, "UTF-8"); // NOI18N
-                bos.close ();
-                fos = new FileOutputStream (dest);
-                is = new ByteArrayInputStream (bos.toByteArray ());
-                FileUtil.copy (is, fos);
-            } finally {
-                if (is != null) {
-                    is.close ();
+            try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+                XMLUtil.write(doc, bos, "UTF-8"); // NOI18N
+                try (OutputStream fos = new FileOutputStream(dest)) {
+                    fos.write(bos.toByteArray());
                 }
-                if (fos != null) {
-                    fos.close ();
-                }
-                bos.close ();
             }
-        } catch (java.io.FileNotFoundException fnfe) {
-            Exceptions.printStackTrace (fnfe);
         } catch (java.io.IOException ioe) {
             Exceptions.printStackTrace (ioe);
-        } finally {
-            try {
-                bos.close ();
-            } catch (IOException x) {
-                Exceptions.printStackTrace (x);
-            }
         }
     }
 
@@ -536,20 +515,9 @@ public class Utilities {
         
         dest.getParentFile ().mkdirs ();
         assert dest.getParentFile ().exists () && dest.getParentFile ().isDirectory () : "Parent of " + dest + " exists and is directory.";
-        InputStream is = null;
-        OutputStream fos = null;            
         
-        try {
-            try {
-                fos = new FileOutputStream (dest);
-                is = new ByteArrayInputStream (content.toString().getBytes());
-                FileUtil.copy (is, fos);
-            } finally {
-                if (is != null) is.close();
-                if (fos != null) fos.close();
-            }                
-        } catch (java.io.FileNotFoundException fnfe) {
-            Exceptions.printStackTrace(fnfe);
+        try (OutputStream fos = new FileOutputStream(dest)) {
+            fos.write(content.toString().getBytes());
         } catch (java.io.IOException ioe) {
             Exceptions.printStackTrace(ioe);
         }
@@ -612,7 +580,6 @@ public class Utilities {
     }
     
     static void writeUpdateOfUpdaterJar (JarEntry updaterJarEntry, File zipFileWithUpdater, File targetCluster) throws IOException {
-        JarFile jf = new JarFile(zipFileWithUpdater);
         String entryPath = updaterJarEntry.getName();
         String entryName = entryPath.contains("/") ? entryPath.substring(entryPath.lastIndexOf("/") + 1) : entryPath;
         File dest = new File (targetCluster, UpdaterDispatcher.UPDATE_DIR + // updater
@@ -622,19 +589,11 @@ public class Utilities {
         
         dest.getParentFile ().mkdirs ();
         assert dest.getParentFile ().exists () && dest.getParentFile ().isDirectory () : "Parent of " + dest + " exists and is directory.";
-        InputStream is = null;
-        OutputStream fos = null;            
-        
-        try {
-            try {
-                fos = new FileOutputStream (dest);
-                is = jf.getInputStream (updaterJarEntry);
-                FileUtil.copy (is, fos);
-            } finally {
-                if (is != null) is.close();
-                if (fos != null) fos.close();
-                jf.close();
-            }                
+
+        try (JarFile jf = new JarFile(zipFileWithUpdater);
+             InputStream is = jf.getInputStream(updaterJarEntry);
+             OutputStream os = new FileOutputStream(dest)) {
+            is.transferTo(os);
         } catch (java.io.FileNotFoundException fnfe) {
             getLogger ().log (Level.SEVERE, fnfe.getLocalizedMessage (), fnfe);
         } catch (java.io.IOException ioe) {

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogCache.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/updateprovider/AutoupdateCatalogCache.java
@@ -30,7 +30,6 @@ import java.nio.file.Files;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.modules.autoupdate.services.AutoupdateSettings;
-import org.openide.filesystems.FileUtil;
 import org.openide.modules.Places;
 import org.openide.util.Utilities;
 
@@ -259,12 +258,8 @@ public final class AutoupdateCatalogCache {
         if (!temp.renameTo(cache)) {
             err.log(Level.INFO, "Cannot rename temp {0} to cache {1}", new Object[]{temp, cache});
             err.log(Level.INFO, "Trying to copy {0} to cache {1}", new Object[] {temp, cache});
-            try {
-                FileOutputStream os = new FileOutputStream(cache);
-                FileInputStream is = new FileInputStream(temp);
-                FileUtil.copy(is, os);
-                os.close();
-                is.close();
+            try (FileInputStream is = new FileInputStream(temp); FileOutputStream os = new FileOutputStream(cache)) {
+                is.transferTo(os);
                 temp.delete();
             } catch (IOException ex) {
                 err.log(Level.INFO, "Cannot even copy: {0}", ex.getMessage());

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/DefaultTestCase.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/DefaultTestCase.java
@@ -32,7 +32,6 @@ import org.netbeans.core.startup.MainLookup;
 import org.netbeans.modules.autoupdate.services.*;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogProvider;
-import org.openide.filesystems.FileUtil;
 import org.openide.util.Lookup;
 
 /**
@@ -59,12 +58,8 @@ public class DefaultTestCase extends NbTestCase {
     }
 
     public void populateCatalog(InputStream is) throws FileNotFoundException, IOException {
-        OutputStream os = new FileOutputStream(catalogFile);
-        try {
-            FileUtil.copy(is, os);
-        } finally {
-            is.close();
-            os.close();
+        try (is; OutputStream os = new FileOutputStream(catalogFile)) {
+            is.transferTo(os);
         }
     }
     

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/DifferentReleaseVersionsTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/DifferentReleaseVersionsTest.java
@@ -195,7 +195,7 @@ public class DifferentReleaseVersionsTest extends NbTestCase {
         jos.putNextEntry(new ZipEntry("netbeans/modules/" + moduleFile + ".jar"));
 
         FileInputStream fis = new FileInputStream(jar);
-        FileUtil.copy(fis, jos);
+        fis.transferTo(jos);
         fis.close();
         jar.delete();
         jos.close();

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/InternalUpdatesTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/InternalUpdatesTest.java
@@ -193,7 +193,7 @@ public class InternalUpdatesTest extends NbTestCase {
         jos.putNextEntry(new ZipEntry("netbeans/modules/" + moduleFile + ".jar"));
 
         FileInputStream fis = new FileInputStream(jar);
-        FileUtil.copy(fis, jos);
+        fis.transferTo(jos);
         fis.close();
         jar.delete();
         jos.close();

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/TestUtils.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/TestUtils.java
@@ -22,6 +22,7 @@ package org.netbeans.api.autoupdate;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -37,7 +38,6 @@ import org.netbeans.spi.autoupdate.CustomInstaller;
 import org.netbeans.spi.autoupdate.UpdateItem;
 import org.netbeans.spi.autoupdate.UpdateLicense;
 import org.netbeans.spi.autoupdate.UpdateProvider;
-import org.openide.filesystems.FileUtil;
 /**
  *
  * @author Radek Matous, Jirka Rechtacek
@@ -78,9 +78,9 @@ public class TestUtils {
             }
         }
         
-        FileOutputStream os = new FileOutputStream(create);
-        FileUtil.copy(res.openStream(), os);
-        os.close();
+        try (InputStream is = res.openStream(); FileOutputStream os = new FileOutputStream(create)) {
+            is.transferTo(os);
+        }
         
         return create;
     }

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NbmExternalTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/NbmExternalTest.java
@@ -225,7 +225,7 @@ public class NbmExternalTest extends NbTestCase {
         jos.putNextEntry(new ZipEntry("netbeans/modules/" + moduleFile + ".jar.external"));
 
         FileInputStream fis = new FileInputStream(ext);
-        FileUtil.copy(fis, jos);
+        fis.transferTo(jos);
         fis.close();
         ext.delete();
         jos.close();

--- a/platform/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoHid.java
+++ b/platform/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoHid.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.Locale;
 import java.util.jar.JarEntry;
@@ -31,7 +32,6 @@ import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import org.netbeans.SetupHid;
-import org.openide.filesystems.FileUtil;
 
 /**
  * Basic infrastructure for testing OSGi functionality.
@@ -72,24 +72,22 @@ public class NetigsoHid extends SetupHid {
         while (f.exists()) {
             f = new File(f.getParentFile(), f.getName() + i++);
         }
-        Manifest mf = new Manifest(new ByteArrayInputStream(manifest.getBytes("utf-8")));
+        Manifest mf = new Manifest(new ByteArrayInputStream(manifest.getBytes(StandardCharsets.UTF_8)));
         mf.getMainAttributes().putValue("Manifest-Version", "1.0");
-        JarOutputStream os = new JarOutputStream(new FileOutputStream(f), mf);
-        JarFile jf = new JarFile(orig);
-        Enumeration<JarEntry> en = jf.entries();
-        InputStream is;
-        while (en.hasMoreElements()) {
-            JarEntry e = en.nextElement();
-            if (e.getName().equals("META-INF/MANIFEST.MF")) {
-                continue;
+        try (JarOutputStream os = new JarOutputStream(new FileOutputStream(f), mf); JarFile jf = new JarFile(orig)) {
+            Enumeration<JarEntry> en = jf.entries();
+            while (en.hasMoreElements()) {
+                JarEntry e = en.nextElement();
+                if (e.getName().equals("META-INF/MANIFEST.MF")) {
+                    continue;
+                }
+                os.putNextEntry(e);
+                try (InputStream is = jf.getInputStream(e)) {
+                    is.transferTo(os);
+                }
+                os.closeEntry();
             }
-            os.putNextEntry(e);
-            is = jf.getInputStream(e);
-            FileUtil.copy(is, os);
-            is.close();
-            os.closeEntry();
         }
-        os.close();
 
         return f;
     }

--- a/platform/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoReloadTest.java
+++ b/platform/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoReloadTest.java
@@ -82,7 +82,7 @@ public class NetigsoReloadTest extends NetigsoHid {
         
         FileOutputStream os = new FileOutputStream(withoutA);
         FileInputStream is = new FileInputStream(withActivator);
-        FileUtil.copy(is, os);
+        is.transferTo(os);
         is.close();
         os.close();
         

--- a/platform/core.osgi/test/unit/src/org/netbeans/core/osgi/OSGiProcess.java
+++ b/platform/core.osgi/test/unit/src/org/netbeans/core/osgi/OSGiProcess.java
@@ -37,7 +37,6 @@ import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.types.resources.FileResource;
 import org.netbeans.SetupHid;
 import org.netbeans.nbbuild.MakeOSGi;
-import org.openide.filesystems.FileUtil;
 import org.openide.modules.Dependency;
 import org.openide.util.Utilities;
 import org.openide.util.test.TestFileUtils;
@@ -185,16 +184,9 @@ class OSGiProcess {
                 if (!dir.isDirectory() && !dir.mkdirs()) {
                     throw new IOException("could not make dir " + dir);
                 }
-                OutputStream os = new FileOutputStream(f);
-                try {
-                    InputStream is = OSGiProcess.class.getClassLoader().getResourceAsStream(clazz.getName().replace('.', '/') + ".class");
-                    try {
-                        FileUtil.copy(is, os);
-                    } finally {
-                        is.close();
-                    }
-                } finally {
-                    os.close();
+                try (InputStream is = OSGiProcess.class.getClassLoader().getResourceAsStream(clazz.getName().replace('.', '/') + ".class");
+                     OutputStream os = new FileOutputStream(f)) {
+                    is.transferTo(os);
                 }
             }
             if (newModule.manifest != null) {

--- a/platform/core.startup.base/src/org/netbeans/core/startup/layers/ArchiveURLMapper.java
+++ b/platform/core.startup.base/src/org/netbeans/core/startup/layers/ArchiveURLMapper.java
@@ -242,16 +242,8 @@ public class ArchiveURLMapper extends URLMapper {
                     copy = copy.getCanonicalFile();
                     copy.deleteOnExit();
                 }
-                InputStream is = fo.getInputStream();
-                try {
-                    OutputStream os = new FileOutputStream(copy);
-                    try {
-                        FileUtil.copy(is, os);
-                    } finally {
-                        os.close();
-                    }
-                } finally {
-                    is.close();
+                try (InputStream is = fo.getInputStream(); OutputStream os = new FileOutputStream(copy)) {
+                    is.transferTo(os);
                 }
                 copiedJARs.put(archiveFileURI, copy);
             }

--- a/platform/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/RemoveWritablesModifiedTest.java
+++ b/platform/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/RemoveWritablesModifiedTest.java
@@ -117,17 +117,15 @@ public class RemoveWritablesModifiedTest extends NbTestCase {
         // XXX use TestFileUtils.writeZipFile
         File jarFile = new File( getWorkDir(), "mymodule.jar" );
         
-        JarOutputStream os = new JarOutputStream(new FileOutputStream(jarFile), new Manifest(
-            new ByteArrayInputStream(manifest.getBytes())
-        ));
-        JarEntry entry = new JarEntry("foo/mf-layer.xml");
-        os.putNextEntry( entry );
-        
-        File l3 = new File(new File(new File(getDataDir(), "layers"), "data"), "layer3.xml");
-        InputStream is = new FileInputStream(l3);
-        FileUtil.copy( is, os );
-        is.close();
-        os.close();
+        try (JarOutputStream os = new JarOutputStream(new FileOutputStream(jarFile), new Manifest(new ByteArrayInputStream(manifest.getBytes())))) {
+            JarEntry entry = new JarEntry("foo/mf-layer.xml");
+            os.putNextEntry(entry);
+
+            File l3 = new File(new File(new File(getDataDir(), "layers"), "data"), "layer3.xml");
+            try (InputStream is = new FileInputStream(l3)) {
+                is.transferTo(os);
+            }
+        }
         
         return jarFile;
     }

--- a/platform/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/RemoveWritablesTest.java
+++ b/platform/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/RemoveWritablesTest.java
@@ -173,17 +173,15 @@ public class RemoveWritablesTest extends NbTestCase {
         // XXX use TestFileUtils.writeZipFile
         File jarFile = new File( getWorkDir(), "mymodule.jar" );
         
-        JarOutputStream os = new JarOutputStream(new FileOutputStream(jarFile), new Manifest(
-            new ByteArrayInputStream(manifest.getBytes())
-        ));
-        JarEntry entry = new JarEntry("foo/mf-layer.xml");
-        os.putNextEntry( entry );
-        
-        File l3 = new File(new File(new File(getDataDir(), "layers"), "data"), "layer3.xml");
-        InputStream is = new FileInputStream(l3);
-        FileUtil.copy( is, os );
-        is.close();
-        os.close();
+        try (JarOutputStream os = new JarOutputStream(new FileOutputStream(jarFile), new Manifest(new ByteArrayInputStream(manifest.getBytes())))) {
+            JarEntry entry = new JarEntry("foo/mf-layer.xml");
+            os.putNextEntry(entry);
+            
+            File l3 = new File(new File(new File(getDataDir(), "layers"), "data"), "layer3.xml");
+            try (InputStream is = new FileInputStream(l3)) {
+                is.transferTo(os );
+            }
+        }
         
         return jarFile;
     }

--- a/platform/core.startup/test/unit/src/org/netbeans/MainCLITest.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/MainCLITest.java
@@ -69,7 +69,7 @@ public class MainCLITest extends NbTestCase {
         os.write (TestHandler.class.getName ().getBytes ());
         String res = "/" + TestHandler.class.getName ().replace ('.', '/') + ".class";
         os.putNextEntry(new ZipEntry(res));
-        FileUtil.copy(getClass().getResourceAsStream(res), os);
+        getClass().getResourceAsStream(res).transferTo(os);
         os.close();
         
         TestHandler.called = false;

--- a/platform/core.startup/test/unit/src/org/netbeans/core/startup/ModuleListStartLevelTest.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/core/startup/ModuleListStartLevelTest.java
@@ -59,7 +59,7 @@ public class ModuleListStartLevelTest extends SetupHid {
         InputStream is = ModuleListStartLevelTest.class.getResourceAsStream("ModuleList-com-jcraft-jsch.xml");
         assertNotNull("Module definition found", is);
         final OutputStream os = fo.getOutputStream();
-        FileUtil.copy(is, os);
+        is.transferTo(os);
         os.close();
         is.close();
     }

--- a/platform/core.startup/test/unit/src/org/netbeans/core/startup/NbURLStreamHandlerFactoryTest.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/core/startup/NbURLStreamHandlerFactoryTest.java
@@ -180,7 +180,7 @@ public class NbURLStreamHandlerFactoryTest extends NbTestCase {
         URLConnection conn = u.openConnection();
         InputStream is = conn.getInputStream();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        FileUtil.copy(is, baos);
+        is.transferTo(baos);
         is.close();
         return baos.toString("UTF-8");
     }

--- a/platform/core.startup/test/unit/src/org/netbeans/core/startup/layers/DelayFSEventsTest.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/core/startup/layers/DelayFSEventsTest.java
@@ -114,22 +114,19 @@ public class DelayFSEventsTest extends NbTestCase implements FileChangeListener 
     private File createModuleJar(String manifest) throws IOException {
         File jarFile = new File( getWorkDir(), "mymodule.jar" );
         
-        JarOutputStream os = new JarOutputStream(new FileOutputStream(jarFile), new Manifest(
-            new ByteArrayInputStream(manifest.getBytes())
-        ));
-        JarEntry entry = new JarEntry("foo/mf-layer.xml");
-        os.putNextEntry( entry );
-        
-        File l3 = new File(new File(new File(getDataDir(), "layers"), "data"), "layer3.xml");
-        InputStream is = new FileInputStream(l3);
-        FileUtil.copy( is, os );
-        is.close();
-        os.putNextEntry(new JarEntry("org/netbeans/core/startup/layers/DelayFSInstaller.class"));
-        is = DelayFSEventsTest.class.getResourceAsStream("DelayFSInstaller.class");
-        FileUtil.copy (is, os);
-        
-        os.close();
-        
+        try (JarOutputStream os = new JarOutputStream(new FileOutputStream(jarFile), new Manifest(new ByteArrayInputStream(manifest.getBytes())))) {
+
+            os.putNextEntry(new JarEntry("foo/mf-layer.xml"));
+            File l3 = new File(new File(new File(getDataDir(), "layers"), "data"), "layer3.xml");
+            try (InputStream is = new FileInputStream(l3)) {
+                is.transferTo(os);
+            }
+
+            os.putNextEntry(new JarEntry("org/netbeans/core/startup/layers/DelayFSInstaller.class"));
+            try (InputStream is = DelayFSEventsTest.class.getResourceAsStream("DelayFSInstaller.class")) {
+                is.transferTo(os);
+            }
+        }
         return jarFile;
     }
 

--- a/platform/javahelp/src/org/netbeans/modules/javahelp/HelpSetRegistrationProcessor.java
+++ b/platform/javahelp/src/org/netbeans/modules/javahelp/HelpSetRegistrationProcessor.java
@@ -45,7 +45,6 @@ import javax.tools.Diagnostic.Kind;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 import org.netbeans.api.javahelp.HelpSetRegistration;
-import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.annotations.LayerBuilder;
 import org.openide.filesystems.annotations.LayerGeneratingProcessor;
 import org.openide.filesystems.annotations.LayerGenerationException;
@@ -126,14 +125,11 @@ public class HelpSetRegistrationProcessor extends LayerGeneratingProcessor {
                         File config = Files.createTempFile("jhindexer-config", ".txt").toFile();
                         try {
                             AtomicInteger cnt = new AtomicInteger();
-                            OutputStream os = new FileOutputStream(config);
-                            try {
+                            try (OutputStream os = new FileOutputStream(config)) {
                                 PrintWriter pw = new PrintWriter(os);
                                 pw.println("IndexRemove " + d + File.separator);
                                 scan(d, pw, cnt, new HashSet<String>(Arrays.asList(r.excludes())), "");
                                 pw.flush();
-                            } finally {
-                                os.close();
                             }
                             processingEnv.getMessager().printMessage(Kind.NOTE, "Indexing " + cnt + " HTML files in " + d + " into " + out);
                             File db = createTempFile("jhindexer-out", "");
@@ -147,16 +143,8 @@ public class HelpSetRegistrationProcessor extends LayerGeneratingProcessor {
                             } finally {
                                 for (File f : db.listFiles()) {
                                     FileObject dest = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "", out + f.getName(), e);
-                                    os = dest.openOutputStream();
-                                    try {
-                                        InputStream is = new FileInputStream(f);
-                                        try {
-                                            FileUtil.copy(is, os);
-                                        } finally {
-                                            is.close();
-                                        }
-                                    } finally {
-                                        os.close();
+                                    try (InputStream is = new FileInputStream(f); OutputStream os = dest.openOutputStream()) {
+                                        is.transferTo(os);
                                     }
                                     f.delete();
                                 }

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileUtilTest.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/FileUtilTest.java
@@ -76,7 +76,7 @@ public class FileUtilTest extends NbTestCase {
         InputStream is = fi.getInputStream();
         OutputStream os = fo.getOutputStream();
         long start = System.currentTimeMillis();
-        FileUtil.copy(is, os);
+        is.transferTo(os);
         long end = System.currentTimeMillis();
         long timeDefault = end - start + 1;
         is.close();
@@ -87,7 +87,7 @@ public class FileUtilTest extends NbTestCase {
         fileOut.createNewFile();
         os = new FileOutputStream(fileOut);
         start = System.currentTimeMillis();
-        FileUtil.copy(is, os);
+        is.transferTo(os);
         end = System.currentTimeMillis();
         is.close();
         os.close();

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/MIMESupportLoggingTest.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/MIMESupportLoggingTest.java
@@ -19,13 +19,11 @@
 
 package org.netbeans.modules.masterfs.filebasedfs;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.logging.LogRecord;
 import org.openide.filesystems.*;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -160,12 +158,9 @@ public class MIMESupportLoggingTest extends NbTestCase {
     }
 
     public static final File copyStringToFile (File f, String content) throws Exception {
-        FileOutputStream os = new FileOutputStream(f);
-        InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-        FileUtil.copy(is, os);
-        os.close ();
-        is.close();
-
+        try (FileOutputStream os = new FileOutputStream(f)) {
+            os.write(content.getBytes(StandardCharsets.UTF_8));
+        }
         return f;
     }
 }

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/providers/ProvidedExtensionsTest.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/providers/ProvidedExtensionsTest.java
@@ -28,9 +28,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import junit.framework.AssertionFailedError;
@@ -913,13 +911,9 @@ public class ProvidedExtensionsTest extends NbTestCase {
                     if (from.isDirectory()) {
                         from.renameTo(to);
                     } else {
-                        InputStream inputStream = new FileInputStream(from);
-                        OutputStream outputStream = new FileOutputStream(to);
-                        try {
-                            FileUtil.copy(inputStream, outputStream);
-                        } finally {
-                            if (inputStream != null) inputStream.close();
-                            if (outputStream != null) outputStream.close();
+                        try (InputStream is = new FileInputStream(from);
+                             OutputStream os = new FileOutputStream(to)) {
+                            is.transferTo(os);
                         }
                         to.setLastModified(from.lastModified());
                         assertTrue(from.delete());
@@ -949,13 +943,9 @@ public class ProvidedExtensionsTest extends NbTestCase {
                     assertFalse(to.exists());
                     
                     assertFalse(from.equals(to));
-                    InputStream inputStream = new FileInputStream(from);
-                    OutputStream outputStream = new FileOutputStream(to);
-                    try {
-                        FileUtil.copy(inputStream, outputStream);
-                    } finally {
-                        if (inputStream != null) inputStream.close();
-                        if (outputStream != null) outputStream.close();
+                    try (InputStream is = new FileInputStream(from);
+                         OutputStream os = new FileOutputStream(to)) {
+                        is.transferTo(os);
                     }
                     assertTrue(from.exists());
                     assertTrue(to.exists());

--- a/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoHid.java
+++ b/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoHid.java
@@ -97,7 +97,7 @@ public class NetigsoHid extends SetupHid {
             }
             os.putNextEntry(e);
             is = jf.getInputStream(e);
-            FileUtil.copy(is, os);
+            is.transferTo(os);
             is.close();
             os.closeEntry();
         }

--- a/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoLayerTest.java
+++ b/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoLayerTest.java
@@ -159,7 +159,7 @@ public class NetigsoLayerTest extends SetupHid {
             }
             os.putNextEntry(e);
             is = jf.getInputStream(e);
-            FileUtil.copy(is, os);
+            is.transferTo(os);
             is.close();
             os.closeEntry();
         }

--- a/platform/openide.filesystems/src/org/openide/filesystems/FileUtil.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/FileUtil.java
@@ -90,7 +90,7 @@ public final class FileUtil extends Object {
     /** transient attributes which should not be copied
     * of type Set<String>
     */
-    static final Set<String> transientAttributes = new HashSet<String>();
+    static final Set<String> transientAttributes = new HashSet<>();
 
     static {
         transientAttributes.add("templateWizardURL"); // NOI18N
@@ -519,24 +519,14 @@ public final class FileUtil extends Object {
     
     /** Copies stream of files.
     * <P>
-    * Please be aware, that this method doesn't close any of passed streams.
+    * Calls {@link InputStream#transferTo(java.io.OutputStream)} which should be now preferred.
     * @param is input stream
     * @param os output stream
+    * @deprecated use {@link InputStream#transferTo(java.io.OutputStream)}
     */
-    public static void copy(InputStream is, OutputStream os)
-    throws IOException {
-        final byte[] BUFFER = new byte[65536];
-        int len;
-
-        for (;;) {
-            len = is.read(BUFFER);
-
-            if (len == -1) {
-                return;
-            }
-
-            os.write(BUFFER, 0, len);
-        }
+    @Deprecated
+    public static void copy(InputStream is, OutputStream os) throws IOException {
+        is.transferTo(os);
     }
 
     /** Copies file to the selected folder.
@@ -555,32 +545,24 @@ public final class FileUtil extends Object {
         FileObject dest = destFolder.createData(newName, newExt);
 
         FileLock lock = null;
-        InputStream bufIn = null;
-        OutputStream bufOut = null;
 
         try {
             lock = dest.lock();
-            bufIn = source.getInputStream();
-
-            if (dest instanceof AbstractFileObject) {
-                /** prevents from firing fileChange*/
-                bufOut = ((AbstractFileObject) dest).getOutputStream(lock, false);
-            } else {
-                bufOut = dest.getOutputStream(lock);
+            try (InputStream bufIn = source.getInputStream()) {
+                OutputStream bufOut;
+                if (dest instanceof AbstractFileObject afo) {
+                    /** prevents from firing fileChange*/
+                    bufOut = afo.getOutputStream(lock, false);
+                } else {
+                    bufOut = dest.getOutputStream(lock);
+                }
+                try (bufOut) {
+                    bufIn.transferTo(bufOut);
+                }
             }
-
-            copy(bufIn, bufOut);
             copyPosixPerms(source, dest);
             copyAttributes(source, dest);
         } finally {
-            if (bufIn != null) {
-                bufIn.close();
-            }
-
-            if (bufOut != null) {
-                bufOut.close();
-            }
-
             if (lock != null) {
                 lock.releaseLock();
             }
@@ -1122,12 +1104,8 @@ public final class FileUtil extends Object {
                 FileLock lock = fd.lock();
 
                 try {
-                    OutputStream os = fd.getOutputStream(lock);
-
-                    try {
-                        copy(jis, os);
-                    } finally {
-                        os.close();
+                    try (OutputStream os = fd.getOutputStream(lock)) {
+                        jis.transferTo(os);
                     }
                 } finally {
                     lock.releaseLock();

--- a/platform/openide.filesystems/src/org/openide/filesystems/JarFileSystem.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/JarFileSystem.java
@@ -21,7 +21,6 @@ package org.openide.filesystems;
 
 import java.beans.PropertyVetoException;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -461,18 +460,9 @@ public class JarFileSystem extends AbstractFileSystem {
         return (retVal == -1) ? 0 : retVal;
     }
 
-    private InputStream getMemInputStream(JarFile jf, JarEntry je)
-    throws IOException {
+    private InputStream getMemInputStream(JarFile jf, JarEntry je) throws IOException {
         InputStream is = getInputStream4336753(jf, je);
-        ByteArrayOutputStream os = new ByteArrayOutputStream(is.available());
-
-        try {
-            FileUtil.copy(is, os);
-        } finally {
-            os.close();
-        }
-
-        return new ByteArrayInputStream(os.toByteArray());
+        return new ByteArrayInputStream(is.readAllBytes());
     }
 
     private InputStream getTemporaryInputStream(JarFile jf, JarEntry je, boolean forceRecreate)
@@ -501,18 +491,8 @@ public class JarFileSystem extends AbstractFileSystem {
         if (createContent || forceRecreate) {
             // JDK 1.3 contains bug #4336753
             //is = j.getInputStream (je);
-            InputStream is = getInputStream4336753(jf, je);
-
-            try {
-                OutputStream os = new FileOutputStream(f);
-
-                try {
-                    FileUtil.copy(is, os);
-                } finally {
-                    os.close();
-                }
-            } finally {
-                is.close();
+            try (InputStream is = getInputStream4336753(jf, je); OutputStream os = new FileOutputStream(f)) {
+                is.transferTo(os);
             }
         }
 

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/FileObjectTestHid.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/FileObjectTestHid.java
@@ -1853,7 +1853,7 @@ public class FileObjectTestHid extends TestBaseHid {
         
         InputStream is = getClass ().getResourceAsStream(getClass().getName().substring(getClass().getName().lastIndexOf('.')+1)+".class");
         OutputStream os = fo.getOutputStream (lock);
-        FileUtil.copy (is, os);
+        is.transferTo (os);
         is.close ();
         os.close ();
         lock.releaseLock ();

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/MemoryFSTestHid.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/MemoryFSTestHid.java
@@ -76,7 +76,7 @@ public class MemoryFSTestHid extends TestBaseHid {
         assertEquals(file.lastModified().getTime(), conn.getLastModified());
         assertEquals("text/x-hello", conn.getContentType());
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        FileUtil.copy(conn.getInputStream(), baos);
+        conn.getInputStream().transferTo(baos);
         assertEquals("hello", baos.toString());
         assertEquals(file, URLMapper.findFileObject(u));
         assertEquals(null, URLMapper.findURL(file, URLMapper.EXTERNAL));

--- a/platform/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectTest.java
+++ b/platform/openide.loaders/test/unit/src/org/openide/loaders/InstanceDataObjectTest.java
@@ -1069,7 +1069,7 @@ public class InstanceDataObjectTest extends NbTestCase {
         try {
             outputStream = fo.getOutputStream(fLock);
             inputStream = primaryFile.getInputStream();
-            FileUtil.copy(inputStream, outputStream);            
+            inputStream.transferTo(outputStream);            
         } finally {
             if (fLock != null) fLock.releaseLock();  
             if (inputStream != null) inputStream.close();

--- a/platform/options.api/src/org/netbeans/modules/options/export/OptionsExportModel.java
+++ b/platform/options.api/src/org/netbeans/modules/options/export/OptionsExportModel.java
@@ -1083,7 +1083,7 @@ public final class OptionsExportModel {
      */
     private void copyFile(String relativePath, OutputStream out) throws IOException {
         try (InputStream in = getInputStream(relativePath)) {
-            FileUtil.copy(in, out);
+            in.transferTo(out);
         }
     }
 
@@ -1134,7 +1134,7 @@ public final class OptionsExportModel {
                 out.putNextEntry(new ZipEntry(relativePath));
                 // Transfer bytes from the file to the ZIP file
                 try (FileInputStream in = new FileInputStream(new File(sourceDir, relativePath))) {
-                    FileUtil.copy(in, out);
+                    in.transferTo(out);
                 }
                 // Complete the entry
                 out.closeEntry();

--- a/platform/queries/test/unit/src/org/netbeans/api/queries/FileEncodingQueryTest.java
+++ b/platform/queries/test/unit/src/org/netbeans/api/queries/FileEncodingQueryTest.java
@@ -158,12 +158,8 @@ public class FileEncodingQueryTest extends NbTestCase {
         
         Charset encoding = FileEncodingQuery.getEncoding(fo);
         InputStream ins = fo.getInputStream();
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        FileUtil.copy(ins, baos);
+        byte[] arr = ins.readAllBytes();
         ins.close();
-        byte[] arr = baos.toByteArray();
-        baos.close();
-        baos = null;
         
         final Reader in = new InputStreamReader (new ByteArrayInputStream(arr),encoding);
         final ByteArrayOutputStream outbs = new ByteArrayOutputStream();

--- a/platform/settings/test/unit/src/org/netbeans/modules/settings/convertors/SerialDataConvertorTest.java
+++ b/platform/settings/test/unit/src/org/netbeans/modules/settings/convertors/SerialDataConvertorTest.java
@@ -621,7 +621,7 @@ public class SerialDataConvertorTest extends NbTestCase {
                 try {
                     l = corrupted.lock();
                     os = corrupted.getOutputStream(l);
-                    FileUtil.copy(valid.getInputStream(), os);
+                    valid.getInputStream().transferTo(os);
                     os.flush();
                 } finally {
                     if (os != null) try { os.close(); } catch (IOException ex) {}

--- a/platform/settings/test/unit/src/org/netbeans/modules/settings/convertors/XMLPropertiesConvertorTest.java
+++ b/platform/settings/test/unit/src/org/netbeans/modules/settings/convertors/XMLPropertiesConvertorTest.java
@@ -476,7 +476,7 @@ public final class XMLPropertiesConvertorTest extends NbTestCase {
                 try {
                     l = corrupted.lock();
                     os = corrupted.getOutputStream(l);
-                    FileUtil.copy(valid.getInputStream(), os);
+                    valid.getInputStream().transferTo(os);
                     os.flush();
                 } finally {
                     if (os != null) try { os.close(); } catch (IOException ex) {}

--- a/platform/settings/test/unit/src/org/netbeans/spi/settings/DOMConvertorTest.java
+++ b/platform/settings/test/unit/src/org/netbeans/spi/settings/DOMConvertorTest.java
@@ -86,7 +86,7 @@ public class DOMConvertorTest extends NbTestCase {
             assertEquals(cs2.b1, cs2.b2);
         } catch (IOException e) {
             System.err.println("File contents:\n");
-            FileUtil.copy(fo.getInputStream(), System.err);
+            fo.getInputStream().transferTo(System.err);
             throw e;
         }
         } catch (Exception ex) {
@@ -119,7 +119,7 @@ public class DOMConvertorTest extends NbTestCase {
             assertEquals(cs2.b1, cs2.b2);
         } catch (IOException e) {
             System.err.println("File contents:\n");
-            FileUtil.copy(fo.getInputStream(), System.err);
+            fo.getInputStream().transferTo(System.err);
             throw e;
         }
         } catch (Exception ex) {

--- a/profiler/profiler.j2se/test/unit/src/org/netbeans/modules/profiler/categories/j2se/TestUtilities.java
+++ b/profiler/profiler.j2se/test/unit/src/org/netbeans/modules/profiler/categories/j2se/TestUtilities.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.profiler.categories.j2se;
 
-import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
@@ -70,31 +69,22 @@ public class TestUtilities extends ProxyLookup {
         });
     }
     
-    public static final FileObject copyStringToFileObject(FileObject fo, String content) 
-        throws IOException 
-     {
-        OutputStream os = fo.getOutputStream();
-        try {
-            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-            FileUtil.copy(is, os);
+    public static final FileObject copyStringToFileObject(FileObject fo, String content) throws IOException {
+        try (OutputStream os = fo.getOutputStream()) {
+            os.write(content.getBytes(StandardCharsets.UTF_8));
             return fo;
-        } finally {
-            os.close();
         }
     }
 
     public static final String copyFileObjectToString (FileObject fo) throws java.io.IOException {
         int s = (int)FileUtil.toFile(fo).length();
         byte[] data = new byte[s];
-        InputStream stream = fo.getInputStream();
-        try {
+        try (InputStream stream = fo.getInputStream()) {
             int len = stream.read(data);
             if (len != s) {
                 throw new EOFException("truncated file");
             }
             return new String (data);
-        } finally {
-            stream.close();
         }
     }
     

--- a/profiler/profiler.nbimpl/test/unit/src/org/netbeans/modules/profiler/nbimpl/TestUtilities.java
+++ b/profiler/profiler.nbimpl/test/unit/src/org/netbeans/modules/profiler/nbimpl/TestUtilities.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.profiler.nbimpl;
 
-import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
@@ -75,13 +74,9 @@ public class TestUtilities extends ProxyLookup {
     public static final FileObject copyStringToFileObject(FileObject fo, String content) 
         throws IOException 
      {
-        OutputStream os = fo.getOutputStream();
-        try {
-            InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-            FileUtil.copy(is, os);
+        try (OutputStream os = fo.getOutputStream()) {
+            os.write(content.getBytes(StandardCharsets.UTF_8));
             return fo;
-        } finally {
-            os.close();
         }
     }
 

--- a/profiler/profiler/test/unit/src/org/netbeans/modules/profiler/SampledCPUSnapshotTest.java
+++ b/profiler/profiler/test/unit/src/org/netbeans/modules/profiler/SampledCPUSnapshotTest.java
@@ -77,7 +77,7 @@ public class SampledCPUSnapshotTest {
         assertNotNull("Sample npss file found", is);
         FileObject sample = FileUtil.createMemoryFileSystem().getRoot().createData("sample.npss");
         try (OutputStream os = sample.getOutputStream()) {
-            FileUtil.copy(is, os);
+            is.transferTo(os);
         }
         return new SampledCPUSnapshot(sample);
     }

--- a/rust/rust.cargo/nbproject/project.properties
+++ b/rust/rust.cargo/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/rust/rust.kit/nbproject/project.properties
+++ b/rust/rust.kit/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/rust/rust.options/nbproject/project.properties
+++ b/rust/rust.options/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.11

--- a/rust/rust.project.api/nbproject/project.properties
+++ b/rust/rust.project.api/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/rust/rust.project/nbproject/project.properties
+++ b/rust/rust.project/nbproject/project.properties
@@ -17,5 +17,5 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
+javac.release=21
 

--- a/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/RustProjectOperationsTest.java
+++ b/rust/rust.project/test/unit/src/org/netbeans/modules/rust/project/RustProjectOperationsTest.java
@@ -79,7 +79,7 @@ public class RustProjectOperationsTest {
         try {
             try (InputStream is = RustProjectOperationsTest.class.getResourceAsStream("data/" + fileName);
                  OutputStream os = tempFile.getOutputStream()) {
-                FileUtil.copy(is, os);
+                is.transferTo(os);
             }
             RustProjectOperations.updateProjectName(tempFile, "Renamed\"Test");
             String reference = URLMapper

--- a/rust/rust.sources/nbproject/project.properties
+++ b/rust/rust.sources/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
+javac.release=21
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/LibraryProvider.java
+++ b/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/LibraryProvider.java
@@ -245,7 +245,7 @@ public final class LibraryProvider {
         try (InputStream input = urlConnection.getInputStream()) {
             File file = Files.createTempFile("cdjns-download-", "tmp").toFile();
             try (OutputStream output = new FileOutputStream(file)) {
-                FileUtil.copy(input, output);
+                input.transferTo(output);
                 return file;
             }
         }

--- a/webcommon/javascript.jstestdriver/src/org/netbeans/modules/javascript/jstestdriver/wizard/InstallJasmineWizardDescriptorPanel.java
+++ b/webcommon/javascript.jstestdriver/src/org/netbeans/modules/javascript/jstestdriver/wizard/InstallJasmineWizardDescriptorPanel.java
@@ -105,13 +105,8 @@ public class InstallJasmineWizardDescriptorPanel implements WizardDescriptor.Pan
     }
 
     private static void download(String url, File target) throws IOException {
-        try {
-            InputStream is = new URL(url).openStream();
-            try {
-                copyToFile(is, target);
-            } finally {
-                is.close();
-            }
+        try (InputStream is = new URL(url).openStream()) {
+            copyToFile(is, target);
         } catch (IOException ex) {
             // error => ensure file is deleted
             target.delete();
@@ -154,21 +149,15 @@ public class InstallJasmineWizardDescriptorPanel implements WizardDescriptor.Pan
     }
 
     private static File copyToFile(InputStream is, File target) throws IOException {
-        OutputStream os = new FileOutputStream(target);
-        try {
-            FileUtil.copy(is, os);
-        } finally {
-            os.close();
+        try (OutputStream os = new FileOutputStream(target)) {
+            is.transferTo(os);
         }
         return target;
     }
 
     private static void writeFile(InputStream str, FileObject fo) throws IOException {
-        OutputStream out = fo.getOutputStream();
-        try {
-            FileUtil.copy(str, out);
-        } finally {
-            out.close();
+        try (OutputStream out = fo.getOutputStream()) {
+            str.transferTo(out);
         }
     }
 

--- a/webcommon/javascript.nodejs/src/org/netbeans/modules/javascript/nodejs/ui/wizard/NewSampleWizardIterator.java
+++ b/webcommon/javascript.nodejs/src/org/netbeans/modules/javascript/nodejs/ui/wizard/NewSampleWizardIterator.java
@@ -236,15 +236,13 @@ public final class NewSampleWizardIterator extends BaseWizardIterator {
 
     private static void writeFile(ZipInputStream str, FileObject fo) throws IOException {
         try (OutputStream out = fo.getOutputStream()) {
-            FileUtil.copy(str, out);
+            str.transferTo(out);
         }
     }
 
     private static void filterProjectXml(FileObject fo, ZipInputStream str, String name) throws IOException {
         try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            FileUtil.copy(str, baos);
-            Document doc = XMLUtil.parse(new InputSource(new ByteArrayInputStream(baos.toByteArray())), false, false, null, null);
+            Document doc = XMLUtil.parse(new InputSource(new ByteArrayInputStream(str.readAllBytes())), false, false, null, null);
             NodeList nl = doc.getDocumentElement().getElementsByTagName("name"); // NOI18N
             if (nl != null) {
                 for (int i = 0; i < nl.getLength(); i++) {

--- a/webcommon/javascript.nodejs/src/org/netbeans/modules/javascript/nodejs/util/FileUtils.java
+++ b/webcommon/javascript.nodejs/src/org/netbeans/modules/javascript/nodejs/util/FileUtils.java
@@ -392,7 +392,7 @@ public final class FileUtils {
                         throw new IOException("Cannot create new file " + destPath);
                     }
                     try (BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(destPath))) {
-                        FileUtil.copy(tarInputStream, outputStream);
+                        tarInputStream.transferTo(outputStream);
                     }
                 }
                 tarEntry = tarInputStream.getNextTarEntry();

--- a/webcommon/web.client.samples/src/org/netbeans/modules/web/client/samples/wizard/iterator/SampleWizardIterator.java
+++ b/webcommon/web.client.samples/src/org/netbeans/modules/web/client/samples/wizard/iterator/SampleWizardIterator.java
@@ -89,24 +89,19 @@ public class SampleWizardIterator extends AbstractWizardIterator {
         }
         FileLock lock = fo.lock();
         try {
-            BufferedReader reader = new BufferedReader(new InputStreamReader( 
-                    new FileInputStream(FileUtil.toFile(fo)), StandardCharsets.UTF_8));
-            String line;
-            StringBuilder sb = new StringBuilder();
-            while ((line = reader.readLine()) != null) {
-                for (Entry<String, String> entry : map.entrySet()) {
-                    line = line.replace(entry.getKey(), entry.getValue());
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(FileUtil.toFile(fo)), StandardCharsets.UTF_8))) {
+                String line;
+                StringBuilder sb = new StringBuilder();
+                while ((line = reader.readLine()) != null) {
+                    for (Entry<String, String> entry : map.entrySet()) {
+                        line = line.replace(entry.getKey(), entry.getValue());
+                    }
+                    sb.append(line);
+                    sb.append("\n");
                 }
-                sb.append(line);
-                sb.append("\n");
-            }
-            OutputStreamWriter writer = new OutputStreamWriter(
-                    fo.getOutputStream(lock), StandardCharsets.UTF_8);
-            try {
-                writer.write(sb.toString());
-            } finally {
-                writer.close();
-                reader.close();
+                try (OutputStreamWriter writer = new OutputStreamWriter(fo.getOutputStream(lock), StandardCharsets.UTF_8)) {
+                    writer.write(sb.toString());
+                }
             }
         } finally {
             lock.releaseLock();
@@ -114,8 +109,7 @@ public class SampleWizardIterator extends AbstractWizardIterator {
     }
 
     private void unZipFile(InputStream source, FileObject rootFolder) throws IOException {
-        try {
-            ZipInputStream str = new ZipInputStream(source);
+        try (ZipInputStream str = new ZipInputStream(source)) {
             ZipEntry entry;
             while ((entry = str.getNextEntry()) != null) {
                 if (entry.isDirectory()) {
@@ -125,18 +119,13 @@ public class SampleWizardIterator extends AbstractWizardIterator {
                 FileObject fo = FileUtil.createData(rootFolder, entry.getName());
                 FileLock lock = fo.lock();
                 try {
-                    OutputStream out = fo.getOutputStream(lock);
-                    try {
-                        FileUtil.copy(str, out);
-                    } finally {
-                        out.close();
+                    try (OutputStream out = fo.getOutputStream(lock)) {
+                        str.transferTo(out);
                     }
                 } finally {
                     lock.releaseLock();
                 }
             }
-        } finally {
-            source.close();
         }
     }
 }

--- a/webcommon/web.clientproject.api/src/org/netbeans/modules/web/clientproject/api/sites/SiteHelper.java
+++ b/webcommon/web.clientproject.api/src/org/netbeans/modules/web/clientproject/api/sites/SiteHelper.java
@@ -145,9 +145,8 @@ public final class SiteHelper {
     @NbBundle.Messages("SiteHelper.error.emptyZip=ZIP file with site template is either empty or its download failed.")
     private static void unzipProjectTemplateFile(FileObject targetDir, InputStream source, String rootFolder, String... ignoredFiles) throws IOException {
         boolean firstItem = true;
-        try {
+        try (ZipInputStream str = new ZipInputStream(source)) {
             int stripLen = rootFolder != null ? rootFolder.length() : 0;
-            ZipInputStream str = new ZipInputStream(source);
             ZipEntry entry;
             Set<String> ignored = Collections.emptySet();
             if (ignoredFiles != null && ignoredFiles.length > 0) {
@@ -191,7 +190,6 @@ public final class SiteHelper {
                 }
             }
         } finally {
-            source.close();
             if (firstItem) {
                 DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(Bundle.SiteHelper_error_emptyZip()));
             }
@@ -199,18 +197,14 @@ public final class SiteHelper {
     }
 
     private static void writeFile(ZipInputStream str, FileObject fo) throws IOException {
-        OutputStream out = fo.getOutputStream();
-        try {
-            FileUtil.copy(str, out);
-        } finally {
-            out.close();
+        try (OutputStream out = fo.getOutputStream()) {
+            str.transferTo(out);
         }
     }
 
     private static String getZipRootFolder(InputStream source) throws IOException {
         String folder = null;
-        try {
-            ZipInputStream str = new ZipInputStream(source);
+        try (ZipInputStream str = new ZipInputStream(source)) {
             ZipEntry entry;
             boolean first = true;
             while ((entry = str.getNextEntry()) != null) {
@@ -238,8 +232,6 @@ public final class SiteHelper {
                     }
                 }
             }
-        } finally {
-            source.close();
         }
         return folder;
     }

--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ant/LicensePanelSupportImpl.java
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ant/LicensePanelSupportImpl.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.web.clientproject.ant;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -105,11 +104,8 @@ extends Licenses implements CustomizerUtilities.LicensePanelContentHandler {
             } else {
                 fo = FileUtil.toFileObject(file);
             }
-            OutputStream out = fo.getOutputStream();
-            try {
-                FileUtil.copy(new ByteArrayInputStream(licenseContent.getBytes()), out);
-            } finally {
-                out.close();
+            try (OutputStream out = fo.getOutputStream()) {
+                out.write(licenseContent.getBytes());
             }
         }
     }

--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ui/wizard/CreateSiteTemplate.java
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ui/wizard/CreateSiteTemplate.java
@@ -717,7 +717,7 @@ public class CreateSiteTemplate extends javax.swing.JPanel implements ExplorerMa
                 ZipEntry ze = new ZipEntry(relPath);
                 str.putNextEntry(ze);
                 if (is != null) {
-                    FileUtil.copy(fo.getInputStream(), str);
+                    fo.getInputStream().transferTo(str);
                 }
             } finally {
                 if (is != null) {


### PR DESCRIPTION
waited with this until most of the codebase migrated to JDK 17+ (https://github.com/apache/netbeans/issues/8813), so that we don't have to do it multiple times.

motivation:

 - JDK's `InputStream` implementation of `transferTo()` is somewhat similar to `FileUtil.copy()` (the buffer is a little bit smaller)
 - subclasses like `BufferedInputStream`, `FileInputStream` and others have specialized implementations

changes:

 - deprecated `FileUtil.copy()` and replaced usage with `transferTo()`
 - bumped enterprise/web.jsf.navigation, enterprise/web.jsf, enterprise/websvc.utilities and groovy/groovy.samples to release 17
 - bumped remaining rust cluster to release 21
 - some sections were further simplified after inlining (ARM, `readAllBytes()` or `write(bytes)` conversions)
