### PR TITLE
Revert "Replace delete-artifact action with REST api calls using gh CLI"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2575,30 +2575,19 @@ jobs:
     #  * nothing else failed (allows manual restarts)
     #  * the workflow got cancelled
     if: ${{ always() && needs.base-build.result == 'success' && (!contains(needs.*.result, 'failure') || cancelled()) }}
-    permissions:
-      actions: write
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
 
       - name: Delete Workspace Artifact
-        run: |
-          ARTIFACT_ID=$(gh api /repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts --jq ".artifacts[] | select(.name == \"${NAME}\") | .id")
-          echo ${ARTIFACT_ID}
-          if [ -n "$ARTIFACT_ID" ]; then
-            gh api /repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID} -X DELETE
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NAME: build.tar.zst
+        uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
+        with:
+          name: build.tar.zst 
+          useGlob: false
 
       - name: Delete Dev Build Artifact
+        uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
         if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:dev-build') && cancelled() }}
-        run: |
-          ARTIFACT_ID=$(gh api /repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts --jq ".artifacts[] | select(.name == \"${NAME}\") | .id")
-          if [ -n "$ARTIFACT_ID" ]; then
-            gh api /repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID} -X DELETE
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NAME: dev-build_${{github.event.pull_request.number || github.run_id}}.zip
+        with:
+          name: dev-build_${{github.event.pull_request.number || github.run_id}}.zip
+          useGlob: false


### PR DESCRIPTION
Reverts apache/netbeans#9286

for some reason the permission is only changed to write on master, but PR workflows still have it set to read. This causes the cleanup job to fail. There might be another guard somewhere which specifically sets this permission back to `read`.

e.g https://github.com/apache/netbeans/actions/runs/26810081110

<img width="310" height="212" alt="image" src="https://github.com/user-attachments/assets/970e2b9d-9ff3-4598-bd80-380ea1432328" />

Its not clear to my why it worked back when I tested it originally.

the successful merge run for comparison:
https://github.com/apache/netbeans/actions/runs/26761144212/job/78899977569
<img width="414" height="334" alt="image" src="https://github.com/user-attachments/assets/f3762ae9-4045-4ca7-ab3e-f05b185b8d63" />
