### PR TITLE
CI: update remaining ant tests for JDK 21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -943,6 +943,9 @@ jobs:
 #      - name: java/ant.grammar
 #        run: ant $OPTS -f java/ant.grammar test
 
+      - name: extide/o.apache.tools.ant.module
+        run: ant $OPTS -f extide/o.apache.tools.ant.module test
+
       - name: java/gradle.test
         run: ant $OPTS -f java/gradle.test test
 
@@ -958,21 +961,10 @@ jobs:
         if: ${{ matrix.java == '21' || matrix.java == '25' }}
         run: ant $OPTS -f java/gradle.dependencies test
 
-      # TODO next are JDK 21 or 25 incompatibe steps
+      # TODO next are JDK 25 incompatibe steps
       - name: java/java.mx.project
         if: ${{ matrix.java == '21' }}
         run: .github/retry.sh ant $OPTS -f java/java.mx.project test
-
-      - name: Set up JDK 17 for ant
-        uses: actions/setup-java@v5
-        if: ${{ matrix.java == '21' }}
-        with:
-          java-version: 17
-          distribution: ${{ env.DEFAULT_JAVA_DISTRIBUTION }}
-
-      - name: extide/o.apache.tools.ant.module
-        if: ${{ matrix.java == '21' }}
-        run: ant $OPTS -f extide/o.apache.tools.ant.module test
 
       - name: apisupport.ant
         if: ${{ matrix.java == '21' }}

--- a/extide/o.apache.tools.ant.module/nbproject/project.properties
+++ b/extide/o.apache.tools.ant.module/nbproject/project.properties
@@ -55,3 +55,6 @@ test.config.stableBTD.excludes=\
     **/TargetListerTest.class,\
     **/AntProjectChildrenTest.class,\
     **/AntLoggerTest.class
+
+# java.lang.IllegalAccessError: class com.sun.tools.javac.main.Main (in unnamed module @0x75d433d1) cannot access class jdk.internal.opt.CommandLine$UnmatchedQuote (in module jdk.internal.opt) ...
+test.jms.flags=--add-exports=jdk.internal.opt/jdk.internal.opt=ALL-UNNAMED


### PR DESCRIPTION
added missing jms flag

all ant tests run now on JDK 21

meta https://github.com/apache/netbeans/issues/7871