### PR TITLE
JS: reformatting fails for classes that contain a static initializer

### DIFF
--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/formatter/JsFormatVisitor.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/formatter/JsFormatVisitor.java
@@ -969,13 +969,15 @@ public class JsFormatVisitor extends NodeVisitor<LexicalContext> {
 
     @Override
     public boolean enterClassElement(ClassElement propertyNode) {
-        FormatToken colon = tokenUtils.getNextToken(getFinish(propertyNode.getKey()),
-                JsTokenId.OPERATOR_COLON, getFinish(propertyNode));
-        if (colon != null) {
-            TokenUtils.appendToken(colon, FormatToken.forFormat(FormatToken.Kind.AFTER_PROPERTY_OPERATOR));
-            FormatToken before = colon.previous();
-            if (before != null) {
-                TokenUtils.appendTokenAfterLastVirtual(before, FormatToken.forFormat(FormatToken.Kind.BEFORE_PROPERTY_OPERATOR));
+        if (propertyNode.getKey() != null) {
+            FormatToken colon = tokenUtils.getNextToken(getFinish(propertyNode.getKey()),
+                    JsTokenId.OPERATOR_COLON, getFinish(propertyNode));
+            if (colon != null) {
+                TokenUtils.appendToken(colon, FormatToken.forFormat(FormatToken.Kind.AFTER_PROPERTY_OPERATOR));
+                FormatToken before = colon.previous();
+                if (before != null) {
+                    TokenUtils.appendTokenAfterLastVirtual(before, FormatToken.forFormat(FormatToken.Kind.BEFORE_PROPERTY_OPERATOR));
+                }
             }
         }
         return super.enterPropertyNode(propertyNode);

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/formatter/staticClassInitializer1.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/formatter/staticClassInitializer1.js
@@ -1,0 +1,9 @@
+class Dummy {
+                                                       #privateField;
+                                                       constructor(v) {
+                                                         this.#privateField = v;
+                                                       }
+                                                       static {
+                                                         console.log("Dummy");
+                                                       }
+                                                     }

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/formatter/staticClassInitializer1.js.formatted
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/formatter/staticClassInitializer1.js.formatted
@@ -1,0 +1,9 @@
+class Dummy {
+    #privateField;
+    constructor(v) {
+        this.#privateField = v;
+    }
+    static {
+        console.log("Dummy");
+    }
+}

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/formatter/JsFormatterTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/formatter/JsFormatterTest.java
@@ -2543,4 +2543,8 @@ public class JsFormatterTest extends JsFormatterTestBase {
                 "} //comment2\n" +
                 "p = stripName(p);", null);
     }
+
+    public void testFormatStaticClassInitializer() throws Exception {
+        reformatFileContents("testfiles/formatter/staticClassInitializer1.js",new IndentPrefs(4, 4));
+    }
 }


### PR DESCRIPTION
static initializers have no identifier so don't try to scan them

Closes: #9339