### PR TITLE
Fix sporadic "Could not validate Info.xml" build error

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MakeNBM.java
@@ -31,7 +31,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -65,7 +64,6 @@ import org.apache.tools.ant.taskdefs.Copy;
 import org.apache.tools.ant.taskdefs.ExecTask;
 import org.apache.tools.ant.taskdefs.Jar;
 import org.apache.tools.ant.taskdefs.SignJar;
-import org.apache.tools.ant.types.Commandline;
 import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.types.Path;
 import org.apache.tools.ant.types.ZipFileSet;
@@ -1102,13 +1100,16 @@ public class MakeNBM extends Task {
     static void validateAgainstAUDTDs(InputSource input, final Path updaterJar, final Task task) throws IOException, SAXException {
         XMLUtil.parse(input, true, false, XMLUtil.rethrowHandler(), new EntityResolver() {
             ClassLoader loader = new AntClassLoader(task.getProject(), updaterJar);
+            @Override
             public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
                 String remote = "http://www.netbeans.org/dtds/";
                 if (systemId.startsWith(remote)) {
                     String rsrc = "org/netbeans/updater/resources/" + systemId.substring(remote.length());
-                    URL u = loader.getResource(rsrc);
-                    if (u != null) {
-                        return new InputSource(u.toString());
+                    InputStream entity = loader.getResourceAsStream(rsrc);
+                    if (entity != null) {
+                        try (entity) {
+                            return new InputSource(new ByteArrayInputStream(entity.readAllBytes()));
+                        }
                     } else {
                         task.log(rsrc + " not found in " + updaterJar, Project.MSG_WARN);
                     }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/XMLUtil.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/XMLUtil.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -87,6 +88,7 @@ public final class XMLUtil extends Object {
             factory.setNamespaceAware(namespaceAware);
 
             try {
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
                 builder = factory.newDocumentBuilder();
             } catch (ParserConfigurationException ex) {
                 throw new SAXException(ex);
@@ -127,6 +129,7 @@ public final class XMLUtil extends Object {
     public static Document createDocument(String rootQName) throws DOMException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             return factory.newDocumentBuilder().getDOMImplementation().createDocument(null, rootQName, null);
         } catch (ParserConfigurationException ex) {
             throw (DOMException)new DOMException(DOMException.NOT_SUPPORTED_ERR, "Cannot create parser").initCause(ex); // NOI18N


### PR DESCRIPTION
as observed in https://github.com/apache/netbeans/actions/runs/32883200508?pr=9573 (and others, e.g https://github.com/apache/netbeans/actions/runs/31745293654/attempts/1), CI fails sometimes in `platform/autoupdate.services` with 

```
netbeans/nbbuild/templates/common.xml:487: Could not validate Info.xml before writing: java.util.zip.ZipException: ZipFile invalid LOC header (bad signature)
	at java.base/java.util.zip.ZipFile$ZipFileInputStream.initDataOffset(ZipFile.java:935)
	at java.base/java.util.zip.ZipFile$ZipFileInputStream.read(ZipFile.java:946)
	at java.base/java.util.zip.ZipFile$ZipFileInputStream.read(ZipFile.java:970)
	at java.base/java.io.FilterInputStream.read(FilterInputStream.java:71)
	at java.base/java.io.FilterInputStream.read(FilterInputStream.java:71)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLEntityManager$RewindableInputStream.readAndBuffer(XMLEntityManager.java:3027)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLEntityManager.setupCurrentEntity(XMLEntityManager.java:706)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLEntityManager.startEntity(XMLEntityManager.java:1398)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLEntityManager.startDTDEntity(XMLEntityManager.java:1364)
	at ... more xerces
	at org.netbeans.nbbuild.XMLUtil.parse(XMLUtil.java:106)
	at org.netbeans.nbbuild.MakeNBM.validateAgainstAUDTDs(MakeNBM.java:1103)
	at org.netbeans.nbbuild.MakeNBM.createInfoXml(MakeNBM.java:1045)
	at org.netbeans.nbbuild.MakeNBM.lambda$execute$1(MakeNBM.java:625)
	at org.netbeans.nbbuild.MakeNBM.execute(MakeNBM.java:646)
```

Looking at the [performance metrics](https://github.com/apache/netbeans/actions/metrics/performance?sort=failureRate&tab=jobs) of the workflow, the job has currently a 29% failure rate.


This was also locally reproducible after downloading the CI artifact. First 'ant build-nbms' would fail, second invocation would always succeed.

It can't be a coincidence that the module which provides the updater.jar (but none of the other modules) fails while reading a xml file from the very same jar. Unfortunately I couldn't find the cause, but eagerly loading the resource with ant's project CL appears to resolve the issue.

