### PR TITLE
Fix GlassFish 8.x install detection when modules/glassfish.jar is absent

### DIFF
--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/wizards/ServerWizardIterator.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/wizards/ServerWizardIterator.java
@@ -337,7 +337,17 @@ public class ServerWizardIterator extends PortCollection implements WizardDescri
         wizard.putProperty(WizardDescriptor.PROP_ERROR_MESSAGE, errMsg); // getSanitizedPath(installDir)));
         File jar = ServerUtilities.getJarName(glassfishDir.getAbsolutePath(), ServerUtilities.GFV3_JAR_MATCHER);
         if (jar == null || !jar.exists()) {
-            return null;
+            // GlassFish 8 no longer ships a versioned modules/glassfish*.jar; the
+            // bootstrap jar lives at lib/bootstrap/glassfish.jar in every
+            // distribution (both the full and the web profile). Accept that as
+            // proof of a GlassFish install while staying backward compatible with
+            // GlassFish 3-7. The actual version is still resolved further below
+            // through ServerUtils.getServerVersion() (modules/common-util.jar).
+            File bootstrapJar = new File(glassfishDir,
+                    "lib" + File.separator + "bootstrap" + File.separator + "glassfish.jar"); // NOI18N
+            if (!bootstrapJar.exists()) {
+                return null;
+            }
         }
 
         File containerRef = new File(glassfishDir, "config" + File.separator + "glassfish.container");


### PR DESCRIPTION
Fixes #9441

### What

The *Add Server → GlassFish Server* wizard rejects a **GlassFish 8.x Web Profile** installation as invalid, while accepting the Full distribution of the same version. Reported downstream at eclipse-ee4j/glassfish#26098.

### Root cause

`ServerWizardIterator.isValidInstall()` requires a jar in `modules/` whose name matches `ServerUtilities.GFV3_JAR_MATCHER`:

```
glassfish(?:-[0-9bSNAPHOT]+(?:\.[0-9]+(?:_[0-9]+|)|).*|).jar
```

This was meant to find the kernel jar `modules/glassfish.jar` (or `glassfish-<version>.jar`) shipped by GlassFish 3–7. GlassFish 8 no longer ships it — the bootstrap jar moved to `lib/bootstrap/glassfish.jar`, which `getJarName()` (it only scans `modules/`) never sees. Detection then falls back to matching the loose regex against whatever else is in `modules/`:

| Distribution | `modules/*.jar` that match (case-sensitive) |
|---|---|
| Full | `glassfish-batch-commands.jar`, `glassfish-batch-connector.jar` |
| Web Profile | *(none)* |

The Full profile passes only by accident — `glassfish-batch-*.jar` matches because the char class `[0-9bSNAPHOT]` contains a lowercase `b` (`glassfish-api.jar`, `glassfish-naming.jar`, etc. do not match). The Web Profile excludes the Batch feature, so no jar qualifies, `getJarName()` returns `null`, and the install is rejected.

Version detection itself is unaffected: `ServerUtils.getServerVersion()` (reads `Bundle-Version` from `modules/common-util.jar`) works for both profiles. Only the brittle jar-presence gate fails.

### Fix

When the legacy `modules/glassfish*.jar` is absent, fall back to `lib/bootstrap/glassfish.jar`, which is present in every GlassFish distribution (full and web). This is backward compatible with GlassFish 3–7, and the `config/glassfish.container` check plus version resolution via `getServerVersion()` are left unchanged.

### Testing

Verified against staged GlassFish 8.x builds: `lib/bootstrap/glassfish.jar` exists in both the full and web profile distributions, and neither has `modules/glassfish.jar`. With this change the web profile directory is accepted by the wizard; the full distribution and older (3–7) installs continue to be detected.
