### PR TITLE
Adjust GlassFish plugin for changes in GlassFish 7.1

### DIFF
--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/GlassfishInstance.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/GlassfishInstance.java
@@ -1198,6 +1198,16 @@ public class GlassfishInstance implements ServerInstanceImplementation,
         return properties.get(GlassfishModule.GLASSFISH_FOLDER_ATTR);
     }
 
+    /**
+     * Get additional JVM options configured for this server instance.
+     * <p/>
+     * @return Additional JVM options string, or empty string if not set.
+     */
+    public String getAdditionalLauncherJvmOptions() {
+        String value = properties.get(GlassfishModule.JVM_OPTIONS_ATTR);
+        return value != null ? value : "";
+    }
+
     @Override
     public String getDisplayName() {
         return properties.get(GlassfishModule.DISPLAY_NAME_ATTR);

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/StartTask.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/StartTask.java
@@ -45,6 +45,7 @@ import org.netbeans.modules.glassfish.tooling.TaskEvent;
 import org.netbeans.modules.glassfish.tooling.TaskState;
 import org.netbeans.modules.glassfish.tooling.TaskStateListener;
 import org.netbeans.modules.glassfish.tooling.data.GlassFishServerStatus;
+import org.netbeans.modules.glassfish.tooling.data.GlassFishVersion;
 import org.netbeans.modules.glassfish.tooling.data.StartupArgs;
 import org.netbeans.modules.glassfish.tooling.data.StartupArgsEntity;
 import org.netbeans.modules.glassfish.tooling.server.FetchLogSimple;
@@ -672,6 +673,10 @@ public class StartTask extends BasicTask<TaskState> {
         
         // append other options from startup extenders, e.g. for profiling
         appendStartupExtenderParams(optList);
+        // append module path args required for GlassFish 7.1+
+        appendGlassFish71PlusArgs(optList);
+        // append additional JVM options configured for this instance
+        appendConfiguredJvmOptions(optList);
 
         return new StartupArgsEntity(
                 glassfishArgs,
@@ -730,12 +735,45 @@ public class StartTask extends BasicTask<TaskState> {
     
     private void appendStartupExtenderParams(List<String> optList) {
         for (StartupExtender args : StartupExtender.getExtenders(
-                Lookups.singleton(support.getInstanceProvider().getInstance(instance.getProperty("url"))), 
+                Lookups.singleton(support.getInstanceProvider().getInstance(instance.getProperty("url"))),
                 getMode(instance.getProperty(GlassfishModule.JVM_MODE)))) {
             for (String arg : args.getArguments()) {
                 String[] argSplitted = arg.trim().split("\\s+(?=-)");
                 optList.addAll(Arrays.asList(argSplitted));
             }
+        }
+    }
+
+    /**
+     * Appends module path arguments required for GlassFish 7.1 and later.
+     * <p/>
+     * GlassFish 7.1+ requires {@code --module-path} and {@code --add-modules}
+     * JVM arguments to boot correctly.
+     * <p/>
+     * @param optList JVM options list to append arguments to.
+     */
+    private void appendGlassFish71PlusArgs(List<String> optList) {
+        GlassFishVersion version = instance.getVersion();
+        if (version != null && GlassFishVersion.ge(version, GlassFishVersion.GF_7_1_0)) {
+            String glassfishRoot = instance.getGlassfishRoot();
+            if (glassfishRoot != null) {
+                optList.add("--module-path");
+                optList.add(glassfishRoot + "/lib/bootstrap");
+                optList.add("--add-modules");
+                optList.add("ALL-MODULE-PATH");
+            }
+        }
+    }
+
+    /**
+     * Appends additional JVM options configured for this server instance.
+     * <p/>
+     * @param optList JVM options list to append arguments to.
+     */
+    private void appendConfiguredJvmOptions(List<String> optList) {
+        String jvmOptions = instance.getAdditionalLauncherJvmOptions().trim();
+        if (!jvmOptions.isEmpty()) {
+            optList.addAll(Arrays.asList(Utilities.parseParameters(jvmOptions)));
         }
     }
 

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/Bundle.properties
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/Bundle.properties
@@ -161,3 +161,6 @@ InstancePanel.installationLocationField.text=
 InstancePanel.domainsFolderField.text=
 InstancePanel.userNameField.text=
 InstancePanel.hostRemoteField.text=
+
+InstanceLocalPanel.additionalLauncherJvmOptionsLabel=Additional Launcher JVM Options:
+InstancePanel.additionalLauncherJvmOptionsField.text=

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/InstanceLocalPanel.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/InstanceLocalPanel.java
@@ -139,6 +139,7 @@ public class InstanceLocalPanel extends InstancePanel {
         super.enableFields();
         hostLocalField.setEnabled(true);
         localIpCB.setEnabled(true);
+        additionalLauncherJvmOptionsField.setEnabled(true);
     }
 
 }

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/InstancePanel.form
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/InstancePanel.form
@@ -98,16 +98,21 @@
                   </Group>
                   <Group type="102" attributes="0">
                       <Group type="103" groupAlignment="1" attributes="0">
-                          <Component id="jdbcDriverDeployment" alignment="0" pref="265" max="32767" attributes="0"/>
+                          <Component id="jdbcDriverDeployment" alignment="0" pref="327" max="32767" attributes="0"/>
                           <Component id="httpMonitor" alignment="0" max="32767" attributes="0"/>
                           <Component id="commetSupport" max="32767" attributes="0"/>
                       </Group>
                       <EmptySpace min="-2" max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="preserveSessions" pref="319" max="32767" attributes="0"/>
+                          <Component id="preserveSessions" pref="387" max="32767" attributes="0"/>
                           <Component id="startDerby" max="32767" attributes="0"/>
                           <Component id="showPassword" alignment="0" max="32767" attributes="0"/>
                       </Group>
+                  </Group>
+                  <Group type="102" attributes="0">
+                      <Component id="jvmOptionsLabel" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace min="-2" max="-2" attributes="0"/>
+                      <Component id="additionalLauncherJvmOptionsField" pref="0" max="32767" attributes="0"/>
                   </Group>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
@@ -174,7 +179,12 @@
                   <Component id="jdbcDriverDeployment" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="startDerby" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace max="32767" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="jvmOptionsLabel" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="additionalLauncherJvmOptionsField" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace pref="82" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -423,6 +433,26 @@
           <ResourceString bundle="org/netbeans/modules/glassfish/common/ui/Bundle.properties" key="InstancePanel.hostRemoteField.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
+    </Component>
+    <Component class="javax.swing.JLabel" name="jvmOptionsLabel">
+      <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="additionalLauncherJvmOptionsField"/>
+        </Property>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/glassfish/common/ui/Bundle.properties" key="InstanceLocalPanel.jvmOptionsLabel_1" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JTextField" name="additionalLauncherJvmOptionsField">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/glassfish/common/ui/Bundle.properties" key="InstancePanel.additionalLauncherJvmOptionsField.text_1" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="additionalLauncherJvmOptionsFieldActionPerformed"/>
+      </Events>
     </Component>
   </SubComponents>
 </Form>

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/InstancePanel.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/InstancePanel.java
@@ -449,6 +449,31 @@ public abstract class InstancePanel extends javax.swing.JPanel {
     }
 
     /**
+     * Additional Launcher JVM options field initialization.
+     * <p/>
+     * Initialize JVM options field with value stored in GlassFish instance object.
+     */
+    protected void initAdditionalLauncherJvmOptions() {
+        additionalLauncherJvmOptionsField.setText(instance.getAdditionalLauncherJvmOptions());
+    }
+
+    /**
+     * JVM options field storage.
+     * <p/>
+     * Store JVM options when form field value differs from GlassFish instance property.
+     */
+    protected void storeJvmOptions() {
+        String jvmOptions = additionalLauncherJvmOptionsField.getText().trim();
+        if (!jvmOptions.equals(instance.getAdditionalLauncherJvmOptions())) {
+            if (jvmOptions.isEmpty()) {
+                instance.removeProperty(GlassfishModule.JVM_OPTIONS_ATTR);
+            } else {
+                instance.putProperty(GlassfishModule.JVM_OPTIONS_ATTR, jvmOptions);
+            }
+        }
+    }
+
+    /**
      * Administrator user credentials storage.
      * <p/>
      * Store administrator user name and password when form fields values
@@ -512,6 +537,7 @@ public abstract class InstancePanel extends javax.swing.JPanel {
         showPassword.setEnabled(false);
         preserveSessions.setEnabled(false);
         startDerby.setEnabled(false);
+        additionalLauncherJvmOptionsField.setEnabled(false);
     }
 
     /**
@@ -526,6 +552,7 @@ public abstract class InstancePanel extends javax.swing.JPanel {
         initDomainAndTarget();
         initCredentials();
         initCheckBoxes();
+        initAdditionalLauncherJvmOptions();
         updatePasswordVisibility();
         // do the magic according to loopback checkbox
         localIpCBActionPerformed(null);
@@ -542,6 +569,7 @@ public abstract class InstancePanel extends javax.swing.JPanel {
         storeTarget();
         storeCredentials();
         storeCheckBoxes();
+        storeJvmOptions();
     }
 
     /**
@@ -614,6 +642,8 @@ public abstract class InstancePanel extends javax.swing.JPanel {
         passwordField = new javax.swing.JPasswordField();
         hostRemoteLabel = new javax.swing.JLabel();
         hostRemoteField = new javax.swing.JTextField();
+        jvmOptionsLabel = new javax.swing.JLabel();
+        additionalLauncherJvmOptionsField = new javax.swing.JTextField();
 
         setName(org.openide.util.NbBundle.getMessage(InstancePanel.class, "InstanceLocalPanel.displayName")); // NOI18N
         setPreferredSize(new java.awt.Dimension(602, 304));
@@ -717,6 +747,11 @@ public abstract class InstancePanel extends javax.swing.JPanel {
 
         hostRemoteField.setText(org.openide.util.NbBundle.getMessage(InstancePanel.class, "InstancePanel.hostRemoteField.text")); // NOI18N
 
+        jvmOptionsLabel.setLabelFor(additionalLauncherJvmOptionsField);
+        org.openide.awt.Mnemonics.setLocalizedText(jvmOptionsLabel, org.openide.util.NbBundle.getMessage(InstancePanel.class, "InstanceLocalPanel.additionalLauncherJvmOptionsLabel")); // NOI18N
+
+        additionalLauncherJvmOptionsField.setText(org.openide.util.NbBundle.getMessage(InstancePanel.class, "InstancePanel.additionalLauncherJvmOptionsField.text")); // NOI18N
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
@@ -763,14 +798,18 @@ public abstract class InstancePanel extends javax.swing.JPanel {
                                     .addComponent(passwordField)))))
                     .addGroup(layout.createSequentialGroup()
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                            .addComponent(jdbcDriverDeployment, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, 265, Short.MAX_VALUE)
+                            .addComponent(jdbcDriverDeployment, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, 327, Short.MAX_VALUE)
                             .addComponent(httpMonitor, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                             .addComponent(commetSupport, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(preserveSessions, javax.swing.GroupLayout.DEFAULT_SIZE, 319, Short.MAX_VALUE)
+                            .addComponent(preserveSessions, javax.swing.GroupLayout.DEFAULT_SIZE, 387, Short.MAX_VALUE)
                             .addComponent(startDerby, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                            .addComponent(showPassword, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))))
+                            .addComponent(showPassword, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
+                    .addGroup(layout.createSequentialGroup()
+                        .addComponent(jvmOptionsLabel)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(additionalLauncherJvmOptionsField, javax.swing.GroupLayout.PREFERRED_SIZE, 1, Short.MAX_VALUE)))
                 .addContainerGap())
         );
 
@@ -828,7 +867,11 @@ public abstract class InstancePanel extends javax.swing.JPanel {
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jdbcDriverDeployment)
                     .addComponent(startDerby))
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jvmOptionsLabel)
+                    .addComponent(additionalLauncherJvmOptionsField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addContainerGap(82, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -873,6 +916,7 @@ public abstract class InstancePanel extends javax.swing.JPanel {
     }//GEN-LAST:event_localIpCBActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
+    protected javax.swing.JTextField additionalLauncherJvmOptionsField;
     protected javax.swing.JCheckBox commetSupport;
     protected javax.swing.JTextField dasPortField;
     protected javax.swing.JLabel dasPortLabel;
@@ -890,6 +934,7 @@ public abstract class InstancePanel extends javax.swing.JPanel {
     protected javax.swing.JTextField installationLocationField;
     protected javax.swing.JLabel installationLocationLabel;
     protected javax.swing.JCheckBox jdbcDriverDeployment;
+    protected javax.swing.JLabel jvmOptionsLabel;
     protected javax.swing.JCheckBox localIpCB;
     protected javax.swing.JPasswordField passwordField;
     protected javax.swing.JLabel passwordLabel;

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/InstanceRemotePanel.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/InstanceRemotePanel.java
@@ -49,6 +49,8 @@ public class InstanceRemotePanel extends InstancePanel {
         localIpCB.setVisible(false);
         domainLabel.setVisible(true);
         domainField.setVisible(true);
+        jvmOptionsLabel.setVisible(false);
+        additionalLauncherJvmOptionsField.setVisible(false);
     }
 
     // Implemented abstract methods                                           //

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/spi/GlassfishModule.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/spi/GlassfishModule.java
@@ -98,6 +98,9 @@ public interface GlassfishModule {
     /** Key to mark properties already imported into NetBeans 7.3 and fixed. */
     public static final String NB73_IMPORT_FIXED = "nb73ImportFixed";
 
+    /** Additional JVM options to pass when starting the server. */
+    public static final String JVM_OPTIONS_ATTR = "jvmOptions"; // NOI18N
+
     /** Properties fetching timeout [ms]. */
     public static final int PROPERTIES_FETCH_TIMEOUT = 10000;
 


### PR DESCRIPTION
The launcher mechanism of GlassFish changed in 7.1. It's supposed to be an internal feature while it's recommended launching GlassFish using scripts in bin directory (e.g. bin/asadmin).

This PR doesn't do that, it just adjust the current launching mechanism in Netbeans to adapt to GlassFish 7.1+ - define modulepath and add modules.

It also adds "Additional JVM Options" field in case it's needed to adjust the launchers options if needed, e.g. if something will change again in GlassFish launcher.
