### PR TITLE
PHP: Support variadic marked variables in PHPDoc

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/PHPDocCommentParser.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/PHPDocCommentParser.java
@@ -204,9 +204,13 @@ public class PHPDocCommentParser {
         if (types.isEmpty()) {
             List<PHPDocTypeNode> docTypes = findTypes(description, start, originalComment, originalCommentStart, type);
             if (PHP_DOC_VAR_TYPE_TAGS.contains(type)) {
-                String variable = getVaribleName(description);
+                String variable = getVariableName(description);
                 PHPDocNode varibaleNode = null;
                 if (variable != null) {
+                    // Strip variadic prefix from variable
+                    if (variable.startsWith("...")) { //NOI18N
+                        variable = variable.substring(3);
+                    }
                     int startOfVariable = findStartOfDocNode(originalComment, originalCommentStart, variable, start);
                     if (startOfVariable != -1) {
                         varibaleNode = new PHPDocNode(startOfVariable, startOfVariable + variable.length(), variable);
@@ -298,7 +302,7 @@ public class PHPDocCommentParser {
             tokens = Arrays.copyOfRange(tokens, 1, tokens.length);
         }
         ArrayList<String> types = new ArrayList<>();
-        if (tokens.length > 0 && (isReturnTag(tagType) || !tokens[0].startsWith("$"))) { //NOI18N
+        if (tokens.length > 0 && (isReturnTag(tagType) || !isVariableName(tokens[0]))) {
             if (findParameterStartPosition(tokens[0]) != -1) {
                 // e.g. @method voidReturn((X&Y)|Z $param)
                 types.add(Type.VOID);
@@ -320,16 +324,21 @@ public class PHPDocCommentParser {
         return types;
     }
 
-    private String getVaribleName(String description) {
+    private String getVariableName(String description) {
         String[] tokens = description.trim().split("[ \n\t]+"); //NOI18N
         String variable = null;
 
-        if (tokens.length > 0 && tokens[0].length() > 0 && tokens[0].charAt(0) == '$') {
+        if (tokens.length > 0 && tokens[0].length() > 0 && isVariableName(tokens[0])) {
             variable = tokens[0].trim();
-        } else if ((tokens.length > 1) && (tokens[1].charAt(0) == '$')) {
+        } else if ((tokens.length > 1) && isVariableName(tokens[1])) {
             variable = tokens[1].trim();
         }
         return variable;
+    }
+
+    public static boolean isVariableName(String token) {
+        return token.startsWith("$") /* variable */ //NOI18N
+                || token.startsWith("...$")  /* variadic variable */; //NOI18N
     }
 
     private String getMethodName(String description) {
@@ -366,7 +375,7 @@ public class PHPDocCommentParser {
             String[] tokens = parameters.split("[,]+"); //NOI18N
             String paramName;
             for (String token : tokens) {
-                paramName = getVaribleName(token.trim());
+                paramName = getVariableName(token.trim());
                 if (paramName != null) {
                     int startOfParamName = findStartOfDocNode(description, startOfDescription, paramName, position);
                     if (startOfParamName != -1) {

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/NonvarargsParam01.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/NonvarargsParam01.pass
@@ -1,0 +1,12 @@
+<PHPDocBlock start='3' end='23'>
+    <Tags>
+        <PHPDocVarTypeTag start='3' end='26' kind='param'>
+            <Variable>
+                <PHPDocNode start='20' end='26' value='$param'/>
+            </Variable>
+            <Types>
+                <PHPDocTypeNode start='13' end='19' value='string' isArray='false'/>
+            </Types>
+        </PHPDocVarTypeTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/NonvarargsParam02.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/NonvarargsParam02.pass
@@ -1,0 +1,11 @@
+<PHPDocBlock start='3' end='16'>
+    <Tags>
+        <PHPDocVarTypeTag start='3' end='19' kind='param'>
+            <Variable>
+                <PHPDocNode start='13' end='19' value='$param'/>
+            </Variable>
+            <Types>
+            </Types>
+        </PHPDocVarTypeTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/VarargsParam01.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/VarargsParam01.pass
@@ -1,0 +1,12 @@
+<PHPDocBlock start='3' end='26'>
+    <Tags>
+        <PHPDocVarTypeTag start='3' end='29' kind='param'>
+            <Variable>
+                <PHPDocNode start='23' end='29' value='$param'/>
+            </Variable>
+            <Types>
+                <PHPDocTypeNode start='13' end='19' value='string' isArray='false'/>
+            </Types>
+        </PHPDocVarTypeTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/VarargsParam02.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/VarargsParam02.pass
@@ -1,0 +1,11 @@
+<PHPDocBlock start='3' end='19'>
+    <Tags>
+        <PHPDocVarTypeTag start='3' end='22' kind='param'>
+            <Variable>
+                <PHPDocNode start='16' end='22' value='$param'/>
+            </Variable>
+            <Types>
+            </Types>
+        </PHPDocVarTypeTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest.java
@@ -430,6 +430,26 @@ public class PHPDocCommentParserTest extends PHPTestBase {
         perform(comment, "ReturnTypeObjectShapes02");
     }
 
+    public void testVarargsParam01() throws Exception {
+        String comment = " * @param string ...$param";
+        perform(comment, "VarargsParam01");
+    }
+
+    public void testVarargsParam02() throws Exception {
+        String comment = " * @param ...$param";
+        perform(comment, "VarargsParam02");
+    }
+
+    public void testNonvarargsParam01() throws Exception {
+        String comment = " * @param string $param";
+        perform(comment, "NonvarargsParam01");
+    }
+
+    public void testNonvarargsParam02() throws Exception {
+        String comment = " * @param $param";
+        perform(comment, "NonvarargsParam02");
+    }
+
     public void perform(String comment, String filename) throws Exception {
         PHPDocCommentParser parser = new PHPDocCommentParser();
         PHPDocBlock block = parser.parse(0, comment.length(), comment);


### PR DESCRIPTION
Variadic variables (...$variable) were not correctly parsed by the PHPDoc parser. The issue manifests like this:

- variadic variables in PHPDoc are not highlighted by usage marker
- renaming does not work for variadic marked variables

Closes: #9437