### PR TITLE
Add `cnd.lsp` module to the friends list of the `nativeexecution` module

### DIFF
--- a/ide/dlight.nativeexecution/apichanges.xml
+++ b/ide/dlight.nativeexecution/apichanges.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Search for CHANGEME in this document when copying and using it: -->
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<?xml-stylesheet type="text/xml" href="CHANGEME/nbbuild/javadoctools/apichanges.xsl"?>
+<!DOCTYPE apichanges PUBLIC "-//NetBeans//DTD API changes list 1.0//EN" "../../nbbuild/javadoctools/apichanges.dtd">
+
+<apichanges>
+
+    <!-- First, a list of API names you may use: -->
+    <apidefs>
+        <apidef name="apisupport_spi">Netbeans Modules APISupport SPI</apidef>
+        <!-- etc. -->
+    </apidefs>
+
+    <!-- ACTUAL CHANGES BEGIN HERE: -->
+
+    <changes>
+        <change id="lsp-native-execution-support">
+            <api name="dlight_nativeexecution"/>
+            <summary>Integration with LSP and adjustments for native execution redirection</summary>
+            <version major="1" minor="72"/> <date day="1" month="6" year="2026"/>
+            <author login="piotrhoppe"/>
+            <compatibility binary="compatible" source="compatible" semantic="compatible"/>
+            <description>
+                <p>
+                    Add cnd.lsp module to the friends list of the nativeexecution module
+                </p>
+            </description>
+            </change>
+    </changes>
+
+    <!-- Now the surrounding HTML text and document structure: -->
+
+    <htmlcontents>
+<!--
+
+                            NO NO NO NO NO!
+
+         ==============>    DO NOT EDIT ME!  <==============
+
+          AUTOMATICALLY GENERATED FROM APICHANGES.XML, DO NOT EDIT
+
+                SEE CHANGEME/apichanges.xml
+
+-->
+    <head>
+      <title>Change History for the Database Explorer API</title>
+    </head>
+    <body>
+
+<p class="overviewlink"><a href="overview-summary.html">Overview</a></p>
+
+<h1>Introduction</h1>
+
+<p>This document lists changes made to the APISupport SPI.</p>
+
+<!-- The actual lists of changes, as summaries and details: -->
+
+      <hr/><standard-changelists module-code-name="org.netbeans.modules.apisupport.project"/>
+
+      <hr/><p>@FOOTER@</p>
+
+    </body>
+  </htmlcontents>
+
+</apichanges>

--- a/ide/dlight.nativeexecution/nbproject/project.properties
+++ b/ide/dlight.nativeexecution/nbproject/project.properties
@@ -18,6 +18,7 @@ is.autoload=true
 javac.release=11
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
+javadoc.apichanges=${basedir}/apichanges.xml
 project.license=apache20-asf
 nbm.executable.files=bin/nativeexecution/**
 jnlp.indirect.files=bin/nativeexecution/**

--- a/ide/dlight.nativeexecution/nbproject/project.xml
+++ b/ide/dlight.nativeexecution/nbproject/project.xml
@@ -259,6 +259,7 @@
                 <friend>org.netbeans.modules.cnd.dwarfdiscovery</friend>
                 <friend>org.netbeans.modules.cnd.gizmo</friend>
                 <friend>org.netbeans.modules.cnd.highlight</friend>
+                <friend>org.netbeans.modules.cnd.lsp</friend>
                 <friend>org.netbeans.modules.cnd.makeproject</friend>
                 <friend>org.netbeans.modules.cnd.makeproject.ui</friend>
                 <friend>org.netbeans.modules.cnd.mixeddev</friend>


### PR DESCRIPTION
The `cnd.lsp` module uses the `nativeexecution` API but is missing from its friends list. This PR adds `cnd.lsp` to the allowed friends of the `nativeexecution` module.

This is part of the ongoing work on standalone [netbeans cnd](https://github.com/piotrhoppe/netbeans-cnd) plugin.

@jtulach please review.