### PR TITLE
Detect property names at the beginning of events

### DIFF
--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/web/multiview/PagesMultiViewElement.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/web/multiview/PagesMultiViewElement.java
@@ -131,10 +131,10 @@ public class PagesMultiViewElement extends ToolBarMultiViewElement implements ja
     public void propertyChange(java.beans.PropertyChangeEvent evt) {
         if (!dObj.isChangedFromUI()) {
             String name = evt.getPropertyName();
-            if ( name.indexOf("WelcomeFileList")>0 || //NOI18N
-                 name.indexOf("JspConfig")>0 || //NOI18N
-                 name.indexOf("ErrorPage")>0 || //NOI18N
-                 name.indexOf("version")>0 ) { //NOI18N
+            if ( name.indexOf("WelcomeFileList")>=0 || //NOI18N
+                 name.indexOf("JspConfig")>=0 || //NOI18N
+                 name.indexOf("ErrorPage")>=0 || //NOI18N
+                 name.indexOf("version")>=0 ) { //NOI18N
                 // repaint view if the wiew is active and something is changed with elements listed above
                 MultiViewPerspective perspective = dObj.getSelectedPerspective();
                 // dont repaint if the top component doens't exist any more


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/6702420.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Allowed matching web descriptor property names at index zero to trigger the expected view refresh.
