### PR TITLE
When running javac for a tagged CompilationController, do not set partial reparse positions.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CompilationInfoImpl.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CompilationInfoImpl.java
@@ -518,6 +518,10 @@ public final class CompilationInfoImpl {
         userCache.remove(CacheClearPolicy.ON_TASK_END);
         userCache.remove(CacheClearPolicy.ON_CHANGE);
     }
+
+    boolean isDetached() {
+        return isDetached;
+    }
     
     /**
      * Sets the {@link CompilationUnitTree}

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
@@ -423,7 +423,7 @@ public class JavacParser extends Parser {
                     boolean needsFullReparse = true;
                     if (supportsReparse) {
                         final Pair<DocPositionRegion,MethodTree> _changedMethod = changedMethod.getAndSet(null);
-                        if (_changedMethod != null && ciImpl != null) {
+                        if (_changedMethod != null && ciImpl != null && !ciImpl.isDetached()) {
                             LOGGER.log(Level.FINE, "\t:trying partial reparse:\n{0}", _changedMethod.first().getText());                           //NOI18N
                             PartialReparser reparser = Lookup.getDefault().lookup(PartialReparser.class);
                             needsFullReparse = !reparser.reparseMethod(ciImpl, snapshot, _changedMethod.second(), _changedMethod.first().getText());
@@ -683,7 +683,7 @@ public class JavacParser extends Parser {
                 currentInfo.setCompilationUnit(unit);
 
                 final Document doc = currentInfo.getDocument();
-                if (doc != null && supportsReparse) {
+                if (doc != null && supportsReparse && !currentInfo.isDetached()) {
                     final FindMethodRegionsVisitor v = new FindMethodRegionsVisitor(doc,Trees.instance(currentInfo.getJavacTask()).getSourcePositions(),this.parserCanceled, unit);
                     doc.render(v);
                     synchronized (positions) {

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PartialReparseTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PartialReparseTest.java
@@ -24,6 +24,7 @@ import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.TreePath;
 import com.sun.source.util.TreePathScanner;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.ArrayList;
@@ -52,12 +53,15 @@ import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.java.source.TestUtil;
 import org.openide.util.SharedClassObject;
 import org.netbeans.api.editor.mimelookup.test.MockMimeLookup;
+import org.netbeans.api.java.source.CompilationController;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.java.source.ElementHandle;
 import org.netbeans.api.java.source.SourceUtils;
+import org.netbeans.modules.java.preprocessorbridge.api.JavaSourceUtil;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.cookies.EditorCookie;
+import org.openide.util.Exceptions;
 
 /**
  *
@@ -380,12 +384,38 @@ public class PartialReparseTest extends NbTestCase {
                   info -> {});
     }
 
+    public void testTaggedControllerDoesNotBreakPartialReparse() throws Exception {
+        doRunTest("""
+                  package test;
+                  public class Test {
+                      void t() {
+                          java.util.List.of("a").stream().^^
+                      }
+                  }
+                  """,
+                  "filter(predicate)",
+                  info -> {},
+                  file -> {
+                      try {
+                          CompilationController cc = (CompilationController)
+                              JavaSourceUtil.createControllerHandle(file, 0, null)
+                                            .getCompilationController();
+                          cc.toPhase(Phase.RESOLVED);
+                      } catch (IOException ex) {
+                          throw new AssertionError(ex.getMessage(), ex);
+                      }
+                  });
+    }
+
     private void doRunTest(String code, String inject) throws Exception {
         doRunTest(code, inject, info -> {});
     }
 
     private void doRunTest(String code, String inject, Consumer<CompilationInfo> callback) throws Exception {
+        doRunTest(code, inject, callback, file -> {});
+    }
 
+    private void doRunTest(String code, String inject, Consumer<CompilationInfo> callback, Consumer<FileObject> runBeforeModification) throws Exception {
         FileObject srcDir = FileUtil.createFolder(getWorkDir());
         FileObject src = srcDir.createFolder("test").createData("Test.java");
 
@@ -404,6 +434,8 @@ public class PartialReparseTest extends NbTestCase {
             topLevel[0] = cc.getCompilationUnit();
             callback.accept(cc);
         }, true);
+
+        runBeforeModification.accept(src);
 
         // replace snippet and run again
         replaceSourceSnippetInDoc(doc, code, inject);


### PR DESCRIPTION
Manual testcase thanks for @mbien:

> paste and save file:
java.util.List.of("").stream().
now use auto completion to add filter method:
java.util.List.of("").stream().filter(predicate)
hit completion again and it won't suggest to insert a predicate, unless you ctrl+s first (followed by ESC to get rid of the completion popup), after that completion works again for predicate.


The reason for this behavior is an interaction between code templates and partial reparse. It is unclear why this is happening (more visibly?) now, may have some relation to end positions being stored on trees, which makes the model a little bit less forgiving w.r.t. end position updates.

The problem is this:
- the code is parsed normally (OK)
- when the `filter` CC item is confirmed, it inserts a code template. The code template will create a temporary copy of javac/AST/a tagged compilation controller. Note the other features will still be using the "old", shared, instance of javac/ASTs. This by itself is OK, but this will set a shared `positions` inside `JavacParser` to values from the temporary javac/AST, replacing the correct ones
- then the document changes. The new (broken) `positions` are used to find which method was modified - i.e. the modified method that will be found is from the temporary controller, not from the shared one. And this method will be updated. But code templates won't use it anymore, and every other feature will use the stale AST, until a full reparse is forced in one way or another.

The proposal here is to not set and use `JavacParser.positions` when parsing from the temporary controllers.

An alternative would be to keep the partial reparse state inside `CompilationInfoImpl` itself, although I am not convinced at this point that it is better.

---
**^Add meaningful description above**

<details open>
<summary>Click to collapse/expand PR instructions</summary>

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

### LLMs, Commit messages and PR description:

 - Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.
 - LLM assisted commits should be attributed with an `Assisted-by: MODEL_NAME MODEL_VERSION` line appended to the commit message.
   - Please mention coding assistance in the PR description too (eg. by adding the same `Assisted-by` line from above)
   - Please describe the changes in your own words - we'd like to know you understand the changes being made!

If you're a first time contributor, see the Contributing guidelines for more information.

If you're a committer, please label the PR before pressing "Create pull request" so that the right test jobs can run.

### PR approval and merge checklist:

1. [x] Was this PR [correctly labeled](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=240884239#PRsandYouAreviewerGuide-PRtriggeredCIJobs(conditionalCIpipeline)), did the right tests run? When did they run?
2. [x] Is this PR [squashed](https://cwiki.apache.org/confluence/display/NETBEANS/git%3A+squash+and+merge)?
3. [x] Are author name / email address correct? Are [co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line) correctly listed? Do the commit messages need updates?
3. [x] Does the PR title and description still fit after the Nth iteration? Is the description sufficient to appear in the release notes?

If this PR targets the delivery branch: [don't merge](https://cwiki.apache.org/confluence/display/NETBEANS/Pull+requests+for+delivery). ([full wiki article](https://cwiki.apache.org/confluence/display/NETBEANS/PRs+and+You+-+A+reviewer+Guide))

</details>