### PR TITLE
CI: fix setup-java ea temurin sigcheck failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,9 +72,9 @@ env:
   #  - EA builds must be available for the upcoming release (note: some vendors skip builds)
   #  - linux, win, mac (arm)
   #  - reliable / no extra sauce
-  DEFAULT_JAVA_DISTRIBUTION: 'temurin'
+#  DEFAULT_JAVA_DISTRIBUTION: 'temurin'
 #  DEFAULT_JAVA_DISTRIBUTION: 'sapmachine'
-#  DEFAULT_JAVA_DISTRIBUTION: 'zulu'
+  DEFAULT_JAVA_DISTRIBUTION: 'zulu'
 
   # labels are mapped to env vars for pipeline customization. If this is not a PR, (almost) everything will run, but with a reduced matrix.
   # note: env vars don't work in the job's 'if' field but do work within jobs ( https://github.com/actions/runner/issues/1189 ), the whole expression must be duplicated


### PR DESCRIPTION
setup-java action got updated to 6.01.
```
2026-09-10T09:25:40.6652165Z Download action repository 'actions/setup-java@v6' (SHA:de7274f081f381c8f8158605e0321c36c376e2e6)
```
and is now failing

```
  Downloading Java 27.0.0+35.0.ea (Temurin-Hotspot) from https://github.com/adoptium/temurin27-binaries/releases/download/jdk-27%2B35-ea-beta/OpenJDK27U-jdk_x64_linux_hotspot_27_35-ea.tar.gz ...
  Error: Java setup process failed due to: Checksum verification failed for Temurin-Hotspot version 27.0.0+35.0.ea: sha256 expected 8f2b21d827d4bccc7b3fe0ef0cdc4b5d1ffaa47b587bb3c8dcb8eec3e57c95b0, actual bc2676d99d27fb3bb28fd8cef928d8eb1f20eb388b72d291875ed8b08b25bff4.
  Error: Checksum verification failed for Temurin-Hotspot version 27.0.0+35.0.ea: sha256 expected 8f2b21d827d4bccc7b3fe0ef0cdc4b5d1ffaa47b587bb3c8dcb8eec3e57c95b0, actual bc2676d99d27fb3bb28fd8cef928d8eb1f20eb388b72d291875ed8b08b25bff4.
```

whats funny is that the setup-java update is supposed to have a fix for this very issue: https://github.com/actions/setup-java/pull/1260 / https://github.com/actions/setup-java/releases/tag/v6.0.1