### PR TITLE
GlassFish: Show supported range when no compatible JDK is installed

### DIFF
--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/Bundle.properties
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/Bundle.properties
@@ -104,8 +104,11 @@ instance installed in {1}.<br/>Please make sure that this server is \
 GlassFish 3.0 or later and that server is registered properly in NetBeans.<html>
 
 JavaSEPlatformPanel.title=Java SE Platform
-JavaSEPlatformPanel.warning=<html>GlassFish server could not be started with \
+JavaSEPlatformPanel.warning=<html>GlassFish server can not be started with \
 <i>{0}</i>. Please select another Java SE Platform.</html>
+JavaSEPlatformPanel.noPlatform=<html>GlassFish server can not be started with \
+<i>{0}</i> and no installed Java SE platform is compatible with this server \
+(supported: {1}). Use <b>Manage Platforms</b> to register a compatible JDK.</html>
 JavaSEPlatformPanel.javaLabel=Java Platform:
 JavaSEPlatformPanel.platformButton=Manage Platforms
 JavaSEPlatformPanel.propertiesLabel=Update properties:

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/JavaSEPlatformPanel.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/JavaSEPlatformPanel.java
@@ -105,9 +105,20 @@ public class JavaSEPlatformPanel extends JPanel {
         JavaPlatform platform = JavaUtils.findInstalledPlatform(javaHome);
         String platformName = platform != null
                 ? platform.getDisplayName() : javaHome.getAbsolutePath();
-        String message = NbBundle.getMessage(
-                JavaSEPlatformPanel.class,
-                "JavaSEPlatformPanel.warning", platformName);
+        // When no installed platform is compatible the selection combo is
+        // empty and OK stays disabled, so point the user at "Manage Platforms"
+        // and name the supported range instead of the generic warning.
+        JavaPlatform[] supportedPlatforms
+                = JavaUtils.findSupportedPlatforms(instance);
+        String message = supportedPlatforms == null
+                || supportedPlatforms.length == 0
+                ? NbBundle.getMessage(
+                        JavaSEPlatformPanel.class,
+                        "JavaSEPlatformPanel.noPlatform", platformName,
+                        JavaUtils.supportedJavaSERange(instance))
+                : NbBundle.getMessage(
+                        JavaSEPlatformPanel.class,
+                        "JavaSEPlatformPanel.warning", platformName);
         String title = NbBundle.getMessage(
                 JavaSEPlatformPanel.class,
                 "JavaSEPlatformPanel.title", platformName);

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/utils/JavaUtils.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/utils/JavaUtils.java
@@ -223,6 +223,43 @@ public class JavaUtils {
     }
 
     /**
+     * Build a human readable description of the Java SE versions supported
+     * by the given GlassFish server instance.
+     * <p/>
+     * The result is a compact range (e.g. <code>"17 - 25"</code>) when the
+     * supported set spans more than one version, the single version otherwise,
+     * or an empty <code>String</code> when nothing is declared as supported.
+     * <p/>
+     * @param instance GlassFish server instance to inspect.
+     * @return Description of the supported Java SE version range.
+     */
+    public static String supportedJavaSERange(
+            @NonNull final GlassfishInstance instance) {
+        Parameters.notNull("instance", instance);
+        GlassFishJavaSEConfig javaSEConfig
+                = ConfigBuilderProvider.getBuilder(instance)
+                .getJavaSEConfig(instance.getVersion());
+        Set<JavaSEPlatform> supportedPlatforms
+                = javaSEConfig != null ? javaSEConfig.getPlatforms() : null;
+        if (supportedPlatforms == null || supportedPlatforms.isEmpty()) {
+            return "";
+        }
+        JavaSEPlatform min = null;
+        JavaSEPlatform max = null;
+        for (JavaSEPlatform platform : supportedPlatforms) {
+            if (min == null || platform.ordinal() < min.ordinal()) {
+                min = platform;
+            }
+            if (max == null || platform.ordinal() > max.ordinal()) {
+                max = platform;
+            }
+        }
+        return min == max
+                ? min.toString()
+                : min.toString() + " - " + max.toString();
+    }
+
+    /**
      * Search for first available installed folder in Java SE platform.
      * <p/>
      * @param platform Java SE platform to search for first available


### PR DESCRIPTION
### Problem
On a machine whose only registered JDK is unsupported by the target GlassFish
server (e.g. JDK 26 with GlassFish 8.0, which supports 21–25), starting the
server pops up the *"select a Java SE platform"* dialog with an **empty platform
dropdown**, a generic *"please select another platform"* warning, and only a
**Cancel** button — a dead end, since there is nothing to select.

### Fix
Detect the empty-supported-platforms case in `JavaSEPlatformPanel` and show a
message that:
- names the Java SE range the server actually supports, and
- points the user at the existing **Manage Platforms** button.

That button already re-runs `findSupportedPlatforms` and re-enables **OK** once a
compatible JDK is registered, so the dialog becomes actionable instead of a dead
end. A small `JavaUtils.supportedJavaSERange(instance)` helper derives the range
from the server config.

### Why not just add JDK 26/27 to the configs (the original approach)
The first revision of this PR added `<platform version="26"/>` / `27` to the
GlassFish 7.1/8.0 configs. As @pepness and @mbien pointed out (and verified),
**GlassFish 8.0.x does not actually boot on JDK 26** — it fails with the classic
asm/OSGi resolution error (`osgi.ee=JavaSE;version=1.5.0`). Advertising 26/27
would only trade the empty-dialog bug for a *"server dies at startup with a
cryptic OSGi trace"* bug. Once a GlassFish release genuinely boots on JDK 26,
bumping the config is a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)