### PR TITLE
Fixed more ternary concatenation bugs

### DIFF
--- a/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/share/configbean/customizers/common/TextMapping.java
+++ b/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/share/configbean/customizers/common/TextMapping.java
@@ -75,8 +75,8 @@ public class TextMapping {
     @Override
     public int hashCode() {
         int hash = 7;
-        hash = 17 * hash + this.xmlText != null ? this.xmlText.hashCode() : 0;
-        hash = 17 * hash + this.displayText != null ? this.displayText.hashCode() : 0;
+        hash = 17 * hash + (this.xmlText != null ? this.xmlText.hashCode() : 0);
+        hash = 17 * hash + (this.displayText != null ? this.displayText.hashCode() : 0);
         return hash;
     }
 

--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/optional/TomcatIncrementalDeployment.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/optional/TomcatIncrementalDeployment.java
@@ -83,7 +83,7 @@ public class TomcatIncrementalDeployment extends IncrementalDeployment {
                 return f;
             }*/
         }
-        throw new IllegalArgumentException ("ModuleType:" + module == null ? null : module.getModuleType() + " Configuration:"+configuration); //NOI18N
+        throw new IllegalArgumentException("ModuleType:" + (module == null ? null : module.getModuleType()) + " Configuration:" + configuration); //NOI18N
     }
     
     @Override

--- a/ide/css.visual/src/org/netbeans/modules/css/visual/PropertyValuesEditor.java
+++ b/ide/css.visual/src/org/netbeans/modules/css/visual/PropertyValuesEditor.java
@@ -278,7 +278,7 @@ public class PropertyValuesEditor extends PropertyEditorSupport implements ExPro
     
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "; property: " + pmodel != null ? pmodel.getName() : "?"; //NOI18N
+        return getClass().getSimpleName() + "; property: " + (pmodel != null ? pmodel.getName() : "?"); //NOI18N
     }
 
     @Override

--- a/ide/project.ant/src/org/netbeans/spi/project/support/ant/ReferenceHelper.java
+++ b/ide/project.ant/src/org/netbeans/spi/project/support/ant/ReferenceHelper.java
@@ -1918,7 +1918,7 @@ public final class ReferenceHelper {
         
         public @Override String toString() {
             return "ReferenceHelper.RawReference<" + foreignProjectName + "," + 
-                artifactType + "," + newScriptLocation != null ? newScriptLocation : scriptLocation + 
+                artifactType + "," + (newScriptLocation != null ? newScriptLocation : scriptLocation) + 
                 "," + targetName + "," + cleanTargetName + "," + artifactID + ">"; // NOI18N
         }
         

--- a/ide/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/visitor/FindUsageVisitorTest.java
+++ b/ide/xml.schema.model/test/unit/src/org/netbeans/modules/xml/schema/model/visitor/FindUsageVisitorTest.java
@@ -110,7 +110,7 @@ public class FindUsageVisitorTest extends TestCase {
 
     public int findUsageCountForItem(NamedReferenceable<SchemaComponent> ref) {
         long startTime = System.currentTimeMillis();
-        System.out.println("Finding Usage for " + ref.getName() == null? ref : ref.getName());
+        System.out.println("Finding Usage for " + (ref.getName() == null ? ref : ref.getName()));
         FindUsageVisitor usage = new FindUsageVisitor();
         Preview preview = usage.findUsages(Collections.singletonList(schema), ref);
         System.out.println(preview.getUsages().size() + " occurances found!!!");

--- a/java/java.platform/src/org/netbeans/api/java/platform/Profile.java
+++ b/java/java.platform/src/org/netbeans/api/java/platform/Profile.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.api.java.platform;
 
+import java.util.Objects;
 import org.openide.modules.SpecificationVersion;
 
 /**
@@ -25,8 +26,8 @@ import org.openide.modules.SpecificationVersion;
  */
 public class Profile {
 
-    private String name;
-    private SpecificationVersion version;
+    private final String name;
+    private final SpecificationVersion version;
 
     /**
      * Creates new Profile
@@ -55,7 +56,8 @@ public class Profile {
     }
 
 
-    public int hashCode () {
+    @Override
+    public int hashCode() {
         int hc = 0;
         if (name != null)
             hc = name.hashCode() << 16;
@@ -64,7 +66,8 @@ public class Profile {
         return hc;
     }
 
-    public boolean equals (Object other) {
+    @Override
+    public boolean equals(Object other) {
         if (other instanceof Profile) {
             Profile op = (Profile) other;
             return this.name == null ? op.name == null : this.name.equals(op.name) &&
@@ -74,10 +77,11 @@ public class Profile {
             return false;
     }
 
-    public String toString () {
+    @Override
+    public String toString() {
         String str;
         str = this.name == null ? "" : this.name;
-        str += " " + this.version == null ? "" : this.version.toString(); // NOI18N
+        str += " " + Objects.toString(this.version, ""); // NOI18N
         return str;
     }
 }

--- a/java/javadoc/src/org/netbeans/modules/javadoc/hints/Analyzer.java
+++ b/java/javadoc/src/org/netbeans/modules/javadoc/hints/Analyzer.java
@@ -657,7 +657,12 @@ final class Analyzer extends DocTreePathScanner<Void, List<ErrorDescription>> {
         final TypeElement errorEl = elements.getTypeElement("java.lang.Error");
         final TypeElement runtimeEl = elements.getTypeElement("java.lang.RuntimeException");
         if(throwableEl == null || errorEl == null || runtimeEl == null) {
-            LOG.warning("Broken java-platform, cannot resolve " + throwableEl == null? "java.lang.Throwable" : errorEl == null? "java.lang.Error" : "java.lang.RuntimeException"); //NOI18N
+            LOG.log(Level.WARNING, "Broken java-platform, cannot resolve {0}", 
+                    throwableEl == null
+                            ? "java.lang.Throwable"
+                            : errorEl == null
+                                    ? "java.lang.Error"
+                                    : "java.lang.RuntimeException");
             return null;
         }
         TypeMirror throwable = throwableEl.asType();

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/CaseDeclaration.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/CaseDeclaration.java
@@ -86,7 +86,7 @@ public class CaseDeclaration extends BodyDeclaration {
     public String toString() {
         StringBuilder sbAttributes = new StringBuilder();
         getAttributes().forEach(attribute -> sbAttributes.append(attribute).append(" ")); // NOI18N
-        return sbAttributes.toString() + "case" + name + initializer == null ? "" : " = " + initializer; // NOI18N
+        return sbAttributes.toString() + "case" + name + (initializer == null ? "" : " = " + initializer); // NOI18N
     }
 
 }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/EnumDeclaration.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/EnumDeclaration.java
@@ -104,6 +104,6 @@ public class EnumDeclaration extends TypeDeclaration {
         for (Expression expression : getInterfaces()) {
             sb.append(expression).append(","); // NOI18N
         }
-        return sbAttributes.toString() + "enum " + getName() + backingType == null ? "" : ": " + backingType + " implements " + sb + getBody(); // NOI18N
+        return sbAttributes.toString() + "enum " + getName() + (backingType == null ? "" : ": " + backingType) + " implements " + sb + getBody(); // NOI18N
     }
 }


### PR DESCRIPTION
inspired by https://github.com/apache/netbeans/pull/9459

I ran:
```java
"possible bug: ambiguous ternary concatenation":
$pre + $nullable != null ? $a : $b =>
$pre + ($nullable != null ? $a : $b)
;;

"possible bug: ambiguous ternary concatenation":
$pre + $nullable == null ? $a : $b =>
$pre + ($nullable == null ? $a : $b)
;;
```

Eval order is from left to right which can lead to undesired effects when the right side has a ternary operator.

This puts the ternary operation in braces (or avoids the situation by other means)

