### PR TITLE
Fix #9337 — recognize compact -T<n> and --threads=<n> Maven flags

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
@@ -896,29 +896,38 @@ public class MavenCommandLineExecutor extends AbstractMavenExecutor {
             if (p.equals("-1") || p.equals("--serial") || p.equals("-Dmvnd.serial")) { // "behave like standard maven" mode
                 return false;
             }
-            if (i + 1 < params.size() && (p.equals("-T") || p.equals("--threads"))) {
-                if (params.get(i+1).equals("1")) {
-                    return false;
-                }
-            }
             try {
                 if (p.startsWith("-Dmvnd.threads=") && Integer.parseInt(p.substring(15)) == 1)  {
                     return false;
                 }
-            } catch (NumberFormatException ignored) {} 
+            } catch (NumberFormatException ignored) {}
         }
-        return true;
+        String threads = threadsArgValue(params);
+        return threads == null || !threads.equals("1");
     }
 
     // mvn is ST by default
     static boolean isMultiThreadedMaven(List<String> params) {
-        for (int i = 0; i < params.size() - 1; i++) {
+        String threads = threadsArgValue(params);
+        return threads != null && !threads.equals("1");
+    }
+
+    // Recognizes -T <n>, -T<n>, --threads <n>, --threads=<n>; #9337
+    // The suffix is returned verbatim - Maven validates the value itself, so anything other than "1" is treated as multi-threaded by callers.
+    private static String threadsArgValue(List<String> params) {
+        for (int i = 0; i < params.size(); i++) {
             String p = params.get(i);
-            if ((p.equals("-T") || p.equals("--threads")) && !params.get(i+1).equals("1")) {
-                return true;
+            if (p.equals("-T") || p.equals("--threads")) {
+                if (i + 1 < params.size()) {
+                    return params.get(i + 1);
+                }
+            } else if (p.startsWith("-T") && p.length() > 2) {
+                return p.substring(2);
+            } else if (p.startsWith("--threads=")) {
+                return p.substring("--threads=".length());
             }
         }
-        return false;
+        return null;
     }
 
     /**

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/execute/MavenCommandParametersAnalyzerTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/execute/MavenCommandParametersAnalyzerTest.java
@@ -126,6 +126,42 @@ public class MavenCommandParametersAnalyzerTest {
         assertFalse(isMultiThreadedMaven("-T 1"));
     }
 
+    // #9337 — compact -T<n> form
+    @Test
+    public void validateMultiThreadedCompactT2() {
+        assertTrue(isMultiThreadedMaven("-T2"));
+    }
+
+    @Test
+    public void validateMultiThreadedCompactT10() {
+        assertTrue(isMultiThreadedMaven("-T10 -Dmaven.test.skip=true"));
+    }
+
+    @Test
+    public void validateMultiThreadedCompactT1C() {
+        assertTrue(isMultiThreadedMaven("-T1C"));
+    }
+
+    @Test
+    public void validateSingleThreadedCompactT1() {
+        assertFalse(isMultiThreadedMaven("-T1"));
+    }
+
+    @Test
+    public void validateMultiThreadedThreadsEquals() {
+        assertTrue(isMultiThreadedMaven("--threads=2"));
+    }
+
+    @Test
+    public void validateSingleThreadedThreadsEquals1() {
+        assertFalse(isMultiThreadedMaven("--threads=1"));
+    }
+
+    @Test
+    public void validateDanglingTFlagIsNotMultiThreaded() {
+        assertFalse(isMultiThreadedMaven("-T"));
+    }
+
     private boolean isMultiThreadedMaven(String params) {
         return MavenCommandLineExecutor.isMultiThreadedMaven(Arrays.asList(params.split(" ")));
     }

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/execute/MavenDaemonCommandParametersAnalyzerTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/execute/MavenDaemonCommandParametersAnalyzerTest.java
@@ -163,6 +163,38 @@ public class MavenDaemonCommandParametersAnalyzerTest {
         assertTrue(checkisMultiThreadedMvnd("-Dmvnd.threads=foo -Dmaven.test.skip=true"));
     }
 
+    // #9337 — compact -T<n> form
+    @Test
+    public void validateMultiThreadedCompactT2() {
+        assertTrue(checkisMultiThreadedMvnd("-T2"));
+    }
+
+    @Test
+    public void validateSingleThreadedCompactT1() {
+        assertFalse(checkisMultiThreadedMvnd("-T1"));
+    }
+
+    @Test
+    public void validateMultiThreadedThreadsEquals() {
+        assertTrue(checkisMultiThreadedMvnd("--threads=2"));
+    }
+
+    @Test
+    public void validateSingleThreadedThreadsEquals1() {
+        assertFalse(checkisMultiThreadedMvnd("--threads=1"));
+    }
+
+    @Test
+    public void validateMultiThreadedCompactT1C() {
+        assertTrue(checkisMultiThreadedMvnd("-T1C"));
+    }
+
+    @Test
+    public void validateDanglingTFlagIsMultiThreadedMvnd() {
+        // mvnd is MT by default; lone -T with no value should not flip to ST
+        assertTrue(checkisMultiThreadedMvnd("-T"));
+    }
+
     private boolean checkisMultiThreadedMvnd(String params) {
         return MavenCommandLineExecutor.isMultiThreadedMvnd(Arrays.asList(params.split(" ")));
     }


### PR DESCRIPTION
NetBeans only detected the spaced forms (`-T 2`, `--threads 2`) as parallel builds. The compact forms (`-T2`) and GNU-style equals form (`--threads=2`) were not recognized, so for multi-module projects NetBeans kept its output tree-folding active and crashed with an NPE in `CommandLineOutputHandler.trimTree` when concurrent module events arrived (`Cannot read field "type" because "start" is null`).

Extracts a `threadsArgValue()` helper that recognizes all four forms and uses it from both `isMultiThreadedMaven` and `isMultiThreadedMvnd`.

### Side effects, both intentional improvements

- mvnd: compact `-T1` now correctly flips to single-threaded mode (previously only the spaced `-T 1` did).
- A non-numeric suffix after `-T` (e.g. `-Tfoo`) is now reported as the threads value verbatim; Maven itself rejects such input.

### Tests

Added cases for `-T2`, `-T10`, `-T1C`, `-T1`, `--threads=2`, `--threads=1`, and a dangling `-T` to both `MavenCommandParametersAnalyzerTest` and `MavenDaemonCommandParametersAnalyzerTest`.