### PR TITLE
Add form.binding as friend to form and form.nb modules

### DIFF
--- a/java/form.nb/nbproject/project.xml
+++ b/java/form.nb/nbproject/project.xml
@@ -341,7 +341,10 @@
                     </run-dependency>
                 </dependency>
             </module-dependencies>
-            <public-packages/>
+            <friend-packages>
+                <friend>org.netbeans.modules.form.binding</friend>
+                <package>org.netbeans.modules.nbform.project</package>
+            </friend-packages>
         </data>
     </configuration>
 </project>

--- a/java/form/nbproject/project.xml
+++ b/java/form/nbproject/project.xml
@@ -338,7 +338,12 @@
                     </test-dependency>
                 </test-type>
             </test-dependencies>
-            <public-packages/>
+            <friend-packages>
+                <friend>org.netbeans.modules.form.binding</friend>
+                <package>org.netbeans.modules.form</package>
+                <package>org.netbeans.modules.form.codestructure</package>
+                <package>org.netbeans.modules.form.project</package>
+            </friend-packages>
             <class-path-extension>
                 <runtime-relative-path>ext/AbsoluteLayout.jar</runtime-relative-path>
             </class-path-extension>


### PR DESCRIPTION
This PR adds `com.netbeans.modules.form.binding` as friend to `com.netbeans.modules.form` and `com.netbeans.modules.nbform` 

It enables building form.binding module as a plugin. The module was removed during the transition to Apache.

Here is the plugin that will be published to the plugin portal after Apache NetBeans 31 is released https://github.com/oyarzun/nb-form-binding

