### PR TITLE
Replace delete-artifact action with REST api calls using gh CLI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2575,19 +2575,30 @@ jobs:
     #  * nothing else failed (allows manual restarts)
     #  * the workflow got cancelled
     if: ${{ always() && needs.base-build.result == 'success' && (!contains(needs.*.result, 'failure') || cancelled()) }}
+    permissions:
+      actions: write
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
 
       - name: Delete Workspace Artifact
-        uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
-        with:
-          name: build.tar.zst 
-          useGlob: false
+        run: |
+          ARTIFACT_ID=$(gh api /repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts --jq ".artifacts[] | select(.name == \"${NAME}\") | .id")
+          echo ${ARTIFACT_ID}
+          if [ -n "$ARTIFACT_ID" ]; then
+            gh api /repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID} -X DELETE
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NAME: build.tar.zst
 
       - name: Delete Dev Build Artifact
-        uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
         if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:dev-build') && cancelled() }}
-        with:
-          name: dev-build_${{github.event.pull_request.number || github.run_id}}.zip
-          useGlob: false
+        run: |
+          ARTIFACT_ID=$(gh api /repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts --jq ".artifacts[] | select(.name == \"${NAME}\") | .id")
+          if [ -n "$ARTIFACT_ID" ]; then
+            gh api /repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID} -X DELETE
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NAME: dev-build_${{github.event.pull_request.number || github.run_id}}.zip


### PR DESCRIPTION
tried to come up with a way to remove the third party action.

attempt 1 using `github-script` looked like:
```yml
      - name: Delete Workflow Artifacts
        uses: actions/github-script@v8
        with:
          script: |
            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
              owner: context.repo.owner,
              repo: context.repo.repo,
              run_id: context.runId
            });
            for (const artifact of artifacts.data.artifacts) {
              if (artifact.name === "build.tar.zst") {
                console.log("removing " + artifact.name);
                await github.rest.actions.deleteArtifact({
                  owner: context.repo.owner,
                  repo: context.repo.repo,
                  artifact_id: artifact.id
                });
              }
            }
```

 attempt 2 using gh CLI:
```yml
      - name: Delete Workspace Artifact
        run: |
          ARTIFACT_ID=$(gh api /repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts --jq ".artifacts[] | select(.name == \"${NAME}\") | .id")
          if [ -n "$ARTIFACT_ID" ]; then
            gh api /repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID} -X DELETE
          fi
        env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          NAME: build.tar.zst
```

both would require
```yml
    permissions:
      actions: write
```
unfortunately

I don't know what black magic `geekyeggo/delete-artifact` uses to delete it without permissions set.