### PR TITLE
Running `ide/projectui` tests in the CI checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -761,6 +761,9 @@ jobs:
       - name: ide/projectuiapi.base
         run: ant $OPTS -f ide/projectuiapi.base test
 
+      - name: ide/projectui
+        run: ant $OPTS -f ide/projectui test
+
       - name: ide/refactoring.api
         run: ant $OPTS -f ide/refactoring.api test
 

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectUtilitiesTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectUtilitiesTest.java
@@ -23,20 +23,16 @@ import java.awt.GraphicsEnvironment;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;
 import junit.framework.Test;
-import junit.framework.TestSuite;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.junit.MockServices;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.junit.NbTestSuite;
-import org.netbeans.junit.RandomlyFails;
 import org.netbeans.modules.project.ui.actions.TestSupport;
 import org.netbeans.spi.project.AuxiliaryConfiguration;
 import org.openide.cookies.EditorCookie;
@@ -49,7 +45,6 @@ import org.openide.loaders.DataObjectNotFoundException;
 import org.openide.text.CloneableEditorSupport;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.Lookups;
-import org.openide.util.test.RestrictThreadCreation;
 import org.openide.windows.CloneableTopComponent;
 import org.openide.windows.TopComponent;
 import org.openide.windows.WindowManager;
@@ -135,16 +130,6 @@ public class ProjectUtilitiesTest extends NbTestCase {
         (tc1_1_navigator = new SimpleTopComponent2 (do1_1_open, NAVIGATOR_MODE)).open ();
         
         ExitDialog.SAVE_ALL_UNCONDITIONALLY = true;
-
-        RestrictThreadCreation.permitStandard();
-        RestrictThreadCreation.permit(OpenProjectList.class.getName() + "$LoadOpenProjects.waitFinished",
-                OpenProjectList.class.getName() + "$LoadOpenProjects.resultChanged",
-                "org.openide.text.CloneableEditorSupport.prepareDocument",
-                "org.openide.text.CloneableEditor.initialize",
-                "org.openide.util.lookup.MetaInfServicesLookup.beforeLookup",
-                "org.netbeans.modules.project.ui.OpenProjectList.close",
-                "org.netbeans.modules.project.ui.OpenProjectList.doOpenProject");
-        RestrictThreadCreation.forbidNewThreads(false);
     }
     
     @SuppressWarnings("deprecation")

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeInitializedSoonerTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeInitializedSoonerTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ui.OpenProjects;
@@ -122,9 +123,10 @@ public class ProjectsRootNodeInitializedSoonerTest extends NbTestCase {
         }
         H h = new H();
         h.setLevel(Level.ALL);
-        OpenProjectList.LOGGER.addHandler(h);
-        OpenProjectList.LOGGER.setUseParentHandlers(false);
-        OpenProjectList.LOGGER.setLevel(Level.ALL);
+        Logger projectsRootNodeLOG = Logger.getLogger("org.netbeans.modules.project.ui.ProjectsRootNode");
+        projectsRootNodeLOG.addHandler(h);
+        projectsRootNodeLOG.setUseParentHandlers(false);
+        projectsRootNodeLOG.setLevel(Level.ALL);
 
         assertEquals("30 children", 30, logicalView.getChildren().getNodesCount(true));
 

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePhysicalViewTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodePhysicalViewTest.java
@@ -34,6 +34,7 @@ import org.netbeans.junit.MockServices;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.junit.RandomlyFails;
 import org.netbeans.modules.project.ui.actions.TestSupport;
+import org.netbeans.modules.projectapi.nb.TimedWeakReference;
 import org.netbeans.spi.project.ui.LogicalViewProvider;
 import org.netbeans.spi.project.ui.ProjectOpenedHook;
 import org.openide.filesystems.FileObject;
@@ -67,6 +68,8 @@ public class ProjectsRootNodePhysicalViewTest extends NbTestCase {
     @Override
     protected void setUp() throws Exception {
         clearWorkDir();
+
+        TimedWeakReference.TIMEOUT = 1;
         
         MockServices.setServices(TestSupport.TestProjectFactory.class);
         

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectsRootNodeTest.java
@@ -403,7 +403,7 @@ public class ProjectsRootNodeTest extends NbTestCase {
             }
         };
         ProjectsRootNode.checkNoLazyNode(ch);
-        Node[] ns = ch.getNodes(true);
+        Node[] ns = ch.getNodes(false);
         assertEquals(1, ns.length);
         assertEquals("p - Testing", ns[0].getDisplayName());
     }


### PR DESCRIPTION
- enabling `projectui` tests in the CI
   - really fails in [org.netbeans.modules.project.ui.ProjectUtilitiesTest](https://github.com/apache/netbeans/actions/runs/33939694408/job/101235743948?pr=9603#step:69:846) - fixed in 1328e4b
   - and `org.netbeans.modules.project.ui.ProjectsRootNodeTest` - fixed in 64b8585
   - and `org.netbeans.modules.project.ui.ProjectsRootNodeInitializedSoonerTest` - [removed](https://github.com/apache/netbeans/pull/9603#discussion_r3939587287) 
- [x] fixing the failing tests
- [ide/projectui tests](https://github.com/apache/netbeans/actions/runs/34012385963/job/101431244685?pr=9603#step:69:7146) are successfully running on the CI 
- the tests [executed 37 times successfully](https://github.com/apache/netbeans/pull/9603#issuecomment-5578704069) on my local machine