### PR TITLE
Add support for GlassFish 8.0.1, 8.0.2, 8.0.3, and 8.0.4

### DIFF
--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/Bundle.properties
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/Bundle.properties
@@ -194,6 +194,10 @@ STR_7024_SERVER_NAME=GlassFish Server 7.0.24
 STR_7025_SERVER_NAME=GlassFish Server 7.0.25
 STR_710_SERVER_NAME=GlassFish Server 7.1.0
 STR_800_SERVER_NAME=GlassFish Server 8.0.0
+STR_801_SERVER_NAME=GlassFish Server 8.0.1
+STR_802_SERVER_NAME=GlassFish Server 8.0.2
+STR_803_SERVER_NAME=GlassFish Server 8.0.3
+STR_804_SERVER_NAME=GlassFish Server 8.0.4
 
 # CommonServerSupport.java
 MSG_FLAKEY_NETWORK=<html>Network communication problem<br/>Could not establish \

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
@@ -587,6 +587,50 @@ public enum ServerDetails {
         "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/8.0.0/glassfish-8.0.0.zip", // NOI18N
         "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/8.0.0/glassfish-8.0.0.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
+    ),
+
+    /**
+     * details for an instance of GlassFish Server 8.0.1
+     */
+    GLASSFISH_SERVER_8_0_1(NbBundle.getMessage(ServerDetails.class, "STR_801_SERVER_NAME", new Object[]{}), // NOI18N
+        GlassfishInstanceProvider.JAKARTAEE11_DEPLOYER_FRAGMENT,
+        GlassFishVersion.GF_8_0_1,
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/8.0.1/glassfish-8.0.1.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/8.0.1/glassfish-8.0.1.zip", // NOI18N
+        "http://www.eclipse.org/legal/epl-2.0" //NOI18N
+    ),
+
+    /**
+     * details for an instance of GlassFish Server 8.0.2
+     */
+    GLASSFISH_SERVER_8_0_2(NbBundle.getMessage(ServerDetails.class, "STR_802_SERVER_NAME", new Object[]{}), // NOI18N
+        GlassfishInstanceProvider.JAKARTAEE11_DEPLOYER_FRAGMENT,
+        GlassFishVersion.GF_8_0_2,
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/8.0.2/glassfish-8.0.2.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/8.0.2/glassfish-8.0.2.zip", // NOI18N
+        "http://www.eclipse.org/legal/epl-2.0" //NOI18N
+    ),
+
+    /**
+     * details for an instance of GlassFish Server 8.0.3
+     */
+    GLASSFISH_SERVER_8_0_3(NbBundle.getMessage(ServerDetails.class, "STR_803_SERVER_NAME", new Object[]{}), // NOI18N
+        GlassfishInstanceProvider.JAKARTAEE11_DEPLOYER_FRAGMENT,
+        GlassFishVersion.GF_8_0_3,
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/8.0.3/glassfish-8.0.3.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/8.0.3/glassfish-8.0.3.zip", // NOI18N
+        "http://www.eclipse.org/legal/epl-2.0" //NOI18N
+    ),
+
+    /**
+     * details for an instance of GlassFish Server 8.0.4
+     */
+    GLASSFISH_SERVER_8_0_4(NbBundle.getMessage(ServerDetails.class, "STR_804_SERVER_NAME", new Object[]{}), // NOI18N
+        GlassfishInstanceProvider.JAKARTAEE11_DEPLOYER_FRAGMENT,
+        GlassFishVersion.GF_8_0_4,
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/8.0.4/glassfish-8.0.4.zip", // NOI18N
+        "https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish/8.0.4/glassfish-8.0.4.zip", // NOI18N
+        "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     );
     
     /**

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/wizards/Bundle.properties
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/wizards/Bundle.properties
@@ -197,6 +197,10 @@ STR_710_SERVER_NAME=GlassFish Server 7.1.0
 
 STR_V8_FAMILY_NAME=GlassFish Server
 STR_800_SERVER_NAME=GlassFish Server 8.0.0
+STR_801_SERVER_NAME=GlassFish Server 8.0.1
+STR_802_SERVER_NAME=GlassFish Server 8.0.2
+STR_803_SERVER_NAME=GlassFish Server 8.0.3
+STR_804_SERVER_NAME=GlassFish Server 8.0.4
 
 LBL_SELECT_BITS=Select
 LBL_ChooseOne=Choose server to download:

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersion.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersion.java
@@ -149,7 +149,16 @@ public enum GlassFishVersion {
     /** GlassFish 7.1.0 */
     GF_7_1_0       ((short) 7, (short) 1, (short) 0, (short) 0, GlassFishVersion.GF_7_1_0_STR),
     /** GlassFish 8.0.0 */
-    GF_8_0_0       ((short) 8, (short) 0, (short) 0, (short) 0, GlassFishVersion.GF_8_0_0_STR);
+    GF_8_0_0       ((short) 8, (short) 0, (short) 0, (short) 0, GlassFishVersion.GF_8_0_0_STR),
+    /** GlassFish 8.0.1 */
+    GF_8_0_1       ((short) 8, (short) 0, (short) 1, (short) 0, GlassFishVersion.GF_8_0_1_STR),
+    /** GlassFish 8.0.2 */
+    GF_8_0_2       ((short) 8, (short) 0, (short) 2, (short) 0, GlassFishVersion.GF_8_0_2_STR),
+    /** GlassFish 8.0.3 */
+    GF_8_0_3       ((short) 8, (short) 0, (short) 3, (short) 0, GlassFishVersion.GF_8_0_3_STR),
+    /** GlassFish 8.0.4 */
+    GF_8_0_4       ((short) 8, (short) 0, (short) 4, (short) 0, GlassFishVersion.GF_8_0_4_STR);
+
     // Class attributes                                                       //
     /** GlassFish version enumeration length. */
     public static final int length = GlassFishVersion.values().length;
@@ -437,6 +446,26 @@ public enum GlassFishVersion {
     /** Additional {@code String} representations of GF_8_0_0 value. */
     static final String GF_8_0_0_STR_NEXT[] = {"8.0.0", "8.0.0.0"};
 
+    /** A {@code String} representation of GF_8_0_1 value. */
+    static final String GF_8_0_1_STR = "8.0.1";
+    /** Additional {@code String} representations of GF_8_0_1 value. */
+    static final String GF_8_0_1_STR_NEXT[] = {"8.0.1", "8.0.1.0"};
+
+    /** A {@code String} representation of GF_8_0_2 value. */
+    static final String GF_8_0_2_STR = "8.0.2";
+    /** Additional {@code String} representations of GF_8_0_2 value. */
+    static final String GF_8_0_2_STR_NEXT[] = {"8.0.2", "8.0.2.0"};
+
+    /** A {@code String} representation of GF_8_0_3 value. */
+    static final String GF_8_0_3_STR = "8.0.3";
+    /** Additional {@code String} representations of GF_8_0_3 value. */
+    static final String GF_8_0_3_STR_NEXT[] = {"8.0.3", "8.0.3.0"};
+
+    /** A {@code String} representation of GF_8_0_4 value. */
+    static final String GF_8_0_4_STR = "8.0.4";
+    /** Additional {@code String} representations of GF_8_0_4 value. */
+    static final String GF_8_0_4_STR_NEXT[] = {"8.0.4", "8.0.4.0"};
+
     /**
      * Stored <code>String</code> values for backward <code>String</code>
      * conversion.
@@ -501,6 +530,10 @@ public enum GlassFishVersion {
         initStringValuesMapFromArray(GF_7_0_25, GF_7_0_25_STR_NEXT);
         initStringValuesMapFromArray(GF_7_1_0, GF_7_1_0_STR_NEXT);
         initStringValuesMapFromArray(GF_8_0_0, GF_8_0_0_STR_NEXT);
+        initStringValuesMapFromArray(GF_8_0_1, GF_8_0_1_STR_NEXT);
+        initStringValuesMapFromArray(GF_8_0_2, GF_8_0_2_STR_NEXT);
+        initStringValuesMapFromArray(GF_8_0_3, GF_8_0_3_STR_NEXT);
+        initStringValuesMapFromArray(GF_8_0_4, GF_8_0_4_STR_NEXT);
     }
 
     // Static methods                                                         //

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/ConfigBuilderProvider.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/ConfigBuilderProvider.java
@@ -251,6 +251,26 @@ public class ConfigBuilderProvider {
             = new Config.Next(GlassFishVersion.GF_8_0_0,
                     ConfigBuilderProvider.class.getResource("GlassFishV8_0_0.xml"));
 
+    /** Library builder configuration since GlassFish 8.0.1. */
+    private static final Config.Next CONFIG_V8_0_1
+            = new Config.Next(GlassFishVersion.GF_8_0_1,
+                    ConfigBuilderProvider.class.getResource("GlassFishV8_0_0.xml"));
+
+    /** Library builder configuration since GlassFish 8.0.2. */
+    private static final Config.Next CONFIG_V8_0_2
+            = new Config.Next(GlassFishVersion.GF_8_0_2,
+                    ConfigBuilderProvider.class.getResource("GlassFishV8_0_0.xml"));
+
+    /** Library builder configuration since GlassFish 8.0.3. */
+    private static final Config.Next CONFIG_V8_0_3
+            = new Config.Next(GlassFishVersion.GF_8_0_3,
+                    ConfigBuilderProvider.class.getResource("GlassFishV8_0_0.xml"));
+
+    /** Library builder configuration since GlassFish 8.0.4. */
+    private static final Config.Next CONFIG_V8_0_4
+            = new Config.Next(GlassFishVersion.GF_8_0_4,
+                    ConfigBuilderProvider.class.getResource("GlassFishV8_0_0.xml"));
+
     /** Library builder configuration for GlassFish cloud. */
     private static final Config config
             = new Config(CONFIG_V3, CONFIG_V4, CONFIG_V4_1, CONFIG_V5, 
@@ -266,7 +286,8 @@ public class ConfigBuilderProvider {
                          CONFIG_V7_0_18, CONFIG_V7_0_19, CONFIG_V7_0_20,
                          CONFIG_V7_0_21, CONFIG_V7_0_22, CONFIG_V7_0_23,
                          CONFIG_V7_0_24, CONFIG_V7_0_25, CONFIG_V7_1_0,
-                         CONFIG_V8_0_0);
+                         CONFIG_V8_0_0, CONFIG_V8_0_1, CONFIG_V8_0_2,
+                         CONFIG_V8_0_3, CONFIG_V8_0_4);
 
     /** Builders array for each server instance. */
     private static final ConcurrentMap<GlassFishServer, ConfigBuilder> builders

--- a/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/admin/AdminFactoryTest.java
+++ b/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/admin/AdminFactoryTest.java
@@ -217,7 +217,7 @@ public class AdminFactoryTest extends CommandTest {
     }
     
     /**
-     * Test factory functionality for GlassFish v. 8.0.0
+     * Test factory functionality for GlassFish v. 8.0.4
      * <p/>
      * Factory should initialize REST {@code Runner} and point it to
      * provided {@code Command} instance.
@@ -225,7 +225,7 @@ public class AdminFactoryTest extends CommandTest {
     @Test
     public void testGetInstanceforVersionGF8() {
         GlassFishServerEntity srv = new GlassFishServerEntity();
-        srv.setVersion(GlassFishVersion.GF_8_0_0);
+        srv.setVersion(GlassFishVersion.GF_8_0_4);
         AdminFactory af = AdminFactory.getInstance(srv.getVersion());
         assertTrue(af instanceof AdminFactoryRest);
         Command cmd = new CommandVersion();

--- a/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersionTest.java
+++ b/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersionTest.java
@@ -147,6 +147,14 @@ public class GlassFishVersionTest {
                 GlassFishVersion.GF_7_1_0_STR_NEXT);
         verifyToValueFromAdditionalArray(GlassFishVersion.GF_8_0_0,
                 GlassFishVersion.GF_8_0_0_STR_NEXT);
+        verifyToValueFromAdditionalArray(GlassFishVersion.GF_8_0_1,
+                GlassFishVersion.GF_8_0_1_STR_NEXT);
+        verifyToValueFromAdditionalArray(GlassFishVersion.GF_8_0_2,
+                GlassFishVersion.GF_8_0_2_STR_NEXT);
+        verifyToValueFromAdditionalArray(GlassFishVersion.GF_8_0_3,
+                GlassFishVersion.GF_8_0_3_STR_NEXT);
+        verifyToValueFromAdditionalArray(GlassFishVersion.GF_8_0_4,
+                GlassFishVersion.GF_8_0_4_STR_NEXT);
     }
 
     /**
@@ -181,7 +189,9 @@ public class GlassFishVersionTest {
             GlassFishVersion.GF_7_0_20, GlassFishVersion.GF_7_0_21,
             GlassFishVersion.GF_7_0_22, GlassFishVersion.GF_7_0_23,
             GlassFishVersion.GF_7_0_24, GlassFishVersion.GF_7_0_25,
-            GlassFishVersion.GF_7_1_0, GlassFishVersion.GF_8_0_0
+            GlassFishVersion.GF_7_1_0, GlassFishVersion.GF_8_0_0,
+            GlassFishVersion.GF_8_0_1, GlassFishVersion.GF_8_0_2,
+            GlassFishVersion.GF_8_0_3, GlassFishVersion.GF_8_0_4
         };
         String strings[] = {
             "1.0.1.4", "2.0.1.5", "2.1.0.3", "2.1.1.7",
@@ -197,7 +207,8 @@ public class GlassFishVersionTest {
             "7.0.14.0", "7.0.15.0", "7.0.16.0", "7.0.17.0",
             "7.0.18.0", "7.0.19.0", "7.0.20.0", "7.0.21.0",
             "7.0.22.0", "7.0.23.0", "7.0.24.0", "7.0.25.0",
-            "7.1.0.0", "8.0.0.0"
+            "7.1.0.0", "8.0.0.0", "8.0.1.0", "8.0.2.0",
+            "8.0.3.0", "8.0.4.0"
         };
         for (int i = 0; i < versions.length; i++) {
             GlassFishVersion version = GlassFishVersion.toValue(strings[i]);

--- a/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/utils/EnumUtilsTest.java
+++ b/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/utils/EnumUtilsTest.java
@@ -22,7 +22,7 @@ import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_3;
 import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_4;
 import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_6_2_5;
 import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_7_1_0;
-import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_8_0_0;
+import static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion.GF_8_0_4;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import org.testng.annotations.Test;
@@ -48,8 +48,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testEq() {
-        assertFalse(EnumUtils.eq(GF_8_0_0, GF_7_1_0), "Equals for a > b shall be false.");
-        assertTrue(EnumUtils.eq(GF_8_0_0, GF_8_0_0), "Equals for a == b shall be true.");
+        assertFalse(EnumUtils.eq(GF_8_0_4, GF_7_1_0), "Equals for a > b shall be false.");
+        assertTrue(EnumUtils.eq(GF_8_0_4, GF_8_0_4), "Equals for a == b shall be true.");
         assertFalse(EnumUtils.eq(GF_7_1_0, GF_6_2_5), "Equals for a > b shall be false.");
         assertTrue(EnumUtils.eq(GF_7_1_0, GF_7_1_0), "Equals for a == b shall be true.");
         assertFalse(EnumUtils.eq(GF_4, GF_3), "Equals for a > b shall be false.");
@@ -72,8 +72,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testNe() {
-        assertTrue(EnumUtils.ne(GF_8_0_0, GF_7_1_0), "Not equals for a > b shall be true.");
-        assertFalse(EnumUtils.ne(GF_8_0_0, GF_8_0_0), "Not equals for a == b shall be false.");
+        assertTrue(EnumUtils.ne(GF_8_0_4, GF_7_1_0), "Not equals for a > b shall be true.");
+        assertFalse(EnumUtils.ne(GF_8_0_4, GF_8_0_4), "Not equals for a == b shall be false.");
         assertTrue(EnumUtils.ne(GF_7_1_0, GF_6_2_5), "Not equals for a > b shall be true.");
         assertFalse(EnumUtils.ne(GF_7_1_0, GF_7_1_0), "Not equals for a == b shall be false.");
         assertTrue(EnumUtils.ne(GF_4, GF_3), "Not equals for a > b shall be true.");
@@ -96,8 +96,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testLt() {
-        assertFalse(EnumUtils.lt(GF_8_0_0, GF_7_1_0), "Less than for a > b shall be false.");
-        assertFalse(EnumUtils.lt(GF_8_0_0, GF_8_0_0), "Less than for a == b shall be false.");
+        assertFalse(EnumUtils.lt(GF_8_0_4, GF_7_1_0), "Less than for a > b shall be false.");
+        assertFalse(EnumUtils.lt(GF_8_0_4, GF_8_0_4), "Less than for a == b shall be false.");
         assertFalse(EnumUtils.lt(GF_7_1_0, GF_6_2_5), "Less than for a > b shall be false.");
         assertFalse(EnumUtils.lt(GF_7_1_0, GF_7_1_0), "Less than for a == b shall be false.");
         assertFalse(EnumUtils.lt(GF_4, GF_3), "Less than for a > b shall be false.");
@@ -120,8 +120,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testLe() {
-        assertFalse(EnumUtils.le(GF_8_0_0, GF_7_1_0), "Less than or equal for a > b shall be false.");
-        assertTrue(EnumUtils.le(GF_8_0_0, GF_8_0_0), "Less than or equal for a == b shall be true.");
+        assertFalse(EnumUtils.le(GF_8_0_4, GF_7_1_0), "Less than or equal for a > b shall be false.");
+        assertTrue(EnumUtils.le(GF_8_0_4, GF_8_0_4), "Less than or equal for a == b shall be true.");
         assertFalse(EnumUtils.le(GF_7_1_0, GF_6_2_5), "Less than or equal for a > b shall be false.");
         assertTrue(EnumUtils.le(GF_7_1_0, GF_7_1_0), "Less than or equal for a == b shall be true.");
         assertFalse(EnumUtils.le(GF_4, GF_3), "Less than or equal for a > b shall be false.");
@@ -144,8 +144,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testGt() {
-        assertTrue(EnumUtils.gt(GF_8_0_0, GF_7_1_0), "Greater than for a > b shall be true.");
-        assertFalse(EnumUtils.gt(GF_8_0_0, GF_8_0_0), "Greater than for a == b shall be false.");
+        assertTrue(EnumUtils.gt(GF_8_0_4, GF_7_1_0), "Greater than for a > b shall be true.");
+        assertFalse(EnumUtils.gt(GF_8_0_4, GF_8_0_4), "Greater than for a == b shall be false.");
         assertTrue(EnumUtils.gt(GF_7_1_0, GF_6_2_5), "Greater than for a > b shall be true.");
         assertFalse(EnumUtils.gt(GF_7_1_0, GF_7_1_0), "Greater than for a == b shall be false.");
         assertTrue(EnumUtils.gt(GF_4, GF_3), "Greater than for a > b shall be true.");
@@ -168,8 +168,8 @@ public class EnumUtilsTest {
      */
     @Test
     public void testGe() {
-        assertTrue(EnumUtils.ge(GF_8_0_0, GF_7_1_0), "Greater than or equal for a > b shall be true.");
-        assertTrue(EnumUtils.ge(GF_8_0_0, GF_8_0_0), "Greater than or equal for a == b shall be true.");
+        assertTrue(EnumUtils.ge(GF_8_0_4, GF_7_1_0), "Greater than or equal for a > b shall be true.");
+        assertTrue(EnumUtils.ge(GF_8_0_4, GF_8_0_4), "Greater than or equal for a == b shall be true.");
         assertTrue(EnumUtils.ge(GF_7_1_0, GF_6_2_5), "Greater than or equal for a > b shall be true.");
         assertTrue(EnumUtils.ge(GF_7_1_0, GF_7_1_0), "Greater than or equal for a == b shall be true.");
         assertTrue(EnumUtils.ge(GF_4, GF_3), "Greater than or equal for a > b shall be true.");


### PR DESCRIPTION
NetBeans GlassFish module notes:

- Add support for GlassFish 8.0.1, 8.0.2, 8.0.3, and 8.0.4

NetBeans Testing:

- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of Verify Sigtests
- Verify successful execution of unit tests for modules `glassfish.common`, `glassfish.javaee`, `glassfish.tooling`, and `glassfish.eecommon`
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Successfully register GlassFish 8.0.4, create a web app and verify that it works.

[Release Notes for GlassFish 8](https://github.com/eclipse-ee4j/glassfish/releases/tag/8.0.4)