### PR TITLE
Reduce log level for PersistenceManager deserialization problems to INFO

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/persistence/PersistenceManager.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/persistence/PersistenceManager.java
@@ -598,7 +598,7 @@ public final class PersistenceManager implements PropertyChangeListener {
     private final Set<String> warnedIDs = Collections.synchronizedSet(new HashSet<>());
     /** Avoid printing dozens of warnings about the same ID in one IDE session. */
     private Level warningLevelForDeserTC(String id) {
-        return warnedIDs.add(id) ? Level.WARNING : Level.FINE;
+        return warnedIDs.add(id) ? Level.INFO : Level.FINE;
     }
     
     /** @return Searches for TopComponent with given string id and returns


### PR DESCRIPTION
As part of 892e14c11c2b3c753030c667883d75a0cc574224 the default detail level of the logging of PersistenceManager problems was reduced and is only retained if FINE lgging is enabled. On the other hand the log level for the shorted message was raised to WARNING from INFO.

This causes the problem to become visible to the end user. Logs with level WARNING and an attached exception cause a visible notification via the chain:

`NbErrorManager` -> `NotifyExcPanel#notify` -> `NotifyExcPanel#shallNotify`

This in turn even shows the detailed message because the content of the serialization problem is attached to the exception via

`Exceptions.attachLocalizedMessage`

in `XMLSettingsSupport`.

Closes: #9524