### PR TITLE
Remove textmate grammar registration by delete key and select the next one for fast deletion

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/options/LanguageServersPanel.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/options/LanguageServersPanel.java
@@ -19,6 +19,8 @@
 package org.netbeans.modules.lsp.client.options;
 
 import java.awt.Component;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 import java.beans.BeanInfo;
 import java.io.File;
 import java.util.ArrayList;
@@ -49,6 +51,14 @@ final class LanguageServersPanel extends javax.swing.JPanel {
         this.usedIds = new HashSet<>();
         initComponents();
         this.languagesList.addListSelectionListener(evt -> setEnableDisable());
+        this.languagesList.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                if (e.getKeyCode() == KeyEvent.VK_DELETE) {
+                    removeSelected();
+                }
+            }
+        });
         setEnableDisable();
     }
 
@@ -164,9 +174,23 @@ final class LanguageServersPanel extends javax.swing.JPanel {
     }//GEN-LAST:event_editActionPerformed
 
     private void removeActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_removeActionPerformed
-        languages.remove(languagesList.getSelectedIndex());
-        controller.changed();
+        removeSelected();
     }//GEN-LAST:event_removeActionPerformed
+
+    private void removeSelected() {
+        int idx = languagesList.getSelectedIndex();
+        if (idx == -1) {
+            return;
+        }
+        languages.remove(idx);
+        controller.changed();
+        
+        if (languages.getSize() > 0) {
+            int next = Math.min(idx, languages.getSize() - 1);
+            languagesList.setSelectedIndex(next);
+            languagesList.ensureIndexIsVisible(next);
+        }
+    }
 
     private LanguageDescription openCustomizeDialog(LanguageDescription desc, String title) {
         LanguageDescriptionPanel panel = new LanguageDescriptionPanel(desc, usedIds);


### PR DESCRIPTION
If you have a veeeery long list of textmate grammar registrations in the options panel and you need to remove a line to check whether this makes the error or not, after removing with alt + r you need to select another one manually. This PR fixes this problem and also we can now delete via delete key.


### PR approval and merge checklist:

1. [ ] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [ ] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [ ] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [ ] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>