### PR TITLE
Fix unresolved sticky class GC roots

### DIFF
--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofGCRoots.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofGCRoots.java
@@ -39,16 +39,16 @@ class HprofGCRoots {
     private final Object lastThreadObjGCLock = new Object();
     private Map<Long,GCRoot> gcRoots;
     private final Object gcRootLock = new Object();
-    private List gcRootsList;
+    private List<HprofGCRoot> gcRootsList;
 
     HprofGCRoots(HprofHeap h) {
         heap = h;
     }
 
-    Collection<GCRoot> getGCRoots() {
+    Collection<HprofGCRoot> getGCRoots() {
         synchronized (gcRootLock) {
             if (gcRoots == null) {
-                List<GCRoot> rootList = new ArrayList<>();
+                List<HprofGCRoot> rootList = new ArrayList<>();
                 computeGCRootsFor(heap.getHeapTagBound(HprofHeap.ROOT_UNKNOWN), rootList);
                 computeGCRootsFor(heap.getHeapTagBound(HprofHeap.ROOT_JNI_GLOBAL), rootList);
                 computeGCRootsFor(heap.getHeapTagBound(HprofHeap.ROOT_JNI_LOCAL), rootList);
@@ -67,10 +67,8 @@ class HprofGCRoots {
                 computeGCRootsFor(heap.getHeapTagBound(HprofHeap.ROOT_VM_INTERNAL), rootList);
                 computeGCRootsFor(heap.getHeapTagBound(HprofHeap.ROOT_JNI_MONITOR), rootList);
 
-                rootList.sort(new Comparator() {
-                    public int compare(Object o1, Object o2) {
-                        HprofGCRoot r1 = (HprofGCRoot) o1;
-                        HprofGCRoot r2 = (HprofGCRoot) o2;
+                rootList.sort(new Comparator<HprofGCRoot>() {
+                    public int compare(HprofGCRoot r1, HprofGCRoot r2) {
                         int kind = r1.getKind().compareTo(r2.getKind());
 
                         if (kind != 0) {
@@ -92,8 +90,10 @@ class HprofGCRoots {
             if (gcRoots == null) {
                 heap.getGCRoots();
                 roots = new HashMap<>();
-                for (GCRoot r : getGCRoots()) {
-                    roots.put(r.getInstance().getInstanceId(), r);
+                for (HprofGCRoot root : getGCRoots()) {
+                    // A GC root is identified by its HPROF ID. Some valid root
+                    // records do not have a corresponding heap Instance.
+                    roots.put(root.getInstanceId(), root);
                 }
                 gcRoots = roots;
             } else {
@@ -126,7 +126,7 @@ class HprofGCRoots {
         return map.get(threadSerialNumber);
     }
 
-    private void computeGCRootsFor(TagBounds tagBounds, Collection<GCRoot> roots) {
+    private void computeGCRootsFor(TagBounds tagBounds, Collection<HprofGCRoot> roots) {
         if (tagBounds != null) {
             int rootTag = tagBounds.tag;
             long[] offset = new long[]{tagBounds.startOffset};

--- a/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapSegmentTest.java
+++ b/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapSegmentTest.java
@@ -31,6 +31,8 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.netbeans.lib.profiler.heap.HeapUtils.HprofGenerator;
 
@@ -43,6 +45,67 @@ public class HeapSegmentTest {
     @Test
     public void singleObjectMultipleSegments() throws IOException {
         singleObject(true);
+    }
+
+    @Test
+    public void stickyClassRootKeepsStaticReferencesReachable() throws IOException {
+        File mydump = File.createTempFile("mydump", ".hprof");
+        final int[] targetId = new int[1];
+        try (HprofGenerator gen = new HprofGenerator(new FileOutputStream(mydump))) {
+            gen.writeHeapSegment(new HprofGenerator.Generator<HprofGenerator.HeapSegment>() {
+                @Override
+                public void generate(HprofGenerator.HeapSegment seg) throws IOException {
+                    seg.newClass("java.lang.Class").dumpClass();
+                    seg.newClass("com.oracle.svm.core.heap.heapImpl.DiscoverableReference")
+                            .addField("rawReferent", Object.class)
+                            .dumpClass();
+                    HprofGenerator.ClassInstance targetClass = seg.newClass("text.Target").dumpClass();
+                    targetId[0] = seg.dumpInstance(targetClass);
+                    HprofGenerator.ClassInstance rootClass = seg.newClass("text.Root")
+                            .addStaticObjectField("target", targetId[0])
+                            .dumpClass();
+                    seg.dumpStickyClassRoot(rootClass);
+                }
+            }, true);
+        }
+
+        Heap heap = HeapFactory.createHeap(mydump);
+        assertEquals("One sticky class root", 1, heap.getGCRoots().size());
+        GCRoot root = (GCRoot) heap.getGCRoots().iterator().next();
+        Instance rootInstance = root.getInstance();
+        assertTrue("Class object instance", rootInstance instanceof ClassDumpInstance);
+        assertEquals("Root found by class object ID", root, heap.getGCRoot(rootInstance));
+
+        Instance target = heap.getInstanceByID(targetId[0]);
+        assertNotNull("Static field target", target);
+        heap.getBiggestObjectsByRetainedSize(1);
+        assertEquals("Target reached from sticky class", rootInstance, target.getNearestGCRootPointer());
+        assertTrue("Sticky class retains its static target", rootInstance.getRetainedSize() > rootInstance.getSize());
+    }
+
+    @Test
+    public void unresolvedStickyClassRootDoesNotBreakRetainedSize() throws IOException {
+        File mydump = File.createTempFile("mydump", ".hprof");
+        try (HprofGenerator gen = new HprofGenerator(new FileOutputStream(mydump))) {
+            gen.writeHeapSegment(new HprofGenerator.Generator<HprofGenerator.HeapSegment>() {
+                @Override
+                public void generate(HprofGenerator.HeapSegment seg) throws IOException {
+                    seg.newClass("java.lang.Class").dumpClass();
+                    seg.newClass("com.oracle.svm.core.heap.heapImpl.DiscoverableReference")
+                            .addField("rawReferent", Object.class)
+                            .dumpClass();
+                    HprofGenerator.ClassInstance ordinaryClass = seg.newClass("text.Ordinary").dumpClass();
+                    seg.dumpInstance(ordinaryClass);
+                    seg.dumpStickyClassRoot(Integer.MAX_VALUE);
+                }
+            }, true);
+        }
+
+        Heap heap = HeapFactory.createHeap(mydump);
+        assertEquals("One unresolved sticky class root", 1, heap.getGCRoots().size());
+        GCRoot root = (GCRoot) heap.getGCRoots().iterator().next();
+        assertNull("No heap object for unresolved root", root.getInstance());
+        assertNotNull("Retained-size computation completes", heap.getBiggestObjectsByRetainedSize(1));
     }
 
     private static void singleObject(boolean flush) throws IOException {

--- a/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapUtils.java
+++ b/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapUtils.java
@@ -170,6 +170,15 @@ final class HeapUtils {
                 return instanceId;
             }
 
+            public void dumpStickyClassRoot(ClassInstance clazz) throws IOException {
+                dumpStickyClassRoot(clazz.id);
+            }
+
+            public void dumpStickyClassRoot(int classId) throws IOException {
+                heap.writeByte(0x05);
+                heap.writeInt(classId);
+            }
+
             public final class ThreadBuilder {
 
                 private String groupName;
@@ -235,6 +244,7 @@ final class HeapUtils {
 
                 private final int classId;
                 private TreeMap<String, Class<?>> fieldNamesAndTypes = new TreeMap<>();
+                private TreeMap<String, Integer> staticObjectFields = new TreeMap<>();
 
                 private ClassBuilder(int id) {
                     this.classId = id;
@@ -242,6 +252,11 @@ final class HeapUtils {
 
                 public ClassBuilder addField(String name, Class<?> type) {
                     fieldNamesAndTypes.put(name, type);
+                    return this;
+                }
+
+                public ClassBuilder addStaticObjectField(String name, int instanceId) {
+                    staticObjectFields.put(name, instanceId);
                     return this;
                 }
 
@@ -257,7 +272,12 @@ final class HeapUtils {
                     heap.writeInt(0); // reserved 2
                     heap.writeInt(0); // instance size
                     heap.writeShort(0); // # of constant pool entries
-                    heap.writeShort(0); // # of static fields
+                    heap.writeShort(staticObjectFields.size()); // # of static fields
+                    for (Map.Entry<String, Integer> entry : staticObjectFields.entrySet()) {
+                        heap.writeInt(writeString(entry.getKey()));
+                        heap.writeByte(0x02); // object
+                        heap.writeInt(entry.getValue());
+                    }
                     heap.writeShort(fieldNamesAndTypes.size()); // # of instance fields
                     int fieldBytes = 0;
                     for (Map.Entry<String, Class<?>> entry : fieldNamesAndTypes.entrySet()) {
@@ -299,6 +319,7 @@ final class HeapUtils {
                     }
                     ClassInstance inst = new ClassInstance(classId, fieldNamesAndTypes, fieldBytes);
                     fieldNamesAndTypes = new TreeMap<>();
+                    staticObjectFields = new TreeMap<>();
                     return inst;
                 }
             }


### PR DESCRIPTION
Fixes #6357.

`ROOT_STICKY_CLASS` records contain the HPROF object ID of the class object they keep alive. NetBeans already indexes `CLASS_DUMP` IDs in the heap object map and represents them as `ClassDumpInstance`s, so resolvable sticky-class roots can participate in nearest-GC-root and retained-size traversal, including references held in static fields.

The remaining problem was in `HprofGCRoots.getGCRoot(Long)`. When building its object-ID-to-root lookup, it unnecessarily resolved every root through `GCRoot.getInstance()` and then recovered the ID from the returned `Instance`. Some valid root records in the issue dump refer to loaded-class IDs for which the dump contains no corresponding resolvable heap object. `getInstance()` therefore returns `null`, and dereferencing it caused the reported `NullPointerException`.

This change builds the lookup directly from the target object ID stored in each HPROF GC-root record. Resolvable class-object roots continue to be seeded into reachability through the existing `idToOffsetMap`, so objects reachable only through their static fields remain reachable. Unresolved root records remain available from `getGCRoots()`, but no synthetic object or references are invented when the dump has no matching heap record.

The internal root collection is now typed as `HprofGCRoot`, making the raw target-ID invariant compile-time checked rather than relying on a runtime cast. No public API signatures change.

The synthetic HPROF test support now writes static object fields and either resolved or unresolved sticky-class root IDs. Regression coverage verifies both that:

- a sticky class resolves to a `ClassDumpInstance`, is found by GC-root lookup, and retains an object referenced only by a static field;
- an unresolved sticky-class root remains recorded and retained-size computation completes without an exception.

Validation performed:

- Reproduced the original failure path with the dump from issue #6357.
- Verified the issue dump contains 3,166 sticky-class roots: 2,882 resolve to heap class objects and 284 have no corresponding heap object.
- Verified `getBiggestObjectsByRetainedSize(15)` completes successfully on the issue dump.
- Ran `HeapSegmentTest`: 4 tests passed.
- Ran the complete `profiler/lib.profiler` unit suite with the module access required by its legacy CPU tests: 70 tests ran, 68 passed, and 2 failed.
- The two remaining failures are the existing `testHeapDumpLog` golden-file comparisons in `HeapTest` and `HeapFromBufferTest`; they contain the same JVM system properties in a different iteration order on this JDK and are unrelated to the GC-root change.

Assisted-by: OpenAI GPT-5 Codex
