### PR TITLE
CDI: fix injection warning for jakarta predefined bean classes

### DIFF
--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/EnableBeansFilter.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/EnableBeansFilter.java
@@ -190,7 +190,7 @@ class EnableBeansFilter {
             //no implementation on classpath/sources or it's fileterd by common logic(for usual beans)
             //first check if we have a class in white list (i.e. must be implemented in ee7 environment)
             String nm = myResult.getVariableType().toString();
-            if(nm.startsWith("javax.") || nm.startsWith("java.")) {//NOI18N
+            if(nm.startsWith("javax.") || nm.startsWith("java.") || nm.startsWith("jakarta.")) {//NOI18N
                 InjectableResultImpl res = handleEESpecificImplementations(getResult(), firstElement, enabledTypes);
                 if(res != null) {
                     return res;


### PR DESCRIPTION
The warning said "No enabled eligible for injection beans are found", because the filter class did not check "jakarta." namespace

<img width="683" height="128" alt="image" src="https://github.com/user-attachments/assets/fe9489f9-ffdf-40d1-a746-9ffbfa1e50aa" />