### PR TITLE
JSF: skip looking for managed/named beans on incompatible JSF versions

### DIFF
--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/el/JsfELVariableResolver.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/el/JsfELVariableResolver.java
@@ -25,14 +25,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
+
 import org.netbeans.api.java.source.ClasspathInfo;
 import org.netbeans.api.java.source.CompilationController;
 import org.netbeans.api.java.source.JavaSource;
@@ -56,19 +57,19 @@ import org.netbeans.modules.parsing.api.UserTask;
 import org.netbeans.modules.parsing.spi.ParseException;
 import org.netbeans.modules.parsing.spi.Parser.Result;
 import org.netbeans.modules.web.common.api.LexerUtils;
-import org.netbeans.modules.web.el.ELTypeUtilities;
 import org.netbeans.modules.web.el.spi.ELVariableResolver;
 import org.netbeans.modules.web.el.spi.ELVariableResolver.VariableInfo;
 import org.netbeans.modules.web.el.spi.ResolverContext;
 import org.netbeans.modules.web.jsf.api.editor.JSFBeanCache;
+import org.netbeans.modules.web.jsf.api.facesmodel.JsfVersionUtils;
 import org.netbeans.modules.web.jsf.api.facesmodel.ManagedBean;
 import org.netbeans.modules.web.jsf.api.metamodel.FacesManagedBean;
 import org.netbeans.modules.web.jsf.api.metamodel.ManagedProperty;
-import org.netbeans.modules.web.jsf.editor.JsfSupportImpl;
 import org.netbeans.modules.web.jsf.editor.JsfUtils;
 import org.netbeans.modules.web.jsf.editor.index.CompositeComponentModel;
 import org.netbeans.modules.web.jsf.editor.index.JsfPageModelFactory;
 import org.netbeans.modules.web.jsfapi.api.DefaultLibraryInfo;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
 import org.openide.util.Parameters;
@@ -227,8 +228,12 @@ public final class JsfELVariableResolver implements ELVariableResolver {
             List<FacesManagedBean> beans = (List<FacesManagedBean>) context.getContent(CONTENT_NAME);
             result.addAll(beans);
 
-            // issue #225844 - get beans defined via ui:param tag
-            result.addAll(getFaceletParameters(target, beans));
+            // managed beans have been removed in Faces 4.0
+            JsfVersion jsfVersion = JsfVersionUtils.forProject(project);
+            if (jsfVersion != null && !jsfVersion.isAtLeast(JsfVersion.JSF_4_0)) {
+                // issue #225844 - get beans defined via ui:param tag
+                result.addAll(getFaceletParameters(target, beans));
+            }
 
             return result;
         }

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/el/WebBeansELVariableResolver.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/el/WebBeansELVariableResolver.java
@@ -23,10 +23,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+
 import org.netbeans.modules.j2ee.metadata.model.api.MetadataModel;
-import org.netbeans.modules.j2ee.metadata.model.api.MetadataModelAction;
 import org.netbeans.modules.j2ee.metadata.model.api.MetadataModelException;
 import org.netbeans.modules.parsing.api.Snapshot;
 import org.netbeans.modules.web.beans.api.model.WebBeansModel;
@@ -98,7 +99,8 @@ public final class WebBeansELVariableResolver implements ELVariableResolver {
 
     private List<WebBean> getWebBeans(FileObject target, ResolverContext context) {
         JsfSupportImpl jsfSupport = JsfSupportImpl.findFor(target);
-        if (jsfSupport == null) {
+        // CDI support was introduced in JSF 2.2, so skip the check for 2.1 or older
+        if (jsfSupport == null || jsfSupport.getJsfVersion().isAtMost(JsfVersion.JSF_2_1)) {
             return Collections.<WebBean>emptyList();
         } else {
             if (context.getContent(CONTENT_NAME) == null) {
@@ -131,10 +133,10 @@ public final class WebBeansELVariableResolver implements ELVariableResolver {
         return Collections.emptyList();
     }
 
-     private static final class WebBean {
+    private static final class WebBean {
 
-        private Element element;
-        private String name;
+        private final Element element;
+        private final String name;
 
         private WebBean(Element element, String name) {
             this.element = element;
@@ -146,8 +148,7 @@ public final class WebBeansELVariableResolver implements ELVariableResolver {
         }
 
         public String getBeanClassName() {
-            if (getElement() instanceof ExecutableElement) {
-                ExecutableElement methodElement = (ExecutableElement) getElement();
+            if (getElement() instanceof ExecutableElement methodElement) {
                 String returnType = methodElement.getReturnType().toString();
                 int genericOffset = returnType.indexOf('<');
                 return genericOffset == -1 ? returnType : returnType.substring(0, genericOffset);
@@ -161,8 +162,7 @@ public final class WebBeansELVariableResolver implements ELVariableResolver {
         }
 
         private String getEnclodingClass() {
-            if (getElement() instanceof ExecutableElement) {
-                ExecutableElement methodElement = (ExecutableElement) getElement();
+            if (getElement() instanceof ExecutableElement methodElement) {
                 return methodElement.getEnclosingElement().asType().toString();
             } else {
                 return getElement().asType().toString();

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/editor/JSFBeanCache.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/editor/JSFBeanCache.java
@@ -24,14 +24,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.netbeans.api.project.Project;
 
+import org.netbeans.api.project.Project;
 import org.netbeans.modules.j2ee.metadata.model.api.MetadataModel;
-import org.netbeans.modules.j2ee.metadata.model.api.MetadataModelAction;
-import org.netbeans.modules.j2ee.metadata.model.api.MetadataModelException;
 import org.netbeans.modules.web.jsf.JSFUtils;
+import org.netbeans.modules.web.jsf.api.facesmodel.JsfVersionUtils;
 import org.netbeans.modules.web.jsf.api.metamodel.FacesManagedBean;
 import org.netbeans.modules.web.jsf.api.metamodel.JsfModel;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.openide.util.Lookup;
 
 /**
@@ -42,7 +42,7 @@ import org.openide.util.Lookup;
  * @author ads
  */
 public class JSFBeanCache {
-    
+
     public static List<FacesManagedBean> getBeans(Project project) {
         //unit testing, tests can provider a fake beans provider >>>
         JsfBeansProvider beansProvider = Lookup.getDefault().lookup(JsfBeansProvider.class);
@@ -51,34 +51,34 @@ public class JSFBeanCache {
         }
         //<<<
 
-        final List<FacesManagedBean> beans = new ArrayList<FacesManagedBean>();
+        final List<FacesManagedBean> beans = new ArrayList<>();
+
+        // managed beans have been removed in Faces 4.0
+        JsfVersion jsfVersion = JsfVersionUtils.forProject(project);
+        if (jsfVersion != null && jsfVersion.isAtLeast(JsfVersion.JSF_4_0)) {
+            return beans;
+        }
+
         MetadataModel<JsfModel> model = JSFUtils.getModel(project);
         if ( model == null){
             return beans;
         }
         try {
-            model.runReadAction( new MetadataModelAction<JsfModel, Void>() {
-
-                public Void run( JsfModel model ) throws Exception {
-                    List<FacesManagedBean> managedBeans = model.getElements( 
-                            FacesManagedBean.class);
-                    beans.addAll( managedBeans );
-                    return null;
-                }
+            model.runReadAction(jsfModel -> {
+                List<FacesManagedBean> managedBeans = jsfModel.getElements(
+                        FacesManagedBean.class);
+                beans.addAll( managedBeans );
+                return null;
             });
-        }
-        catch (MetadataModelException e) {
-            LOG.log( Level.WARNING , e.getMessage(), e );
         }
         catch (IOException e) {
             LOG.log( Level.WARNING , e.getMessage(), e );
         }
         return beans;
     }
-    
+
     private static final Logger LOG = Logger.getLogger( 
             JSFBeanCache.class.getCanonicalName() );
-
 
     //for unit tests>>>
     public static interface JsfBeansProvider {
@@ -87,5 +87,5 @@ public class JSFBeanCache {
 
     }
     //<<<
-    
+
 }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/editor/JSFBeanCache.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/editor/JSFBeanCache.java
@@ -24,14 +24,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.netbeans.api.project.Project;
 
+import org.netbeans.api.project.Project;
 import org.netbeans.modules.j2ee.metadata.model.api.MetadataModel;
-import org.netbeans.modules.j2ee.metadata.model.api.MetadataModelAction;
-import org.netbeans.modules.j2ee.metadata.model.api.MetadataModelException;
 import org.netbeans.modules.web.jsf.JSFUtils;
+import org.netbeans.modules.web.jsf.api.facesmodel.JsfVersionUtils;
 import org.netbeans.modules.web.jsf.api.metamodel.FacesManagedBean;
 import org.netbeans.modules.web.jsf.api.metamodel.JsfModel;
+import org.netbeans.modules.web.jsfapi.api.JsfVersion;
 import org.openide.util.Lookup;
 
 /**
@@ -42,7 +42,7 @@ import org.openide.util.Lookup;
  * @author ads
  */
 public class JSFBeanCache {
-    
+
     public static List<FacesManagedBean> getBeans(Project project) {
         //unit testing, tests can provider a fake beans provider >>>
         JsfBeansProvider beansProvider = Lookup.getDefault().lookup(JsfBeansProvider.class);
@@ -51,34 +51,34 @@ public class JSFBeanCache {
         }
         //<<<
 
-        final List<FacesManagedBean> beans = new ArrayList<FacesManagedBean>();
+        final List<FacesManagedBean> beans = new ArrayList<>();
+
+        // managed beans have been removed in Faces 4.0
+        JsfVersion jsfVersion = JsfVersionUtils.forProject(project);
+        if (jsfVersion == null || jsfVersion.isAtLeast(JsfVersion.JSF_4_0)) {
+            return beans;
+        }
+
         MetadataModel<JsfModel> model = JSFUtils.getModel(project);
         if ( model == null){
             return beans;
         }
         try {
-            model.runReadAction( new MetadataModelAction<JsfModel, Void>() {
-
-                public Void run( JsfModel model ) throws Exception {
-                    List<FacesManagedBean> managedBeans = model.getElements( 
-                            FacesManagedBean.class);
-                    beans.addAll( managedBeans );
-                    return null;
-                }
+            model.runReadAction(jsfModel -> {
+                List<FacesManagedBean> managedBeans = jsfModel.getElements(
+                        FacesManagedBean.class);
+                beans.addAll( managedBeans );
+                return null;
             });
-        }
-        catch (MetadataModelException e) {
-            LOG.log( Level.WARNING , e.getMessage(), e );
         }
         catch (IOException e) {
             LOG.log( Level.WARNING , e.getMessage(), e );
         }
         return beans;
     }
-    
+
     private static final Logger LOG = Logger.getLogger( 
             JSFBeanCache.class.getCanonicalName() );
-
 
     //for unit tests>>>
     public static interface JsfBeansProvider {
@@ -87,5 +87,5 @@ public class JSFBeanCache {
 
     }
     //<<<
-    
+
 }


### PR DESCRIPTION
- do not search CDI Named beans on JSF 2.1- (CDI support was introduced in 2.2)
- do not search managed beans on Faces 4.0 or upper since support was removed

small code refactors/modernization