### PR TITLE
make jnlp build process runnable again

### DIFF
--- a/extide/gradle/nbproject/project.properties
+++ b/extide/gradle/nbproject/project.properties
@@ -43,3 +43,7 @@ extra.module.files=\
 # It shall be built on the lowest language level that the Gradle integration supports
 tooling.javac.release=8
 tooling.gradle.version=8.11.1
+
+jnlp.verify.excludes=modules/gradle/nb-tooling.gradle,\
+    modules/gradle/daemon-loader/build.gradle,\
+    modules/gradle/daemon-loader/settings.gradle

--- a/harness/apisupport.harness/release/jnlp.xml
+++ b/harness/apisupport.harness/release/jnlp.xml
@@ -127,6 +127,7 @@
                 keystore="${jnlp.signjar.keystore}"
                 storepass="${jnlp.signjar.password}"
                 dname="${jnlp.signjar.vendor}"
+                keyalg="DSA"
         />
     </target>
 

--- a/java/java.j2seplatform/nbproject/project.properties
+++ b/java/java.j2seplatform/nbproject/project.properties
@@ -19,7 +19,7 @@ javac.compilerargs=-Xlint -Xlint:-serial
 javac.release=17
 extra.module.files=modules/ext/org-netbeans-modules-java-j2seplatform-probe.jar
 jnlp.indirect.jars=modules/ext/org-netbeans-modules-java-j2seplatform-probe.jar
-
+jnlp.verify.excludes=scripts/J2SEPlatformProbe.java
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/java/java.mx.project/nbproject/project.properties
+++ b/java/java.mx.project/nbproject/project.properties
@@ -24,3 +24,5 @@ requires.nb.javac=true
 test.run.args=-Dorg.netbeans.modules.java.mx.project.test.mxpath=${basedir}/test/unit/data/mx/mx
 
 test.jms.flags=--add-opens=java.base/java.net=ALL-UNNAMED 
+
+jnlp.verify.excludes=org.eclipse.jdt.core.prefs

--- a/java/java.openjdk.project/nbproject/project.properties
+++ b/java/java.openjdk.project/nbproject/project.properties
@@ -28,3 +28,9 @@ test.config.default.excludes=**/ModulesHintTest.class
 
 # remove default compiler JMS flags to fix "WARNING: Unknown module: jdk.compiler specified to --add-opens" warnings
 jms-compiler.flags.jvm=
+
+jnlp.verify.excludes=scripts/build-generic.xml,\
+   scripts/build-langtools.xml,\
+   modules/ext/fakeJdkClasses.zip,\
+   patterns/project-marker-jdk,\
+   scripts/build-langtools-consol.xml

--- a/java/maven.embedder/nbproject/project.properties
+++ b/java/maven.embedder/nbproject/project.properties
@@ -29,8 +29,53 @@ javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml
 jnlp.indirect.files=modules/ext/maven/rootpackage/default-report.xml,modules/ext/maven/settings.xml
 # Will not be able to run bundled Maven, but embedder should work and should be able to specify external Maven:
-jnlp.verify.excludes=maven/NOTICE,maven/bin/mvnDebug,maven/bin/m2.conf,maven/LICENSE,maven/README.txt,maven/conf/settings.xml,maven/bin/mvnyjp,maven/bin/mvn,maven/bin/mvn.bat,maven/bin/mvnDebug.bat,maven/lib/ext/README.txt, maven/lib/maven-settings-builder.license, maven/lib/org.eclipse.sisu.inject.license, maven/lib/wagon-http.license, maven/lib/maven-compat.license, maven/lib/org.eclipse.sisu.plexus.license, maven/lib/maven-artifact.license, maven/lib/maven-settings.license, maven/lib/maven-model.license, maven/lib/maven-embedder.license, maven/lib/maven-builder-support.license, maven/lib/aether-util.license, maven/lib/maven-model-builder.license, maven/lib/wagon-provider-api.license, maven/lib/wagon-file.license, maven/lib/slf4j-api.license, maven/lib/aether-impl.license, maven/lib/aether-transport-wagon.license, maven/lib/plexus-cipher.license, maven/bin/mvnDebug.cmd, maven/conf/logging/simplelogger.properties, maven/lib/plexus-sec-dispatcher.license, maven/bin/mvn.cmd, maven/lib/maven-aether-provider.license, maven/lib/aether-api.license, maven/lib/cdi-api.license, maven/lib/aether-spi.license, maven/lib/commons-lang3.license, maven/lib/jsr250-api.license, maven/lib/jsoup.license, maven/lib/maven-repository-metadata.license, maven/lib/wagon-http-shared.license, maven/lib/maven-core.license, maven/lib/maven-plugin-api.license, maven/lib/aether-connector-basic.license, maven/lib/slf4j-simple.license, maven/conf/toolchains.xml
-# gen-sigtest fails with:
+jnlp.verify.excludes=maven/lib/ext/hazelcast/README.txt,\
+  maven/lib/org.eclipse.sisu.plexus.license,\
+  maven/lib/asm.license,\
+  maven/boot/plexus-classworlds.license,\
+  maven/NOTICE,\
+  maven/lib/plexus-utils.license,\
+  maven/bin/m2.conf,\
+  maven/lib/ext/redisson/README.txt,\
+  maven/README.txt,\
+  maven/lib/slf4j-api.license,\
+  maven/bin/mvnDebug.cmd,\
+  maven/lib/ext/README.txt,\
+  maven/conf/logging/simplelogger.properties,\
+  maven/bin/mvn.cmd,\
+  maven/bin/mvnDebug,\
+  maven/lib/jansi-native/Windows/x86_64/jansi.dll,\
+  maven/lib/jspecify.license,\
+  maven/LICENSE,\
+  maven/lib/jansi-2.4.2.jar,\
+  maven/lib/commons-cli.license,\
+  maven/lib/commons-codec.license,\
+  maven/lib/aopalliance.license,\
+  maven/lib/error_prone_annotations.license,\
+  maven/lib/guice.license,\
+  maven/lib/gson.license,\
+  maven/lib/org.eclipse.sisu.inject.license,\
+  maven/lib/jansi-native/Windows/arm64/jansi.dll,\
+  maven/lib/failureaccess.license,\
+  maven/lib/javax.annotation-api.license,\
+  maven/lib/httpcore.license,\
+  maven/lib/plexus-interpolation.license,\
+  maven/lib/jcl-over-slf4j.license,\
+  maven/lib/jansi-native/Windows/x86/jansi.dll,\
+  maven/lib/plexus-cipher.license,\
+  maven/lib/plexus-sec-dispatcher.license,\
+  maven/conf/settings.xml,\
+  maven/lib/jansi-native/README.txt,\
+  maven/lib/jansi.license,\
+  maven/bin/mvnyjp,\
+  maven/bin/mvn,\
+  maven/lib/guava.license,\
+  maven/lib/plexus-component-annotations.license,\
+  maven/lib/javax.inject.license,\
+  maven/lib/httpclient.license,\
+  maven/conf/toolchains.xml
+
+ # gen-sigtest fails with:
 # Fatal error: class junit.framework.TestCase not found
 sigtest.gen.fail.on.error=false
 

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeJNLP.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeJNLP.java
@@ -250,7 +250,7 @@ public class MakeJNLP extends Task {
                 to.getParentFile().mkdirs();
             }
             getSignTask().setSignedjar(to);
-            getSignTask().setDigestAlg("SHA1");
+            getSignTask().setDigestAlg("SHA256");
             getSignTask().execute();
         } else if (to != null) {
             Copy copy = (Copy)getProject().createTask("copy");

--- a/nbbuild/antsrc/org/netbeans/nbbuild/VerifyJNLP.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/VerifyJNLP.java
@@ -217,7 +217,7 @@ public class VerifyJNLP extends Task {
                                     break; // just check one representative file
                                 }
                             }
-                        } catch (IOException x) {
+                        } catch (SecurityException | IOException x) {
                             error(jnlp, results, "Signatures", "error examining signatures in " + f + ": " + x);
                         }
                     }

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -370,6 +370,7 @@ metabuild.hash=${metabuild.hash}</echo>
         keystore="${jnlp.signjar.keystore}"
         storepass="${jnlp.signjar.password}"
         dname="${jnlp.signjar.vendor}"
+        keyalg="DSA"
     />
   </target>
 
@@ -385,12 +386,7 @@ metabuild.hash=${metabuild.hash}</echo>
       <mkdir dir="${jnlp.dest.dir}" />
       <makeurl property="jnlp.codebase" file="${jnlp.dest.dir}"/> <!-- fallback value unless otherwise configured -->
       <property name="jnlp.fail.on.error" value="true"/>
-      <pathconvert property="jnlp.modules.fullpath">
-          <path>
-              <dirset dir="${nb_all}" includes="${config.jnlp.stable}"/>
-          </path>
-          <mapper type="identity"/>
-      </pathconvert>
+      <resolvelist name="alljnlpmodules" path="jnlp.modules.fullpath" dir="${nb_all}" list="${nb.clusters.list}" modules="${config.jnlp.stable}"/>
       <sortsuitemodules unsortedmodules="${jnlp.modules.fullpath}" sortedmodulesproperty="jnlp.modules.sorted"/>
       <subant-junit target="jnlp" failonerror="${jnlp.fail.on.error}" report="${nb.build.dir}/build-all-jnlp.xml">
           <buildpath path="${jnlp.modules.sorted}"/>


### PR DESCRIPTION
kind of the opposite of #9312

I do not remember if it was possible to generate a NetBeans jnlp back in the day.
` ant build-jnlp` build only the different modules

this seems to work to rebuild jnlp files. this is quite long (20minutes)

the sha1 is not working  anymore so need a bump to sha256
jnlp.verify.exclusion updated to match what ant warns about.

Some late verification like this one are failling (jarsigner also say so): 

```
<testcase classname="org.netbeans.nbbuild.VerifyJNLP" name="/home/barboni/fork/netbeans/netbeans/nbbootstrap/netbeans/nbbuild/build/jnlp/org-eclipse-core-contenttype.jnlp/testSignatures" time="0.0">
<failure message="error examining signatures in /home/barboni/fork/netbeans/netbeans/nbbootstrap/netbeans/nbbuild/build/jnlp/org-eclipse-core-contenttype/org-eclipse-core-contenttype.jar: java.lang.SecurityException: invalid SHA1 signature file digest for org/eclipse/core/internal/content/XMLRootHandler$StopParsingException.class" type="junit.framework.AssertionFailedError">error examining signatures in /home/barboni/fork/netbeans/netbeans/nbbootstrap/netbeans/nbbuild/build/jnlp/org-eclipse-core-contenttype/org-eclipse-core-contenttype.jar: java.lang.SecurityException: invalid SHA1 signature file digest for org/eclipse/core/internal/content/XMLRootHandler$StopParsingException.class</failure>
</testcase>

```

