### PR TITLE
Let `ProjectsRootNode.getNodes(true)` use the real keys

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/ProjectsRootNode.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/ProjectsRootNode.java
@@ -276,16 +276,12 @@ public class ProjectsRootNode extends AbstractNode {
         @Override
         public void addNotify() {   
             OpenProjectList.getDefault().addPropertyChangeListener(this);              
-            if (Boolean.getBoolean("test.projectnode.sync")) {
-                setKeys( getKeys());
-            } else {
-                RP.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        setKeys( getKeys() );
-                    }
-                });
-            }
+            RP.post(new Runnable() {
+                @Override
+                public void run() {
+                    setKeys( getKeys() );
+                }
+            });
         }
 
         @Override
@@ -307,7 +303,13 @@ public class ProjectsRootNode extends AbstractNode {
             return super.getNodesCount(optimalResult);
         }
 
-
+        @Override
+        public Node[] getNodes(boolean optimalResult) {
+            if (optimalResult) {
+                setKeys(getKeys());
+            }
+            return super.getNodes(optimalResult);
+        }
         
         @Override
         protected Node[] createNodes(Pair p) {

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/CloseProjectsTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/CloseProjectsTest.java
@@ -104,8 +104,6 @@ public class CloseProjectsTest extends NbTestCase {
         OpenProjectListSettings.getInstance().setOpenProjectsURLs(list);
         OpenProjectListSettings.getInstance().setOpenProjectsDisplayNames(names);
         OpenProjectListSettings.getInstance().setOpenProjectsIcons(icons);
-         //compute project root node children in sync mode
-        System.setProperty("test.projectnode.sync", "true");
     }
 
     public void testClose() throws Exception {
@@ -113,11 +111,11 @@ public class CloseProjectsTest extends NbTestCase {
         L listener = new L();
         logicalView.addNodeListener(listener);
         
-        assertEquals("30 children", 30, logicalView.getChildren().getNodesCount());
+        assertEquals("30 children", 30, logicalView.getChildren().getNodesCount(true));
         listener.assertEvents("None", 0);
         assertEquals("No project opened yet", 0, TestProjectOpenedHookImpl.opened);
         
-        Node[] nodeArray = logicalView.getChildren().getNodes();
+        Node[] nodeArray = logicalView.getChildren().getNodes(true);
         Project[] arr = new Project[nodeArray.length];
         int i = 0;
         for (Node n : nodeArray) {
@@ -133,7 +131,7 @@ public class CloseProjectsTest extends NbTestCase {
             i++;
         }
         ProjectsRootNode.ProjectChildren.RP.post(new Runnable() {public @Override void run() {}}).waitFinished();
-        assertEquals("Just fifteen left nodes", 15, logicalView.getChildren().getNodesCount());
+        assertEquals("Just fifteen left nodes", 15, logicalView.getChildren().getNodesCount(true));
 
         // let the project open hook run
         down.countDown();
@@ -141,7 +139,7 @@ public class CloseProjectsTest extends NbTestCase {
         OpenProjects.getDefault().close(arr);
         
         ProjectsRootNode.ProjectChildren.RP.post(new Runnable() {public @Override void run() {}}).waitFinished();
-        assertEquals("View is empty", 0, logicalView.getChildren().getNodesCount());
+        assertEquals("View is empty", 0, logicalView.getChildren().getNodesCount(true));
     }
     
     private static class L implements NodeListener {

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectHookThrowsExceptionTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectHookThrowsExceptionTest.java
@@ -86,9 +86,6 @@ public class OpenProjectHookThrowsExceptionTest extends NbTestCase {
         OpenProjectListSettings.getInstance().setOpenProjectsURLs(list);
         OpenProjectListSettings.getInstance().setOpenProjectsDisplayNames(names);
         OpenProjectListSettings.getInstance().setOpenProjectsIcons(icons);
-        
-        //compute project root node children in sync mode
-        System.setProperty("test.projectnode.sync", "true");
     }
 
     public void testBehaviourOfProjectsLogicNode() throws Exception {
@@ -97,11 +94,11 @@ public class OpenProjectHookThrowsExceptionTest extends NbTestCase {
         L listener = new L();
         logicalView.addNodeListener(listener);
         
-        assertEquals("2 children", 2, logicalView.getChildren().getNodesCount());
+        assertEquals("2 children", 2, logicalView.getChildren().getNodesCount(true));
         listener.assertEvents("None", 0);
         assertEquals("No project opened yet", 0, TestProjectOpenedHookImpl.opened);
         
-        for (Node n : logicalView.getChildren().getNodes()) {
+        for (Node n : logicalView.getChildren().getNodes(true)) {
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNull("No project of this type, yet", p);
         }
@@ -114,7 +111,7 @@ public class OpenProjectHookThrowsExceptionTest extends NbTestCase {
         
         OpenProjectList.waitProjectsFullyOpen();
 
-        Node[] nodes = logicalView.getChildren().getNodes();
+        Node[] nodes = logicalView.getChildren().getNodes(true);
         assertEquals("No projects open", 0, nodes.length);
         
         listener.assertEvents("Goal is to receive no events at all", 1);

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListNestedTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListNestedTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.project.ui;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.event.ChangeListener;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.api.project.ui.OpenProjects;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.project.ui.actions.TestSupport;
+import org.netbeans.spi.project.SubprojectProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.test.MockLookup;
+
+public class OpenProjectListNestedTest extends NbTestCase {
+    static final Logger LOG = Logger.getLogger("test.OpenProjectListNestedTest");
+    
+    public OpenProjectListNestedTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected Level logLevel() {
+        return Level.FINER;
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        OpenProjects.getDefault().close(OpenProjects.getDefault().openProjects().get());
+        OpenProjectList.waitProjectsFullyOpen();
+    }
+
+    public void testOpenNestedProjects() throws Exception {
+        doOpenProjects(true, () -> {
+            var em = OpenProjects.getDefault().createLogicalView();
+            var all = em.getRootContext().getChildren().getNodes(true);
+            assertEquals("Two projects are visible", 2, all.length);
+            return null;
+        });
+    }
+
+    public void testOpenNonNestedProjects() throws Exception {
+        doOpenProjects(false, () -> {
+            var em = OpenProjects.getDefault().createLogicalView();
+            var all = em.getRootContext().getChildren().getNodes(true);
+            assertEquals("One project is visible", 1, all.length);
+            return null;
+        });
+    }
+
+    private void doOpenProjects(boolean withSubprojects, Callable<Void> inner) throws Exception {
+        MockLookup.setInstances(new TestSupport.TestProjectFactory());
+        clearWorkDir();
+        FileObject workDir = FileUtil.toFileObject(getWorkDir());
+        assertNotNull(workDir);
+        FileObject prjFo = TestSupport.createTestProject(workDir, "prj1");
+        FileObject nestedFo = TestSupport.createTestProject(prjFo, "nested1");
+        final TestSupport.TestProject mainPrj = (TestSupport.TestProject) ProjectManager.getDefault().findProject(prjFo);
+        final TestSupport.TestProject nestedPrj = (TestSupport.TestProject) ProjectManager.getDefault().findProject(nestedFo);
+        assertNotNull("Project found", mainPrj);
+        var subProvider = new SubprojectProvider() {
+            @Override
+            public Set<? extends Project> getSubprojects() {
+                return Set.of(nestedPrj);
+            }
+
+            @Override
+            public void addChangeListener(ChangeListener listener) {
+            }
+
+            @Override
+            public void removeChangeListener(ChangeListener listener) {
+            }
+        };
+        if (withSubprojects) {
+            mainPrj.setLookup(Lookups.singleton(subProvider));
+        }
+
+        OpenProjectList.waitProjectsFullyOpen();
+        assertEquals("Initially empty", 0, OpenProjects.getDefault().openProjects().get().length);
+
+        OpenProjects.getDefault().open(new Project[] { mainPrj }, true);
+        
+        List<Project> arr = Arrays.asList(OpenProjects.getDefault().openProjects().get());
+        if (withSubprojects) {
+            assertEquals("Both projects open", 2, arr.size());
+            assertTrue("Prj1 is there", arr.contains(mainPrj));
+            assertTrue("Nested1 is there", arr.contains(nestedPrj));
+            inner.call();
+            OpenProjects.getDefault().close (new Project[] { nestedPrj, mainPrj });
+        } else {
+            assertEquals("However one project instance is there", 1, arr.size());
+            assertEquals("arr[0] is equal to p", arr.get(0), mainPrj);
+            inner.call();
+            OpenProjects.getDefault().close (new Project[] { mainPrj });
+        }
+
+        if (OpenProjects.getDefault().getOpenProjects().length != 0) {
+            fail("All projects shall be closed: " + Arrays.asList(OpenProjects.getDefault().getOpenProjects()));
+        }
+        assertFalse("No project is opened", OpenProjects.getDefault().isProjectOpen(mainPrj));
+        assertFalse("No project is opened", OpenProjects.getDefault().isProjectOpen(nestedPrj));
+
+        OpenProjectList.OPENING_RP.post(new Runnable() {public void run() {}}).waitFinished(); // flush running tasks
+    }
+}

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListSetMain2Test.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListSetMain2Test.java
@@ -88,9 +88,6 @@ public class OpenProjectListSetMain2Test extends NbTestCase {
         OpenProjectListSettings.getInstance().setOpenProjectsURLs(list);
         OpenProjectListSettings.getInstance().setOpenProjectsDisplayNames(names);
         OpenProjectListSettings.getInstance().setOpenProjectsIcons(icons);
-        
-         //compute project root node children in sync mode
-        System.setProperty("test.projectnode.sync", "true");
     }
 
     @RandomlyFails // NB-Core-Build #1058
@@ -99,11 +96,11 @@ public class OpenProjectListSetMain2Test extends NbTestCase {
         L listener = new L();
         logicalView.addNodeListener(listener);
         
-        assertEquals("30 children", 30, logicalView.getChildren().getNodesCount());
+        assertEquals("30 children", 30, logicalView.getChildren().getNodesCount(true));
         listener.assertEvents("None", 0);
         assertEquals("No project opened yet", 0, opened);
         
-        for (Node n : logicalView.getChildren().getNodes()) {
+        for (Node n : logicalView.getChildren().getNodes(true)) {
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNull("No project of this type, yet", p);
 
@@ -127,7 +124,7 @@ public class OpenProjectListSetMain2Test extends NbTestCase {
         
         OpenProjectList.waitProjectsFullyOpen();
 
-        for (Node n : logicalView.getChildren().getNodes()) {
+        for (Node n : logicalView.getChildren().getNodes(true)) {
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNotNull("Nodes have correct project of this type", p);
         }
@@ -214,7 +211,7 @@ public class OpenProjectListSetMain2Test extends NbTestCase {
                 }
 
                 int o = 0;
-                for (Node n : logicalView.getChildren().getNodes()) {
+                for (Node n : logicalView.getChildren().getNodes(true)) {
                     TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
                     if (p != null) {
                         o++;

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListSetMainTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/OpenProjectListSetMainTest.java
@@ -87,9 +87,6 @@ public class OpenProjectListSetMainTest extends NbTestCase {
         OpenProjectListSettings.getInstance().setOpenProjectsURLs(list);
         OpenProjectListSettings.getInstance().setOpenProjectsDisplayNames(names);
         OpenProjectListSettings.getInstance().setOpenProjectsIcons(icons);
-        
-         //compute project root node children in sync mode
-        System.setProperty("test.projectnode.sync", "true");
     }
 
     @RandomlyFails // NB-Core-Build #1058
@@ -98,12 +95,12 @@ public class OpenProjectListSetMainTest extends NbTestCase {
         L listener = new L();
         logicalView.addNodeListener(listener);
         
-        assertEquals("30 children", 30, logicalView.getChildren().getNodesCount());
+        assertEquals("30 children", 30, logicalView.getChildren().getNodesCount(true));
         listener.assertEvents("None", 0);
         assertEquals("No project opened yet", 0, TestProjectOpenedHookImpl.opened);
         
         Node main = null;
-        for (Node n : logicalView.getChildren().getNodes()) {
+        for (Node n : logicalView.getChildren().getNodes(true)) {
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNull("No project of this type, yet", p);
 
@@ -127,7 +124,7 @@ public class OpenProjectListSetMainTest extends NbTestCase {
         
         OpenProjectList.waitProjectsFullyOpen();
 
-        for (Node n : logicalView.getChildren().getNodes()) {
+        for (Node n : logicalView.getChildren().getNodes(true)) {
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNotNull("Nodes have correct project of this type", p);
         }

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeFindTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeFindTest.java
@@ -47,10 +47,6 @@ public class ProjectsRootNodeFindTest extends NbTestCase {
     }            
 
     public void testFindNode() throws Exception{
-        
-         //compute project root node children in sync mode
-        System.setProperty("test.projectnode.sync", "true");
-        
         //prepearing project
         MockLookup.setInstances(new TestSupport.TestProjectFactory());
         CountDownLatch down = new CountDownLatch(1);
@@ -79,7 +75,7 @@ public class ProjectsRootNodeFindTest extends NbTestCase {
         OpenProjectListSettings.getInstance().setOpenProjectsIcons(icons);
 
         Node logicalView = new ProjectsRootNode(ProjectsRootNode.LOGICAL_VIEW);
-        assertEquals("2 children", 2, logicalView.getChildren().getNodesCount());
+        assertEquals("2 children", 2, logicalView.getChildren().getNodesCount(true));
 
         // let project open code run
         down.countDown();

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeInitializedSoonerTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeInitializedSoonerTest.java
@@ -60,10 +60,6 @@ public class ProjectsRootNodeInitializedSoonerTest extends NbTestCase {
     }
 
     public void testWrongOrderOfInitialization() throws Exception {
-        
-        //compute project root node children in sync mode
-        System.setProperty("test.projectnode.sync", "true");
-        
         MockLookup.setInstances(new TestSupport.TestProjectFactory());
         List<URL> list = new ArrayList<URL>();
         List<ExtIcon> icons = new ArrayList<ExtIcon>();
@@ -130,14 +126,14 @@ public class ProjectsRootNodeInitializedSoonerTest extends NbTestCase {
         OpenProjectList.LOGGER.setUseParentHandlers(false);
         OpenProjectList.LOGGER.setLevel(Level.ALL);
 
-        assertEquals("30 children", 30, logicalView.getChildren().getNodesCount());
+        assertEquals("30 children", 30, logicalView.getChildren().getNodesCount(true));
 
         OpenProjectList.waitProjectsFullyOpen();
         assertTrue("Handler was called", h.ok);
         assertEquals("All projects opened", 30, TestProjectOpenedHookImpl.opened);
 
         int i = 0;
-        for (Node n : logicalView.getChildren().getNodes()) {
+        for (Node n : logicalView.getChildren().getNodes(true)) {
             i++;
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNotNull("Project type is correct " + i, p);

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeNotRecognizedTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeNotRecognizedTest.java
@@ -53,9 +53,6 @@ public class ProjectsRootNodeNotRecognizedTest extends NbTestCase {
 
     @RandomlyFails // NB-Core-Build #4346: child at 0
     public void testBadgingNodeIsOKIfProjectIsNoLongerRecognized() throws Exception{
-        
-        //compute project root node children in sync mode
-        System.setProperty("test.projectnode.sync", "true");        
         //prepearing project
         MockLookup.setInstances(new TestFactory());
         down = new CountDownLatch(1);
@@ -80,7 +77,7 @@ public class ProjectsRootNodeNotRecognizedTest extends NbTestCase {
         OpenProjectListSettings.getInstance().setOpenProjectsIcons(icons);
 
         Node logicalView = new ProjectsRootNode(ProjectsRootNode.PHYSICAL_VIEW);
-        assertEquals("2 children", 2, logicalView.getChildren().getNodesCount());
+        assertEquals("2 children", 2, logicalView.getChildren().getNodesCount(true));
         assertNotNull("Still lazy project", logicalView.getChildren().getNodeAt(0).getLookup().lookup(LazyProject.class));
 
         // let project open code run

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePhysicalViewModeSourcesTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePhysicalViewModeSourcesTest.java
@@ -90,9 +90,6 @@ public class ProjectsRootNodePhysicalViewModeSourcesTest extends NbTestCase {
         OpenProjectListSettings.getInstance().setOpenProjectsURLs(list);
         OpenProjectListSettings.getInstance().setOpenProjectsDisplayNames(names);
         OpenProjectListSettings.getInstance().setOpenProjectsIcons(icons);
-        
-         //compute project root node children in sync mode
-        System.setProperty("test.projectnode.sync", "true");
     }
 
     public void testBehaviourOfProjectsLogicNode() throws InterruptedException {
@@ -100,11 +97,11 @@ public class ProjectsRootNodePhysicalViewModeSourcesTest extends NbTestCase {
         L listener = new L();
         view.addNodeListener(listener);
         
-        assertEquals("30 children", 30, view.getChildren().getNodesCount());
+        assertEquals("30 children", 30, view.getChildren().getNodesCount(true));
         listener.assertEvents("None", 0);
         assertEquals("No project opened yet", 0, TestProjectOpenedHookImpl.opened);
         
-        for (Node n : view.getChildren().getNodes()) {
+        for (Node n : view.getChildren().getNodes(true)) {
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNull("No project of this type, yet", p);
         }
@@ -117,7 +114,7 @@ public class ProjectsRootNodePhysicalViewModeSourcesTest extends NbTestCase {
         
         OpenProjectList.waitProjectsFullyOpen();
 
-        Node[] all = view.getChildren().getNodes();
+        Node[] all = view.getChildren().getNodes(true);
         assertEquals("3x30", 90, all.length);
         for (Node n : all) {
             LogicalView v = n.getLookup().lookup(LogicalView.class);

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePhysicalViewTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePhysicalViewTest.java
@@ -92,9 +92,6 @@ public class ProjectsRootNodePhysicalViewTest extends NbTestCase {
         OpenProjectListSettings.getInstance().setOpenProjectsURLs(list);
         OpenProjectListSettings.getInstance().setOpenProjectsDisplayNames(names);
         OpenProjectListSettings.getInstance().setOpenProjectsIcons(icons);
-        
-         //compute project root node children in sync mode
-        System.setProperty("test.projectnode.sync", "true");
     }
 
     @RandomlyFails // NB-Core-Build #3939: "Can be garbage collected when closed" involving TimedWeakReference
@@ -127,11 +124,11 @@ public class ProjectsRootNodePhysicalViewTest extends NbTestCase {
         L listener = new L();
         view.addNodeListener(listener);
         
-        assertEquals("30 children", 30, view.getChildren().getNodesCount());
+        assertEquals("30 children", 30, view.getChildren().getNodesCount(true));
         listener.assertEvents("None", 0);
         assertEquals("No project opened yet", 0, TestProjectOpenedHookImpl.opened);
         
-        for (Node n : view.getChildren().getNodes()) {
+        for (Node n : view.getChildren().getNodes(true)) {
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNull("No project of this type, yet", p);
         }
@@ -144,7 +141,7 @@ public class ProjectsRootNodePhysicalViewTest extends NbTestCase {
         
         OpenProjectList.waitProjectsFullyOpen();
 
-        for (Node n : view.getChildren().getNodes()) {
+        for (Node n : view.getChildren().getNodes(true)) {
             LogicalView v = n.getLookup().lookup(LogicalView.class);
             assertEquals("View is not present in physical view", null, v);
         }
@@ -152,7 +149,7 @@ public class ProjectsRootNodePhysicalViewTest extends NbTestCase {
         listener.assertEvents("Goal is to receive no events at all", 0);
         
         
-        return view.getChildren().getNodes()[0];
+        return view.getChildren().getNodes(true)[0];
     }
     
     private static class L implements NodeListener {

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredFromContextOpenTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredFromContextOpenTest.java
@@ -91,9 +91,6 @@ public class ProjectsRootNodePreferredFromContextOpenTest extends NbTestCase {
         OpenProjectListSettings.getInstance().setOpenProjectsURLs(list);
         OpenProjectListSettings.getInstance().setOpenProjectsDisplayNames(names);
         OpenProjectListSettings.getInstance().setOpenProjectsIcons(icons);
-        
-         //compute project root node children in sync mode
-        System.setProperty("test.projectnode.sync", "true");
     }
 
     public void testPreferencesInOpenCanBeChanged() throws InterruptedException, IOException {
@@ -101,16 +98,16 @@ public class ProjectsRootNodePreferredFromContextOpenTest extends NbTestCase {
         L listener = new L();
         logicalView.addNodeListener(listener);
         
-        assertEquals("10 children", 10, logicalView.getChildren().getNodesCount());
+        assertEquals("10 children", 10, logicalView.getChildren().getNodesCount(true));
         listener.assertEvents("None", 0);
         assertEquals("No project opened yet", 0, TestProjectOpenedHookImpl.opened);
         
-        for (Node n : logicalView.getChildren().getNodes()) {
+        for (Node n : logicalView.getChildren().getNodes(true)) {
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNull("No project of this type, yet", p);
         }
         
-        Node midNode = logicalView.getChildren().getNodes()[5];
+        Node midNode = logicalView.getChildren().getNodes(true)[5];
         {
             TestSupport.TestProject p = midNode.getLookup().lookup(TestSupport.TestProject.class);
             assertNull("No project of this type, yet", p);
@@ -135,7 +132,7 @@ public class ProjectsRootNodePreferredFromContextOpenTest extends NbTestCase {
         {
             TestSupport.TestProject p = null;
             for (int i = 0; i < 10; i++) {
-                Node midNode2 = logicalView.getChildren().getNodes()[5];
+                Node midNode2 = logicalView.getChildren().getNodes(true)[5];
                 p = midNode.getLookup().lookup(TestSupport.TestProject.class);
                 if (p != null) {
                     break;
@@ -152,7 +149,7 @@ public class ProjectsRootNodePreferredFromContextOpenTest extends NbTestCase {
         assertEquals("All projects opened", 10, TestProjectOpenedHookImpl.opened);
         
 
-        for (Node n : logicalView.getChildren().getNodes()) {
+        for (Node n : logicalView.getChildren().getNodes(true)) {
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNotNull("Nodes have correct project of this type", p);
         }

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredFromPopupTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredFromPopupTest.java
@@ -93,9 +93,6 @@ public class ProjectsRootNodePreferredFromPopupTest extends NbTestCase {
         OpenProjectListSettings.getInstance().setOpenProjectsURLs(list);
         OpenProjectListSettings.getInstance().setOpenProjectsDisplayNames(names);
         OpenProjectListSettings.getInstance().setOpenProjectsIcons(icons);
-        
-         //compute project root node children in sync mode
-        System.setProperty("test.projectnode.sync", "true");
     }
 
     public void testPreferencesInOpenCanBeChanged() throws InterruptedException, IOException, Exception {
@@ -103,16 +100,16 @@ public class ProjectsRootNodePreferredFromPopupTest extends NbTestCase {
         L listener = new L();
         logicalView.addNodeListener(listener);
         
-        assertEquals("10 children", 10, logicalView.getChildren().getNodesCount());
+        assertEquals("10 children", 10, logicalView.getChildren().getNodesCount(true));
         listener.assertEvents("None", 0);
         assertEquals("No project opened yet", 0, TestProjectOpenedHookImpl.opened);
         
-        for (Node n : logicalView.getChildren().getNodes()) {
+        for (Node n : logicalView.getChildren().getNodes(true)) {
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNull("No project of this type, yet", p);
         }
         
-        Node midNode = logicalView.getChildren().getNodes()[5];
+        Node midNode = logicalView.getChildren().getNodes(true)[5];
         {
             TestSupport.TestProject p = midNode.getLookup().lookup(TestSupport.TestProject.class);
             assertNull("No project of this type, yet", p);
@@ -141,7 +138,7 @@ public class ProjectsRootNodePreferredFromPopupTest extends NbTestCase {
         {
             TestSupport.TestProject p = null;
             for (int i = 0; i < 10; i++) {
-                Node midNode2 = logicalView.getChildren().getNodes()[5];
+                Node midNode2 = logicalView.getChildren().getNodes(true)[5];
                 p = midNode.getLookup().lookup(TestSupport.TestProject.class);
                 if (p != null) {
                     break;
@@ -158,7 +155,7 @@ public class ProjectsRootNodePreferredFromPopupTest extends NbTestCase {
         assertEquals("All projects opened", 10, TestProjectOpenedHookImpl.opened);
         
 
-        for (Node n : logicalView.getChildren().getNodes()) {
+        for (Node n : logicalView.getChildren().getNodes(true)) {
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNotNull("Nodes have correct project of this type", p);
         }

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredOpen2Test.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredOpen2Test.java
@@ -19,14 +19,11 @@
 
 package org.netbeans.modules.project.ui;
 
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.junit.Log;
 import org.netbeans.modules.project.ui.actions.TestSupport.TestProject;
 import org.netbeans.spi.project.ui.LogicalViewProvider;
-import org.openide.loaders.DataObject;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
@@ -55,8 +52,6 @@ public class ProjectsRootNodePreferredOpen2Test extends ProjectsRootNodePreferre
         log = Log.enable("", Level.WARNING);
         Logger.getLogger("org.netbeans.ui").setLevel(Level.OFF);
         Logger.getLogger("org.openide.util").setLevel(Level.OFF);
-         //compute project root node children in sync mode
-        System.setProperty("test.projectnode.sync", "true");
     }
 
     @Override

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredOpenTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePreferredOpenTest.java
@@ -98,12 +98,8 @@ implements PropertyChangeListener {
         OpenProjectListSettings.getInstance().setOpenProjectsIcons(icons);
         
         OpenProjects.getDefault().addPropertyChangeListener(this);
-        
-         //compute project root node children in sync mode
-        System.setProperty("test.projectnode.sync", "true");
     }
 
-    @RandomlyFails // NB-Core-Build #1001
     public void testPreferencesInOpenCanBeChanged() throws InterruptedException {
         assertEquals("No events in API", 0, events);
         
@@ -112,18 +108,18 @@ implements PropertyChangeListener {
         logicalView.addNodeListener(listener);
         
         assertEquals("No events in API", 0, events);
-        assertEquals("10 children", 10, logicalView.getChildren().getNodesCount());
+        assertEquals("10 children", 10, logicalView.getChildren().getNodesCount(true));
         listener.assertEvents("None", 0);
         assertEquals("No project opened yet", 0, TestProjectOpenedHookImpl.opened);
         assertEquals("No events in API", 0, events);
         
-        for (Node n : logicalView.getChildren().getNodes()) {
+        for (Node n : logicalView.getChildren().getNodes(true)) {
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNull("No project of this type, yet", p);
         }
         assertEquals("No events in API", 0, events);
         
-        Node midNode = logicalView.getChildren().getNodes()[5];
+        Node midNode = logicalView.getChildren().getNodes(true)[5];
         {
             TestSupport.TestProject p = midNode.getLookup().lookup(TestSupport.TestProject.class);
             assertNull("No project of this type, yet", p);
@@ -138,7 +134,7 @@ implements PropertyChangeListener {
         Thread.sleep(300);
         assertEquals("Still no processing", 0, TestProjectOpenedHookImpl.opened);
         // trigger initialization of the node, shall trigger OpenProjectList.preferredProject(lazyP);
-        midNode.getChildren().getNodes();
+        midNode.getChildren().getNodes(true);
         first.countDown();
         
         TestProjectOpenedHookImpl.toOpen.await();
@@ -146,7 +142,7 @@ implements PropertyChangeListener {
         {
             TestSupport.TestProject p = null;
             for (int i = 0; i < 10; i++) {
-                Node midNode2 = logicalView.getChildren().getNodes()[5];
+                Node midNode2 = logicalView.getChildren().getNodes(true)[5];
                 p = midNode.getLookup().lookup(TestSupport.TestProject.class);
                 if (p != null) {
                     break;
@@ -160,7 +156,7 @@ implements PropertyChangeListener {
         {
             int cnt = 0;
             for (int i = 0; i < 10; i++) {
-                Node n = logicalView.getChildren().getNodes()[i];
+                Node n = logicalView.getChildren().getNodes(true)[i];
                 TestSupport.TestProject p = null;
                 p = n.getLookup().lookup(TestSupport.TestProject.class);
                 if (p != null) {
@@ -180,7 +176,7 @@ implements PropertyChangeListener {
         assertEquals("All projects opened", 10, TestProjectOpenedHookImpl.opened);
         
 
-        for (Node n : logicalView.getChildren().getNodes()) {
+        for (Node n : logicalView.getChildren().getNodes(true)) {
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNotNull("Nodes have correct project of this type", p);
         }

--- a/java/java.lsp.server/arch.xml
+++ b/java/java.lsp.server/arch.xml
@@ -513,6 +513,13 @@
          <li>
              <b>com.dukescript.presenters.browserDebug</b>
          </li>
+         <li>
+             <api type="export" group="systemproperty" name="treeViewProvider.sync" category="private">
+                 Should <code>Children.getNodes(optimalResult)</code> be called
+                 with <code>true</code>? Then set the <code>treeViewProvider.sync</code>
+                 property to <code>"true"</code>. Useful while testing.
+             </api>
+         </li>
      </ul>
  </answer>
 

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
@@ -470,8 +470,9 @@ public abstract class TreeViewProvider {
     }
 
     public final CompletionStage<Node[]> getChildren(Node nodeOrNull) {
-        Node node = getNodeOrRoot(nodeOrNull);
-        return CompletableFuture.completedFuture(node.getChildren().getNodes());
+        var node = getNodeOrRoot(nodeOrNull);
+        var optimalResult = Boolean.getBoolean("treeViewProvider.sync");
+        return CompletableFuture.completedFuture(node.getChildren().getNodes(optimalResult));
     }
 
     public final CompletionStage<Node> getParent(Node node) {

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/ProjectViewTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/ProjectViewTest.java
@@ -417,7 +417,7 @@ public class ProjectViewTest extends NbTestCase {
         InitializeResult result = server.initialize(new InitializeParams()).get();
                 
         // by default the ProjectsRootNode initializes its contents asynchronously; a proper reaction to that will be tested in another testcase. Save the complexity here.
-        System.setProperty("test.projectnode.sync", "true");
+        System.setProperty("treeViewProvider.sync", "true");
 
         CompletableFuture<TreeItem> explorer = server.getTreeViewService().explorerManager(new CreateExplorerParams("foundProjects"));
         TreeItem root = explorer.get();

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/ScanInProgressTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/usages/ScanInProgressTest.java
@@ -75,9 +75,6 @@ public class ScanInProgressTest extends NbTestCase implements PropertyChangeList
 
     @Override
     protected void setUp() throws Exception {
-        //ensure ProjectsRootNode children are processed synchronously:
-        System.setProperty("test.projectnode.sync", "true");
-
         clearWorkDir();
 
         MockServices.setServices(TestSupport.TestProjectFactory.class);
@@ -119,18 +116,18 @@ public class ScanInProgressTest extends NbTestCase implements PropertyChangeList
         logicalView.addNodeListener(listener);
 
         assertEquals("No events in API", 0, events);
-        assertEquals("10 children", 10, logicalView.getChildren().getNodesCount());
+        assertEquals("10 children", 10, logicalView.getChildren().getNodesCount(true));
         listener.assertEvents("None", 0);
         assertEquals("No project opened yet", 0, TestProjectOpenedHookImpl.opened);
         assertEquals("No events in API", 0, events);
 
-        for (Node n : logicalView.getChildren().getNodes()) {
+        for (Node n : logicalView.getChildren().getNodes(true)) {
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNull("No project of this type, yet", p);
         }
         assertEquals("No events in API", 0, events);
 
-        Node midNode = logicalView.getChildren().getNodes()[5];
+        Node midNode = logicalView.getChildren().getNodes(true)[5];
         {
             TestSupport.TestProject p = midNode.getLookup().lookup(TestSupport.TestProject.class);
             assertNull("No project of this type, yet", p);
@@ -145,7 +142,7 @@ public class ScanInProgressTest extends NbTestCase implements PropertyChangeList
         Thread.sleep(300);
         assertEquals("Still no processing", 0, TestProjectOpenedHookImpl.opened);
         // trigger initialization of the node, shall trigger OpenProjectList.preferredProject(lazyP);
-        midNode.getChildren().getNodes();
+        midNode.getChildren().getNodes(true);
         first.countDown();
 
         TestProjectOpenedHookImpl.toOpen.await();
@@ -153,7 +150,7 @@ public class ScanInProgressTest extends NbTestCase implements PropertyChangeList
         {
             TestSupport.TestProject p = null;
             for (int i = 0; i < 10; i++) {
-                Node midNode2 = logicalView.getChildren().getNodes()[5];
+                Node midNode2 = logicalView.getChildren().getNodes(true)[5];
                 p = midNode.getLookup().lookup(TestSupport.TestProject.class);
                 if (p != null) {
                     break;
@@ -167,7 +164,7 @@ public class ScanInProgressTest extends NbTestCase implements PropertyChangeList
         {
             int cnt = 0;
             for (int i = 0; i < 10; i++) {
-                Node n = logicalView.getChildren().getNodes()[i];
+                Node n = logicalView.getChildren().getNodes(true)[i];
                 TestSupport.TestProject p = null;
                 p = n.getLookup().lookup(TestSupport.TestProject.class);
                 if (p != null) {
@@ -187,7 +184,7 @@ public class ScanInProgressTest extends NbTestCase implements PropertyChangeList
         assertEquals("All projects opened", 10, TestProjectOpenedHookImpl.opened);
 
 
-        for (Node n : logicalView.getChildren().getNodes()) {
+        for (Node n : logicalView.getChildren().getNodes(true)) {
             TestSupport.TestProject p = n.getLookup().lookup(TestSupport.TestProject.class);
             assertNotNull("Nodes have correct project of this type", p);
         }


### PR DESCRIPTION
While writing a unit tests for `ProjectsRootNode` I realized that `ProjectsRootNode.getNodes(true)` violates the intended behavior. It should always wait for _optimal result_, but it doesn't not. The `addNotify` schedules `setKeys` called into a deferred `RP` task.... as such `getChildren().getNodes(true)` may return empty array while they should see the result of `setKeys`.

Modifying the code in `getNodes(boolean optimalResult)` to update the keys when `optimalResult` is requested. This alignes with `ProjectsRootNode.getNodesCount` which was already updating the keys with `setKeys` when optimal result was requested.

Prior to change in `ProjectsRootNode.getNodes(boolean)` my new unit tests (also part of this PR) were failing. Now they are reliably passing.