### PR TITLE
Revert xml factory config change in nbbuild util

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/XMLUtil.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/XMLUtil.java
@@ -88,7 +88,8 @@ public final class XMLUtil extends Object {
             factory.setNamespaceAware(namespaceAware);
 
             try {
-                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                //TODO org.netbeans.modules.apisupport.project.suite.BuildNBMSTest#testBuildNBMS failure
+//                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
                 builder = factory.newDocumentBuilder();
             } catch (ParserConfigurationException ex) {
                 throw new SAXException(ex);


### PR DESCRIPTION
overlooked test failure of `BuildNBMTest` in `apisupport.ant`, lets document it and partially revert the factory config change of d9331e2a78c / https://github.com/apache/netbeans/pull/9575