### PR TITLE
Work around unresolved sticky class GC roots

### DIFF
--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofGCRoots.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofGCRoots.java
@@ -93,7 +93,10 @@ class HprofGCRoots {
                 heap.getGCRoots();
                 roots = new HashMap<>();
                 for (GCRoot r : getGCRoots()) {
-                    roots.put(r.getInstance().getInstanceId(), r);
+                    Instance instance = r.getInstance();
+                    if (instance != null) {
+                        roots.put(instance.getInstanceId(), r);
+                    }
                 }
                 gcRoots = roots;
             } else {

--- a/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapSegmentTest.java
+++ b/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapSegmentTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import org.junit.Test;
 import org.netbeans.lib.profiler.heap.HeapUtils.HprofGenerator;
 
@@ -43,6 +44,29 @@ public class HeapSegmentTest {
     @Test
     public void singleObjectMultipleSegments() throws IOException {
         singleObject(true);
+    }
+
+    @Test
+    public void unresolvedStickyClassRootDoesNotBreakGCRootLookup() throws IOException {
+        File mydump = File.createTempFile("mydump", ".hprof");
+        try (HprofGenerator gen = new HprofGenerator(new FileOutputStream(mydump))) {
+            gen.writeHeapSegment(new HprofGenerator.Generator<HprofGenerator.HeapSegment>() {
+                @Override
+                public void generate(HprofGenerator.HeapSegment seg) throws IOException {
+                    seg.newClass("com.oracle.svm.core.heap.heapImpl.DiscoverableReference")
+                            .addField("rawReferent", Object.class)
+                            .dumpClass();
+                    HprofGenerator.ClassInstance clazz = seg.newClass("text.HelloWorld").dumpClass();
+                    seg.dumpStickyClassRoot(clazz);
+                    seg.dumpInstance(clazz);
+                }
+            }, true);
+        }
+
+        Heap heap = HeapFactory.createHeap(mydump);
+        assertEquals("One unresolved sticky class root", 1, heap.getGCRoots().size());
+        Instance instance = (Instance) heap.getJavaClassByName("text.HelloWorld").getInstances().iterator().next();
+        assertNull("Non-root instance", heap.getGCRoot(instance));
     }
 
     private static void singleObject(boolean flush) throws IOException {

--- a/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapUtils.java
+++ b/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapUtils.java
@@ -170,6 +170,11 @@ final class HeapUtils {
                 return instanceId;
             }
 
+            public void dumpStickyClassRoot(ClassInstance clazz) throws IOException {
+                heap.writeByte(0x05);
+                heap.writeInt(clazz.id);
+            }
+
             public final class ThreadBuilder {
 
                 private String groupName;


### PR DESCRIPTION
Fixes #6357.

`ROOT_STICKY_CLASS` roots can refer to class object ids that are known from `LOAD_CLASS` records but are not represented as resolvable `Instance`s by this parser. In the attached issue dump, the failing sticky-class roots are known loaded classes, but `GCRoot.getInstance()` returns `null` for them.

`LOAD_CLASS` records describe classes loaded by the VM: they provide the class object id and class name metadata. They do not by themselves provide the full heap object data that NetBeans uses to construct an `Instance`; that comes from matching heap dump records such as `CLASS_DUMP`. When a sticky-class root points at a `LOAD_CLASS` id without a matching resolvable instance entry, the parser can identify the loaded class metadata but cannot return an `Instance`, so the result is `null`.

`HprofGCRoots.getGCRoot(Long)` assumed every parsed GC root has a non-null `Instance` when building its instance lookup map. That made retained-size computation fail with a `NullPointerException` before it could finish walking nearest GC roots.

This change makes the GC-root lookup tolerate those unresolved roots. I also added a small synthetic HPROF regression that writes an unresolved sticky class root and verifies GC-root lookup handles it.

Validation performed:

- Reproduced the original NPE with the dump from issue #6357 before the fix.
- Verified the same `getBiggestObjectsByRetainedSize(15)` reproducer succeeds with the fixed profiler jar.
- Ran `HeapSegmentTest`: `OK (3 tests)`.
- Ran broader heap unit classes; only the existing `testHeapDumpLog` golden-file assertions failed due to JVM system property output differences, unrelated to this change.

Assisted-by: OpenAI GPT-5 Codex

---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

### LLMs, Commit messages and PR description:

 - Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.
 - LLM assisted commits should be attributed with an `Assisted-by: MODEL_NAME MODEL_VERSION` line appended to the commit message.
   - Please mention coding assistance in the PR description too (eg. by adding the same `Assisted-by` line from above)
   - Please describe the changes in your own words - we'd like to know you understand the changes being made!

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [ ] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [ ] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [ ] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-a-commit-with-multiple-authors-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [ ] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>
