### PR TITLE
Enable loading of bundles importing java.-packages and update Bouncy Castle to fix jgit signing

### DIFF
--- a/ide/bcpg/external/bcpg-jdk18on-1.83-license.txt
+++ b/ide/bcpg/external/bcpg-jdk18on-1.83-license.txt
@@ -1,5 +1,5 @@
 Name: Bouncy Castle Java OpenPGP/BCPG
-Version: 1.77
+Version: 1.83
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcpg/external/binaries-list
+++ b/ide/bcpg/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-BB0BE51E8B378BAAE6E0D86F5282CD3887066539 org.bouncycastle:bcpg-jdk18on:1.77
+4369727B9B02E6C62C26FDE862AC42D77CE8EDEF org.bouncycastle:bcpg-jdk18on:1.83

--- a/ide/bcpg/nbproject/project.properties
+++ b/ide/bcpg/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcpg-jdk18on-1.77.jar=modules/bcpg.jar
+release.external/bcpg-jdk18on-1.83.jar=modules/bcpg.jar
 is.autoload=true

--- a/ide/bcpg/nbproject/project.xml
+++ b/ide/bcpg/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcpg.jar</runtime-relative-path>
-                <binary-origin>external/bcpg-jdk18on-1.77.jar</binary-origin>
+                <binary-origin>external/bcpg-jdk18on-1.83.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/bcpkix/external/bcpkix-jdk18on-1.83-license.txt
+++ b/ide/bcpkix/external/bcpkix-jdk18on-1.83-license.txt
@@ -1,5 +1,5 @@
 Name: Bouncy Castle Java Provider
-Version: 1.77
+Version: 1.83
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcpkix/external/binaries-list
+++ b/ide/bcpkix/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-ED953791BA0229747DD0FD9911E3D76A462ACFD3 org.bouncycastle:bcpkix-jdk18on:1.77
+3F4300D0441459BFA64A481C80062B002FF0CF65 org.bouncycastle:bcpkix-jdk18on:1.83

--- a/ide/bcpkix/nbproject/project.properties
+++ b/ide/bcpkix/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcpkix-jdk18on-1.77.jar=modules/bcpkix.jar
+release.external/bcpkix-jdk18on-1.83.jar=modules/bcpkix.jar
 is.autoload=true

--- a/ide/bcpkix/nbproject/project.xml
+++ b/ide/bcpkix/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcpkix.jar</runtime-relative-path>
-                <binary-origin>external/bcpkix-jdk18on-1.77.jar</binary-origin>
+                <binary-origin>external/bcpkix-jdk18on-1.83.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/bcprov/external/bcprov-jdk18on-1.83-license.txt
+++ b/ide/bcprov/external/bcprov-jdk18on-1.83-license.txt
@@ -1,5 +1,5 @@
 Name: Bouncy Castle Java Provider
-Version: 1.77
+Version: 1.83
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcprov/external/binaries-list
+++ b/ide/bcprov/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-2CC971B6C20949C1FF98D1A4BC741EE848A09523 org.bouncycastle:bcprov-jdk18on:1.77
+310E719F391BD9F4EE5103CA299C172643EFB595 org.bouncycastle:bcprov-jdk18on:1.83

--- a/ide/bcprov/nbproject/project.properties
+++ b/ide/bcprov/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcprov-jdk18on-1.77.jar=modules/bcprov.jar
+release.external/bcprov-jdk18on-1.83.jar=modules/bcprov.jar
 is.autoload=true

--- a/ide/bcprov/nbproject/project.xml
+++ b/ide/bcprov/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcprov.jar</runtime-relative-path>
-                <binary-origin>external/bcprov-jdk18on-1.77.jar</binary-origin>
+                <binary-origin>external/bcprov-jdk18on-1.83.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/bcutil/external/bcutil-jdk18on-1.83-license.txt
+++ b/ide/bcutil/external/bcutil-jdk18on-1.83-license.txt
@@ -1,5 +1,5 @@
 Name: Bouncy Castle ASN.1 Extension and Utility APIs
-Version: 1.77
+Version: 1.83
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcutil/external/binaries-list
+++ b/ide/bcutil/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-DE3EAEF351545FE8562CF29DDFF4A403A45B49B7 org.bouncycastle:bcutil-jdk18on:1.77
+DA0747F51FE1774F8E922B498B9C3E0EBE87B2D4 org.bouncycastle:bcutil-jdk18on:1.83

--- a/ide/bcutil/nbproject/project.properties
+++ b/ide/bcutil/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcutil-jdk18on-1.77.jar=modules/bcutil.jar
+release.external/bcutil-jdk18on-1.83.jar=modules/bcutil.jar
 is.autoload=true

--- a/ide/bcutil/nbproject/project.xml
+++ b/ide/bcutil/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcutil.jar</runtime-relative-path>
-                <binary-origin>external/bcutil-jdk18on-1.77.jar</binary-origin>
+                <binary-origin>external/bcutil-jdk18on-1.83.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/platform/netbinox/external/M20140115-0800.patch
+++ b/platform/netbinox/external/M20140115-0800.patch
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 diff --git a/bundles/org.eclipse.osgi/core/framework/org/eclipse/osgi/framework/internal/core/Framework.java b/bundles/org.eclipse.osgi/core/framework/org/eclipse/osgi/framework/internal/core/Framework.java
-index 617db7f..1851f4a 100644
+index 617db7f49..1851f4ade 100644
 --- a/bundles/org.eclipse.osgi/core/framework/org/eclipse/osgi/framework/internal/core/Framework.java
 +++ b/bundles/org.eclipse.osgi/core/framework/org/eclipse/osgi/framework/internal/core/Framework.java
 @@ -563,11 +563,19 @@ public class Framework implements EventPublisher, Runnable {
@@ -42,3 +42,16 @@ index 617db7f..1851f4a 100644
  		return result;
  	}
  
+diff --git a/bundles/org.eclipse.osgi/resolver/src/org/eclipse/osgi/internal/resolver/StateBuilder.java b/bundles/org.eclipse.osgi/resolver/src/org/eclipse/osgi/internal/resolver/StateBuilder.java
+index b6964980a..d9d2f996d 100644
+--- a/bundles/org.eclipse.osgi/resolver/src/org/eclipse/osgi/internal/resolver/StateBuilder.java
++++ b/bundles/org.eclipse.osgi/resolver/src/org/eclipse/osgi/internal/resolver/StateBuilder.java
+@@ -819,7 +819,7 @@ public class StateBuilder {
+ 					throw new BundleException(message + " : " + NLS.bind(StateMsg.HEADER_PACKAGE_DUPLICATES, packageNames[j]), BundleException.MANIFEST_ERROR); //$NON-NLS-1$
+ 				}
+ 				// check for java.*
+-				if (!jreBundle && packageNames[j].startsWith("java.")) { //$NON-NLS-1$
++				if (false && !jreBundle && packageNames[j].startsWith("java.")) { //$NON-NLS-1$
+ 					String message = NLS.bind(Msg.MANIFEST_INVALID_HEADER_EXCEPTION, headerKey, elements[i].toString());
+ 					throw new BundleException(message + " : " + NLS.bind(StateMsg.HEADER_PACKAGE_JAVA, packageNames[j]), BundleException.MANIFEST_ERROR); //$NON-NLS-1$
+ 				}

--- a/platform/netbinox/external/binaries-list
+++ b/platform/netbinox/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-CB97D80CEDF7963313E1B1EADC0F1E49F62570DD org.eclipse.osgi_3.9.1.nb9.jar
+FAE5455278493B0125564195DB3F3B92F4169A6E org.eclipse.osgi_3.9.1.nb10.jar

--- a/platform/netbinox/external/org.eclipse.osgi_3.9.1.v20140110-1610-license.txt
+++ b/platform/netbinox/external/org.eclipse.osgi_3.9.1.v20140110-1610-license.txt
@@ -2,7 +2,7 @@ Name: Equinox
 Version: 3.9.1
 Description: Eclipse OSGi container
 License: OSGi
-Files: org.eclipse.osgi_3.9.1.nb9.jar
+Files: org.eclipse.osgi_3.9.1.nb10.jar
 Origin: Eclipse
 URL: http://www.eclipse.org/equinox/
 

--- a/platform/netbinox/external/rebuild-equinox.sh
+++ b/platform/netbinox/external/rebuild-equinox.sh
@@ -20,19 +20,20 @@ BASE=`dirname $0`
 cd $BASE
 BASE=`pwd`
 
-git clone https://git.eclipse.org/r/equinox/rt.equinox.framework
-cd rt.equinox.framework
+git clone https://github.com/eclipse-equinox/equinox.framework
+cd equinox.framework
 git checkout M20140115-0800
 git show M20140115-0800:bundles/org.eclipse.osgi/core/framework/org/eclipse/osgi/framework/internal/core/Framework.java  >Framework.java
+git show M20140115-0800:bundles/org.eclipse.osgi/resolver/src/org/eclipse/osgi/internal/resolver/StateBuilder.java  >StateBuilder.java
 patch <../M20140115-0800.patch
 if ! [ -e org.eclipse.osgi-3.9.1.v20140110-1610.jar ]; then
   wget https://repo.eclipse.org/content/repositories/releases/org/eclipse/core/org.eclipse.osgi/3.9.1.v20140110-1610/org.eclipse.osgi-3.9.1.v20140110-1610.jar
 fi
 mkdir -p out
-javac -cp org.eclipse.osgi-3.9.1.v20140110-1610.jar Framework.java -d out || exit 1
+javac --release 17 -cp org.eclipse.osgi-3.9.1.v20140110-1610.jar Framework.java StateBuilder.java -d out || exit 1
 cd out
 zip -d ../org.eclipse.osgi-3.9.1.v20140110-1610.jar META-INF/ECLIPSE_.SF META-INF/ECLIPSE_.RSA
 zip -r ../org.eclipse.osgi-3.9.1.v20140110-1610.jar .
 
 cd "$BASE"
-mv rt.equinox.framework/org.eclipse.osgi-3.9.1.v20140110-1610.jar org.eclipse.osgi_3.9.1.nb9.jar
+mv equinox.framework/org.eclipse.osgi-3.9.1.v20140110-1610.jar org.eclipse.osgi_3.9.1.nb10.jar

--- a/platform/netbinox/nbproject/project.properties
+++ b/platform/netbinox/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-release.external/org.eclipse.osgi_3.9.1.nb9.jar=modules/ext/org.eclipse.osgi_3.9.1.nb9.jar
+release.external/org.eclipse.osgi_3.9.1.nb10.jar=modules/ext/org.eclipse.osgi_3.9.1.nb10.jar
 javac.release=17
 
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/platform/netbinox/nbproject/project.xml
+++ b/platform/netbinox/nbproject/project.xml
@@ -127,8 +127,8 @@
                 <package>org.eclipse.osgi.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/org.eclipse.osgi_3.9.1.nb9.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.osgi_3.9.1.nb9.jar</binary-origin>
+                <runtime-relative-path>ext/org.eclipse.osgi_3.9.1.nb10.jar</runtime-relative-path>
+                <binary-origin>external/org.eclipse.osgi_3.9.1.nb10.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
jgit signing requires bouncy castle libraries with a version higher equal to or higher than 1.79. 

Recent versions of bouncy castle declare an import package:

```
Import-Package: java.io;resolution:=optional,java.lang;resolution:=optional,java.lang.ref;resolution:=optional,java.lang.reflect;resolution:=optional,java.math;resolution:=optional,java.net;resolution:=optional,java.nio;resolution:=optional,java.nio.channels;resolution:=optional,java.nio.charset;resolution:=optional,java.security;resolution:=optional,java.security.cert;resolution:=optional,java.security.interfaces;resolution:=optional,java.security.spec;resolution:=optional,java.sql;resolution:=optional,java.text;resolution:=optional,java.util;resolution:=optional,java.util.concurrent;resolution:=optional,java.util.concurrent.atomic;resolution:=optional,java.util.logging;resolution:=optional,java.util.zip;resolution:=optional,javax.crypto;resolution:=optional,javax.crypto.interfaces;resolution:=optional,javax.crypto.spec;resolution:=optional,javax.naming;resolution:=optional,javax.naming.directory;resolution:=optional,javax.security.auth;resolution:=optional,javax.security.auth.callback;resolution:=optional,javax.security.auth.x500;resolution:=optional
```

which is rejected by the NetBeans bundled equinox version. The validation provided by this version rejects alls `java.*` imports. This PR removes that check and updates bouncy castle to 18.3.

Closes: #8894
Closes: #8776