### PR TITLE
Expanding list of recognized JavaScript and TypeScript extensions

### DIFF
--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsLanguage.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsLanguage.java
@@ -49,7 +49,7 @@ import org.openide.windows.TopComponent;
 public class JsLanguage extends DefaultLanguageConfig {
 
     @MIMEResolver.ExtensionRegistration(
-        extension={ "js", "sdoc", "jsx", "mjs" },
+        extension={ "js", "sdoc", "jsx", "mjs", "cjs", "es6", "pac" },
         displayName="#JsResolver",
         mimeType=JsTokenId.JAVASCRIPT_MIME_TYPE,
         position=190

--- a/webcommon/typescript.editor/src/org/netbeans/modules/typescript/editor/TypeScriptDataObjectDataObject.java
+++ b/webcommon/typescript.editor/src/org/netbeans/modules/typescript/editor/TypeScriptDataObjectDataObject.java
@@ -44,7 +44,7 @@ import static org.netbeans.modules.typescript.editor.TypeScriptEditorKit.TYPESCR
 @MIMEResolver.ExtensionRegistration(
         displayName = "#LBL_TypeScriptDataObject_LOADER",
         mimeType = TYPESCRIPT_MIME_TYPE,
-        extension = {"ts", "tsx"},
+        extension = {"ts", "tsx", "mts", "cts"},
         position = 193 // lower than 218 as CND also recognizes .ts file
 )
 @DataObject.Registration(


### PR DESCRIPTION
While working with modern JavaScript I noticed increased presence of files with `.mjs` and `.cjs` extensions. The leading `m` signals to the JavaScript engine that the file is supposed to be treated as [ECMAScript module](https://nodejs.org/api/esm.html). The leading `c` signals [CommonJS](https://en.wikipedia.org/wiki/CommonJS) module. The same pattern seems to emerge in TypeScript as well. Let NetBeans extensions for JavaScript and TypeScript be expanded to cover these widely used extensions!

- I took copied the actual list of extensions from https://github.com/microsoft/vscode/blob/db81a24a9eabe181928830b72567387ef1bf81b5/extensions/typescript-language-features/src/configuration/languageDescription.ts#L36
- another indication `.mjs` is needed: https://github.com/oracle/graaljs/blob/33e69fbb659cc796867cf17f0adcc89d05bfe0e9/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/lang/JavaScriptLanguage.java#L168

Previously I always expanded the list of extensions manually in _Tools/Options_, but given how frequent they have become I believe enlisting them by default would improve the UX.