### PR TITLE
CI: Try running some tests in parallel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1465,7 +1465,7 @@ jobs:
 
 
   java-hints-test:
-    name: Java Hints ${{ matrix.config }} on Linux/JDK ${{ matrix.java }}
+    name: Java Hints on Linux/JDK ${{ matrix.java }}
     # equals env.test_java == 'true'
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Java') || contains(github.event.pull_request.labels.*.name, 'ci:all-tests') || github.event_name != 'pull_request' }}
     needs: base-build
@@ -1474,7 +1474,6 @@ jobs:
     strategy:
       matrix:
         java: [ '21', '27-ea' ]
-        config: [ 'batch1', 'batch2' ]
         exclude:
           - java: ${{ github.event_name == 'pull_request' && 'nothing' || '27-ea' }}
       fail-fast: false
@@ -1501,18 +1500,15 @@ jobs:
         run: tar --zstd -xf build.tar.zst
 
       - name: java.hints (unreliable tests)
-        if: ${{ (matrix.config == 'batch2') && success() }}
         run: .github/retry.sh ant $OPTS -Dtest.config=unreliable -f java/java.hints test
 
-      - name: java.hints ${{ matrix.config }}
-        run: ant $OPTS -Dtest.config=${{ matrix.config }} -f java/java.hints test
+      - name: java.hints
+        run: ant $OPTS -Dtest.threads=4 -f java/java.hints test
 
       - name: java.hints.declarative
-        if: ${{ (matrix.config == 'batch2') && success() }}
         run: ant $OPTS -f java/java.hints.declarative test
 
       - name: spi.java.hints
-        if: ${{ (matrix.config == 'batch2') && success() }}
         run: ant $OPTS -f java/spi.java.hints test
 
       - name: Create Test Summary

--- a/java/java.hints/nbproject/project.properties
+++ b/java/java.hints/nbproject/project.properties
@@ -61,17 +61,9 @@ test.runner=junit
 
 test-unit-sys-prop.hints-tools.jar.location=${tools.jar}
 
-test.config.batch1.includes=\
+test.config.default.includes=\
     **/*Test.class
-test.config.batch1.excludes=\
-    **/errors/*Test.class,\
-    **/jdk/*Test.class,\
-    ${test.config.unreliable.includes}
-
-test.config.batch2.includes=\
-    **/errors/*Test.class,\
-    **/jdk/*Test.class
-test.config.batch2.excludes=\
+test.config.default.excludes=\
     ${test.config.unreliable.includes}
 
 # frequent failures

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertSwitchToRuleSwitchTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertSwitchToRuleSwitchTest.java
@@ -18,10 +18,7 @@
  */
 package org.netbeans.modules.java.hints.jdk;
 
-import com.sun.tools.javac.tree.JCTree;
 import javax.lang.model.SourceVersion;
-import junit.framework.Test;
-import junit.framework.TestSuite;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.java.hints.test.api.HintTest;
 
@@ -1046,17 +1043,4 @@ public class ConvertSwitchToRuleSwitchTest extends NbTestCase {
                             + "}");
     }
 
-    public static Test suite() {
-        TestSuite suite = new TestSuite();
-        try {
-            Class.forName("com.sun.source.tree.CaseTree$CaseKind", false, JCTree.class.getClassLoader());
-            suite.addTestSuite(ConvertSwitchToRuleSwitchTest.class);
-        } catch (ClassNotFoundException ex) {
-            //OK
-            suite.addTest(new ConvertSwitchToRuleSwitchTest("noop"));
-        }
-        return suite;
-    }
-
-    public void noop() {}
 }

--- a/nbbuild/templates/common.xml
+++ b/nbbuild/templates/common.xml
@@ -760,11 +760,12 @@
 
     <target name="-do-junit" depends="test-init,-setup-continue-after-failing">
         <property name="test.jms.flags" value=""/>
+        <property name="test.threads" value="1"/>
         <macrodef name="junit-impl">
             <attribute name="test.type"/>
             <attribute name="disable.apple.ui" default="false"/>
             <sequential>
-                <junit showoutput="true" fork="true" failureproperty="tests.failed" errorproperty="tests.failed" filtertrace="${test.filter.trace}" tempdir="${build.test.@{test.type}.results.dir}" timeout="${test.timeout}" jvm="${test.nbjdk.java}">
+                <junit showoutput="true" fork="true" threads="${test.threads}" failureproperty="tests.failed" errorproperty="tests.failed" filtertrace="${test.filter.trace}" tempdir="${build.test.@{test.type}.results.dir}" timeout="${test.timeout}" jvm="${test.nbjdk.java}">
                     <batchtest todir="${build.test.@{test.type}.results.dir}">
                         <fileset dir="${build.test.@{test.type}.classes.dir}" includes="${test.includes}" excludes="${test.excludes}"/>
                     </batchtest>


### PR DESCRIPTION
standard linux runner has 4 cores

java.hints module:
 - hints tests have their workspace split by FQ test name and appear to be able to run concurrently on a per-class basis
