### PR TITLE
Netigso (OSGI): Fix parsing of complex Export-Package manifest entries

### DIFF
--- a/platform/core.netigso/src/org/netbeans/core/netigso/Netigso.java
+++ b/platform/core.netigso/src/org/netbeans/core/netigso/Netigso.java
@@ -27,16 +27,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.security.ProtectionDomain;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.StringTokenizer;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -291,7 +292,7 @@ implements Cloneable, Stamps.Updater {
                         }
                     }
                     if (exported instanceof String) {
-                        for (String p : exported.toString().split(",")) { // NOI18N
+                        for (String p : splitExportPackages(exported.toString())) {
                             pkgs.add(extractBundleName(p));
                         }
                     }
@@ -800,4 +801,48 @@ implements Cloneable, Stamps.Updater {
     public final byte[] patchBC(ClassLoader l, String className, ProtectionDomain pd, byte[] arr) {
         return patchByteCode(l, className, pd, arr);
     }
+
+    static List<String> splitExportPackages(String exportPkg) {
+        List<String> elements = new ArrayList<>();
+        StringBuilder buffer = new StringBuilder();
+        boolean inQuotedString = false;
+        for (int i = 0; i < exportPkg.length(); i++) {
+            char nextChar = exportPkg.charAt(i);
+            switch(nextChar) {
+                case '"' -> {
+                    inQuotedString = ! inQuotedString;
+                    buffer.append(nextChar);
+                }
+                case ',' -> {
+                    if (inQuotedString) {
+                        buffer.append(nextChar);
+                    } else {
+                        elements.add(buffer.toString());
+                        buffer.setLength(0);
+                    }
+                }
+                case '\\' -> {
+                    buffer.append(nextChar);
+                    if (inQuotedString) {
+                        if((i + 1) == exportPkg.length()) {
+                            throw new IllegalStateException("Invalid escape sequence");
+                        }
+                        nextChar = exportPkg.charAt(i + 1);
+                        i++;
+                        if (nextChar == '"' || nextChar == '\\') {
+                            buffer.append(nextChar);
+                        } else {
+                            throw new IllegalStateException("Invalid escape sequence");
+                        }
+                    }
+                }
+                default -> buffer.append(nextChar);
+            }
+        }
+        if(! buffer.isEmpty()){
+            elements.add(buffer.toString());
+        }
+        return elements;
+    }
+
 }

--- a/platform/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoTest.java
+++ b/platform/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoTest.java
@@ -22,6 +22,7 @@ package org.netbeans.core.netigso;
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import org.netbeans.MockModuleInstaller;
 import org.netbeans.MockEvents;
 import org.netbeans.Module;
@@ -213,4 +214,26 @@ public class NetigsoTest extends NetigsoHid {
             mgr.mutexPrivileged().exitWriteAccess();
         }
     }
+
+    public void testSplitExportPackages() {
+        String exportPkgs = "a.b,"
+                + "a.b.c;version=\"1.0.0\";uses:=\"x.y.z,x.y.z.k\","
+                + "a.b.c.d;version=\"1.0.0\","
+                + "a.b.c.e;version=\"1.0.0\";uses:=\"x.y.z\"";
+        List<String> result = Netigso.splitExportPackages(exportPkgs);
+        assertEquals(4, result.size());
+        assertEquals("a.b", result.get(0));
+        assertEquals("a.b.c;version=\"1.0.0\";uses:=\"x.y.z,x.y.z.k\"", result.get(1));
+        assertEquals("a.b.c.d;version=\"1.0.0\"", result.get(2));
+        assertEquals("a.b.c.e;version=\"1.0.0\";uses:=\"x.y.z\"", result.get(3));
+
+        // Test that the \" are ignored.
+        exportPkgs = "x.y.z,a.b.c;a=\"\\\"\",d.e.f";
+        result = Netigso.splitExportPackages(exportPkgs);
+        assertEquals(3, result.size());
+        assertEquals("x.y.z", result.get(0));
+        assertEquals("a.b.c;a=\"\\\"\"", result.get(1));
+        assertEquals("d.e.f", result.get(2));
+    }
+
 }


### PR DESCRIPTION
Export-Package entries are not just comma separated values, but can contain parameters, which themselves can contain commas in quoted strings. These cases need to be handled correctly.

By doing that, we properly the exported packages even if the input string contains syntax like `org.sample.pkg1;version="1.0.0";uses:="fr.free.ylc,fr.free.ylc.sample",org.sample.pkg2;version="1.0.0"`