### PR TITLE
Update Reformatter to honour case wrap settings with switch expressions (GH7326).

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
@@ -3047,7 +3047,14 @@ public class Reformatter implements ReformatTask {
                 }
             }
             else if (caseBody != null) {
-                newline();
+                switch (cs.wrapCaseStatements()) {
+                    case WRAP_ALWAYS -> {
+                        newline();
+                    }
+                    default -> {
+                        spaces(1, true);
+                    }
+                }
                 scan(caseBody, p);
                 spaces(cs.spaceBeforeSemi() ? 1 : 0);
                 accept(SEMICOLON);

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/ReformatterTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/ReformatterTest.java
@@ -66,21 +66,21 @@ import org.openide.util.lookup.ServiceProvider;
  *
  * @author Dusan Balek
  */
-public class FormatingTest extends NbTestCase {
+public class ReformatterTest extends NbTestCase {
 
     File testFile = null;
     private String sourceLevel = "1.8";
     private static final List<String> EXTRA_OPTIONS = new ArrayList<>();
 
     /** Creates a new instance of FormatingTest */
-    public FormatingTest(String name) {
+    public ReformatterTest(String name) {
         super(name);
     }
 
     public static NbTestSuite suite() {
         NbTestSuite suite = new NbTestSuite();
-        suite.addTestSuite(FormatingTest.class);
-//        suite.addTest(new FormatingTest("testLabelled"));
+        suite.addTestSuite(ReformatterTest.class);
+//        suite.addTest(new ReformatterTest("testLabelled"));
         return suite;
     }
 

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/ReformatterTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/ReformatterTest.java
@@ -2891,6 +2891,74 @@ public class ReformatterTest extends NbTestCase {
         reformat(doc, content, golden);
     }
 
+    public void testSwitchCaseExprWrapping() throws Exception {
+        try {
+            SourceVersion.valueOf("RELEASE_17"); //NOI18N
+        } catch (IllegalArgumentException ex) {
+            //OK, no RELEASE_17, skip test
+            return;
+        }
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile, "");
+        FileObject testSourceFO = FileUtil.toFileObject(testFile);
+        DataObject testSourceDO = DataObject.find(testSourceFO);
+        EditorCookie ec = (EditorCookie) testSourceDO.getCookie(EditorCookie.class);
+        final Document doc = ec.openDocument();
+        doc.putProperty(Language.class, JavaTokenId.language());
+        Preferences preferences = MimeLookup.getLookup(JavaTokenId.language().mimeType()).lookup(Preferences.class);
+
+        String content
+                = """
+                package p;
+
+                public class Test {
+
+                    String choose(String str) {
+                        IntStream iso = IntStream.of(1, 2);
+                        return switch (str) {
+                            case null -> "case with null formatting";
+                            case String string when (string.length() == iso.filter(i -> i / 2 == 0).count() || string.length() == 0) ->
+                                "case with pattern matching + condition + lambda expression formatting";
+                            case String s when s.length() == 1 -> "case with pattern matching + condition formatting";
+                            case String s when s.length() == 2 -> {
+                                yield "case with pattern matching + condition formatting";
+                            }
+                            default -> "default formatting";
+                        };
+                    }
+                }
+                """;
+
+        String golden
+                = """
+                package p;
+
+                public class Test {
+
+                    String choose(String str) {
+                        IntStream iso = IntStream.of(1, 2);
+                        return switch (str) {
+                            case null ->
+                                "case with null formatting";
+                            case String string when (string.length() == iso.filter(i -> i / 2 == 0).count() || string.length() == 0) ->
+                                "case with pattern matching + condition + lambda expression formatting";
+                            case String s when s.length() == 1 ->
+                                "case with pattern matching + condition formatting";
+                            case String s when s.length() == 2 -> {
+                                yield "case with pattern matching + condition formatting";
+                            }
+                            default ->
+                                "default formatting";
+                        };
+                    }
+                }
+                """;
+        reformat(doc, content, golden);
+        preferences.put("wrapCaseStatements", CodeStyle.WrapStyle.WRAP_NEVER.name());
+        reformat(doc, content, content);
+
+    }
+
     public void testSwitchCaseNullAndDefault() throws Exception {
         try {
             SourceVersion.valueOf("RELEASE_17"); //NOI18N


### PR DESCRIPTION
Update Reformatter to only add a newline to cases in switch expressions when `wrapCaseStatements` is set to `WRAP_ALWAYS` (default).

Fixes #7326 

Alternative might be to ignore the force wrap setting when we have an `ARROW` rather than `COLON`.  I'm not sure the default works as well in those cases.