### PR TITLE
Remove the Solaris/SPARC/SunOS support from Netbeans.

### DIFF
--- a/harness/nbjunit/src/org/netbeans/junit/MemoryMeasurement.java
+++ b/harness/nbjunit/src/org/netbeans/junit/MemoryMeasurement.java
@@ -83,7 +83,7 @@ public class MemoryMeasurement {
     public static long getProcessMemoryFootPrint(long pid) throws MemoryMeasurementFailedException {
         String platform = getPlatform();
         //System.out.println("PLATFORM = "+getPlatform());
-        if (platform.equals(SOLARIS)|platform.equals(LINUX)) {
+        if (platform.equals(LINUX)) {
             // call unix method
             return getProcessMemoryFootPrintOnUnix(pid);
         } else if (platform.equals(WINDOWS)) {
@@ -98,13 +98,11 @@ public class MemoryMeasurement {
     /** */    
     private static final long UNKNOWN_VALUE = -1;
    
-    private static final String SOLARIS = "solaris";
     private static final String LINUX   = "linux";
     private static final String WINDOWS = "win32";
     private static final String UNKNOWN = "unknown";
     
     private static final String [][] SUPPORTED_PLATFORMS = {
-        {"SunOS",SOLARIS},
         {"Linux",LINUX},
         {"Windows NT",WINDOWS},
         {"Windows 2000",WINDOWS},

--- a/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/TerminalLocalNativeProcess.java
+++ b/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/TerminalLocalNativeProcess.java
@@ -262,7 +262,7 @@ public final class TerminalLocalNativeProcess extends AbstractNativeProcess {
             return -1;
         }
 
-        if (osFamily == OSFamily.LINUX || osFamily == OSFamily.SUNOS) {
+        if (osFamily == OSFamily.LINUX) {
             File f = new File("/proc/" + pid); // NOI18N
 
             while (f.exists()) {

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/Startup.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/Startup.java
@@ -586,13 +586,6 @@ public final class Startup {
         return result;
     }
 
-    private static boolean isSolaris10 () {
-        String osName = System.getProperty ("os.name");
-        String osVersion = System.getProperty ("os.version");
-        boolean result = osName.startsWith ("SunOS") && "5.10".equals(osVersion);
-        return result;
-    }
-
     /** If it is solaris or linux, we can use GTK where supported by getting
      * the platform specific look and feel.
      *
@@ -608,8 +601,7 @@ public final class Startup {
         boolean result = !"Solaris".equals (osName) &&
             !osName.startsWith ("SunOS") &&
             !osName.endsWith ("Linux") ||
-            UIManager.getSystemLookAndFeelClassName().indexOf("Motif") > -1 ||
-            isSolaris10();
+            UIManager.getSystemLookAndFeelClassName().indexOf("Motif") > -1;
         return result;
     }
 

--- a/platform/o.n.swing.tabcontrol/beanstubs/org/openide/util/Utilities.java
+++ b/platform/o.n.swing.tabcontrol/beanstubs/org/openide/util/Utilities.java
@@ -126,8 +126,6 @@ public final class Utilities {
                 operatingSystem = OS_WIN_OTHER;
             else if ("Solaris".equals (osName)) // NOI18N
                 operatingSystem = OS_SOLARIS;
-            else if (osName.startsWith ("SunOS")) // NOI18N
-                operatingSystem = OS_SOLARIS;
             // JDK 1.4 b2 defines os.name for me as "Redhat Linux" -jglick
             else if (osName.endsWith ("Linux")) // NOI18N
                 operatingSystem = OS_LINUX;
@@ -137,8 +135,6 @@ public final class Utilities {
                 operatingSystem = OS_AIX;
             else if ("Irix".equals (osName)) // NOI18N
                 operatingSystem = OS_IRIX;
-            else if ("SunOS".equals (osName)) // NOI18N
-                operatingSystem = OS_SUNOS;
             else if ("Digital UNIX".equals (osName)) // NOI18N
                 operatingSystem = OS_TRU64;
             else if ("OS/2".equals (osName)) // NOI18N

--- a/platform/openide.util/src/org/openide/util/BaseUtilities.java
+++ b/platform/openide.util/src/org/openide/util/BaseUtilities.java
@@ -228,8 +228,6 @@ public abstract class BaseUtilities {
                 operatingSystem = OS_WIN_OTHER;
             } else if ("Solaris".equals(osName)) { // NOI18N
                 operatingSystem = OS_SOLARIS;
-            } else if (osName.startsWith("SunOS")) { // NOI18N
-                operatingSystem = OS_SOLARIS;
             }
             // JDK 1.4 b2 defines os.name for me as "Redhat Linux" -jglick
             else if (osName.endsWith("Linux")) { // NOI18N
@@ -240,8 +238,6 @@ public abstract class BaseUtilities {
                 operatingSystem = OS_AIX;
             } else if ("Irix".equals(osName)) { // NOI18N
                 operatingSystem = OS_IRIX;
-            } else if ("SunOS".equals(osName)) { // NOI18N
-                operatingSystem = OS_SUNOS;
             } else if ("Digital UNIX".equals(osName)) { // NOI18N
                 operatingSystem = OS_TRU64;
             } else if ("OS/2".equals(osName)) { // NOI18N

--- a/platform/spi.quicksearch/src/org/netbeans/modules/quicksearch/SearchResultRender.java
+++ b/platform/spi.quicksearch/src/org/netbeans/modules/quicksearch/SearchResultRender.java
@@ -186,9 +186,6 @@ class SearchResultRender extends JLabel implements ListCellRenderer {
             if (Utilities.isMac()) {
                 // Mac cloverleaf symbol
                 sb.append ("\u2318+");
-            } else if (isSolaris()) {
-                // Sun meta symbol
-                sb.append ("\u25C6+");
             } else {
                 sb.append ("Meta+");
             }
@@ -202,10 +199,5 @@ class SearchResultRender extends JLabel implements ListCellRenderer {
                 KeyStroke.getKeyStroke (keyStroke.getKeyCode (), 0)
             ));
         return sb.toString ();
-    }
-
-    private static boolean isSolaris () {
-        String osName = System.getProperty ("os.name");
-        return osName != null && osName.startsWith ("SunOS");
     }
 }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/global/Platform.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/global/Platform.java
@@ -413,12 +413,6 @@ public class Platform implements CommonConstants {
         } else if (osName.startsWith("Windows ")) { // NOI18N
 
             return OS_WIN_OTHER;
-        } else if ("Solaris".equals(osName)) { // NOI18N
-
-            return OS_SOLARIS;
-        } else if (osName.startsWith("SunOS")) { // NOI18N
-
-            return OS_SOLARIS;
         } else if (osName.endsWith("Linux")) { // NOI18N
 
             return OS_LINUX;
@@ -431,9 +425,6 @@ public class Platform implements CommonConstants {
         } else if ("Irix".equals(osName)) { // NOI18N
 
             return OS_IRIX;
-        } else if ("SunOS".equals(osName)) { // NOI18N
-
-            return OS_SOLARIS;
         } else if ("Digital UNIX".equals(osName)) { // NOI18N
 
             return OS_TRU64;


### PR DESCRIPTION
Remove the Solaris/SPARC/SunOS support from Netbeans.

It's been deprecated since JDK15.
No one has stepped up to support it.
There is no reason to have platform-specific support in Netbeans.

Therefore, remove it.