### PR TITLE
PHP: Fix formatting of enums with names that are keywords (unset, if,case, ...) 

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
@@ -1230,7 +1230,11 @@ public class FormatVisitor extends DefaultVisitor {
             }
         }
         scan(node.getAttributes());
-        while (ts.moveNext() && ts.token().id() != PHPTokenId.PHP_STRING) {
+        // Scan through everything until the identifier for the case is reached.
+        // The token id can't be used as the identifier may not be a plain string
+        // but could be a keyword in other contexts (unset being one example).
+        int identifierStart = node.getName().getStartOffset();
+        while (ts.moveNext() && ts.offset() < identifierStart) {
             addFormatToken(formatTokens);
         }
         FormatToken lastWhitespace = formatTokens.remove(formatTokens.size() - 1);

--- a/php/php.editor/test/unit/data/testfiles/formatting/php81/enumerations_02.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/php81/enumerations_02.php
@@ -1,0 +1,38 @@
+Some text to ensure the PHP start offset
+
+does not
+
+match the start of the original text
+
+<?php
+enum Type {
+    case NORMAL_LABEL;
+	case UNSET;
+      case enum;
+               case case;
+           case class;
+        case if;
+}
+?>
+
+Some more filler text
+
+<?php
+
+enum Type2 {
+    case NORMAL_LABEL;
+	case UNSET;
+      case enum;
+      #[AAA]
+               case case;
+           case class;
+        case if;
+
+ public function test(int $test): void {
+}
+
+public static function staticTest(Foo&Bar $param): void {
+}
+}
+
+?>

--- a/php/php.editor/test/unit/data/testfiles/formatting/php81/enumerations_02.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/php81/enumerations_02.php.formatted
@@ -1,0 +1,43 @@
+Some text to ensure the PHP start offset
+
+does not
+
+match the start of the original text
+
+<?php
+
+enum Type {
+
+    case NORMAL_LABEL;
+    case UNSET;
+    case enum;
+    case case;
+    case class;
+    case if;
+}
+?>
+
+Some more filler text
+
+<?php
+
+enum Type2 {
+
+    case NORMAL_LABEL;
+    case UNSET;
+    case enum;
+
+    #[AAA]
+    case case;
+    case class;
+    case if;
+
+    public function test(int $test): void {
+        
+    }
+
+    public static function staticTest(Foo&Bar $param): void {
+        
+    }
+}
+?>

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
@@ -1066,6 +1066,11 @@ public class PHPFormatterTest extends PHPFormatterTestBase {
         reformatFileContents("testfiles/formatting/php81/enumerations_01.php", options);
     }
 
+    public void testEnumerations_02() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        reformatFileContents("testfiles/formatting/php81/enumerations_02.php", options);
+    }
+
     public void testEnumDeclarationBracePlacement_01() throws Exception {
         HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
         options.put(FmtOptions.CLASS_DECL_BRACE_PLACEMENT, CodeStyle.BracePlacement.NEW_LINE);


### PR DESCRIPTION
Trying to format an enum like this:

```php
  enum Type {
	  case UNSET;
  }
```

Results in a deformed case:

```php
  enum Type {
  
      case UNSET;
      }
```

with assertions enabled, it causes an error like this:

```
  SEVERE [org.openide.util.RequestProcessor]: Error in RequestProcessor org.netbeans.modules.progress.ui.RunOffEDTImpl$1
  java.lang.AssertionError: The same token (index: 14 - WHITESPACE, format tokens: 25, offset: 33)  was precessed before.
  Please report this to help fix issue 188809.
  <?php
  enum Type {
  	case UNSET;
  }
  	at org.netbeans.modules.php.editor.indent.FormatVisitor.addFormatToken(FormatVisitor.java:2755)
	at org.netbeans.modules.php.editor.indent.FormatVisitor.visit(FormatVisitor.java:1224)
	at org.netbeans.modules.php.editor.parser.astnodes.CaseDeclaration.accept(CaseDeclaration.java:82)
```

Replacing `UNSET` with `XNSET` results in a valid result.

The problem is located in the `FormatVisitor`, which scans the `case` expression and loops until the first string is found. That works for the normal cases, but not for cases, where the enum name is also a keyword.

The grammar explicitly declares, that everything after the `case` is considered an identifier (ignoring whitespace and comments). The NetBeans lexer however yields an PHP_UNSET for the UNSET case.

Instead of relying on the token ids when scanning the `case` expression, the position of the name of the `case` expression is extracted from the AST and used as a terminator for the scanning sequence.

Closes: #9533