### PR TITLE
Pin runner images to specific OS versions in native binary workflows.

### DIFF
--- a/.github/workflows/native-binary-build-dlight.nativeexecution.yml
+++ b/.github/workflows/native-binary-build-dlight.nativeexecution.yml
@@ -171,7 +171,7 @@ jobs:
   build-macos-x64:
 
     name: Build on MacOS x86_64
-    runs-on: macos-latest
+    runs-on: macos-14
     needs: source
 
     steps:
@@ -200,7 +200,7 @@ jobs:
   build-macos-arm:
 
     name: Build on MacOS arm64
-    runs-on: macos-latest
+    runs-on: macos-14
     needs: source
 
     steps:

--- a/.github/workflows/native-binary-build-lib.profiler.yml
+++ b/.github/workflows/native-binary-build-lib.profiler.yml
@@ -192,7 +192,7 @@ jobs:
   build-windows:
 
     name: Build on Windows
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: source
     
     steps:
@@ -261,7 +261,7 @@ jobs:
   build-macos:
 
     name: Build on MacOS
-    runs-on: macos-latest
+    runs-on: macos-14
     needs: source
 
     steps:


### PR DESCRIPTION
Pin the runner images to specific, older, OS versions for native binary workflows to address workflow failures seen in #9463