### PR TITLE
Bump gradle defaults for JDK 26

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
@@ -103,9 +103,10 @@ public final class GradleDistributionManager {
         GradleVersion.version("8.10"),// JDK-23
         GradleVersion.version("8.14"),// JDK-24
         GradleVersion.version("9.1.0"),// JDK-25
+        GradleVersion.version("9.4.0"),// JDK-26
     };
 
-    private static final GradleVersion LAST_KNOWN_GRADLE = GradleVersion.version("9.1.0"); //NOI18N
+    private static final GradleVersion LAST_KNOWN_GRADLE = GradleVersion.version("9.4.1"); //NOI18N
 
     private static final int LATEST_SUPPORTED_MAJOR = 9;
 

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/newproject/Wizards.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/newproject/Wizards.java
@@ -35,7 +35,7 @@ public final class Wizards {
 
     private Wizards() {};
 
-    private static final List<Integer> JAVA_VERSIONS = List.of(25, 21, 17, 11, 8);
+    private static final List<Integer> JAVA_VERSIONS = List.of(26, 25, 21, 17, 11, 8);
     private static final List<TestFramework> JAVA_TEST_FRAMEWORKS = List.of(
             JUNIT,
             JUNIT_5,


### PR DESCRIPTION
add java 26 to the wizard and set gradle 9.4.0 as JDK 26 compatible

analog to last bump https://github.com/apache/netbeans/pull/8870