### PR TITLE
Open files from imported projects on first run after update.

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectList.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectList.java
@@ -56,6 +56,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import java.util.prefs.Preferences;
 import javax.swing.Icon;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
@@ -428,13 +429,35 @@ public final class OpenProjectList {
             }
             });
             
-            INSTANCE.pchSupport.firePropertyChange(PROPERTY_OPEN_PROJECTS, new Project[0], lazilyOpenedProjects.toArray(new Project[0]));
+            Project[] opened = lazilyOpenedProjects.toArray(Project[]::new);
+            INSTANCE.pchSupport.firePropertyChange(PROPERTY_OPEN_PROJECTS, new Project[0], opened);
             Project main = INSTANCE.mainProject;
             if (main != null) { // else PROPERTY_MAIN_PROJECT would be fired spuriously
                 INSTANCE.pchSupport.firePropertyChange(PROPERTY_MAIN_PROJECT, null, main);
             }
 
+            if (checkFirstRun() && opened.length > 0) {
+                OPENING_RP.execute(() -> {
+                    for (Project p : opened) {
+                        Project del = p.getLookup().lookup(Project.class);
+                        ProjectUtilities.openProjectFiles(del == null ? p : del);
+                    }
+                });
+            }
+
             log(Level.FINER, "updateGlobalState, done, notified"); // NOI18N
+        }
+
+        private boolean checkFirstRun() {
+            Preferences prefs = OpenProjectListSettings.getInstance().getPreferences();
+            String prefKey = "projectListVersion"; // NOI18N
+            String build = System.getProperty("netbeans.buildnumber", "0"); // NOI18N
+            if (!prefs.get(prefKey, "").equals(build)) {
+                prefs.put(prefKey, build);
+                return true;
+            } else {
+                return false;
+            }
         }
 
         boolean closeBeforeOpen(final Project[] arr) {


### PR DESCRIPTION
Open files from imported projects on first run after update.  This follows on from #9449 and uses the now imported attributes to maintain the open files after updating the IDE.  This (partly) resolves #9443 - it does not reopen files that are not part of a project.

~~The code first checks whether any editors are already open, otherwise it interferes with the last focused tab on subsequent runs.  The other option would be to check for first run after update, but I'm not sure we have an easy way to do that?~~  Updated to check and store the build version in the project list preferences so that it only executes on the first run after an import.

The real project is extracted from the project lookup as the configuration cannot be read using the ergonomics wrapper project. (bug??)