### PR TITLE
Gradle "Go to source" on callstack entries in test results does not work

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/api/output/Location.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/api/output/Location.java
@@ -197,7 +197,7 @@ public final class Location {
                 ret.append(className.replace('.', '/'));
             }
             ret.append(".java");
-            return Location.parseLocation(ret.toString() + ":" + line != null ? line : methodName);
+            return Location.parseLocation(ret.toString() + ":" + (line != null ? line : methodName));
         } else {
             return null;
         }


### PR DESCRIPTION
The code always yielded the string representation of the current line as the string contenation is evaluated the the null check in the  ternary expression is checked. That is never null and thus line is returned.

What was meant here is that the first part of the string should be the "location" (classname) followed by a colon and either the line number or the method name.

Add parantheses to fix this.

Closes: #9454