### PR TITLE
Add Visual Studio Code keymap

### DIFF
--- a/ide/defaults/src/org/netbeans/modules/defaults/Bundle.properties
+++ b/ide/defaults/src/org/netbeans/modules/defaults/Bundle.properties
@@ -26,6 +26,7 @@ Keymaps/NetBeans55=NetBeans 5.5
 Keymaps/NetBeans=NetBeans
 Keymaps/Eclipse=Eclipse
 Keymaps/Idea=Idea
+Keymaps/VSCode=Visual Studio Code
 
 # Coloring profile names
 Editors/FontsColors/NetBeans55=NetBeans 5.5

--- a/ide/defaults/src/org/netbeans/modules/defaults/VSCode-keybindings-mac.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/VSCode-keybindings-mac.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<!DOCTYPE bindings PUBLIC "-//NetBeans//DTD Editor KeyBindings settings 1.1//EN" "http://www.netbeans.org/dtds/EditorKeyBindings-1_1.dtd">
+
+<!--
+    This file modifies keybindings from VSCode-keybindings.xml to make them work on Mac OS.
+-->
+
+<bindings>
+    <bind key="C-A" remove="true"/>
+    <bind actionName="select-all" key="M-A"/>
+
+    <bind key="C-BACK_SPACE" remove="true"/>
+    <bind actionName="remove-word-previous" key="A-BACK_SPACE"/>
+
+    <bind key="C-C" remove="true"/>
+    <bind actionName="copy-to-clipboard" key="M-C"/>
+
+    <bind key="C-D" remove="true"/>
+    <bind actionName="addCaretSelectNext" key="M-D"/>
+
+    <bind key="C-DELETE" remove="true"/>
+    <bind actionName="remove-word-next" key="A-DELETE"/>
+
+    <bind key="C-END" remove="true"/>
+    <bind actionName="caret-end" key="M-DOWN"/>
+
+    <bind key="C-EQUALS" remove="true"/>
+    <bind actionName="zoom-text-in" key="M-EQUALS"/>
+
+    <bind key="C-F" remove="true"/>
+    <bind actionName="find" key="M-F"/>
+
+    <bind key="C-H" remove="true"/>
+    <bind actionName="replace" key="MA-F"/>
+
+    <bind key="C-HOME" remove="true"/>
+    <bind actionName="caret-begin" key="M-UP"/>
+
+    <bind key="C-LEFT" remove="true"/>
+    <bind actionName="caret-previous-word" key="A-LEFT"/>
+
+    <bind key="C-MINUS" remove="true"/>
+    <bind actionName="zoom-text-out" key="M-MINUS"/>
+
+    <bind key="C-RIGHT" remove="true"/>
+    <bind actionName="caret-next-word" key="A-RIGHT"/>
+
+    <bind key="C-SLASH" remove="true"/>
+    <bind actionName="toggle-comment" key="M-SLASH"/>
+
+    <bind key="C-U" remove="true"/>
+    <bind actionName="remove-last-caret" key="M-U"/>
+
+    <bind key="C-V" remove="true"/>
+    <bind actionName="paste-from-clipboard" key="M-V"/>
+
+    <bind key="C-X" remove="true"/>
+    <bind actionName="cut-to-clipboard" key="M-X"/>
+
+    <bind key="C-Y" remove="true"/>
+
+    <bind key="C-Z" remove="true"/>
+    <bind actionName="undo" key="M-Z"/>
+
+    <bind key="CS-END" remove="true"/>
+    <bind actionName="selection-end" key="MS-DOWN"/>
+
+    <bind key="CS-HOME" remove="true"/>
+    <bind actionName="selection-begin" key="MS-UP"/>
+
+    <bind key="CS-LEFT" remove="true"/>
+    <bind actionName="selection-previous-word" key="AS-LEFT"/>
+
+    <bind key="CS-L" remove="true"/>
+    <bind actionName="addCaretSelectAll" key="MS-L"/>
+
+    <bind key="CS-RIGHT" remove="true"/>
+    <bind actionName="selection-next-word" key="AS-RIGHT"/>
+
+    <bind key="CS-V" remove="true"/>
+    <bind actionName="clipboard-history" key="MS-V"/>
+
+    <bind key="CS-Z" remove="true"/>
+    <bind actionName="redo" key="MS-Z"/>
+
+    <bind actionName="caret-begin-line" key="M-LEFT"/>
+    <bind actionName="caret-end-line" key="M-RIGHT"/>
+    <bind actionName="find-next" key="M-G"/>
+    <bind actionName="find-previous" key="MS-G"/>
+    <bind actionName="selection-begin-line" key="MS-LEFT"/>
+    <bind actionName="selection-end-line" key="MS-RIGHT"/>
+</bindings>

--- a/ide/defaults/src/org/netbeans/modules/defaults/VSCode-keybindings.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/VSCode-keybindings.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<!DOCTYPE bindings PUBLIC "-//NetBeans//DTD Editor KeyBindings settings 1.1//EN" "http://www.netbeans.org/dtds/EditorKeyBindings-1_1.dtd">
+
+<bindings>
+    <bind actionName="caret-backward" key="KP_LEFT"/>
+    <bind actionName="caret-backward" key="LEFT"/>
+    <bind actionName="caret-begin" key="C-HOME"/>
+    <bind actionName="caret-begin-line" key="HOME"/>
+    <bind actionName="caret-down" key="DOWN"/>
+    <bind actionName="caret-down" key="KP_DOWN"/>
+    <bind actionName="caret-end" key="C-END"/>
+    <bind actionName="caret-end-line" key="END"/>
+    <bind actionName="caret-forward" key="KP_RIGHT"/>
+    <bind actionName="caret-forward" key="RIGHT"/>
+    <bind actionName="caret-next-word" key="C-RIGHT"/>
+    <bind actionName="caret-previous-word" key="C-LEFT"/>
+    <bind actionName="caret-up" key="KP_UP"/>
+    <bind actionName="caret-up" key="UP"/>
+    <bind actionName="clipboard-history" key="CS-V"/>
+    <bind actionName="completion-show" key="C-SPACE"/>
+    <bind actionName="copy-selection-else-line-down" key="AS-DOWN"/>
+    <bind actionName="copy-selection-else-line-up" key="AS-UP"/>
+    <bind actionName="copy-to-clipboard" key="C-C"/>
+    <bind actionName="copy-to-clipboard" key="COPY"/>
+    <bind actionName="cut-to-clipboard" key="C-X"/>
+    <bind actionName="cut-to-clipboard" key="CUT"/>
+    <bind actionName="delete-next" key="DELETE"/>
+    <bind actionName="delete-previous" key="BACK_SPACE"/>
+    <bind actionName="delete-previous" key="S-BACK_SPACE"/>
+    <bind actionName="find" key="C-F"/>
+    <bind actionName="find-next" key="F3"/>
+    <bind actionName="find-previous" key="S-F3"/>
+    <bind actionName="format" key="AS-F"/>
+    <bind actionName="goto" key="C-G"/>
+    <bind actionName="goto-declaration" key="F12"/>
+    <bind actionName="insert-break" key="ENTER"/>
+    <bind actionName="insert-tab" key="TAB"/>
+    <bind actionName="match-brace" key="CS-BACK_SLASH"/>
+    <bind actionName="move-selection-else-line-down" key="A-DOWN"/>
+    <bind actionName="move-selection-else-line-up" key="A-UP"/>
+    <bind actionName="page-down" key="PAGE_DOWN"/>
+    <bind actionName="page-up" key="PAGE_UP"/>
+    <bind actionName="paste-from-clipboard" key="C-V"/>
+    <bind actionName="paste-from-clipboard" key="PASTE"/>
+    <bind actionName="redo" key="C-Y"/>
+    <bind actionName="redo" key="CS-Z"/>
+    <bind actionName="remove-line" key="CS-K"/>
+    <bind actionName="remove-tab" key="S-TAB"/>
+    <bind actionName="remove-word-next" key="C-DELETE"/>
+    <bind actionName="remove-word-previous" key="C-BACK_SPACE"/>
+    <bind actionName="replace" key="C-H"/>
+    <bind actionName="select-all" key="C-A"/>
+    <bind actionName="selection-backward" key="S-LEFT"/>
+    <bind actionName="selection-begin" key="CS-HOME"/>
+    <bind actionName="selection-begin-line" key="S-HOME"/>
+    <bind actionName="selection-down" key="S-DOWN"/>
+    <bind actionName="selection-end" key="CS-END"/>
+    <bind actionName="selection-end-line" key="S-END"/>
+    <bind actionName="selection-forward" key="S-RIGHT"/>
+    <bind actionName="selection-next-word" key="CS-RIGHT"/>
+    <bind actionName="selection-page-down" key="S-PAGE_DOWN"/>
+    <bind actionName="selection-page-up" key="S-PAGE_UP"/>
+    <bind actionName="selection-previous-word" key="CS-LEFT"/>
+    <bind actionName="selection-up" key="S-UP"/>
+    <bind actionName="start-new-line" key="C-ENTER"/>
+    <bind actionName="start-new-line" key="S-ENTER"/>
+    <bind actionName="toggle-comment" key="C-SLASH"/>
+    <bind actionName="toggle-typing-mode" key="INSERT"/>
+    <bind actionName="undo" key="C-Z"/>
+    <bind actionName="undo" key="UNDO"/>
+
+    <bind actionName="addCaretSelectNext" key="C-D"/>
+    <bind actionName="addCaretSelectAll" key="CS-L"/>
+    <bind actionName="add-caret-down" key="CA-DOWN"/>
+    <bind actionName="add-caret-up" key="CA-UP"/>
+    <bind actionName="remove-last-caret" key="C-U"/>
+    <bind actionName="zoom-text-in" key="C-EQUALS"/>
+    <bind actionName="zoom-text-out" key="C-MINUS"/>
+
+    <!-- java -->
+    <bind actionName="complete-line" key="CS-ENTER"/>
+    <bind actionName="fix-imports" key="AS-O"/>
+    <bind actionName="goto-super-implementation" key="CS-F12"/>
+    <bind actionName="in-place-refactoring" key="F2"/>
+</bindings>

--- a/ide/defaults/src/org/netbeans/modules/defaults/mf-layer.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/mf-layer.xml
@@ -1096,6 +1096,63 @@
                 <attr name="originalFile" stringvalue="Actions/Edit/org-openide-actions-UndoAction.instance"/>
             </file>
         </folder>
+        <folder name="VSCode">
+            <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.defaults.Bundle"/>
+            <file name="D-B.shadow">
+                <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-logical-tab-action.instance"/>
+            </file>
+            <file name="D-BACK_QUOTE.shadow">
+                <attr name="originalFile" stringvalue="Actions/Window/ShowTerminalTCAction.instance"/>
+            </file>
+            <file name="D-O.shadow">
+                <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-OpenProject.instance"/>
+            </file>
+            <file name="D-P.shadow">
+                <attr name="originalFile" stringvalue="Actions/Tools/org-netbeans-modules-jumpto-file-FileSearchAction.instance"/>
+            </file>
+            <file name="D-S.shadow">
+                <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-SaveAction.instance"/>
+            </file>
+            <file name="D-S-F.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-netbeans-modules-search-FindInFilesAction.instance"/>
+            </file>
+            <file name="DS-E.shadow">
+                <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-logical-tab-action.instance"/>
+            </file>
+            <file name="DS-G.shadow">
+                <attr name="originalFile" stringvalue="Actions/Window/org-netbeans-core-ide-ServicesTabAction.instance"/>
+            </file>
+            <file name="DS-H.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-netbeans-modules-search-ReplaceInFilesAction.instance"/>
+            </file>
+            <file name="DS-O.shadow">
+                <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-OpenProject.instance"/>
+            </file>
+            <file name="DS-P.shadow">
+                <attr name="originalFile" stringvalue="Actions/Edit/org-netbeans-modules-quicksearch-QuickSearchAction.instance"/>
+            </file>
+            <file name="F2.shadow">
+                <attr name="originalFile" stringvalue="Actions/System/org-openide-actions-RenameAction.instance"/>
+            </file>
+            <file name="F5.shadow">
+                <attr name="originalFile" stringvalue="Actions/Debug/org-netbeans-modules-debugger-ui-actions-DebugMainProjectAction.instance"/>
+            </file>
+            <file name="F9.shadow">
+                <attr name="originalFile" stringvalue="Actions/Debug/org-netbeans-modules-debugger-ui-actions-ToggleBreakpointAction.instance"/>
+            </file>
+            <file name="F10.shadow">
+                <attr name="originalFile" stringvalue="Actions/Debug/org-netbeans-modules-debugger-ui-actions-StepOverAction.instance"/>
+            </file>
+            <file name="F11.shadow">
+                <attr name="originalFile" stringvalue="Actions/Debug/org-netbeans-modules-debugger-ui-actions-StepIntoAction.instance"/>
+            </file>
+            <file name="S-F5.shadow">
+                <attr name="originalFile" stringvalue="Actions/Debug/org-netbeans-modules-debugger-ui-actions-KillAction.instance"/>
+            </file>
+            <file name="S-F11.shadow">
+                <attr name="originalFile" stringvalue="Actions/Debug/org-netbeans-modules-debugger-ui-actions-StepOutAction.instance"/>
+            </file>
+        </folder>
         </folder>
         <folder name="Editors">
 
@@ -1187,6 +1244,14 @@
                     <folder name="Defaults">
                         <file name="org-netbeans-modules-defaults-keybindings.xml" url="Idea-keybindings.xml"/>
                         <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="Idea-keybindings-mac.xml">
+                            <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
+                        </file>
+                    </folder>
+                </folder>
+                <folder name="VSCode">
+                    <folder name="Defaults">
+                        <file name="org-netbeans-modules-defaults-keybindings.xml" url="VSCode-keybindings.xml"/>
+                        <file name="org-netbeans-modules-editor-keybindings-mac.xml" url="VSCode-keybindings-mac.xml">
                             <attr name="nbeditor-settings-targetOS" stringvalue="OS_MAC"/>
                         </file>
                     </folder>


### PR DESCRIPTION
Closes #6458.

Adds a Visual Studio Code keymap profile for NetBeans.

This change registers a new `Visual Studio Code` keymap using the existing NetBeans keymap infrastructure. The profile adds common VS Code-style shortcuts for editor actions, navigation, search, project actions, terminal access, and debugging.

It also adds a macOS-specific keybinding file so shortcuts follow Mac platform conventions where needed.

The shortcuts are mapped to existing NetBeans actions rather than introducing new action implementations.

Local verification:

```bash
xmllint --noout ide/defaults/src/org/netbeans/modules/defaults/VSCode-keybindings.xml ide/defaults/src/org/netbeans/modules/defaults/VSCode-keybindings-mac.xml ide/defaults/src/org/netbeans/modules/defaults/mf-layer.xml
git diff --check
ant -f nbbuild/build.xml bootstrap
ant -f ide/defaults/build.xml build
```

LLM assistance used: OpenAI GPT-5 Codex

Assisted-by: OpenAI GPT-5 Codex