### PR TITLE
Fix search preview editor mime type on JDK 27

### DIFF
--- a/ide/editor/src/org/netbeans/modules/editor/EditorModule.java
+++ b/ide/editor/src/org/netbeans/modules/editor/EditorModule.java
@@ -250,6 +250,8 @@ public class EditorModule extends ModuleInstall {
         if (topComponentRegistryListener != null) {
             TopComponent.getRegistry().removePropertyChangeListener(topComponentRegistryListener);
         }
+        
+        // TODO AppContext and kitRegistryKey don't exist anymore in JDK 27+
 
         // unregister our registry
         try {

--- a/platform/api.search/src/org/netbeans/modules/search/ContextView.java
+++ b/platform/api.search/src/org/netbeans/modules/search/ContextView.java
@@ -25,7 +25,6 @@ import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.Rectangle;
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import static java.lang.Thread.NORM_PRIORITY;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -53,6 +52,7 @@ import org.openide.NotifyDescriptor;
 import org.openide.explorer.ExplorerManager;
 import org.openide.filesystems.FileObject;
 import org.openide.nodes.Node;
+import org.openide.text.CloneableEditorSupport;
 import org.openide.text.NbDocument;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
@@ -450,8 +450,8 @@ public final class ContextView extends JPanel {
              * (in this case, MIME-type only) must be set _before_ the text
              * is set.
              */
-            if ((editorMimeType == null) || !editorMimeType.equals(mimeType)) {
-                editorPane.setContentType(mimeType);
+            if (editorMimeType == null || !editorMimeType.equals(mimeType)) {
+                editorPane.setEditorKit(CloneableEditorSupport.getEditorKit(mimeType));
                 editorMimeType = mimeType;
             }
             editorPane.setText(text);
@@ -488,12 +488,8 @@ public final class ContextView extends JPanel {
                 
                 if (location != null) {
                     final Document document = editorPane.getDocument();
-                    if (document instanceof StyledDocument) {
-                        StyledDocument styledDocument
-                                = (StyledDocument) document;
-                        int cursorOffset = getCursorOffset(
-                                                    (StyledDocument) document,
-                                                    location.getLine() - 1);
+                    if (document instanceof StyledDocument sd) {
+                        int cursorOffset = getCursorOffset(sd, location.getLine() - 1);
                         int startOff = cursorOffset + location.getColumn() - 1;
                         int endOff = startOff + location.getMarkLength();
                         editorPane.setSelectionStart(startOff);


### PR DESCRIPTION
mime types can't be set by String atm since the mime type injection hack doesn't work anymore. Set it by editor kit, similar other code does it (previews in bookmarks view, refactoring view. diffs etc - they all still work on JDK 27).

repro: use right click search and/or replace and look at preview, the editor should not be plain text

edit: this is for delivery, we can cleanup AppContext usages for NB 32 https://github.com/apache/netbeans/issues/9523