### PR TITLE
Inspect all stratas to find a source file

### DIFF
--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/SourcePath.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/SourcePath.java
@@ -420,10 +420,15 @@ public class SourcePath {
                     convertSlash (csf.getSourcePath (stratumn)), true
                 );
                 if (url == null) {
-                    stratumn = csf.getDefaultStratum ();
                     url = getURL (
-                        convertSlash (csf.getSourcePath (stratumn)), true
+                        convertSlash (csf.getSourcePath (csf.getDefaultStratum())), true
                     );
+                    for (var anyStratum : csf.getAvailableStrata()) {
+                        if (url != null) {
+                            break;
+                        }
+                        url = getURL(convertSlash (csf.getSourcePath (anyStratum)), true);
+                    }
                 }
                 if (url == null) {
                     String message = NbBundle.getMessage(SourcePath.class,

--- a/java/kotlin.editor/manifest.mf
+++ b/java/kotlin.editor/manifest.mf
@@ -1,5 +1,6 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: true
 OpenIDE-Module: org.netbeans.modules.kotlin.editor
+OpenIDE-Module-Layer: org/netbeans/modules/kotlin/editor/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/kotlin/editor/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.28

--- a/java/kotlin.editor/nbproject/project.xml
+++ b/java/kotlin.editor/nbproject/project.xml
@@ -26,6 +26,24 @@
             <code-name-base>org.netbeans.modules.kotlin.editor</code-name-base>
             <module-dependencies>
                 <dependency>
+                    <code-name-base>org.netbeans.api.debugger</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.88</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.api.debugger.jpda</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>2</release-version>
+                        <specification-version>3.43</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.api.templates</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -40,6 +58,15 @@
                     <run-dependency>
                         <release-version>1</release-version>
                         <specification-version>1.49</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.textmate.lexer</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>0</release-version>
+                        <specification-version>1.2</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -120,15 +147,6 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>6.81</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.netbeans.modules.textmate.lexer</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>0</release-version>
-                        <specification-version>1.2</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/java/kotlin.editor/src/org/netbeans/modules/kotlin/editor/ToggleKotlinBreakpointActionProvider.java
+++ b/java/kotlin.editor/src/org/netbeans/modules/kotlin/editor/ToggleKotlinBreakpointActionProvider.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.kotlin.editor;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.netbeans.api.debugger.Breakpoint;
+import org.netbeans.api.debugger.DebuggerManager;
+import org.netbeans.api.debugger.jpda.LineBreakpoint;
+import org.netbeans.spi.debugger.*;
+import org.netbeans.spi.debugger.jpda.EditorContext;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.URLMapper;
+import org.openide.util.Exceptions;
+@ActionsProvider.Registrations({
+    @ActionsProvider.Registration(path="netbeans-JPDASession", actions={ "toggleBreakpoint" }, activateForMIMETypes={ "text/x-kotlin" }),
+    @ActionsProvider.Registration(path="", actions={ "toggleBreakpoint" }, activateForMIMETypes={ "text/x-kotlin" })
+})
+public final class ToggleKotlinBreakpointActionProvider extends ActionsProvider {
+    public ToggleKotlinBreakpointActionProvider() {
+    }
+
+    @Override
+    public Set<String> getActions() {
+        return Collections.singleton("toggleBreakpoint");
+    }
+
+    @Override
+    public void doAction(Object o) {
+        final DebuggerManager m = DebuggerManager.getDebuggerManager ();
+        for (EditorContext ctx : m.lookup(null, EditorContext.class)) {
+            String url = ctx.getCurrentURL();
+            int line = ctx.getCurrentLineNumber();
+            if (url != null && line >= 0) {
+                if (!url.endsWith(".kt")) {
+                    continue;
+                }
+                if (removeExistingBreakpoint(m, line, url)) {
+                    return;
+                }
+                createNewBreakpoint(url, line, m);
+                return;
+            }
+        }
+    }
+
+    private static final Pattern PACKAGE = Pattern.compile("package *([\\p{Alnum}+\\.$]+) *");
+    private void createNewBreakpoint(String url, int line, final DebuggerManager m) {
+        try {
+            var b = LineBreakpoint.create(url, line);
+
+            FileObject fo = URLMapper.findFileObject(URI.create(url).toURL());
+            for (String code : fo.asLines()) {
+                Matcher match = PACKAGE.matcher(code);
+                if (match.matches()) {
+                    String pkg = match.group(1);
+                    int slash = url.lastIndexOf("/");
+                    int dot = url.indexOf('.', slash + 1);
+                    if (dot >= 0) {
+                        String filter = pkg + "." + url.substring(slash + 1, dot) + "*";
+                        b.setPreferredClassName(filter);
+                    }
+                    break;
+                }
+            }
+            m.addBreakpoint(b);
+        } catch (IOException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+    }
+
+    private boolean removeExistingBreakpoint(final DebuggerManager m, int line, String url) {
+        for (Breakpoint b : m.getBreakpoints()) {
+            if (b instanceof LineBreakpoint lb) {
+                if (lb.getLineNumber() == line && url.equals(lb.getURL())) {
+                    m.removeBreakpoint(lb);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled(Object o) {
+        final DebuggerManager m = DebuggerManager.getDebuggerManager ();
+        for (EditorContext ctx : m.lookup(null, EditorContext.class)) {
+            String url = ctx.getCurrentURL();
+            int line = ctx.getCurrentLineNumber();
+            if (url != null && line >= 0) {
+                if (url.endsWith(".kt")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void addActionsProviderListener(ActionsProviderListener al) {
+    }
+
+    @Override
+    public void removeActionsProviderListener(ActionsProviderListener al) {
+    }
+
+}

--- a/java/kotlin.editor/src/org/netbeans/modules/kotlin/editor/layer.xml
+++ b/java/kotlin.editor/src/org/netbeans/modules/kotlin/editor/layer.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
+<filesystem>
+    <folder name="Editors">
+        <folder name="text">
+            <folder name="x-kotlin">
+                <folder name="ToolTips">
+                    <file name="org-netbeans-modules-debugger-jpda-truffle-vars-tooltip-ToolTipAnnotation.instance"/>
+                </folder>
+                <file name="org-netbeans-modules-lsp-client-bridge-BridgingLanguageServerProvider.instance">
+                    <!--org.netbeans.modules.lsp.client.newpackage-->
+                    <attr name="instanceOf" stringvalue="org.netbeans.modules.lsp.client.spi.LanguageServerProvider"/>
+                </file>
+                <folder name="SideBar">
+                    <file name="breadcrumbs.instance">
+                        <!--org.netbeans.modules.lsp.client.newpackage-->
+                        <attr name="location" stringvalue="South"/>
+                        <attr intvalue="5232" name="position"/>
+                        <attr boolvalue="false" name="scrollable"/>
+                        <attr methodvalue="org.netbeans.modules.editor.breadcrumbs.spi.BreadcrumbsController.createSideBarFactory" name="instanceCreate"/>
+                    </file>
+                </folder>
+            </folder>
+        </folder>
+    </folder>
+</filesystem>


### PR DESCRIPTION
- trying to debug a Kotlin file
- can specify a _method breakpoint_ 
   - the execution stops, but no location in editor is selected
   - clicking on stacktrace element shows the line in a `.kt` file
- can step over
    - execution does the step, but no location in editor is selected
    - clicking on stacktrace element shows the line in a `.kt` file
- turns out the problem is wrong _stratum_ (from JDK-245)

<img width="761" height="557" alt="strata" src="https://github.com/user-attachments/assets/098b691d-1903-42c9-ad77-f08ef4a59b15" />

- there are too many strata and the default one is _Kotlin_
- when the strata is switched to _Java_ the debugger line gets selected in the editor
- hence this PR tries all available strata to find any line in any existing editor
- with this the stepping seems to work

- TBD: placing a breakpoint in the Kotlin source