### PR TITLE
Propagate canUseRelease into CustomJavacClassLoader

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
@@ -25,6 +25,7 @@ import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import org.apache.tools.ant.BuildException;
@@ -124,7 +125,7 @@ public class CustomJavac extends Javac {
         try {
             Class<?> mainClazz = CustomJavacClassLoader.findMainCompilerClass(getProject());
             if (mainClazz != null) {
-                super.add(CustomJavacClassLoader.createCompiler(mainClazz));
+                super.add(CustomJavacClassLoader.createCompiler(mainClazz, canUseRelease()));
             }
         } catch (ClassNotFoundException | MalformedURLException | URISyntaxException ex) {
             if (ex instanceof BuildException) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavacClassLoader.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavacClassLoader.java
@@ -114,8 +114,8 @@ final class CustomJavacClassLoader extends URLClassLoader {
      * {@link #findMainCompilerClass(org.apache.tools.ant.Project)} method
      * @return instance of Ant Javac compiler using the {@code mainClass}
      */
-    static Javac13 createCompiler(Class<?> mainClass) {
-        return new NbJavacCompiler(mainClass);
+    static Javac13 createCompiler(Class<?> mainClass, boolean canUseRelease) {
+        return new NbJavacCompiler(mainClass, canUseRelease);
     }
 
     private static void assertIsolatedClassLoader(Class<?> c, URLClassLoader loader) throws ClassNotFoundException, BuildException {
@@ -153,9 +153,11 @@ final class CustomJavacClassLoader extends URLClassLoader {
     private static final class NbJavacCompiler extends Javac13 {
 
         private final Class<?> mainClazz;
+        private final boolean canUseRelease;
 
-        NbJavacCompiler(Class<?> mainClazz) {
+        NbJavacCompiler(Class<?> mainClazz, boolean canUseRelease) {
             this.mainClazz = mainClazz;
+            this.canUseRelease = canUseRelease;
         }
 
         @Override
@@ -163,14 +165,8 @@ final class CustomJavacClassLoader extends URLClassLoader {
             attributes.log("Using modern compiler", Project.MSG_VERBOSE);
             Commandline cmd = setupModernJavacCommand();
             final String[] args = cmd.getArguments();
-            boolean bootClasspath = false;
             for (int i = 0; i < args.length; i++) {
-                if (args[i].startsWith("-Xbootclasspath/p:")) { // ide/html
-                    bootClasspath = true;
-                }
-            }
-            for (int i = 0; i < args.length; i++) {
-                if (!bootClasspath) {
+                if (canUseRelease) {
                     if ("-target".equals(args[i]) || "-source".equals(args[i])) {
                         args[i] = "--release";
                         if (args[i + 1].startsWith("1.")) {


### PR DESCRIPTION
- enhances ba99c75 by @mbien to use the `canUseRelease` flag also in custom class loader
- the change is motivated by [failure when fixing nb-javac](https://github.com/JaroslavTulach/nb-javac/pull/39#issuecomment-4379465265)
- with this change the `java/form` builds OK with the nb-javac being developed at https://github.com/JaroslavTulach/nb-javac/pull/39 
- I am setting the target to `delivery`:
   - this change doesn't affect production bits (nb-javac isn't used to produce them)
   - it would be useful to have the `java/form` module from `release300` buildable by nb-javac 