### PR TITLE
Enhance platform launcher to honour JAVA_HOME on macos

### DIFF
--- a/platform/o.n.bootstrap/launcher/unix/nbexec
+++ b/platform/o.n.bootstrap/launcher/unix/nbexec
@@ -146,47 +146,58 @@ parse_args "$@"
 #
 
 if [ -z "$jdkhome" ] ; then
-    # Check Java installed with sdkman
-    if [ -x "$HOME/.sdkman/candidates/java/current/bin/java" ]; then
+    if [ ! -z "$JAVA_HOME" ]; then
+        # Use JAVA_HOME if set
+        jdkhome="${JAVA_HOME}"
+    elif [ -x "$HOME/.sdkman/candidates/java/current/bin/java" ]; then
+        # Check Java installed with sdkman
         jdkhome=`resolve_symlink "$HOME/.sdkman/candidates/java/current"`
     fi
     if [ -z "$jdkhome" ] ; then
         # try to find JDK
         case "`uname`" in
             Darwin*)
-            # check if JAVA_HOME is empty string since java_home will return the value of JAVA_HOME
-            if [ -z "$JAVA_HOME" ]; then
-                unset JAVA_HOME
-            fi
-            # read Java Preferences
+            # read MacOS Java Preferences
             if [ -x "/usr/libexec/java_home" ]; then
-                jdkhome=`/usr/libexec/java_home --version 1.8+`
-            # JDK1.8 as a fallback
-            elif [ -f "/Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home/bin/java" ] ; then
-                jdkhome="/Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home"
+                # NetBeans no longer runs on JDK 8.
+                #   So, ignore locations that are no longer valid for JDK > 8.
+                # Apple java_home tool no longer supports the '+' suffix in --version values,
+                #   i.e. `/usr/libexec/java_home --version 21+` does not work anymore.
+                # Thus it is only being used to obtain the default (most likely latest) version
+                #   found in /Library/Java/JavaVirtualMachines locations.
+                jdkhome=`/usr/libexec/java_home 2>/dev/null`
             fi
-
-            # JRE fallback
-            if [ ! -x "${jdkhome}/bin/java" -a -f "/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java" ] ; then
-                jdkhome="/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home"
-            fi
-            ;;
-            *)
-            if [ ! -z "${JAVA_HOME}" ]; then
-                jdkhome="${JAVA_HOME}"
-            else
-                # Doesn't work with jenv-style shims
+            # Fallback to PATH based value
+            if [ -z "$jdkhome" ]; then
+                # Note: Doesn't work with jenv-style shims
+                # Also, the Apple launcher utilities in /usr/bin/ should be ignored,
+                # as they load Java from the same path as /usr/libexec/java_home checked above.
                 javac=`which javac`
-                if [ -z "$javac" ] ; then
+                if [ ! -z "$javac" -a "$javac" != "/usr/bin/javac" ]; then
+                    javac=`resolve_symlink "$javac"`
+                    jdkhome=`dirname $javac`"/.."
+                else
                     java=`which java`
-                    if [ ! -z "$java" ] ; then
+                    if [ ! -z "$java" -a "$java" != "/usr/bin/java" ]; then
                         java=`resolve_symlink "$java"`
                         jdkhome=`dirname $java`"/.."
                     fi
-                else
-                    javac=`resolve_symlink "$javac"`
-                    jdkhome=`dirname $javac`"/.."
                 fi
+            fi
+            ;;
+            *)
+            # Fallback to PATH based value
+            # Note: Doesn't work with jenv-style shims
+            javac=`which javac`
+            if [ -z "$javac" ] ; then
+                java=`which java`
+                if [ ! -z "$java" ] ; then
+                    java=`resolve_symlink "$java"`
+                    jdkhome=`dirname $java`"/.."
+                fi
+            else
+                javac=`resolve_symlink "$javac"`
+                jdkhome=`dirname $javac`"/.."
             fi
             ;;
         esac


### PR DESCRIPTION
- The nbexec platform launcher, used by ide launcher (netbeans) and the harness launcher (app.sh), even on macos, should honour `JAVA_HOME` and `PATH`-based JDKs when `jdkhome` is unspecified.
- This fix brings parity with unix (PR #8725) and windows (PR #8408) for the nbexec launcher's behaviour on MacOS.

- Additionally, since netbeans is no longer supported on JDK 8, the Apple-specific options targeting JDK 8 as a fallback are removed.

- Finally, the Apple `/usr/libexec/java_home` tool no longer supports a suffix '+' in the version string to indicate a minimum supported version, and only uses the `--version` filter as an exact match.
    - Thus, the `--version` argument has been dropped.
    - The current behaviour of the tool is to return the latest version jvm available in `/Library/Java/JavaVirtualMachines/` (or similar Apple-specific locations only) as the default.
    - The `PATH` based fallback is left as the last one since the `java_home` tool provides the correctly resolved JDK home instead of the Apple java launcher utilities, `/usr/bin/javac` and `/usr/bin/java`, which are expected to always be on the PATH.





---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>