### PR TITLE
Stabilize ClassIndexTest#testQueryIndexRefreshQueryAgain

### DIFF
--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/ClassIndexTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/ClassIndexTest.java
@@ -620,9 +620,12 @@ public class ClassIndexTest extends NbTestCase {
         GlobalPathRegistry.getDefault().register(ClassPath.COMPILE, new ClassPath[] {compilePath});
         GlobalPathRegistry.getDefault().register(ClassPath.SOURCE, new ClassPath[] {sourcePath});
 
-        IndexingManager.getDefault().refreshAllIndices(true, true, root);
+        System.out.println("## 1 before wait: " +SourceUtils.isScanInProgress());
         SourceUtils.waitScanFinished();
-
+        System.out.println("## 2 after wait: " +SourceUtils.isScanInProgress());
+        IndexingManager.getDefault().refreshAllIndices(true, true, root);
+        System.out.println("## 3 after refresh: " +SourceUtils.isScanInProgress());
+        
         result = ci.getDeclaredTypes("TestLib", NameKind.PREFIX, Set.of(ClassIndex.SearchScope.DEPENDENCIES));
         assertNotNull(result);
         assertElementHandles(new String[] {"lib.TestLib"}, result);


### PR DESCRIPTION
swap `waitScanFinished()` with `refreshAllIndices()` and added some debug print for the indexer state.

100x test loop worked https://github.com/mbien/netbeans/actions/runs/33841946719 (local testrun with the same iteration count passed too)

@lahodaj is the test case still working as intended after the two methods are swapped?

issue https://github.com/apache/netbeans/issues/8183#issuecomment-5533384462