### PR TITLE
Fix harness/apisupport.harness build TestDownload check

### DIFF
--- a/harness/apisupport.harness/build.xml
+++ b/harness/apisupport.harness/build.xml
@@ -40,7 +40,7 @@
             </classpath>
         </taskdef>
         <echo file="build/binaries-list">C29635C8A7AFA03D74B33C1884DF8ABB2B3F3DCC org.ow2.asm:asm:9.9</echo>
-        <TestDownload>
+        <TestDownload server="${binaries.server}" repos="${binaries.repos}">
             <manifest dir="build">
                 <include name="binaries-list"/>
             </manifest>


### PR DESCRIPTION
Added the use of `server` and `repos` attributes, as are defined for the `downloadbinaries` task in the *nbbuild/templates/projectized.xml* script.

This would ensure the usage of the expected property values defined for downloads during the build.
The `cache` attribute has been skipped, in order to always test the downloading capabilities of the `DownloadBinaries` task.
