### PR TITLE
Fix sout expansion in unbraced for-loop bodies

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaCodeTemplateFilter.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaCodeTemplateFilter.java
@@ -29,7 +29,9 @@ import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 import com.sun.source.tree.CaseTree;
 import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.EnhancedForLoopTree;
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.ForLoopTree;
 import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreePath;
 import java.util.Set;
@@ -144,7 +146,8 @@ public class JavaCodeTemplateFilter implements CodeTemplateFilter {
                                         }
                                         case FOR_LOOP:
                                         case ENHANCED_FOR_LOOP:
-                                            if (!isRightParenthesisOfLoopPresent(controller, so)) {
+                                            if (!isInLoopBody(controller, tree, so)
+                                                    && !isRightParenthesisOfLoopPresent(controller, so)) {
                                                 treeKindCtx = null;
                                             }
                                             break;
@@ -176,6 +179,18 @@ public class JavaCodeTemplateFilter implements CodeTemplateFilter {
             return tokenId == null ? false : (tokenId == JavaTokenId.RPAREN);
         }
         return false;
+    }
+
+    private boolean isInLoopBody(CompilationController controller, Tree loop, int abbrevStartOffset) {
+        Tree statement;
+        if (loop.getKind() == Tree.Kind.FOR_LOOP) {
+            statement = ((ForLoopTree) loop).getStatement();
+        } else {
+            statement = ((EnhancedForLoopTree) loop).getStatement();
+        }
+        long statementStart = controller.getTrees().getSourcePositions()
+                .getStartPosition(controller.getCompilationUnit(), statement);
+        return statementStart >= 0 && abbrevStartOffset >= statementStart;
     }
     
     private TokenId skipNextWhitespaces(TokenSequence<?> tokenSequence) {

--- a/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaCodeTemplateProcessorTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaCodeTemplateProcessorTest.java
@@ -34,6 +34,7 @@ import org.netbeans.junit.NbTestCase;
 import org.netbeans.lib.editor.codetemplates.CodeTemplateInsertHandler;
 import org.netbeans.lib.editor.codetemplates.api.CodeTemplate;
 import org.netbeans.lib.editor.codetemplates.api.CodeTemplateManager;
+import org.netbeans.lib.editor.codetemplates.spi.CodeTemplateFilter;
 import org.netbeans.lib.editor.codetemplates.storage.CodeTemplateSettingsImpl.OnExpandAction;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -201,6 +202,60 @@ public class JavaCodeTemplateProcessorTest extends NbTestCase {
                              "        }\n" +
                              "    }\n" +
                              "}");
+    }
+
+    public void testSoutTemplateIsAcceptedInUnbracedForLoopBody() throws Exception {
+        assertSoutTemplateAccepted("public class Test {\n"
+                + "    private void test() {\n"
+                + "        for (int i = 0; i < 3; i++)\n"
+                + "            sout\n"
+                + "    }\n"
+                + "}", true);
+    }
+
+    public void testSoutTemplateIsAcceptedInUnbracedEnhancedForLoopBody() throws Exception {
+        assertSoutTemplateAccepted("public class Test {\n"
+                + "    private void test(String[] values) {\n"
+                + "        for (String value : values)\n"
+                + "            sout\n"
+                + "    }\n"
+                + "}", true);
+    }
+
+    public void testSoutTemplateIsRejectedInIncompleteForLoopHeader() throws Exception {
+        assertSoutTemplateAccepted("public class Test {\n"
+                + "    private void test() {\n"
+                + "        for (int i = 0; sout\n"
+                + "    }\n"
+                + "}", false);
+    }
+
+    private void assertSoutTemplateAccepted(String text, boolean expected) throws Exception {
+        clearWorkDir();
+        testFile = FileUtil.toFileObject(getWorkDir()).createData("Test.java");
+        EditorKit kit = new JavaKit();
+        JEditorPane pane = new JEditorPane();
+        SwingUtilities.invokeAndWait(() -> {
+            pane.setEditorKit(kit);
+        });
+        Document doc = pane.getDocument();
+        doc.putProperty(Document.StreamDescriptionProperty, testFile);
+        doc.putProperty(Language.class, JavaTokenId.language());
+        doc.putProperty("mimeType", "text/x-java");
+        pane.setText(text);
+        try (OutputStream out = testFile.getOutputStream();
+             Writer w = new OutputStreamWriter(out)) {
+            w.append(text);
+        }
+        CodeTemplate sout = CodeTemplateManager.get(doc).getCodeTemplates().stream()
+                .filter(template -> "sout".equals(template.getAbbreviation()))
+                .findFirst()
+                .orElseThrow();
+        int abbreviationOffset = text.indexOf("sout");
+        CodeTemplateFilter filter = new JavaCodeTemplateFilter.Factory()
+                .createFilter(doc, abbreviationOffset, -1);
+
+        assertEquals(expected, filter.accept(sout));
     }
 
     public void testInfiteLoop() throws Exception {


### PR DESCRIPTION
## Description

Fixes Apache NetBeans issue #5244. Java code templates such as `sout` were rejected when entered as the single-statement body of a `for` loop without braces.

The filter already supported `FOR_LOOP` and `ENHANCED_FOR_LOOP`, but it applied a loop-header closing-parenthesis check to the body as well. The fix uses the loop statement source position to distinguish body context from header context, preserving the existing header validation.

## Tests

- `ant '-Dcluster.config=basic' build` (baseline passed)
- `ant -f java/java.editor/build.xml test-single -Dtest.includes=org/netbeans/modules/editor/java/JavaCodeTemplateProcessorTest.java` (passed)
- Manual test in rebuilt NetBeans IDE: original unbraced `for` body sequence expands `sout` to `System.out.println("");`
- Full `java.editor` unit suite: unrelated `ComputeImportsTest` CRLF/LF fixture failures on Windows; other suites passed

Assisted-by: GPT-5 Codex GPT-5