### PR TITLE
Fix Save Value to File for large debugger strings (#9452)

### DIFF
--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ShortenedStrings.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ShortenedStrings.java
@@ -43,6 +43,7 @@ import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.text.MessageFormat;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +74,7 @@ import org.openide.util.Exceptions;
  */
 public final class ShortenedStrings {
     
-    private static final Map<String, StringInfo> infoStrings = new WeakHashMap<String, StringInfo>();
+    private static final Map<String, StringInfo> infoStrings = new HashMap<String, StringInfo>();
     private static final Map<StringReference, StringValueInfo> stringsCache = new WeakHashMap<StringReference, StringValueInfo>();
     private static final Set<StringReference> retrievingStrings = new HashSet<StringReference>();
     private static final Map<VirtualMachine, Boolean> isLittleEndianCache =
@@ -85,7 +86,6 @@ public final class ShortenedStrings {
 
             @Override
             public void sessionRemoved(Session session) {
-                // Clean up. WeakHashMap does not clean up if not touched. :-(
                 int n = DebuggerManager.getDebuggerManager().getSessions().length;
                 if (n == 0) {
                     synchronized (infoStrings) {
@@ -107,8 +107,19 @@ public final class ShortenedStrings {
     private ShortenedStrings() {}
     
     public static StringInfo getShortenedInfo(String s) {
+        if (s == null) {
+            return null;
+        }
         synchronized (infoStrings) {
-            return infoStrings.get(s);
+            StringInfo info = infoStrings.get(s);
+            if (info != null) {
+                return info;
+            }
+            // Variable.getValue() wraps Strings in quotes: "content..."
+            if (s.length() >= 2 && s.charAt(0) == '"' && s.charAt(s.length() - 1) == '"') {
+                return infoStrings.get(s.substring(1, s.length() - 1));
+            }
+            return null;
         }
     }
 

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ShortenedStrings.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ShortenedStrings.java
@@ -74,6 +74,17 @@ import org.openide.util.Exceptions;
  */
 public final class ShortenedStrings {
     
+    /**
+     * Shortened display text → full remote content helper.
+     * <p>
+     * Must be a strong map for the duration of a debugger session. A
+     * {@link WeakHashMap} drops the entry as soon as nothing holds the exact
+     * key {@link String} instance. The UI / property editor often holds an
+     * equal but different instance (or a quoted form from
+     * {@code Variable.getValue()}), so lookup fails while the truncated
+     * preview is still shown and "Save Value to File" only writes that
+     * preview. Cleared when the last debugger session ends.
+     */
     private static final Map<String, StringInfo> infoStrings = new HashMap<String, StringInfo>();
     private static final Map<StringReference, StringValueInfo> stringsCache = new WeakHashMap<StringReference, StringValueInfo>();
     private static final Set<StringReference> retrievingStrings = new HashSet<StringReference>();
@@ -86,6 +97,7 @@ public final class ShortenedStrings {
 
             @Override
             public void sessionRemoved(Session session) {
+                // Strong infoStrings map is session-scoped; clear when idle.
                 int n = DebuggerManager.getDebuggerManager().getSessions().length;
                 if (n == 0) {
                     synchronized (infoStrings) {


### PR DESCRIPTION
## Summary
- Keep shortened-string metadata in a strong `HashMap` so `getShortenedInfo()` still resolves after GC (previously a `WeakHashMap` could drop the entry while the truncated `...` display value was still shown).
- Also resolve quoted `Variable.getValue()` forms (`"content..."`) when looking up shortened info.
- Fixes **Save Value to File** writing only the first 100k characters plus `...` instead of streaming the full remote string via `StringInfo.getContent()`.

Fixes #9452

## Test plan
- [ ] Debug an app with a `String` larger than 100_000 characters
- [ ] Open the variable custom editor (`...`) and choose **Save Value to File**
- [ ] Confirm the saved file length matches the full string (no trailing truncation ellipsis)

Standalone verification of the lookup failure mode:
- With `WeakHashMap`, after GC of the map key, lookup of an equal display string returns null → save would write the truncated preview
- With `HashMap`, lookup still succeeds → save can use `getContent()`