### PR TITLE
Bump config importer version gap limit from 3 to 5 releases

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/ReleaseJsonProperties.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ReleaseJsonProperties.java
@@ -48,7 +48,7 @@ import org.w3c.dom.Element;
 public class ReleaseJsonProperties extends Task {
 
     // how many previous versions to suggest importing configuration from
-    private static final int PREVIOUS_VERSIONS_LIMIT = 3;
+    private static final int PREVIOUS_VERSIONS_LIMIT = 5;
 
     /**
      * current branch we works with


### PR DESCRIPTION
the bad config should be hopefully purged by now, lets increase the limit a little.

original issue: https://github.com/apache/netbeans/issues/6135