### PR TITLE
Git push dialog: Sort active git branch to top and select it automatically

### DIFF
--- a/ide/git/src/org/netbeans/modules/git/ui/push/PushBranchesStep.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/push/PushBranchesStep.java
@@ -116,6 +116,7 @@ public class PushBranchesStep extends AbstractWizardPanel implements WizardDescr
                 info.refresh();
                 localBranches.putAll(info.getBranches());
                 localTags.putAll(info.getTags());
+                String headId = info.getActiveBranch().getId();
                 
                 final List<PushMapping> l = new ArrayList<PushMapping>(branches.size());
                 GitClient client;
@@ -160,7 +161,7 @@ public class PushBranchesStep extends AbstractWizardPanel implements WizardDescr
                                 }
                             }
                         }
-                        boolean preselected = !conflicted && updateNeeded;
+                        boolean preselected = !conflicted && (updateNeeded || branch.isActive());
 
                         //add current branch in the list for update or for adding
                         l.add(new PushMapping.PushBranchMapping(remoteBranch == null ? null : remoteBranch.getName(),
@@ -185,7 +186,7 @@ public class PushBranchesStep extends AbstractWizardPanel implements WizardDescr
                     String repoTagId = tags.get(tag.getTagName());
                     if (!tag.getTagId().equals(repoTagId)) {
                         //in the remote there is no such tag, need to add it.
-                        l.add(new PushMapping.PushTagMapping(tag, repoTagId == null ? null : tag.getTagName()));
+                        l.add(new PushMapping.PushTagMapping(tag, repoTagId == null ? null : tag.getTagName(), tag.getTaggedObjectId().equals(headId)));
                     }
                 }
 
@@ -195,7 +196,7 @@ public class PushBranchesStep extends AbstractWizardPanel implements WizardDescr
                     GitTag localTag = localTags.get(tag);
                     if (localTag == null) {
                         //in the local repo no such tag. Probably we need to delete in the remote?
-                        l.add(new PushMapping.PushTagMapping(tag));
+                        l.add(new PushMapping.PushTagMapping(tag, false));
                     }
                 }
 

--- a/ide/git/src/org/netbeans/modules/git/ui/push/PushMapping.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/push/PushMapping.java
@@ -44,11 +44,17 @@ public abstract class PushMapping extends ItemSelector.Item {
     private static final String COLOR_MODIFIED = GitUtils.getColorString(AnnotationColorProvider.getInstance().MODIFIED_FILE.getActualColor());
     private static final String COLOR_REMOVED = GitUtils.getColorString(AnnotationColorProvider.getInstance().REMOVED_FILE.getActualColor());
     private static final String COLOR_CONFLICT = GitUtils.getColorString(AnnotationColorProvider.getInstance().CONFLICT_FILE.getActualColor());
-    
-    protected PushMapping (String localName, String localId, String remoteName, boolean conflict, boolean preselected, boolean updateNeeded) {
+    private final boolean active;
+
+    protected PushMapping (String localName, String localId, String remoteName, boolean conflict, boolean preselected, boolean updateNeeded, boolean active) {
         super(preselected, localName == null || conflict);
         this.localName = localName;
         this.remoteName = remoteName == null ? localName : remoteName;
+        this.active = active;
+        String displayName = localName;
+        if (active && localName != null) {
+            displayName = localName + " (active)"; //NOI18N
+        }
         if (localName == null) {
             // to remove
             label = MessageFormat.format(BRANCH_DELETE_MAPPING_LABEL, remoteName, "<font color=\"" + COLOR_REMOVED + "\">R</font>"); //NOI18N
@@ -61,7 +67,7 @@ public abstract class PushMapping extends ItemSelector.Item {
                     }); //NOI18N
         } else if (remoteName == null) {
             // added
-            label = MessageFormat.format(BRANCH_MAPPING_LABEL, localName, localName, "<font color=\"" + COLOR_NEW + "\">A</font>"); //NOI18N
+            label = MessageFormat.format(BRANCH_MAPPING_LABEL, displayName, localName, "<font color=\"" + COLOR_NEW + "\">A</font>"); //NOI18N
             tooltip = NbBundle.getMessage(
                     PushBranchesStep.class,
                     "LBL_PushBranchMapping.description", //NOI18N
@@ -71,7 +77,7 @@ public abstract class PushMapping extends ItemSelector.Item {
                     }); //NOI18N
         } else if (conflict) {
             // modified
-            label = MessageFormat.format(BRANCH_MAPPING_LABEL, localName, remoteName, "<font color=\"" + COLOR_CONFLICT + "\">C</font>"); //NOI18N
+            label = MessageFormat.format(BRANCH_MAPPING_LABEL, displayName, remoteName, "<font color=\"" + COLOR_CONFLICT + "\">C</font>"); //NOI18N
             tooltip = NbBundle.getMessage(
                     PushBranchesStep.class,
                     "LBL_PushBranchMapping.Mode.conflict.description", //NOI18N
@@ -80,7 +86,7 @@ public abstract class PushMapping extends ItemSelector.Item {
                     });
         } else if (updateNeeded) {
             // modified
-            label = MessageFormat.format(BRANCH_MAPPING_LABEL, localName, remoteName, "<font color=\"" + COLOR_MODIFIED + "\">U</font>"); //NOI18N
+            label = MessageFormat.format(BRANCH_MAPPING_LABEL, displayName, remoteName, "<font color=\"" + COLOR_MODIFIED + "\">U</font>"); //NOI18N
             tooltip = NbBundle.getMessage(
                     PushBranchesStep.class,
                     "LBL_PushBranchMapping.description", //NOI18N
@@ -90,7 +96,7 @@ public abstract class PushMapping extends ItemSelector.Item {
                     });
         } else {
             // up to date
-            label = MessageFormat.format(BRANCH_MAPPING_LABEL_UPTODATE, localName, remoteName);
+            label = MessageFormat.format(BRANCH_MAPPING_LABEL_UPTODATE, displayName, remoteName);
             tooltip = NbBundle.getMessage(PushBranchesStep.class,
                     "LBL_PushBranchMapping.Mode.uptodate.description", //NOI18N
                     remoteName);
@@ -118,6 +124,10 @@ public abstract class PushMapping extends ItemSelector.Item {
         return localName;
     }
 
+    public final boolean isActive () {
+        return active;
+    }
+
     @Override
     public int compareTo (Item t) {
         if (t == null) {
@@ -125,6 +135,17 @@ public abstract class PushMapping extends ItemSelector.Item {
         }
         if (t instanceof PushMapping) {
             PushMapping other = (PushMapping) t;
+            if (isActive() != other.isActive()) {
+                return isActive() ? -1 : 1;
+            }
+            if (isActive()) {
+                if (this instanceof PushBranchMapping && other instanceof PushTagMapping) {
+                    return -1;
+                }
+                if (this instanceof PushTagMapping && other instanceof PushBranchMapping) {
+                    return 1;
+                }
+            }
             if (isDestructive() && other.isDestructive()) {
                 return remoteName.compareTo(other.remoteName);
             } else if (isDestructive() && !other.isDestructive()) {
@@ -162,7 +183,7 @@ public abstract class PushMapping extends ItemSelector.Item {
          * Denotes a branch to be deleted in a remote repository
          */
         public PushBranchMapping (String remoteBranchName, String remoteBranchId, boolean preselected, boolean updateNeeded) {
-            super(null, null, remoteBranchName, false, preselected, updateNeeded);
+            super(null, null, remoteBranchName, false, preselected, updateNeeded, false);
             this.localBranch = null;
             this.remoteBranchName = remoteBranchName;
             this.remoteBranchId = remoteBranchId;
@@ -177,7 +198,8 @@ public abstract class PushMapping extends ItemSelector.Item {
                     remoteBranchName, 
                     conflict,
                     preselected,
-                    updateNeeded);
+                    updateNeeded,
+                    localBranch != null && localBranch.isActive());
             this.localBranch = localBranch;
             this.remoteBranchName = remoteBranchName;
             this.remoteBranchId = remoteBranchId;
@@ -243,8 +265,8 @@ public abstract class PushMapping extends ItemSelector.Item {
          *
          * @param remoteName remote tag name
          */
-        public PushTagMapping(String remoteName) {
-            super(null, null, remoteName, false, false, remoteName != null);
+        public PushTagMapping(String remoteName, boolean active) {
+            super(null, null, remoteName, false, false, remoteName != null, active);
             this.tag = null;
             this.isUpdate = remoteName != null;
             this.remoteTagName = remoteName;
@@ -256,8 +278,8 @@ public abstract class PushMapping extends ItemSelector.Item {
          * @param tag representation of a local tag
          * @param remoteName remote tag name, can be null. If null than we create tag.
          */
-        public PushTagMapping (GitTag tag, String remoteName) {
-            super("tags/" + tag.getTagName(), tag.getTaggedObjectId(), remoteName, false, false, remoteName != null); //NOI18N
+        public PushTagMapping (GitTag tag, String remoteName, boolean active) {
+            super("tags/" + tag.getTagName(), tag.getTaggedObjectId(), remoteName, false, false, remoteName != null, active); //NOI18N
             this.tag = tag;
             this.isUpdate = remoteName != null;
             this.remoteTagName = remoteName;


### PR DESCRIPTION
Select it automatically unless it contains destructive actions. 
Sort active tag to top, do not select it automatically. 
Display "(active)" next to the branch/tag name.

<img width="739" height="247" alt="image" src="https://github.com/user-attachments/assets/d376d90e-bdc1-4e3c-97e7-d5f85ff040a1" />




---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [ ] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [ ] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>