### PR TITLE
CI: Try the arm runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -312,6 +312,11 @@ jobs:
         java: [ '21' ]
     steps:
 
+      - name: Print runner info
+        run: |
+          echo "CPU cores: $(nproc)"
+          free
+
       - name: Check PR labels
         if: ${{ github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name) == '' }}
         run: |
@@ -532,13 +537,18 @@ jobs:
   ide-modules-test:
     name: IDE Modules on Linux/JDK ${{ matrix.java }}
     needs: base-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     strategy:
       matrix:
         java: [ '21' ]
       fail-fast: false
     steps:
+
+      - name: Print runner info
+        run: |
+          echo "CPU cores: $(nproc)"
+          free
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v6
@@ -1279,7 +1289,7 @@ jobs:
     # equals env.test_java == 'true'
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Java') || contains(github.event.pull_request.labels.*.name, 'ci:all-tests') || github.event_name != 'pull_request' }}
     needs: base-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 100
     strategy:
       matrix:
@@ -1469,7 +1479,7 @@ jobs:
     # equals env.test_java == 'true'
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Java') || contains(github.event.pull_request.labels.*.name, 'ci:all-tests') || github.event_name != 'pull_request' }}
     needs: base-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     strategy:
       matrix:
@@ -2369,7 +2379,7 @@ jobs:
     strategy:
       matrix:
         java: [ '21' ]
-        os: [ 'windows-latest', 'ubuntu-latest' ]
+        os: [ 'windows-latest', 'ubuntu-24.04-arm' ]
         exclude:
           - os: ${{ github.event_name == 'pull_request' && 'nothing' || 'windows-latest' }}
       fail-fast: false


### PR DESCRIPTION
rumors say its faster, and it may also have a larger pool

this is just a benchmark for now to get stats for the three longest jobs

jobs:
- IDE Modules: difficult to say due to failures within retry scripts
- Java Hints batch1: `19m 41s -> 18m 25s`
- Java Hints batch2: `13m 24s -> 14m 14s`
- Java Modules: `50m 6s -> 44m 5s `
- PHP: `48m 2s -> 46m 57s `
