### PR TITLE
[PHP] Return type changed in PHP >= 8-0. Fluent setters now return `static`.

### DIFF
--- a/php/php.api.phpmodule/src/org/netbeans/modules/php/api/PhpVersion.java
+++ b/php/php.api.phpmodule/src/org/netbeans/modules/php/api/PhpVersion.java
@@ -246,6 +246,28 @@ public enum PhpVersion {
     }
 
     /**
+     * Check whether this version supports the static return type. (as of PHP 8.0)
+     *
+     * @return {@code true} if this version supports static return type,
+     * {@code false} otherwise
+     * @since 2.107
+     */
+    public boolean hasStaticReturnType() {
+        return this.compareTo(PhpVersion.PHP_80) >= 0;
+    }
+    
+    /**
+     * Check whether this version supports the self return type. (as of PHP 7.0)
+     *
+     * @return {@code true} if this version supports self return type,
+     * {@code false} otherwise
+     * @since 2.107
+     */
+    public boolean hasSelfReturnType() {
+        return this.compareTo(PhpVersion.PHP_70) >= 0;
+    }
+
+    /**
      * Check whether this version supports the never type.
      *
      * @return {@code true} if this version supports never type, {@code false}

--- a/php/php.editor/src/org/netbeans/modules/php/editor/codegen/SinglePropertyMethodCreator.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/codegen/SinglePropertyMethodCreator.java
@@ -191,6 +191,12 @@ public interface SinglePropertyMethodCreator<T extends Property> {
         }
 
         private String getReturnType() {
+            if (cgsInfo.isFluentSetter() && cgsInfo.getPhpVersion().hasStaticReturnType()) {
+                return String.format(": %s ", Type.STATIC); // NOI18N
+            }
+            if (cgsInfo.isFluentSetter() && cgsInfo.getPhpVersion().hasSelfReturnType()) {
+                return String.format(": %s ", Type.SELF); // NOI18N
+            }
             if (!cgsInfo.isFluentSetter() && cgsInfo.getPhpVersion().hasVoidReturnType()) {
                 return String.format(": %s ", Type.VOID); // NOI18N
             }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -2331,7 +2332,9 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
         Model model = request.result.getModel();
         Set<AliasedName> aliasedNames = ModelUtils.getAliasedNames(model, request.anchor);
 
-        for (final PhpElement element : request.index.getTopLevelElements(prefix, aliasedNames, Trait.ALIAS)) {
+        List<PhpElement> topLevelElements = new ArrayList<>(request.index.getTopLevelElements(prefix, aliasedNames, Trait.ALIAS));
+        topLevelElements.sort(Comparator.comparing(PhpElement::getName, String.CASE_INSENSITIVE_ORDER));
+        for (final PhpElement element : topLevelElements) {
             if (CancelSupport.getDefault().isCancelled()) {
                 return;
             }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP71Fluent.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP71Fluent.codegen
@@ -1,89 +1,89 @@
-public  function setInstanceArray(array $$instanceArray) {
+public  function setInstanceArray(array $$instanceArray): self {
 $$this->instanceArray = $instanceArray;
 return $$this;
 }
 
-public  function setInstanceInt(int $$instanceInt) {
+public  function setInstanceInt(int $$instanceInt): self {
 $$this->instanceInt = $instanceInt;
 return $$this;
 }
 
-public  function setInstanceString(string $$instanceString) {
+public  function setInstanceString(string $$instanceString): self {
 $$this->instanceString = $instanceString;
 return $$this;
 }
 
-public  function setInstanceBool(bool $$instanceBool) {
+public  function setInstanceBool(bool $$instanceBool): self {
 $$this->instanceBool = $instanceBool;
 return $$this;
 }
 
-public  function setInstanceNull($$instanceNull) {
+public  function setInstanceNull($$instanceNull): self {
 $$this->instanceNull = $instanceNull;
 return $$this;
 }
 
-public  function setInstanceNullable(?string $$instanceNullable) {
+public  function setInstanceNullable(?string $$instanceNullable): self {
 $$this->instanceNullable = $instanceNullable;
 return $$this;
 }
 
-public  function setInstanceArrayNullable(?array $$instanceArrayNullable) {
+public  function setInstanceArrayNullable(?array $$instanceArrayNullable): self {
 $$this->instanceArrayNullable = $instanceArrayNullable;
 return $$this;
 }
 
-public  function setInstanceClass(Test53 $$instanceClass) {
+public  function setInstanceClass(Test53 $$instanceClass): self {
 $$this->instanceClass = $instanceClass;
 return $$this;
 }
 
-public static function setStaticInt(int $$staticInt) {
+public static function setStaticInt(int $$staticInt): self {
 self::$$staticInt = $staticInt;
 return self;
 }
 
-public static function setStaticNullable(?int $$staticNullable) {
+public static function setStaticNullable(?int $$staticNullable): self {
 self::$$staticNullable = $staticNullable;
 return self;
 }
 
-public  function setInstanceInt74($$instanceInt74) {
+public  function setInstanceInt74($$instanceInt74): self {
 $$this->instanceInt74 = $instanceInt74;
 return $$this;
 }
 
-public  function setInstanceString74($$instanceString74) {
+public  function setInstanceString74($$instanceString74): self {
 $$this->instanceString74 = $instanceString74;
 return $$this;
 }
 
-public  function setInstanceBool74($$instanceBool74) {
+public  function setInstanceBool74($$instanceBool74): self {
 $$this->instanceBool74 = $instanceBool74;
 return $$this;
 }
 
-public  function setInstanceNullable74($$instanceNullable74) {
+public  function setInstanceNullable74($$instanceNullable74): self {
 $$this->instanceNullable74 = $instanceNullable74;
 return $$this;
 }
 
-public static function setStaticInt74($$staticInt74) {
+public static function setStaticInt74($$staticInt74): self {
 self::$$staticInt74 = $staticInt74;
 return self;
 }
 
-public static function setStaticString74($$staticString74) {
+public static function setStaticString74($$staticString74): self {
 self::$$staticString74 = $staticString74;
 return self;
 }
 
-public static function setStaticBool74($$staticBool74) {
+public static function setStaticBool74($$staticBool74): self {
 self::$$staticBool74 = $staticBool74;
 return self;
 }
 
-public static function setStaticNullable74($$staticNullable74) {
+public static function setStaticNullable74($$staticNullable74): self {
 self::$$staticNullable74 = $staticNullable74;
 return self;
 }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP74Fluent.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP74Fluent.codegen
@@ -23,12 +23,12 @@ $$this->instanceNull = $instanceNull;
 return $$this;
 }
 
-public  function setInstanceNullable(string $$instanceNullable): self {
+public  function setInstanceNullable(?string $$instanceNullable): self {
 $$this->instanceNullable = $instanceNullable;
 return $$this;
 }
 
-public  function setInstanceArrayNullable(array $$instanceArrayNullable): self {
+public  function setInstanceArrayNullable(?array $$instanceArrayNullable): self {
 $$this->instanceArrayNullable = $instanceArrayNullable;
 return $$this;
 }
@@ -43,47 +43,47 @@ self::$$staticInt = $staticInt;
 return self;
 }
 
-public static function setStaticNullable(int $$staticNullable): self {
+public static function setStaticNullable(?int $$staticNullable): self {
 self::$$staticNullable = $staticNullable;
 return self;
 }
 
-public  function setInstanceInt74($$instanceInt74): self {
+public  function setInstanceInt74(int $$instanceInt74): self {
 $$this->instanceInt74 = $instanceInt74;
 return $$this;
 }
 
-public  function setInstanceString74($$instanceString74): self {
+public  function setInstanceString74(string $$instanceString74): self {
 $$this->instanceString74 = $instanceString74;
 return $$this;
 }
 
-public  function setInstanceBool74($$instanceBool74): self {
+public  function setInstanceBool74(bool $$instanceBool74): self {
 $$this->instanceBool74 = $instanceBool74;
 return $$this;
 }
 
-public  function setInstanceNullable74($$instanceNullable74): self {
+public  function setInstanceNullable74(?string $$instanceNullable74): self {
 $$this->instanceNullable74 = $instanceNullable74;
 return $$this;
 }
 
-public static function setStaticInt74($$staticInt74): self {
+public static function setStaticInt74(int $$staticInt74): self {
 self::$$staticInt74 = $staticInt74;
 return self;
 }
 
-public static function setStaticString74($$staticString74): self {
+public static function setStaticString74(string $$staticString74): self {
 self::$$staticString74 = $staticString74;
 return self;
 }
 
-public static function setStaticBool74($$staticBool74): self {
+public static function setStaticBool74(bool $$staticBool74): self {
 self::$$staticBool74 = $staticBool74;
 return self;
 }
 
-public static function setStaticNullable74($$staticNullable74): self {
+public static function setStaticNullable74(?string $$staticNullable74): self {
 self::$$staticNullable74 = $staticNullable74;
 return self;
 }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP80.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP80.codegen
@@ -1,0 +1,72 @@
+public  function setInstanceArray(array $$instanceArray): void {
+$$this->instanceArray = $instanceArray;
+}
+
+public  function setInstanceInt(int $$instanceInt): void {
+$$this->instanceInt = $instanceInt;
+}
+
+public  function setInstanceString(string $$instanceString): void {
+$$this->instanceString = $instanceString;
+}
+
+public  function setInstanceBool(bool $$instanceBool): void {
+$$this->instanceBool = $instanceBool;
+}
+
+public  function setInstanceNull($$instanceNull): void {
+$$this->instanceNull = $instanceNull;
+}
+
+public  function setInstanceNullable(?string $$instanceNullable): void {
+$$this->instanceNullable = $instanceNullable;
+}
+
+public  function setInstanceArrayNullable(?array $$instanceArrayNullable): void {
+$$this->instanceArrayNullable = $instanceArrayNullable;
+}
+
+public  function setInstanceClass(Test53 $$instanceClass): void {
+$$this->instanceClass = $instanceClass;
+}
+
+public static function setStaticInt(int $$staticInt): void {
+self::$$staticInt = $staticInt;
+}
+
+public static function setStaticNullable(?int $$staticNullable): void {
+self::$$staticNullable = $staticNullable;
+}
+
+public  function setInstanceInt74(int $$instanceInt74): void {
+$$this->instanceInt74 = $instanceInt74;
+}
+
+public  function setInstanceString74(string $$instanceString74): void {
+$$this->instanceString74 = $instanceString74;
+}
+
+public  function setInstanceBool74(bool $$instanceBool74): void {
+$$this->instanceBool74 = $instanceBool74;
+}
+
+public  function setInstanceNullable74(?string $$instanceNullable74): void {
+$$this->instanceNullable74 = $instanceNullable74;
+}
+
+public static function setStaticInt74(int $$staticInt74): void {
+self::$$staticInt74 = $staticInt74;
+}
+
+public static function setStaticString74(string $$staticString74): void {
+self::$$staticString74 = $staticString74;
+}
+
+public static function setStaticBool74(bool $$staticBool74): void {
+self::$$staticBool74 = $staticBool74;
+}
+
+public static function setStaticNullable74(?string $$staticNullable74): void {
+self::$$staticNullable74 = $staticNullable74;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP80Fluent.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP80Fluent.codegen
@@ -1,0 +1,90 @@
+public  function setInstanceArray(array $$instanceArray): static {
+$$this->instanceArray = $instanceArray;
+return $$this;
+}
+
+public  function setInstanceInt(int $$instanceInt): static {
+$$this->instanceInt = $instanceInt;
+return $$this;
+}
+
+public  function setInstanceString(string $$instanceString): static {
+$$this->instanceString = $instanceString;
+return $$this;
+}
+
+public  function setInstanceBool(bool $$instanceBool): static {
+$$this->instanceBool = $instanceBool;
+return $$this;
+}
+
+public  function setInstanceNull($$instanceNull): static {
+$$this->instanceNull = $instanceNull;
+return $$this;
+}
+
+public  function setInstanceNullable(?string $$instanceNullable): static {
+$$this->instanceNullable = $instanceNullable;
+return $$this;
+}
+
+public  function setInstanceArrayNullable(?array $$instanceArrayNullable): static {
+$$this->instanceArrayNullable = $instanceArrayNullable;
+return $$this;
+}
+
+public  function setInstanceClass(Test53 $$instanceClass): static {
+$$this->instanceClass = $instanceClass;
+return $$this;
+}
+
+public static function setStaticInt(int $$staticInt): static {
+self::$$staticInt = $staticInt;
+return self;
+}
+
+public static function setStaticNullable(?int $$staticNullable): static {
+self::$$staticNullable = $staticNullable;
+return self;
+}
+
+public  function setInstanceInt74(int $$instanceInt74): static {
+$$this->instanceInt74 = $instanceInt74;
+return $$this;
+}
+
+public  function setInstanceString74(string $$instanceString74): static {
+$$this->instanceString74 = $instanceString74;
+return $$this;
+}
+
+public  function setInstanceBool74(bool $$instanceBool74): static {
+$$this->instanceBool74 = $instanceBool74;
+return $$this;
+}
+
+public  function setInstanceNullable74(?string $$instanceNullable74): static {
+$$this->instanceNullable74 = $instanceNullable74;
+return $$this;
+}
+
+public static function setStaticInt74(int $$staticInt74): static {
+self::$$staticInt74 = $staticInt74;
+return self;
+}
+
+public static function setStaticString74(string $$staticString74): static {
+self::$$staticString74 = $staticString74;
+return self;
+}
+
+public static function setStaticBool74(bool $$staticBool74): static {
+self::$$staticBool74 = $staticBool74;
+return self;
+}
+
+public static function setStaticNullable74(?string $$staticNullable74): static {
+self::$$staticNullable74 = $staticNullable74;
+return self;
+}
+

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
@@ -358,6 +358,26 @@ public class SelectedPropertyMethodsCreatorTest extends PHPTestBase {
         checkResult(new SelectedPropertyMethodsCreator().create(selectAllProperties(cgsInfo.getPossibleSetters()), new SinglePropertyMethodCreator.SingleSetterCreator(cgsInfo)));
     }
 
+    public void testTypedPropertiesSetter_PHP74Fluent() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("^}", PhpVersion.PHP_74);
+        cgsInfo.setPublicModifier(true);
+        cgsInfo.setFluentSetter(true);
+        checkResult(new SelectedPropertyMethodsCreator().create(selectAllProperties(cgsInfo.getPossibleSetters()), new SinglePropertyMethodCreator.SingleSetterCreator(cgsInfo)));
+    }
+
+    public void testTypedPropertiesSetter_PHP80() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("^}", PhpVersion.PHP_80);
+        cgsInfo.setPublicModifier(true);
+        checkResult(new SelectedPropertyMethodsCreator().create(selectAllProperties(cgsInfo.getPossibleSetters()), new SinglePropertyMethodCreator.SingleSetterCreator(cgsInfo)));
+    }
+
+    public void testTypedPropertiesSetter_PHP80Fluent() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("^}", PhpVersion.PHP_80);
+        cgsInfo.setPublicModifier(true);
+        cgsInfo.setFluentSetter(true);
+        checkResult(new SelectedPropertyMethodsCreator().create(selectAllProperties(cgsInfo.getPossibleSetters()), new SinglePropertyMethodCreator.SingleSetterCreator(cgsInfo)));
+    }
+
     // constructor
     public void testTypedPropertiesConstructor_PHP56() throws Exception {
         CGSInfo cgsInfo = getCgsInfo("^}", PhpVersion.PHP_56);


### PR DESCRIPTION
From PHP version 8.0 onwards, the "static" return type has been adopted for fluent setters. In the "Generate Code" menu in NetBeans, no return type was assigned when fluent setters were created. This PR ensures that fluent setters, when used in a project configured with PHP version >= 8.0, correctly have the "static" return type.