### PR TITLE
Fix default name evaluation for CDI beans

### DIFF
--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/WebBeansModelProviderImpl.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/impl/model/WebBeansModelProviderImpl.java
@@ -509,14 +509,10 @@ public class WebBeansModelProviderImpl extends DecoratorInterceptorLogic {
         if ( element instanceof TypeElement ){
             String name = element.getSimpleName().toString();
             if ( name.length() >0 ){
-                // XXX we may use Introspector.decapitalize
-                String withoutPrefix = name.substring(1);
-                // #249438
-                if (!withoutPrefix.isEmpty() && Character.isUpperCase(withoutPrefix.charAt(0))) {
-                    return name;
-                } else {
-                    return Character.toLowerCase(name.charAt(0)) + withoutPrefix;
-                }
+                // According to the CDI spec:
+                // The default name for a managed bean is the unqualified class name of the bean class,
+                // after converting the first character to lower case.
+                return Character.toLowerCase(name.charAt(0)) + name.substring(1);
             }
             else {
                 return name;

--- a/enterprise/web.beans/test/unit/src/org/netbeans/modules/web/beans/model/NamedJakartaTest.java
+++ b/enterprise/web.beans/test/unit/src/org/netbeans/modules/web/beans/model/NamedJakartaTest.java
@@ -112,11 +112,10 @@ public class NamedJakartaTest extends CommonTestCase {
                             String name = model.getName(element);
                             assertEquals("iface", name);
                         }
-                        // #249438
                         else if ("foo.CApital".equals(fqn)) {
                             iface = element;
                             String name = model.getName(element);
-                            assertEquals("CApital", name);
+                            assertEquals("cApital", name);
                         }
                     }
                     else if ( element instanceof VariableElement ){

--- a/enterprise/web.beans/test/unit/src/org/netbeans/modules/web/beans/model/NamedTest.java
+++ b/enterprise/web.beans/test/unit/src/org/netbeans/modules/web/beans/model/NamedTest.java
@@ -112,11 +112,10 @@ public class NamedTest extends CommonTestCase {
                             String name = model.getName(element);
                             assertEquals("iface", name);
                         }
-                        // #249438
                         else if ("foo.CApital".equals(fqn)) {
                             iface = element;
                             String name = model.getName(element);
-                            assertEquals("CApital", name);
+                            assertEquals("cApital", name);
                         }
                     }
                     else if ( element instanceof VariableElement ){


### PR DESCRIPTION
This PR fixes the evaluation of the default name for CDI beans to strictly align with the CDI specifications.

Quoting [CDI 1.1 specs](https://docs.jboss.org/cdi/spec/1.1/cdi-spec.html#managed_bean_name):

> The default name for a managed bean is the unqualified class name of the bean class, after converting the first character to lower case.
> For example, if the bean class is named `ProductList`, the default bean name is `productList`.

Subsequent specifications all maintain the exact same text. Here is the latest: [Jakarta EE CDI 4.1](https://jakarta.ee/specifications/cdi/4.1/jakarta-cdi-spec-4.1#managed_bean_name).

### Historical Notes
I'm not exactly sure why the behavior was originally changed. My guess is that some implementations weren't perfectly aligned with the specifications at the time. For historical context on the deviation, see:
- [NetBeans Bugzilla Issue #249438](https://bz.apache.org/netbeans/show_bug.cgi?id=249438)
- [Related StackOverflow discussion](https://stackoverflow.com/questions/19414709/cant-find-named-cdi-bean-with-default-name-in-el-facelet)
- [commit](https://github.com/codelerity/netbeans-releases/commit/f83450ecb8ed1dcf993ad1c19c04fbb007564543)

NB: this currently targets master, but it would be nice to have this in NB30
