### PR TITLE
Improve perf of EL module by caching ResolverContext in ELParserResult

### DIFF
--- a/enterprise/web.el/src/org/netbeans/modules/web/el/CompilationContext.java
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/CompilationContext.java
@@ -27,19 +27,24 @@ import org.openide.filesystems.FileObject;
  * @author marekfukala
  */
 public class CompilationContext {
-    
+
     private final FileObject file;
     private final CompilationInfo info;
-    private final ResolverContext context = new ResolverContext();
+    private final ResolverContext context;
     private CompilationCache cache;
 
-    private CompilationContext(FileObject file, CompilationInfo info) {
+    private CompilationContext(FileObject file, CompilationInfo info, ResolverContext context) {
         this.file = file;
         this.info = info;
+        this.context = context != null ? context : new ResolverContext();
     }
-    
+
     public static CompilationContext create(FileObject file, CompilationInfo info) {
-        return new CompilationContext(file, info);
+        return create(file, info, new ResolverContext());
+    }
+
+    public static CompilationContext create(FileObject file, CompilationInfo info, ResolverContext context) {
+        return new CompilationContext(file, info, context);
     }
 
     public FileObject file() {
@@ -53,12 +58,12 @@ public class CompilationContext {
     public ResolverContext context() {
         return context;
     }
-    
+
     public synchronized CompilationCache cache() {
         if(cache == null) {
             cache = new CompilationCache();
         }
         return cache;
     }
-    
+
 }

--- a/enterprise/web.el/src/org/netbeans/modules/web/el/ELOccurrencesFinder.java
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/ELOccurrencesFinder.java
@@ -133,7 +133,7 @@ final class ELOccurrencesFinder extends OccurrencesFinder<ELParserResult> {
         try {
             jsource.runUserActionTask((CompilationController info) -> {
                 info.toPhase(JavaSource.Phase.RESOLVED);
-                CompilationContext ccontext = CompilationContext.create(file, info);
+                CompilationContext ccontext = CompilationContext.create(file, info, parserResult.getContext());
                 occurrences.putAll(findMatchingTypes(ccontext, target, matching));
                 if (this.occurrences.isEmpty()) {
                     // perhaps the caret is on a resource bundle key node

--- a/enterprise/web.el/src/org/netbeans/modules/web/el/ELParserResult.java
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/ELParserResult.java
@@ -20,15 +20,19 @@
 package org.netbeans.modules.web.el;
 
 import com.sun.el.parser.Node;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
 import javax.el.ELException;
+
 import org.netbeans.modules.csl.api.Error;
 import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.csl.api.Severity;
 import org.netbeans.modules.csl.spi.ParserResult;
 import org.netbeans.modules.parsing.api.Snapshot;
+import org.netbeans.modules.web.el.spi.ResolverContext;
 import org.openide.filesystems.FileObject;
 
 /**
@@ -41,6 +45,8 @@ public final class ELParserResult extends ParserResult {
     private final List<ELElement> elements = new ArrayList<>();
 
     private final FileObject file;
+
+    private final ResolverContext context = new ResolverContext();
 
     public ELParserResult(Snapshot snapshot) {
         super(snapshot);
@@ -130,6 +136,10 @@ public final class ELParserResult extends ParserResult {
             }
         }
         return result;
+    }
+
+    public ResolverContext getContext() {
+        return context;
     }
 
     private static class ELError implements Error.Badging {

--- a/enterprise/web.el/src/org/netbeans/modules/web/el/completion/ELCodeCompletionHandler.java
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/completion/ELCodeCompletionHandler.java
@@ -151,7 +151,12 @@ public final class ELCodeCompletionHandler implements CodeCompletionHandler2 {
                 @Override
                 public void run(CompilationController info) throws Exception {
                     info.toPhase(JavaSource.Phase.RESOLVED);
-                    CompilationContext ccontext = CompilationContext.create(file, info);
+                    CompilationContext ccontext;
+                    if (context.getParserResult() instanceof ELParserResult elParserResult) {
+                        ccontext = CompilationContext.create(file, info, elParserResult.getContext());
+                    } else {
+                        ccontext = CompilationContext.create(file, info);
+                    }
 
                     // assignments to resolve
                     Node node = nodeToResolve instanceof AstIdentifier && assignments.containsKey((AstIdentifier) nodeToResolve) ?

--- a/enterprise/web.el/src/org/netbeans/modules/web/el/hints/ELHintsProvider.java
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/hints/ELHintsProvider.java
@@ -22,7 +22,7 @@ package org.netbeans.modules.web.el.hints;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import org.netbeans.api.java.source.ClasspathInfo;
+
 import org.netbeans.api.java.source.CompilationController;
 import org.netbeans.api.java.source.JavaSource;
 import org.netbeans.api.java.source.Task;
@@ -33,6 +33,7 @@ import org.netbeans.modules.csl.api.Rule;
 import org.netbeans.modules.csl.api.Rule.AstRule;
 import org.netbeans.modules.csl.api.RuleContext;
 import org.netbeans.modules.web.el.CompilationContext;
+import org.netbeans.modules.web.el.ELParserResult;
 import org.netbeans.modules.web.el.ELTypeUtilities;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
@@ -64,7 +65,12 @@ public final class ELHintsProvider implements HintsProvider {
                 @Override
                 public void run(CompilationController info) throws Exception {
                     info.toPhase(JavaSource.Phase.RESOLVED);
-                    CompilationContext ccontext = CompilationContext.create(file, info);
+                    CompilationContext ccontext;
+                    if (context.parserResult instanceof ELParserResult elParserResult) {
+                        ccontext = CompilationContext.create(file, info, elParserResult.getContext());
+                    } else {
+                        ccontext = CompilationContext.create(file, info);
+                    }
                     for (ELRule rule : ids) {
                         if (manager.isEnabled(rule)) {
                             rule.run(ccontext, context, hints);

--- a/enterprise/web.el/src/org/netbeans/modules/web/el/navigation/ELDeclarationFinder.java
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/navigation/ELDeclarationFinder.java
@@ -23,6 +23,7 @@ import com.sun.el.parser.Node;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.SourcePositions;
 import com.sun.source.util.Trees;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,8 +32,10 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+
 import javax.lang.model.element.Element;
 import javax.swing.text.Document;
+
 import org.netbeans.api.java.source.ClasspathInfo;
 import org.netbeans.api.java.source.CompilationController;
 import org.netbeans.api.java.source.ElementHandle;
@@ -51,6 +54,7 @@ import org.netbeans.modules.web.common.spi.ProjectWebRootQuery;
 import org.netbeans.modules.web.el.AstPath;
 import org.netbeans.modules.web.el.CompilationContext;
 import org.netbeans.modules.web.el.ELElement;
+import org.netbeans.modules.web.el.ELParserResult;
 import org.netbeans.modules.web.el.ELTypeUtilities;
 import org.netbeans.modules.web.el.ResourceBundles;
 import org.netbeans.modules.web.el.completion.ELResourceBundleKeyCompletionItem;
@@ -83,7 +87,12 @@ public class ELDeclarationFinder implements DeclarationFinder {
                 @Override
                 public void run(CompilationController cc) throws Exception {
                     cc.toPhase(JavaSource.Phase.RESOLVED);
-                    CompilationContext context = CompilationContext.create(file, cc);
+                    CompilationContext context;
+                    if (info instanceof ELParserResult elParserResult) {
+                        context = CompilationContext.create(file, cc, elParserResult.getContext());
+                    } else {
+                        context = CompilationContext.create(file, cc);
+                    }
 
                     // resolve beans
                     Element javaElement = ELTypeUtilities.resolveElement(context, nodeElem.second(), nodeElem.first());


### PR DESCRIPTION
Following up #9177 
The main aim is avoiding repeated disk accesses while checking hints (especially resource bundles); it shouldn't have side effects.


---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>