### PR TITLE
GlassFish: Don't pass removed -Djava.endorsed.dirs when running app clients

### DIFF
--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/Hk2JavaEEPlatformImpl.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/Hk2JavaEEPlatformImpl.java
@@ -766,11 +766,26 @@ public class Hk2JavaEEPlatformImpl extends J2eePlatformImpl2 {
             if (J2eePlatform.TOOL_PROP_JVM_OPTS.equals(propertyName)) {
                 if(domainPath != null) {
                     StringBuilder sb = new StringBuilder();
-                    sb.append("-Djava.endorsed.dirs=");
-                     sb.append(quotedString(new File(root,"lib/endorsed").getAbsolutePath()));
-                    sb.append(File.pathSeparator);
-                     sb.append(quotedString(new File(root,"modules/endorsed").getAbsolutePath()));
-                     sb.append(" -javaagent:");
+                    // The endorsed standards mechanism (-Djava.endorsed.dirs) was
+                    // removed in JDK 9 (JEP 220); passing it aborts JVM startup.
+                    // Only emit it for the endorsed directories that actually exist
+                    // (legacy servers on JDK 8 or earlier); modern GlassFish ships
+                    // none, so the option is omitted and the app client can run on
+                    // JDK 9+.
+                    StringBuilder endorsedDirs = new StringBuilder();
+                    for (String endorsedDir : new String[] {"lib/endorsed", "modules/endorsed"}) { // NOI18N
+                        File dir = new File(root, endorsedDir);
+                        if (dir.isDirectory()) {
+                            if (endorsedDirs.length() > 0) {
+                                endorsedDirs.append(File.pathSeparator);
+                            }
+                            endorsedDirs.append(quotedString(dir.getAbsolutePath()));
+                        }
+                    }
+                    if (endorsedDirs.length() > 0) {
+                        sb.append("-Djava.endorsed.dirs=").append(endorsedDirs).append(' '); // NOI18N
+                    }
+                     sb.append("-javaagent:");
                      String url = dm.getCommonServerSupport().getInstanceProperties().get(GlassfishModule.URL_ATTR);
                      File f = new File(root,"lib/gf-client.jar"); // NOI18N
                      if (f.exists()) {


### PR DESCRIPTION
### What

When running a Jakarta EE **application client** against a registered GlassFish server, the run fails immediately because the spawned JVM cannot be created:

```
-Djava.endorsed.dirs=/Applications/glassfish7/glassfish/lib/endorsed:/Applications/glassfish7/glassfish/modules/endorsed is not supported. ...
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

The deploy succeeds; only the client JVM launch fails, every time.

### Root cause

`Hk2JavaEEPlatformImpl.getToolProperty(TOOL_APP_CLIENT_RUNTIME, TOOL_PROP_JVM_OPTS)` always prepended `-Djava.endorsed.dirs=<root>/lib/endorsed:<root>/modules/endorsed` to the app-client container JVM options. This value ends up in the generated `build-impl.xml` via `j2ee.appclient.tool.jvmoptions` and is passed as a `<jvmarg>` to the `run-appclient` macro.

The endorsed-standards mechanism was **removed in JDK 9 (JEP 220)**, and HotSpot deliberately aborts at startup when `java.endorsed.dirs` is set. GlassFish 7 requires JDK 11+ and ships no `endorsed` directories at all, so the option is both invalid and pointing at non-existent paths.

### Fix

Build `-Djava.endorsed.dirs` only from the `lib/endorsed` / `modules/endorsed` directories that actually exist, and omit the option entirely when neither is present. This lets app clients run on JDK 9+ (modern GlassFish), while preserving behavior for legacy servers on JDK 8 that still ship those directories.

### Notes

- The Payara plugin (`payara.jakartaee`) carries the same forked code; left out of this PR to keep it focused on the reported GlassFish case, but it should get the same treatment in a follow-up.

Fixes #6270