### PR TITLE
[PHP] FIXES #9171 Return type not added to constructor override

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/codegen/MethodProperty.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/codegen/MethodProperty.java
@@ -69,7 +69,7 @@ public final class MethodProperty extends Property {
         final String nameAndParams = method.asString(PrintAs.NameAndParamsDeclaration, TypeNameResolverImpl.forNull(), phpVersion);
         final String returnTypeString = method.asString(PrintAs.ReturnTypes, TypeNameResolverImpl.forNull(), phpVersion);
         final String[] split = nameAndParams.split("\\(");
-        if (returnTypes.isEmpty() || returnTypeString.isEmpty()) {
+        if (returnTypes.isEmpty() || returnTypeString.isEmpty() || method.isConstructor()) {
             return String.format("<html><b>%s</b>(%s</html>", split[0], split[1]); // NOI18N
         }
         return String.format("<html><b>%s</b>(%s : %s</html>", split[0], split[1], returnTypeString); // NOI18N

--- a/php/php.editor/src/org/netbeans/modules/php/editor/elements/BaseFunctionElementSupport.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/elements/BaseFunctionElementSupport.java
@@ -109,7 +109,8 @@ public class BaseFunctionElementSupport  {
                     Collection<TypeResolver> returns1 = getReturnTypes();
                     // we can also write the union type in phpdoc e.g. @return int|float
                     // check whether the union type is the actual declared return type to avoid adding the union type for phpdoc
-                    if (returns1.size() == 1 || isReturnUnionType() || isReturnIntersectionType()) {
+                    // I also prevent the return type from being generated in the PHPDoc when it is a constructor.
+                    if (!element.getName().equals(MethodElement.CONSTRUCTOR_NAME) && (returns1.size() == 1 || isReturnUnionType() || isReturnIntersectionType())) {
                         String returnType = asString(PrintAs.ReturnTypes, element, typeNameResolver, phpVersion);
                         if (StringUtils.hasText(returnType)) {
                             boolean isNullableType = CodeUtils.isNullableType(returnType);


### PR DESCRIPTION
As reported in issue https://github.com/apache/netbeans/issues/9171 adding the return type to the constructor in a PHP project caused a conflict with the ‘override methods’ feature, making the code incompatible with PHP inheritance rules.

This PR removes the return type from the constructor, restoring compatibility with PHP conventions and resolving the reported bug.
Effect: the constructor can now be correctly overridden in child classes, as expected by the language.