### PR TITLE
Enable Compact Object Headers (JEP 519)

### DIFF
--- a/nb/ide.launcher/netbeans.conf
+++ b/nb/ide.launcher/netbeans.conf
@@ -66,7 +66,7 @@ netbeans_default_cachedir="${DEFAULT_CACHEDIR_ROOT}/@@metabuild.RawVersion@@"
 # The automatically selected value can be overridden by specifying -J-Xmx
 # here or on the command line.
 #
-netbeans_default_options="-J-XX:+UseStringDeduplication -J-Xss2m @@metabuild.logcli@@ -J-Djava.lang.Runtime.level=FINE -J--sun-misc-unsafe-memory-access=warn -J-Dguice_custom_class_loading=CHILD -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.application.appearance=system -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.extbrowser.manual_chrome_plugin_install=yes @@metabuild.jms-flags@@ -J-XX:+IgnoreUnrecognizedVMOptions -J-javaagent:\"${BASEDIR}/ide/netbeans-javaagent.jar\""
+netbeans_default_options="-J-XX:+UseStringDeduplication -J-XX:+UseCompactObjectHeaders -J-Xss2m @@metabuild.logcli@@ -J-Djava.lang.Runtime.level=FINE -J--sun-misc-unsafe-memory-access=warn -J-Dguice_custom_class_loading=CHILD -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.application.appearance=system -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.extbrowser.manual_chrome_plugin_install=yes @@metabuild.jms-flags@@ -J-XX:+IgnoreUnrecognizedVMOptions -J-javaagent:\"${BASEDIR}/ide/netbeans-javaagent.jar\""
 
 # Default location of JDK:
 # (set by installer or commented out if launcher should decide)


### PR DESCRIPTION
 - sets `-XX:+UseCompactObjectHeaders` for [JEP 519](https://openjdk.org/jeps/519) which is supported from JDK 25 and later
 - NB sets `-XX:+IgnoreUnrecognizedVMOptions `already which means it will be silently ignored on older JDKs
 - (experimental on EOL JDK 24, but it won't enable there without also setting the flag to enable experimental options - which we don't do)

sidenote: I think corretto backported the feature to JDK 17 and 21 too, but all vendors should ship it on 25 and later

tested it on NB since JDK 24 without issues
