### PR TITLE
Move setting of awtAppClassName from MainWindow to Main

### DIFF
--- a/nb/ide.branding/build.xml
+++ b/nb/ide.branding/build.xml
@@ -42,6 +42,7 @@ Contributor(s): Vincent Brabant, Maxym Mykhalchuk
     </copy>
     <replace file="${build.dir}/branding/core.startup/src/org/netbeans/core/startup/Bundle_nb.properties" value="defaultvalue" propertyFile="${nb_all}/nbbuild/build/netbeansrelease.properties">
         <replacefilter token="@@metabuild.ComputedSplashVersion@@" property="metabuild.ComputedSplashVersion"/>
+        <replacefilter token="@@metabuild.ComputedTitleVersion@@" property="metabuild.ComputedTitleVersion"/>
     </replace>
     <locjar warnMissingDir="true"
       basedir="${build.dir}/branding/core.startup/src"

--- a/nb/ide.branding/core.startup/src/org/netbeans/core/startup/Bundle_nb.properties
+++ b/nb/ide.branding/core.startup/src/org/netbeans/core/startup/Bundle_nb.properties
@@ -63,6 +63,7 @@ SplashVersionTextHorizontalAlignment=right
 
 LBL_splash_window_title=Starting Apache NetBeans IDE
 currentVersion=Apache NetBeans IDE @@metabuild.ComputedSplashVersion@@
+AWT_AppClassName=Apache NetBeans IDE @@metabuild.ComputedTitleVersion@@
 
 MSG_warning=NetBeans IDE - Warning
 MSG_info=NetBeans IDE - Information

--- a/platform/core.startup/src/org/netbeans/core/startup/Bundle.properties
+++ b/platform/core.startup/src/org/netbeans/core/startup/Bundle.properties
@@ -28,6 +28,9 @@ OpenIDE-Module-Long-Description=\
 # {0} - build number
 currentVersion=Apache NetBeans Platform Dev (Build {0})
 
+# AppClassName - used on Linux for configuring WM_CLASS
+AWT_AppClassName=Apache NetBeans Platform
+
 ERR_no_user_directory=netbeans.user is not set.\nPlease check your NetBeans startup script.
 # {0} - userdir full path
 # {1} - inst full path

--- a/platform/core.startup/src/org/netbeans/core/startup/Main.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/Main.java
@@ -19,8 +19,10 @@
 
 package org.netbeans.core.startup;
 
+import java.awt.Toolkit;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -246,6 +248,7 @@ public final class Main extends Object {
     if (CLIOptions.isGui ()) {
         try {
             java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment();
+            configureAWTAppClassName();
         } catch (java.lang.InternalError exc) {
             String s = NbBundle.getMessage(Main.class, "EXC_GraphicsStartFails1", exc.getMessage());
             System.out.println(s);
@@ -343,7 +346,7 @@ public final class Main extends Object {
             Logger.getLogger(Main.class.getName()).log(Level.WARNING, "Failed to delete {0}", f);
         }
     }
-  
+
     /** Loads a class from available class loaders. */
     private static Class<?> getKlass(String cls) {
         try {
@@ -358,6 +361,24 @@ public final class Main extends Object {
             return Class.forName(cls, false, loader);
         } catch (ClassNotFoundException e) {
             throw new NoClassDefFoundError(e.getLocalizedMessage());
+        }
+    }
+
+    // moved from MainWindow::init to handle splash, etc.
+    private static void configureAWTAppClassName() {
+        Toolkit toolkit = Toolkit.getDefaultToolkit();
+        Class<?> xtoolkit = toolkit.getClass();
+        if (xtoolkit.getName().equals("sun.awt.X11.XToolkit")) { //NOI18N
+            // TODO those add --add-opens=java.desktop/sun.awt.X11=ALL-UNNAMED
+
+            //#183739 / JDK-6528430 - provide proper app name on Linux
+            try {
+                final Field awtAppClassName = xtoolkit.getDeclaredField("awtAppClassName"); //NOI18N
+                awtAppClassName.setAccessible(true);
+                awtAppClassName.set(null, NbBundle.getMessage(Main.class, "AWT_AppClassName", "").strip()); //NOI18N
+            } catch (Exception x) {
+                Logger.getLogger(Main.class.getName()).log(Level.FINE, "can't change X11 application name", x);
+            }
         }
     }
 

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/MainWindow.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/MainWindow.java
@@ -23,7 +23,6 @@ package org.netbeans.core.windows.view.ui;
 import java.awt.*;
 import java.awt.event.*;
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.*;
 import java.util.List;
 import java.util.logging.Level;
@@ -116,21 +115,6 @@ public final class MainWindow {
        if (mainMenuBar == null) {
            mainMenuBar = createMenuBar();
            ToolbarPool.getDefault().waitFinished();
-
-           Toolkit toolkit = Toolkit.getDefaultToolkit();
-           Class<?> xtoolkit = toolkit.getClass();
-           if (xtoolkit.getName().equals("sun.awt.X11.XToolkit")) { //NOI18N
-               // TODO those add --add-opens=java.desktop/sun.awt.X11=ALL-UNNAMED
-
-               //#183739 / JDK-6528430 - provide proper app name on Linux
-               try {
-                    final Field awtAppClassName = xtoolkit.getDeclaredField("awtAppClassName"); //NOI18N
-                    awtAppClassName.setAccessible(true);
-                    awtAppClassName.set(null, NbBundle.getMessage(MainWindow.class, "CTL_MainWindow_Title_No_Project", "").strip()); //NOI18N
-               } catch (Exception x) {
-                   LOGGER.log(Level.FINE, "can't change X11 application name", x);
-               }
-           }
        }
 
        logLookAndFeelUsage();


### PR DESCRIPTION
Move the setting of awtAppClassName for XToolkit into Main so that it is set before splash and import dialogs are created. This should fix issues with duplicate dock icons caused by incorrect WM_CLASS derived from this field value that need to be worked around in the various package builds.

Follow up to discussion in #9303