### PR TITLE
Fix 'occured' -> 'occurred' typos in 3 files

### DIFF
--- a/harness/nbjunit/src/org/netbeans/junit/MultiTestCase.java
+++ b/harness/nbjunit/src/org/netbeans/junit/MultiTestCase.java
@@ -44,7 +44,7 @@ public abstract class MultiTestCase extends NbTestCase{
     
     private Throwable err = null;
     /**
-     * Internal method to set an error occured while preparation for executing the testcase.
+     * Internal method to set an error occurred while preparation for executing the testcase.
      */
     void setError(Throwable e){
         err = e;

--- a/ide/diff/src/org/netbeans/spi/diff/DiffProvider.java
+++ b/ide/diff/src/org/netbeans/spi/diff/DiffProvider.java
@@ -48,7 +48,7 @@ public abstract class DiffProvider extends Object {
      * @param r1 the first source
      * @param r2 the second source to be compared with the first one.
      * @return the list of differences found, instances of {@link Difference};
-     *         or <code>null</code> when some error occured.
+     *         or <code>null</code> when some error occurred.
      * @throws IOException when the reading from input streams fails.
      */
     public abstract Difference[] computeDiff(Reader r1, Reader r2) throws IOException;

--- a/php/php.samples/samples_src/TodoList/page/500.phtml
+++ b/php/php.samples/samples_src/TodoList/page/500.phtml
@@ -23,7 +23,7 @@ namespace TodoList;
 ?>
 <h1>SERVER ERROR</h1>
 
-<p class="p">Internal server error occured.</p>
+<p class="p">Internal server error occurred.</p>
 <p class="p">
     <i>More information (<b>should be hidden on production server</b>):</i><br />
     <?php echo $extra['message'] ?>


### PR DESCRIPTION
Trivial spelling fix — `occured` → `occurred`.

One occurrence is user-visible HTML rendered on the 500 error page of the PHP TodoList sample:

- `php/php.samples/samples_src/TodoList/page/500.phtml` — `<p>Internal server error occurred.</p>`

The other two are Javadoc:

- `ide/diff/.../DiffProvider.java` — `@return` on `DiffProvider.diff()`
- `harness/nbjunit/.../MultiTestCase.java` — `setError()` javadoc

No functional changes.