### PR TITLE
Upgrade the bundled Ant version to 1.10.17

### DIFF
--- a/extide/o.apache.tools.ant.module/arch.xml
+++ b/extide/o.apache.tools.ant.module/arch.xml
@@ -314,7 +314,7 @@
             <li>
                 <api group="java" name="Ant" type="import" category="third" url="https://ant.apache.org">
                     Ant itself, of course.
-                    1.8.0+ is required, 1.10.15 recommended (and currently bundled); some features may be limited to newer versions.
+                    1.8.0+ is required, 1.10.17 recommended (and currently bundled); some features may be limited to newer versions.
                 </api>
             </li>
         </ol>

--- a/extide/o.apache.tools.ant.module/build.xml
+++ b/extide/o.apache.tools.ant.module/build.xml
@@ -54,18 +54,18 @@
     </target>
 
     <target name="netbeans-extra" depends="jar-bridge">
-        <unzip src="external/apache-ant-1.10.15-bin.zip" dest="build"/>
+        <unzip src="external/apache-ant-1.10.17-bin.zip" dest="build"/>
         <mkdir dir="${cluster}/ant/lib"/>
         <copy todir="${cluster}/ant/lib">
-            <fileset dir="build/apache-ant-1.10.15/lib" includes="*.jar"/>
+            <fileset dir="build/apache-ant-1.10.17/lib" includes="*.jar"/>
         </copy>
         <mkdir dir="${cluster}/ant/bin"/>
         <copy todir="${cluster}/ant/bin">
-            <fileset dir="build/apache-ant-1.10.15/bin"/>
+            <fileset dir="build/apache-ant-1.10.17/bin"/>
         </copy>
         <mkdir dir="${cluster}/ant/etc"/>
         <copy todir="${cluster}/ant/etc">
-            <fileset dir="build/apache-ant-1.10.15/etc"/>
+            <fileset dir="build/apache-ant-1.10.17/etc"/>
         </copy>
     </target>
 
@@ -84,7 +84,7 @@
             <fileset dir="${cluster}">
                 <include name="ant/lib/*.jar"/>
             </fileset>
-            <mapper type="glob" from="ant${file.separator}lib${file.separator}*.jar" to="apache-*-1.10.15.jar"/>
+            <mapper type="glob" from="ant${file.separator}lib${file.separator}*.jar" to="apache-*-1.10.17.jar"/>
         </copy>
         <copy file="${cluster}/ant/nblib/bridge.jar" tofile="${dir}/org-apache-tools-ant-module-bridge.jar"/>
         <!-- XXX ought to only do this in case jnlp.sign.jars=true -->

--- a/extide/o.apache.tools.ant.module/external/ant-1.10.17-license.txt
+++ b/extide/o.apache.tools.ant.module/external/ant-1.10.17-license.txt
@@ -1,10 +1,10 @@
 Name: Apache Ant
 Origin: Apache Software Foundation
-Version: 1.10.15
-Files: apache-ant-1.10.15-bin.zip
+Version: 1.10.17
+Files: apache-ant-1.10.17-bin.zip
 Description: Ant build tool.
 License: Apache-2.0-ant
-URL: https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.15-bin.zip
+URL: https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.17-bin.zip
 
 /*
  *                                 Apache License

--- a/extide/o.apache.tools.ant.module/external/ant-1.10.17-notice.txt
+++ b/extide/o.apache.tools.ant.module/external/ant-1.10.17-notice.txt
@@ -1,5 +1,5 @@
 Apache Ant
-Copyright 1999-2024 The Apache Software Foundation
+Copyright 1999-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).

--- a/extide/o.apache.tools.ant.module/external/binaries-list
+++ b/extide/o.apache.tools.ant.module/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-1B460A543CAF0B2087FEF210C7B4813909901FDC https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.15-bin.zip apache-ant-1.10.15-bin.zip
+DA43C59186A9AB890C6FDD6967053F64C6907249 https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.17-bin.zip apache-ant-1.10.17-bin.zip

--- a/extide/o.apache.tools.ant.module/external/build.xml
+++ b/extide/o.apache.tools.ant.module/external/build.xml
@@ -24,31 +24,31 @@
         <mkdir dir="lib"/>
         <copy todir="lib">
             <fileset dir=".">
-                <include name="ant-antlr-1.10.15.jar" />
-                <include name="ant-apache-bcel-1.10.15.jar" />
-                <include name="ant-apache-bsf-1.10.15.jar" />
-                <include name="ant-apache-log4j-1.10.15.jar" />
-                <include name="ant-apache-oro-1.10.15.jar" />
-                <include name="ant-apache-regexp-1.10.15.jar" />
-                <include name="ant-apache-resolver-1.10.15.jar" />
-                <include name="ant-apache-xalan2-1.10.15.jar" />
-                <include name="ant-commons-logging-1.10.15.jar" />
-                <include name="ant-commons-net-1.10.15.jar" />
-                <include name="ant-jai-1.10.15.jar" />
-                <include name="ant-javamail-1.10.15.jar" />
-                <include name="ant-jdepend-1.10.15.jar" />
-                <include name="ant-jmf-1.10.15.jar" />
-                <include name="ant-jsch-1.10.15.jar" />
-                <include name="ant-junit-1.10.15.jar" />
-                <include name="ant-junit4-1.10.15.jar" />
-                <include name="ant-launcher-1.10.15.jar" />
-                <include name="ant-netrexx-1.10.15.jar" />
-                <include name="ant-swing-1.10.15.jar" />
-                <include name="ant-testutil-1.10.15.jar" />
-                <include name="ant-xz-1.10.15.jar" />
-                <include name="ant-1.10.15.jar" />
+                <include name="ant-antlr-1.10.17.jar" />
+                <include name="ant-apache-bcel-1.10.17.jar" />
+                <include name="ant-apache-bsf-1.10.17.jar" />
+                <include name="ant-apache-log4j-1.10.17.jar" />
+                <include name="ant-apache-oro-1.10.17.jar" />
+                <include name="ant-apache-regexp-1.10.17.jar" />
+                <include name="ant-apache-resolver-1.10.17.jar" />
+                <include name="ant-apache-xalan2-1.10.17.jar" />
+                <include name="ant-commons-logging-1.10.17.jar" />
+                <include name="ant-commons-net-1.10.17.jar" />
+                <include name="ant-jai-1.10.17.jar" />
+                <include name="ant-javamail-1.10.17.jar" />
+                <include name="ant-jdepend-1.10.17.jar" />
+                <include name="ant-jmf-1.10.17.jar" />
+                <include name="ant-jsch-1.10.17.jar" />
+                <include name="ant-junit-1.10.17.jar" />
+                <include name="ant-junit4-1.10.17.jar" />
+                <include name="ant-launcher-1.10.17.jar" />
+                <include name="ant-netrexx-1.10.17.jar" />
+                <include name="ant-swing-1.10.17.jar" />
+                <include name="ant-testutil-1.10.17.jar" />
+                <include name="ant-xz-1.10.17.jar" />
+                <include name="ant-1.10.17.jar" />
             </fileset>
-            <globmapper from="*-1.10.15.jar" to="*.jar"/>
+            <globmapper from="*-1.10.17.jar" to="*.jar"/>
         </copy>
     </target>
     <target name="clean">

--- a/extide/o.apache.tools.ant.module/nbproject/project.properties
+++ b/extide/o.apache.tools.ant.module/nbproject/project.properties
@@ -26,7 +26,7 @@ extra.module.files=\
     ant/lib/,\
     ant/bin/,\
     ant/etc/
-extra.license.files=external/ant-1.10.15-license.txt
+extra.license.files=external/ant-1.10.17-license.txt
 nbm.executable.files=\
     ant/bin/ant,\
     ant/bin/antRun,\


### PR DESCRIPTION
Upgrade the bundled Ant to 1.10.17.

> Ant 1.10.16 is a bugfix release with a few added features. The biggest
> change is the handling of symbolic links on the Windows platform and
> Windows junctions. Java prior to version 24 didn't resolve either when
> providing the canonical path of a file on Windows but does so with Java
> 24 onwards. This may make Ant builds behave differently on Java 23 and
> 24. With Ant 1.10.16 both should behave the same - and it should be
> similar to Ant 1.10.15 running with Java 24 or newer.

From announce email for 1.10.16 ( https://lists.apache.org/thread/q0vfsqvg3f01ggm6sozmmh6x889638p1 )

> Our last release Ant 1.10.16 introduced a regression that may lead to
> NullPointerExceptions in code that uses Ant via its Java API rather than
> via the command line. Ant 1.10.17 only fixes the regression, no other
> changes in functionality have been added.

From announce email for 1.10.17 ( https://lists.apache.org/thread/fj5wd07cv6ynj1xkghxqqgb536rc9pcw )

All changes : https://github.com/apache/ant/blob/rel/1.10.17/WHATSNEW

This replaces #9326 due to the regression fix release.