### PR TITLE
CI: run cleanup job on ubuntu-slim

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2594,8 +2594,7 @@ jobs:
     #  * nothing else failed (allows manual restarts)
     #  * the workflow got cancelled
     if: ${{ always() && needs.base-build.result == 'success' && (!contains(needs.*.result, 'failure') || cancelled()) }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    runs-on: ubuntu-slim
     steps:
 
       - name: Delete Workspace Artifact


### PR DESCRIPTION
it is the only job atm which doesn't need much tooling and/or resources

but since it is running at the end of the workflow, changing it to the small container instance might reduce queue time and therefore overall workflow runtime.

https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/#runner-details

(intentionally left the build enabled to check if the cleanup works)